### PR TITLE
Coin restriction and binary serialization optimisation

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -132,6 +132,7 @@ library
                         Pos.Binary.Address
                         Pos.Binary.Block
                         Pos.Binary.Class
+                        Pos.Binary.Coin
                         Pos.Binary.Crypto
                         Pos.Binary.Communication
                         Pos.Binary.DHTModel

--- a/src/Pos/Binary/Coin.hs
+++ b/src/Pos/Binary/Coin.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BangPatterns #-}
+module Pos.Binary.Coin
+    ( encode
+    , decode
+    ) where
+
+import           Data.Word
+import           Data.Bits
+--import           Data.Binary
+import           Control.Monad         (when)
+import           Data.Binary.Get       (getWord8, Get)
+import           Universum
+import           Pos.Types.Types       (mkCoin, unsafeGetCoin, Coin)
+
+-- number of total coins is 45*10^9 * 10^6
+--
+-- 45*10^15 needs 56 bits to represent
+-- 45*10^9  (integral mega coins) needs 36 bits to represent
+-- 999999   (floating mega coins) needs 20 bits to represent
+--
+-- decimal to needed bits:
+--
+--   0-9 | 4 bits
+--   0-99 | 7 bits
+--   0-999 | 10 bits
+--   0-9999 | 14 bits
+--   0-99999 | 17 bits
+--   0-999999 | 20 bits
+--
+-- coin is splitted in mega coin (10^6) and the remaining coin for serialization
+--
+-- 1000999 coin = 1.000999 mega coin
+-- 
+-- simple varint encoding with word64 limit. the total length of the sequence is encoded
+-- in the first byte with a variable mask.
+--
+--   header    | mask |  spare bits | extra byte | total bits as value | serialized size
+--   ==========+======+=============+============+=====================+================
+--   0 xxxxxxx | 0x7f | 7 bits      | 0          | 7 bits              | 1 byte
+--   10 xxxxxx | 0x3f | 6 bits      | 1          | 14 bits             | 2 bytes
+--   110 xxxxx | 0x1f | 5 bits      | 2          | 21 bits             | 3 bytes
+--   1110 xxxx | 0x0f | 4 bits      | 3          | 27 bits             | 4 bytes
+--   11110 xxx | 0x07 | 3 bits      | 4          | 35 bits             | 5 bytes
+--   111110 xx | 0x03 | 2 bits      | 5          | 42 bits             | 6 bytes
+--   1111110 x | 0x01 | 1 bit       | 6          | 49 bits             | 7 bytes
+--   11111110  | 0x00 | 0 bit       | 7          | 56 bits             | 8 bytes
+--   11111111  | 0x00 | 0 bit       | 8          | 64 bits             | 9 bytes
+--
+-- Specialized to the integral part which only need 36 bits maximum:
+--
+--   header    | mask |  spare bits | extra byte | total bits as value | serialized size
+--   ==========+======+=============+============+=====================+================
+--   0 xxxxxxx | 0x7f | 7 bits      | 0          | 7 bits              | 1 byte
+--   10 xxxxxx | 0x3f | 6 bits      | 1          | 14 bits             | 2 bytes
+--   110 xxxxx | 0x1f | 5 bits      | 2          | 21 bits             | 3 bytes
+--   1110 xxxx | 0x0f | 4 bits      | 3          | 27 bits             | 4 bytes
+--   1111 xxxx | 0x0f | 4 bits      | 4          | 36 bits             | 5 bytes
+--
+-- And the floating part, need 20 bits to represent, encoding value from 0 to 999999:
+--
+--   header    | mask |  spare bits | extra byte | total bits as value | serialized size
+--   ==========+======+=============+============+=====================+================
+--   0 xxxxxx  | 0x7f | 7 bits      | 0          | 7  bits             | 1 byte
+--   10 xxxxxx | 0x3f | 6 bits      | 1          | 14 bits             | 2 bytes
+--   110 xxxxx | 0x3f | 5 bits      | 2          | 21 bits             | 3 bytes
+--
+-- Note: we could save one bit in the 3 bytes scheme here by considering the end of encoding
+-- but we don't need it, so by not changing the scheme we can re-use the previous scheme for
+-- integral as is.
+--
+encode :: Coin -> [Word8]
+encode (unsafeGetCoin -> w) = encodeVarint mega ++ encodeVarint (reversedBase10 micros)
+  where
+    (mega, micros) = w `divMod` 1000000
+
+encodeVarint :: Word64 -> [Word8]
+encodeVarint w
+    | w <= 0x7F         = [fromIntegral w]
+    | w <= 0x3FFF       = [0x80 .|. (w .>>. 8), fromIntegral w]
+    | w <= 0x1FFFFF     = [0xc0 .|. (w .>>. 16), w .>>. 8, fromIntegral w]
+    | w <= 0x0FFFFFFF   = [0xe0 .|. (w .>>. 24), w .>>. 16, w .>>. 8, fromIntegral w]
+    | w <= 0x0FFFFFFFFF = [0xf0 .|. (w .>>. 32), w .>>. 24, w .>>. 16, w .>>. 8, fromIntegral w]
+    | otherwise         = error "invalid encoding for integral part"
+
+expectedContBytes :: Word64 -> Int
+expectedContBytes w
+    | w <= 0x7F         = 0
+    | w <= 0x3FFF       = 1
+    | w <= 0x1FFFFF     = 2
+    | w <= 0x0FFFFFFF   = 3
+    | w <= 0x0FFFFFFFFF = 4
+    | otherwise         = error "invalid encoding"
+
+-- given the header byte, return the number of following byte,
+-- and the initial accumulator
+hdrToParam :: Word8 -> (Int, Word64)
+hdrToParam h
+    | isClear h 7 = (0, fromIntegral (h .&. 0x7f))
+    | isClear h 6 = (1, fromIntegral (h .&. 0x3f))
+    | isClear h 5 = (2, fromIntegral (h .&. 0x1f))
+    | isClear h 4 = (3, fromIntegral (h .&. 0x0f))
+    | otherwise   = (4, fromIntegral (h .&. 0x0f))
+
+decodeVarint :: Get Word64
+decodeVarint = do
+    (nbBytes, acc) <- hdrToParam <$> getWord8
+    conts <- replicateM nbBytes getWord8
+    let val = orAndShift acc conts
+    when (expectedContBytes val /= length conts) $ fail "not canonical encoding"
+    return val
+  where
+    orAndShift acc []     = acc
+    orAndShift acc (x:xs) = orAndShift ((acc `shiftL` 8) .|. fromIntegral x) xs
+
+decode :: Get Coin
+decode = do
+    (mega, microsReversed) <- (,) <$> decodeVarint <*> decodeVarint
+    let micros = reversedBase10 microsReversed
+        w      = mega * 1000000 + micros
+    if micros < 1000000 && w <= unsafeGetCoin maxBound
+        then return $ mkCoin w
+        else fail "coins above limit"
+
+------------
+-- utils
+
+(.>>.) :: Word64 -> Int -> Word8
+(.>>.) w n = fromIntegral (w `shiftR` n)
+
+(.<<.) :: Word8 -> Int -> Word64
+(.<<.) w n = fromIntegral w `shiftL` n
+
+isClear :: Word8 -> Int -> Bool
+isClear w bitN = not (testBit w bitN)
+
+toBase10 :: (Integral n, Ord n, Num n) => Int -> n -> [n]
+toBase10 nbDigits n = loop nbDigits n
+  where
+    loop 0 _ = []
+    loop i n = r : loop (i-1) b
+       where (b, r) = n `divMod` 10
+
+fromBase10 :: Num n => [n] -> n
+fromBase10 = go 0
+  where go !acc []     = acc
+        go !acc (x:xs) = go (acc * 10 + x) xs
+
+reversedBase10 :: (Integral n, Ord n, Num n) => n -> n
+reversedBase10 = fromBase10 . toBase10 6

