### PR TITLE
Update daedalus bridge build script to use nix

### DIFF
--- a/scripts/build-daedalus-bridge.sh
+++ b/scripts/build-daedalus-bridge.sh
@@ -1,4 +1,7 @@
+stack clean --full --nix
+rm -rf .stack-wok
+stack --nix clean cardano-sl
 rm -rf run/* wallet-db/ *key daedalus/src/Generated/
-stack build --flag cardano-sl:with-wallet --flag cardano-sl:with-web
-stack exec -- cardano-wallet-hs2purs
-cd daedalus && npm install && npm run build:prod
+stack --nix build
+stack --nix exec -- cardano-wallet-hs2purs
+cd daedalus && npm install && npm run build:prod && npm link


### PR DESCRIPTION
This PR adds `--nix` argument for building Cardano SL, introduces cleanup before the build and npm linking for the bridge.