### PR TITLE
[DAEF-12] Don't print logPath

### DIFF
--- a/src/launcher/Main.hs
+++ b/src/launcher/Main.hs
@@ -233,7 +233,11 @@ spawnNode (path, args, mbLogPath) = do
         Nothing -> do
             tempdir <- liftIO (fromString <$> getTemporaryDirectory)
             mktemp tempdir "cardano-node-output.log"
-    printf ("Redirecting node's stdout and stderr to "%fp%"\n") logPath
+    -- TODO (jmitchell): Find a safe, reliable way to print `logPath`. Cardano
+    -- fails when it prints unicode characters. In the meantime, don't print it.
+    -- See DAEF-12.
+
+    -- printf ("Redirecting node's stdout and stderr to "%fp%"\n") logPath
     liftIO $ IO.hSetBuffering logHandle IO.LineBuffering
     let cr = (Process.proc (toString path) (map toString args))
                  { Process.std_in  = Process.CreatePipe


### PR DESCRIPTION
As explained in the commented TODO item, printing the logPath crashes cardano
when it includes unicode characters. Until a safe, reliable way is found to
print unicode from Haskell keep this commented out.

Already verified this fixes the problem using the temporary `diagnose/old-master` branch. [This installer](https://ci.appveyor.com/project/IOHK/daedalus/build/0.1.319/artifacts) includes the change from that prior test.