### PR TITLE
[CSL-767] Use backpressure

### DIFF
--- a/src/Pos/Block/Network/Listeners.hs
+++ b/src/Pos/Block/Network/Listeners.hs
@@ -26,7 +26,7 @@ import           Pos.Block.Network.Retrieval (handleUnsolicitedHeaders)
 import           Pos.Block.Network.Types     (MsgBlock (..), MsgGetBlocks (..),
                                               MsgGetHeaders (..), MsgHeaders (..))
 import           Pos.Communication.Protocol  (ConversationActions (..), HandlerSpec (..),
-                                              ListenerSpec (..), OutSpecs, PeerData,
+                                              ListenerSpec (..), OutSpecs,
                                               listenerConv, mergeLs, messageName)
 import           Pos.Communication.Util      (stubListenerConv)
 import qualified Pos.DB                      as DB
@@ -62,7 +62,6 @@ stubListenerConv' = unproxy $ \(_ :: Proxy ssc) ->
             sndName = messageName (Proxy :: Proxy (MsgBlock a b))
             listener _ = N.ListenerActionConversation $
               \_d __nId (_convActions :: N.ConversationActions
-                                             PeerData
                                              (MsgBlock s0 ssc)
                                              MsgGetBlocks m) ->
                   modifyLoggerName (<> "stub") $

--- a/src/Pos/Block/Network/Retrieval.hs
+++ b/src/Pos/Block/Network/Retrieval.hs
@@ -79,7 +79,7 @@ retrievalWorker = worker outs $ \sendActions -> handleAll handleWE $ do
                logDebug "Queue is empty, we're in recovery mode -> querying more"
                whenJustM (mkHeadersRequest (Just $ headerHash rHeader)) $ \mghNext ->
                    handleAll (handleLE recHeaderVar ph) $ reportingFatal $
-                   withConnectionTo sendActions peerId $
+                   withConnectionTo sendActions peerId $ \_peerData ->
                        requestHeaders mghNext (Just rHeader) peerId
            loop queue recHeaderVar
 
@@ -148,7 +148,7 @@ retrievalWorker = worker outs $ \sendActions -> handleAll handleWE $ do
         -- a parameter to the 'Bi' instance of 'MsgBlock'.
         reify maxBlockSize $ \(_ :: Proxy s0) ->
           withConnectionTo sendActions peerId $
-          \(conv :: ConversationActions MsgGetBlocks (MsgBlock s0 ssc) m) -> do
+          \_peerData (conv :: ConversationActions MsgGetBlocks (MsgBlock s0 ssc) m) -> do
             send conv $ mkBlocksRequest lcaChildHash newestHash
             chainE <- runExceptT (retrieveBlocks conv lcaChild newestHash)
             recHeaderVar <- ncRecoveryHeader <$> getNodeContext

--- a/src/Pos/Communication/Types/Protocol.hs
+++ b/src/Pos/Communication/Types/Protocol.hs
@@ -86,7 +86,7 @@ data SendActions m = SendActions {
            :: forall snd rcv t .
             ( Bi snd, Message snd, Bi rcv, Message rcv )
            => NodeId
-           -> (ConversationActions snd rcv m -> m t)
+           -> (m PeerData -> ConversationActions snd rcv m -> m t)
            -> m t
 }
 
@@ -97,11 +97,6 @@ data ConversationActions body rcv m = ConversationActions {
        -- | Receive a message within the context of this conversation.
        --   'Nothing' means end of input (peer ended conversation).
      , recv     :: m (Maybe rcv)
-
-     -- | The data associated with that peer (reported by the peer).
-     --        --   It's in m because trying to take it may block (it may not be
-     --               --   known yet!).
-     , peerData :: m PeerData
 }
 
 newtype PeerId = PeerId ByteString

--- a/src/Pos/DHT/Model/Neighbors.hs
+++ b/src/Pos/DHT/Model/Neighbors.hs
@@ -82,7 +82,7 @@ converseToNode sendActions node handler =
       where
         handleE e | isDevelopment = tryConnect 1
                   | otherwise     = throw e
-        tryConnect i = withConnectionTo sendActions nodeId $ handler nodeId
+        tryConnect i = withConnectionTo sendActions nodeId $ \_peerData -> handler nodeId
           where
             nodeId = toNodeId i node
 

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -271,7 +271,6 @@ runServer transport packedLS (OutSpecs wouts) withNode afterNode (ActionSpec act
     stdGen <- liftIO newStdGen
     logInfo $ sformat ("Our verInfo "%build) ourVerInfo
     node (concrete transport) stdGen BiP (ourPeerId, ourVerInfo) $ \__node ->
-        pure $
         NodeAction listeners $ \sendActions -> do
             t <- withNode __node
             a <- action ourVerInfo sendActions `finally` afterNode t

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -428,6 +428,7 @@ createTransport ip port = do
             (TCP.defaultTCPParameters
              { TCP.transportConnectTimeout =
                    Just $ fromIntegral networkConnectionTimeout
+             , TCP.tcpNewQDisc = TCP.simpleOnePlaceQDisc
              })
     transportE <-
         liftIO $ TCP.createTransport "0.0.0.0" ip (show port) tcpParams

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -48,6 +48,7 @@ import           Mockable                    (CurrentTime, Mockable, MonadMockab
                                               Production (..), Throw, bracket,
                                               currentTime, delay, finally, fork,
                                               killThread, throw)
+import           Network.QDisc.Fair          (fairQDisc)
 import           Network.Transport           (Transport, closeTransport)
 import           Network.Transport.Concrete  (concrete)
 import qualified Network.Transport.TCP       as TCP
@@ -428,7 +429,7 @@ createTransport ip port = do
             (TCP.defaultTCPParameters
              { TCP.transportConnectTimeout =
                    Just $ fromIntegral networkConnectionTimeout
-             , TCP.tcpNewQDisc = TCP.simpleOnePlaceQDisc
+             , TCP.tcpNewQDisc = fairQDisc
              })
     transportE <-
         liftIO $ TCP.createTransport "0.0.0.0" ip (show port) tcpParams

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: c869440f42cdf796a14b06e4d73a56ecb48a293e
+    commit: b913bfc698fd2927ee5031826688eb7245906e6d
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 9865cea6fe7a2b376d67c0ff77efaaa26ea73d45
+    commit: c869440f42cdf796a14b06e4d73a56ecb48a293e
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:
@@ -72,5 +72,3 @@ extra-deps:
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything
-
-


### PR DESCRIPTION
Uses the new `time-warp-nt` feature of queueing disciplines (`QDisc`) to limit the rate at which incoming messages are queued for processing.

The interface of `time-warp-nt` changed slightly while `QDisc`s were introduced, and this Pull requests makes the changes to `cardano-sl` that are necessary to adapt to the new API. In particular, `ConversationActions` no longer has a field that gives the `PeerData`)