--- a/src/Pos/Binary/Types.hs
+++ b/src/Pos/Binary/Types.hs
@@ -12,6 +12,7 @@ import           Universum
 
 import           Pos.Binary.Class      (Bi (..), UnsignedVarInt (..))
 import           Pos.Binary.Merkle     ()
+import qualified Pos.Binary.Coin       as BinCoin
 import           Pos.Binary.Version    ()
 import           Pos.Constants         (epochSlots, protocolMagic)
 import qualified Pos.Data.Attributes   as A
@@ -29,8 +30,8 @@ instance Bi (A.Attributes ()) where
     put = A.putAttributes (\() -> [])
 
 instance Bi T.Coin where
-    put = putWord64be . T.unsafeGetCoin
-    get = T.mkCoin <$> getWord64be
+    put = mapM_ putWord8 . BinCoin.encode
+    get = BinCoin.decode
 
 instance Bi T.Timestamp where
     get = fromInteger <$> get

--- a/src/Pos/Types/Arbitrary.hs
+++ b/src/Pos/Types/Arbitrary.hs
@@ -6,11 +6,9 @@
 module Pos.Types.Arbitrary
        ( BadSigsTx (..)
        , GoodTx (..)
-       , OverflowTx (..)
        , SmallBadSigsTx (..)
        , SmallHashMap (..)
        , SmallGoodTx (..)
-       , SmallOverflowTx (..)
        ) where
 
 import qualified Data.ByteString            as BS (pack)
