### PR TITLE
[CSL-789] Shorten %STACK_ROOT% path length and improve PR caching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ environment:
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET CACHED_STACK_ROOT=C:\sr\pr
 - xcopy /q /s /e /r /k /i /v /h %CACHED_STACK_ROOT% %STACK_ROOT%
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
@@ -52,7 +51,7 @@ test_script:
   - npm run build:prod
 
 after_test:
- - xcopy /q /s /e /r /k /i /v /h %STACK_ROOT% %CACHED_STACK_ROOT%
+ - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER xcopy /q /s /e /r /k /i /v /h %STACK_ROOT% %CACHED_STACK_ROOT%
 
 artifacts:
   - path: daedalus/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- xcopy /q /s /e /r /k /i /v /h %CACHED_STACK_ROOT% %STACK_ROOT%
+- IF EXIST %CACHED_STACK_ROOT% xcopy /q /s /e /r /k /i /v /h %CACHED_STACK_ROOT% %STACK_ROOT%
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,14 @@ cache:
 environment:
   global:
     # Avoid long paths on Windows
-    STACK_ROOT: "c:\\sr\\%APPVEYOR_REPO_BRANCH%"
+    CACHED_STACK_ROOT: "c:\\sr\\%APPVEYOR_REPO_BRANCH%"
+    STACK_ROOT: "c:\\sr"
     CSL_SYSTEM_TAG: "win64"
 
 before_test:
 - Echo %APPVEYOR_BUILD_VERSION% > build-id
-- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET STACK_ROOT=C:\sr\pr
-- Echo Using STACK_ROOT '%STACK_ROOT%'
+- IF DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET CACHED_STACK_ROOT=C:\sr\pr
+- xcopy /q /s /e /r /k /i /v /h %CACHED_STACK_ROOT% %STACK_ROOT%
 # Install stack
 - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
@@ -49,6 +50,9 @@ test_script:
   - ps: Install-Product node 7
   - npm install
   - npm run build:prod
+
+after_test:
+ - xcopy /q /s /e /r /k /i /v /h %STACK_ROOT% %CACHED_STACK_ROOT%
 
 artifacts:
   - path: daedalus/


### PR DESCRIPTION
The latest build on `cardano-sl-0.2` broke, presumably because the recent caching changes for CSL-789 caused excessively long paths.

Rather than using the branch-namespaced cache directory directly, at the beginning of the build this copies to `%STACK_ROOT%` (`C:\sr`) and at the end it copies back to the namespaced cache dir.

Additionally, pull requests shouldn't share a cache across all target branches. Instead this change gives pull requests read access to the target branch's cache, but prevents them from writing changes back to the cache.