### PR TITLE
[CSL-789] Partition Appveyor cache by branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\sr\pr"
+- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT=C:\sr\pr
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
 - IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT=C:\sr\pr
+- Echo Using STACK_ROOT '%STACK_ROOT%'
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\\sr\\pr"
+- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\sr\pr"
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,21 +5,23 @@ build: off
 
 cache:
   # TODO: https://github.com/commercialhaskell/stack/issues/1176#issuecomment-269520803
-  - "c:\\sr"
-  - '.stack-work'
+  - "c:\\sr\\%APPVEYOR_REPO_BRANCH%"
+  # - '.stack-work'
 
 # Avoid long paths on Windows
 environment:
   global:
     # Avoid long paths on Windows
-    STACK_ROOT: "c:\\sr"
+    STACK_ROOT: "c:\\sr\\%APPVEYOR_REPO_BRANCH%"
     CSL_SYSTEM_TAG: "win64"
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
+- IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\\sr\\pr"
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
+
 
 # Install rocksdb
 - git clone https://github.com/facebook/rocksdb.git --branch v4.13.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\\sr\\pr"
+- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT="C:\\sr\\pr"
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe


### PR DESCRIPTION
Appveyor shares the same cache space per-project rather than per-project-branch,
so changes in one branch can affect build results in another branch. To avoid
that, %STACK_ROOT% now includes the branch name.

Pull requests can corrupt the cache for the target branch. To prevent that the
cache isn't touched for pull request builds. This is accomplished by reassigning
%STACK_ROOT% to a different directory.

This change also temporarily disables the cache on the project's local
.stack-work directory. If these changes work as expected it should be renamed to
include the branch as well.