### PR TITLE
Use EKG to monitor, custom nt, nt-tcp, tw-nt

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -143,12 +143,15 @@ function node_cmd {
 
   $dht_cmd
 
+  monitor_port=$((8000+$i))
+
   echo -n " --listen 127.0.0.1:"`get_port $i`
   echo -n " $(logs node$i.log) $time_lord $stats"
   echo -n " $stake_distr $ssc_algo "
   echo -n " $web "
   echo -n " $wallet_args "
   echo -n " --kademlia-dump-path  $(dump_path $kademlia_dump_path)"
+  echo -n " --monitor-port $monitor_port +RTS -T -RTS "
   echo ''
 }
 

--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -21,6 +21,7 @@ data LoggingParams = LoggingParams
     { lpRunnerTag     :: !LoggerName        -- ^ Prefix for logger, like "time-slave"
     , lpHandlerPrefix :: !(Maybe FilePath)  -- ^ Prefix of path for all logs
     , lpConfigPath    :: !(Maybe FilePath)  -- ^ Path to logger configuration
+    , lpEkgPort       :: !(Maybe Int)
     } deriving (Show)
 
 -- | Contains basic & networking parameters for running node.

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RankNTypes          #-}
 
 -- | Runners in various modes.
 
@@ -21,6 +24,7 @@ module Pos.Launcher.Runner
        , setupLoggers
        , bracketDHTInstance
        , runServer
+       , runServer_
        , loggerBracket
        , createTransport
        , bracketTransport
@@ -41,19 +45,21 @@ import           Data.Tagged                 (proxy)
 import qualified Data.Time                   as Time
 import           Formatting                  (build, sformat, shown, (%))
 import           Mockable                    (CurrentTime, Mockable, MonadMockable,
-                                              Production (..), Throw, bracket,
+                                              Production (..), Throw, bracket, finally,
                                               currentTime, delay, fork, killThread, throw)
 import           Network.Transport           (Transport, closeTransport)
 import           Network.Transport.Concrete  (concrete)
 import qualified Network.Transport.TCP       as TCP
-import           Node                        (NodeAction (..), hoistSendActions, node)
+import           Node                        (NodeAction (..), hoistSendActions,
+                                              Node, node)
+import           Node.Util.Monitor           (setupMonitor, stopMonitor)
 import qualified STMContainers.Map           as SM
 import           System.Random               (newStdGen)
 import           System.Wlog                 (LoggerConfig (..), WithLogger, logError,
                                               logInfo, logWarning, mapperB, productionB,
                                               releaseAllHandlers, setupLogging,
                                               usingLoggerName)
-import           Universum                   hiding (bracket)
+import           Universum                   hiding (bracket, finally)
 
 import           Pos.Binary                  ()
 import           Pos.CLI                     (readLoggerConfig)
@@ -92,7 +98,7 @@ import           Pos.Slotting                (SlottingState (..))
 import           Pos.Ssc.Class               (SscConstraint, SscHelpersClass,
                                               SscListenersClass, SscNodeContext,
                                               SscParams, sscCreateNodeContext)