@@ -35,7 +33,6 @@ import           Pos.Script                 (Script)
 import           Pos.Script.Examples        (badIntRedeemer, goodIntRedeemer,
                                              intValidator)
 import           Pos.Types.Arbitrary.Unsafe ()
-import           Pos.Types.Coin             (coinToInteger, unsafeAddCoin, unsafeSubCoin)
 import           Pos.Types.Timestamp        (Timestamp (..))
 import           Pos.Types.Types            (Address (..), ChainDifficulty (..), Coin,
                                              EpochIndex (..), EpochOrSlot (..),
@@ -174,26 +171,6 @@ instance Arbitrary GoodTx where
 instance Arbitrary SmallGoodTx where
     arbitrary = SmallGoodTx <$> makeSmall arbitrary
 
--- | Ill-formed 'Tx' with overflow.
-newtype OverflowTx = OverflowTx
-    { getOverflowTx :: [((Tx, TxDistribution), TxIn, TxOutAux, TxInWitness)]
-    } deriving (Show)
-
-newtype SmallOverflowTx =
-    SmallOverflowTx OverflowTx
-    deriving Show
-
-instance Arbitrary OverflowTx where
-    arbitrary = OverflowTx <$> do
-        txsList <- getNonEmpty <$>
-            (arbitrary :: Gen (NonEmptyList (Tx, SecretKey, SecretKey, Coin)))
-        let halfBound = mkCoin . fromInteger $
-                        coinToInteger (maxBound @Coin) `div` 2
-        buildProperTx txsList (unsafeAddCoin halfBound,
-                               unsafeSubCoin halfBound)
-
-instance Arbitrary SmallOverflowTx where
-    arbitrary = SmallOverflowTx <$> makeSmall arbitrary
 
 -- | Ill-formed 'Tx' with bad signatures.
 newtype BadSigsTx = BadSigsTx

--- a/src/Pos/Types/Arbitrary.hs
+++ b/src/Pos/Types/Arbitrary.hs
@@ -19,7 +19,7 @@ import           Data.DeriveTH              (derive, makeArbitrary)
 import           Data.Time.Units            (Microsecond, Millisecond, fromMicroseconds)
 import           System.Random              (Random)
 import           Test.QuickCheck            (Arbitrary (..), Gen, NonEmptyList (..),
-                                             NonZero (..), choose, choose, elements,
+                                             choose, choose, elements,
                                              oneof)
 import           Test.QuickCheck.Instances  ()
 import           Universum
@@ -43,7 +43,7 @@ import           Pos.Types.Types            (Address (..), ChainDifficulty (..),
                                              SlotId (..), SlotId (..), Tx (..),
                                              TxDistribution (..), TxIn (..),
                                              TxInWitness (..), TxOut (..), TxOutAux,
-                                             makePubKeyAddress, makeScriptAddress, mkCoin)
+                                             makePubKeyAddress, makeScriptAddress, mkCoin, unsafeGetCoin)
 import           Pos.Types.Version          (ApplicationName (..), BlockVersion (..),
                                              SoftwareVersion (..),
                                              applicationNameMaxLength)
