### PR TITLE
Move to LTS Haskell 8.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test_script:
   - cd daedalus
   - Echo %APPVEYOR_BUILD_VERSION% > build-id
   - ps: Install-Product node 7
-  - npm install
+  - scripts\appveyor-retry call npm install
   - npm run build:prod
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test_script:
   - cd daedalus
   - Echo %APPVEYOR_BUILD_VERSION% > build-id
   - ps: Install-Product node 7
-  - scripts\appveyor-retry call npm install
+  - ..\scripts\appveyor-retry call npm install
   - npm run build:prod
 
 artifacts:

--- a/daedalus/package.json
+++ b/daedalus/package.json
@@ -7,8 +7,8 @@
     "start": "npm run build:dev",
     "postinstall": "bower cache clean && bower install",
     "clean": "rimraf dist && rimraf output",
-    "build:prod": "npm run clean && mkdir dist && cross-env NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress",
-    "build:dev": "rimraf output && cross-env NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress",
+    "build:prod": "npm run clean && mkdir dist && cross-env NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress --bail",
+    "build:dev": "rimraf output && cross-env NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress --bail",
     "test": "npm run build:prod && npm run test:mocha",
     "test:mocha": "mocha ./test/**/*.test.js"
   },

--- a/daedalus/package.json
+++ b/daedalus/package.json
@@ -7,8 +7,8 @@
     "start": "npm run build:dev",
     "postinstall": "bower cache clean && bower install",
     "clean": "rimraf dist && rimraf output",
-    "build:prod": "npm run clean && mkdir dist && cross-env NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress --bail",
-    "build:dev": "rimraf output && cross-env NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress --bail",
+    "build:prod": "npm run clean && mkdir dist && cross-env NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress && cross-env NODE_ENV=prod ./node_modules/.bin/webpack --config webpack.config.js --progress --bail",
+    "build:dev": "rimraf output && cross-env NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress && cross-env NODE_ENV=dev ./node_modules/.bin/webpack-dev-server --hot --config webpack.config.js --progress --bail",
     "test": "npm run build:prod && npm run test:mocha",
     "test:mocha": "mocha ./test/**/*.test.js"
   },

--- a/stack.yaml
+++ b/stack.yaml
@@ -66,6 +66,7 @@ extra-deps:
 - derive-2.5.26                   # not yet in lts-8
 - haskell-src-exts-1.17.1         # derive has not moved to 1.18 yet
 - wreq-0.5.0.0                    # not yet in lts-8
+- purescript-bridge-0.8.0.1
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: lts-7.16
-compiler: ghc-8.0.2
+resolver: lts-8.2
 
 flags: {}
 
@@ -30,7 +29,7 @@ packages:
     # We're waiting on next release
     commit: 57adb970e198a9b377769ab46e776ec29f19cff6
   extra-dep: true
-- location: 
+- location:
     git: https://github.com/input-output-hk/cardano-report-server.git
     commit: ede7a1a9eafd88e3449b38c7425f5529d6584014
   extra-dep: true
@@ -65,15 +64,14 @@ extra-deps:
 - QuickCheck-2.9.2
 - cryptonite-openssl-0.5
 - UtilityTM-0.0.4
-- serokell-util-0.1.3.4
+- serokell-util-0.1.3.5
 - pvss-0.1
 - base58-bytestring-0.1.0
-- log-warper-0.4.3
-- turtle-1.3.1                    # earlier versions don't have 'stat'
-- optparse-applicative-0.13.0.0   # needed for turtle
-- criterion-1.1.4.0               # older criterion doesn't like optparse-0.13
-- code-page-0.1.1                 # needed for criterion
-
+- log-warper-0.4.4
+- concurrent-extra-0.7.0.10       # not yet in lts-8
+- derive-2.5.26                   # not yet in lts-8
+- haskell-src-exts-1.17.1         # derive has not moved to 1.18 yet
+- wreq-0.5.0.0                    # not yet in lts-8
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,13 +56,7 @@ nix:
 
 extra-deps:
 - universum-0.2.1
-- pqueue-1.3.2
-- data-msgpack-0.0.8
 - time-units-1.0.0
-- aeson-extra-0.4.0.0
-- recursion-schemes-5
-- QuickCheck-2.9.2
-- cryptonite-openssl-0.5
 - UtilityTM-0.0.4
 - serokell-util-0.1.3.5
 - pvss-0.1


### PR DESCRIPTION
Using GHC 8.0.2 with LTS-7.16 made it difficult to install some
packages (namely intero).