-import           Pos.Ssc.Extra               (runSscHolder)
+import           Pos.Ssc.Extra               (mkSscHolderState, runSscHolder, ignoreSscHolder, mkStateAndRunSscHolder)
 import           Pos.Statistics              (getNoStatsT, runStatsT')
 import           Pos.Txp.Holder              (runTxpLDHolder)
 import qualified Pos.Txp.Types.UtxoView      as UV
@@ -105,6 +111,7 @@ import           Pos.Util.UserSecret         (usKeys)
 import           Pos.Worker                  (allWorkersCount)
 import           Pos.WorkMode                (MinWorkMode, ProductionMode, RawRealMode,
                                               ServiceMode, StatsMode)
+
 data RealModeResources = RealModeResources
     { rmTransport :: Transport
     , rmDHT       :: KademliaDHTInstance
@@ -185,15 +192,38 @@ runRawRealMode res np@NodeParams {..} sscnp listeners outSpecs (ActionSpec actio
        runDBHolder modernDBs . runCH np initNC $ initNodeDBs
        initTip <- runDBHolder modernDBs getTip
        stateM <- liftIO SM.newIO
+       stateM_ <- liftIO SM.newIO
+
+       -- TODO need an effect-free way of running this into IO.
+       let runIO :: forall t . RawRealMode ssc t -> IO t
+           runIO = runProduction .
+                       usingLoggerName lpRunnerTag .
+                       runDBHolder modernDBs .
+                       runCH np initNC .
+                       ignoreSscHolder .
+                       runTxpLDHolder (UV.createFromDB . _gStateDB $ modernDBs) initTip .
+                       runDelegationT def .
+                       runUSHolder .
+                       runKademliaDHT (rmDHT res) .
+                       runPeerStateHolder stateM_
+
+       let startMonitoring node = case lpEkgPort of
+               Nothing -> return Nothing
+               Just port -> Just <$> setupMonitor port runIO node
+
+       let stopMonitoring it = case it of
+               Nothing -> return ()
+               Just ekgServer -> stopMonitor ekgServer
+
        runDBHolder modernDBs .
           runCH np initNC .
-          runSscHolder .
+          (mkStateAndRunSscHolder @ssc) .
           runTxpLDHolder (UV.createFromDB . _gStateDB $ modernDBs) initTip .
           runDelegationT def .
           runUSHolder .
           runKademliaDHT (rmDHT res) .
           runPeerStateHolder stateM .
-          runServer (rmTransport res) listeners outSpecs . ActionSpec $
+          runServer (rmTransport res) listeners outSpecs startMonitoring stopMonitoring . ActionSpec $
               \vI sa -> nodeStartMsg npBaseParams >> action vI sa
   where
     LoggingParams {..} = bpLoggingParams npBaseParams
@@ -211,16 +241,18 @@ runServiceMode res bp@BaseParams{..} listeners outSpecs (ActionSpec action) = do
     usingLoggerName (lpRunnerTag bpLoggingParams) .
       runKademliaDHT (rmDHT res) .
       runPeerStateHolder stateM .
-      runServer (rmTransport res) listeners outSpecs . ActionSpec $
+      runServer_ (rmTransport res) listeners outSpecs . ActionSpec $
           \vI sa -> nodeStartMsg bp >> action vI sa
 
 runServer :: (MonadIO m, MonadMockable m, MonadFix m, WithLogger m, MonadDHT m)
   => Transport
   -> ListenersWithOut m
   -> OutSpecs
+  -> (Node m -> m t)
+  -> (t -> m ())
   -> ActionSpec m b
   -> m b
-runServer transport packedLS (OutSpecs wouts) (ActionSpec action) = do
+runServer transport packedLS (OutSpecs wouts) withNode afterNode (ActionSpec action) = do
     ourPeerId <- PeerId . getMeaningPart <$> currentNodeKey
     let (listeners', InSpecs ins, OutSpecs outs) = unpackLSpecs packedLS
         ourVerInfo = VerInfo protocolMagic lastKnownBlockVersion ins $ outs <> wouts
@@ -228,7 +260,22 @@ runServer transport packedLS (OutSpecs wouts) (ActionSpec action) = do
     stdGen <- liftIO newStdGen
     logInfo $ sformat ("Our verInfo "%build) ourVerInfo
     node (concrete transport) stdGen BiP (ourPeerId, ourVerInfo) $ \__node ->
-        pure $ NodeAction listeners (action ourVerInfo)
+        pure $ NodeAction listeners $ \sendActions -> do
+            t <- withNode __node
+            a <- action ourVerInfo sendActions `finally` afterNode t
+            return a
+
+runServer_ :: (MonadIO m, MonadMockable m, MonadFix m, WithLogger m, MonadDHT m)
+  => Transport
+  -> ListenersWithOut m
+  -> OutSpecs
+  -> ActionSpec m b
+  -> m b
+runServer_ transport packedLS outSpecs =
+    runServer transport packedLS outSpecs acquire release
+    where
+    acquire = const (pure ())
+    release = const (pure ())
 
 -- | ProductionMode runner.
 runProductionMode
@@ -309,7 +356,7 @@ runCH params@NodeParams {..} sscNodeContext act = do
             , ncShutdownNotifyQueue = shutdownQueue
             , ncNodeParams = params
             , ncLoggerConfig = logCfg
-            , ncSendLock = Just sendLock
+            , ncSendLock = Nothing
             }
     runContextHolder ctx act
 
@@ -352,9 +399,9 @@ bracketDHTInstance
     :: BaseParams -> (KademliaDHTInstance -> Production a) -> Production a
 bracketDHTInstance BaseParams {..} action = bracket acquire release action
   where
-    withLog = usingLoggerName $ lpRunnerTag bpLoggingParams
-    acquire = withLog $ startDHTInstance instConfig
-    release = withLog . stopDHTInstance
+    --withLog = usingLoggerName $ lpRunnerTag bpLoggingParams
+    acquire = usingLoggerName (lpRunnerTag bpLoggingParams) (startDHTInstance instConfig)
+    release = usingLoggerName (lpRunnerTag bpLoggingParams) . stopDHTInstance
     instConfig =
         KademliaDHTInstanceConfig
         { kdcKey = bpDHTKey

--- a/src/Pos/Ssc/Extra/Holder.hs
+++ b/src/Pos/Ssc/Extra/Holder.hs
@@ -7,8 +7,10 @@
 
 module Pos.Ssc.Extra.Holder
        ( SscHolder (..)
+       , mkSscHolderState
+       , mkStateAndRunSscHolder
        , runSscHolder
-       , runSscHolderRaw
+       , ignoreSscHolder
        ) where
 
 import qualified Control.Concurrent.STM    as STM
@@ -88,6 +90,20 @@ instance Monad m => MonadSscMem ssc (SscHolder ssc m) where
 -- and using default (uninitialized) local state.
 runSscHolder
     :: forall ssc m a.
+       ( --WithLogger m
+       --, WithNodeContext ssc m
+       --, SscGStateClass ssc
+       --, SscLocalDataClass ssc
+       --, MonadDB ssc m
+       --, MonadSlots m
+       )
+    => SscState ssc
+    -> SscHolder ssc m a
+    -> m a
+runSscHolder st holder = runReaderT (getSscHolder holder) st
+
+mkStateAndRunSscHolder
+    :: forall ssc m a.
        ( WithLogger m
        , WithNodeContext ssc m
        , SscGStateClass ssc
@@ -95,12 +111,26 @@ runSscHolder
        , MonadDB ssc m
        , MonadSlots m
        )
-    => SscHolder ssc m a -> m a
-runSscHolder holder = do
+    => SscHolder ssc m a
+    -> m a
+mkStateAndRunSscHolder holder = do
+    st <- mkSscHolderState
+    runSscHolder st holder
+
+mkSscHolderState 
+    :: forall ssc m .
+       ( WithLogger m
+       , WithNodeContext ssc m
+       , SscGStateClass ssc
+       , SscLocalDataClass ssc
+       , MonadDB ssc m
+       , MonadSlots m
+       )
+    => m (SscState ssc)
+mkSscHolderState = do
     gState <- sscLoadGlobalState @ssc
     ld <- sscNewLocalData @ssc
-    sscState <- liftIO $ SscState <$> STM.newTVarIO gState <*> STM.newTVarIO ld
-    runReaderT (getSscHolder holder) sscState
+    liftIO $ SscState <$> STM.newTVarIO gState <*> STM.newTVarIO ld
 
-runSscHolderRaw :: SscState ssc -> SscHolder ssc m a -> m a
-runSscHolderRaw st holder = runReaderT (getSscHolder holder) st
+ignoreSscHolder :: SscHolder ssc m a -> m a
+ignoreSscHolder holder = runReaderT (getSscHolder holder) (error "don't force me")

--- a/src/Pos/Wallet/Launcher/Runner.hs
+++ b/src/Pos/Wallet/Launcher/Runner.hs
@@ -23,7 +23,7 @@ import           Pos.DHT.Model               (discoverPeers)
 import           Pos.DHT.Real                (runKademliaDHT)
 import           Pos.Launcher                (BaseParams (..), LoggingParams (..),
                                               RealModeResources (..), addDevListeners,
-                                              runServer)
+                                              runServer_)
 import           Pos.Slotting                (SlottingState (..))
 import           Pos.Types                   (unflattenSlotId)
 import           Pos.Wallet.Context          (WalletContext (..), runContextHolder)
@@ -100,7 +100,7 @@ runRawRealWallet res WalletParams {..} listeners (ActionSpec action, outs) =
             runKeyStorage wpKeyFilePath .
             runKademliaDHT (rmDHT res) .
             runPeerStateHolder stateM .
-            runServer (rmTransport res) listeners outs . ActionSpec $
+            runServer_ (rmTransport res) listeners outs . ActionSpec $
                 \vI sa -> logInfo "Started wallet, joining network" >> action vI sa
   where
     LoggingParams {..} = bpLoggingParams wpBaseParams

--- a/src/Pos/Wallet/Web/Server/Full.hs
+++ b/src/Pos/Wallet/Web/Server/Full.hs
@@ -36,7 +36,7 @@ import           Pos.DHT.Real.Real             (runKademliaDHT)
 import           Pos.DHT.Real.Types            (KademliaDHTInstance (..),
                                                 getKademliaDHTInstance)
 import           Pos.Ssc.Class                 (SscConstraint)
-import           Pos.Ssc.Extra                 (SscHolder (..), SscState, runSscHolderRaw)
+import           Pos.Ssc.Extra                 (SscHolder (..), SscState, runSscHolder)
 import           Pos.Txp.Class                 (getTxpLDWrap)
 import qualified Pos.Txp.Holder                as Modern
 import           Pos.Update.MemState.Holder    (runUSHolder)
@@ -98,7 +98,7 @@ convertHandler kinst nc modernDBs tlw ssc ws delWrap psCtx conn handler = do
            . usingLoggerName "wallet-api"
            . Modern.runDBHolder modernDBs
            . runContextHolder nc
-           . runSscHolderRaw ssc
+           . runSscHolder ssc
            . Modern.runTxpLDHolderReader tlw
            . runDelegationTFromTVar delWrap
            . runUSHolder

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -77,6 +77,7 @@ loggingParams tag Args{..} =
     { lpHandlerPrefix = CLI.logPrefix commonArgs
     , lpConfigPath    = CLI.logConfig commonArgs
     , lpRunnerTag = tag
+    , lpEkgPort = monitorPort
     }
 
 baseParams :: LoggerName -> Args -> BaseParams

--- a/src/node/NodeOptions.hs
+++ b/src/node/NodeOptions.hs
@@ -56,6 +56,7 @@ data Args = Args
     , noSystemStart             :: !Int
     , updateLatestPath          :: !FilePath
     , updateWithPackage         :: !Bool
+    , monitorPort               :: !(Maybe Int)
     }
   deriving Show
 
@@ -143,7 +144,11 @@ argsParser =
                    help "Path to update installer file, which should be downloaded by update system")
     <*> switch (long "update-with-package" <>
                 help "Use updating via installer")
-
+    <*> optional
+            (option
+                 auto
+                 (long "monitor-port" <> metavar "INT" <>
+                  help "Run web monitor on this port"))
 
   where
     peerHelpMsg =

--- a/src/smart-generator/Main.hs
+++ b/src/smart-generator/Main.hs
@@ -240,6 +240,7 @@ main = do
             { lpRunnerTag     = "smart-gen"
             , lpHandlerPrefix = CLI.logPrefix goCommonArgs
             , lpConfigPath    = CLI.logConfig goCommonArgs
+            , lpEkgPort       = Nothing
             }
         baseParams =
             BaseParams

--- a/src/wallet/Main.hs
+++ b/src/wallet/Main.hs
@@ -219,6 +219,7 @@ main = do
             { lpRunnerTag     = "smart-wallet"
             , lpHandlerPrefix = CLI.logPrefix woCommonArgs
             , lpConfigPath    = CLI.logConfig woCommonArgs
+            , lpEkgPort       = Nothing
             }
         baseParams =
             BaseParams

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: ee16762f4eab94cbcc7d10935ee870b6038c4a40
+    commit: 40cd15dfc180cdc8e8c50be9ca17062202f95734
   extra-dep: true
 - location:
     git: https://github.com/avieth/network-transport-tcp

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,11 +28,15 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 47821127b615e60b8f2e67f7e8b8f7a3aa116d2b
+    commit: ee16762f4eab94cbcc7d10935ee870b6038c4a40
   extra-dep: true
 - location:
-    git: https://github.com/serokell/network-transport-tcp.git
-    commit: 6cef5a6120d1aa7b87c270a95149bc69403c1376
+    git: https://github.com/avieth/network-transport-tcp
+    commit: 705b3c0d44cb1f4eea904b54431cd467e62dda35
+  extra-dep: true
+- location:
+    git: https://github.com/avieth/network-transport
+    commit: e7a5f44d0d98370d16df103c9dc61ef7bf15aee8
   extra-dep: true
 - location:
     git: https://github.com/input-output-hk/cardano-report-server.git


### PR DESCRIPTION
The custom network-transport, network-transport-tcp, and time-warp-ntbranches chosen in stack.yaml fix some potentially very bad problemswith bidirectional connections: a handler can hang indefinitely in casethe connection is lost to the peer before the ACK is received. Butthat's fixed now. The nt-tcp branch is also patched to deliverConnectionClosed events always, even if the connection is lost of theendpoint is brought down. This makes it easier to clean up inputchannels. The dispatcher remains defensive, though, and will plug inputchannels on end point closed and connection lost events, even though itshouldn't ever have to.