@@ -67,7 +67,7 @@ deriving instance Arbitrary ChainDifficulty
 derive makeArbitrary ''TxOut
 
 instance Arbitrary Coin where
-    arbitrary = mkCoin . getNonZero <$> (arbitrary :: Gen (NonZero Word64))
+    arbitrary = mkCoin <$> choose (1, unsafeGetCoin maxBound)
 
 maxReasonableEpoch :: Integral a => a
 maxReasonableEpoch = 5 * 1000 * 1000 * 1000 * 1000  -- 5 * 10^12, because why not

--- a/src/Pos/Types/Coin.hs
+++ b/src/Pos/Types/Coin.hs
@@ -34,7 +34,7 @@ coinToInteger = toInteger . unsafeGetCoin
 -- | Only use if you're sure there'll be no overflow.
 unsafeAddCoin :: Coin -> Coin -> Coin
 unsafeAddCoin (unsafeGetCoin -> a) (unsafeGetCoin -> b)
-    | res >= a && res >= b = mkCoin res
+    | res >= a && res >= b && res <= unsafeGetCoin (maxBound @Coin) = mkCoin res
     | otherwise = panic "unsafeAddCoin: overflow"
   where
     res = a+b

--- a/src/Pos/Types/Types.hs
+++ b/src/Pos/Types/Types.hs
@@ -197,14 +197,23 @@ import           Pos.Util               (Color (Magenta), colorize)
 -- | Coin is the least possible unit of currency.
 newtype Coin = Coin
     { getCoin :: Word64
-    } deriving (Show, Ord, Eq, Bounded, Generic, Hashable, Data, NFData)
+    } deriving (Show, Ord, Eq, Generic, Hashable, Data, NFData)
 
 instance Buildable Coin where
     build (Coin n) = bprint (int%" coin(s)") n
 
+instance Bounded Coin where
+    minBound = Coin 0
+    maxBound = Coin maxCoinVal
+
+maxCoinVal :: Word64
+maxCoinVal = 44999999999999999
+
 -- | Make Coin from Word64.
 mkCoin :: Word64 -> Coin
-mkCoin = Coin
+mkCoin n
+    | n > maxCoinVal = panic ("mkCoin: too big: " <> show n)
+    | otherwise      = Coin n
 {-# INLINE mkCoin #-}
 
 -- | Coin formatter which restricts type.

--- a/test/Test/Pos/BinarySpec.hs
+++ b/test/Test/Pos/BinarySpec.hs
@@ -8,6 +8,7 @@ import           Test.Hspec    (Spec, describe)
 import           Universum
 
 import qualified Pos.Binary    as B
+import           Pos.Types.Types (Coin)
 
 import           Test.Pos.Util (binaryTest)
 
@@ -27,3 +28,5 @@ spec = describe "Bi" $ do
         describe "FixedSizeInt" $ do
             binaryTest @(B.FixedSizeInt Int)
             binaryTest @(B.FixedSizeInt Int64)
+        describe "Coin" $ do
+            binaryTest @Coin


### PR DESCRIPTION
Not currently passing test due to the overflowTx

The optimisation rely on the fact that `NNNN0000` is a common value