### PR TITLE
[CSL-728] Add tests to 'computeSharesDistr'

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -1114,6 +1114,7 @@ test-suite cardano-test
                        Test.Pos.Genesis.Identity.BinarySpec
                        Test.Pos.MerkleSpec
                        Test.Pos.Script.Identity.BinarySpec
+                       Test.Pos.Ssc.GodTossing.ComputeSharesSpec
                        Test.Pos.Ssc.GodTossing.Identity.BinarySpec
                        Test.Pos.Ssc.GodTossing.Identity.SafeCopySpec
                        Test.Pos.Ssc.GodTossing.SeedSpec

--- a/src/Pos/Ssc/GodTossing.hs
+++ b/src/Pos/Ssc/GodTossing.hs
@@ -17,6 +17,7 @@ module Pos.Ssc.GodTossing
        , module Pos.Ssc.GodTossing.SecretStorage
        , module Pos.Ssc.GodTossing.Seed
        , module Pos.Ssc.GodTossing.GState
+       , module Pos.Ssc.GodTossing.Toss
        , module Pos.Ssc.GodTossing.Type
        , module Pos.Ssc.GodTossing.Types
        , module Pos.Ssc.GodTossing.VssCertData
@@ -34,6 +35,7 @@ import           Pos.Ssc.GodTossing.LocalData
 import           Pos.Ssc.GodTossing.SecretStorage
 import           Pos.Ssc.GodTossing.Seed
 import           Pos.Ssc.GodTossing.GState
+import           Pos.Ssc.GodTossing.Toss
 import           Pos.Ssc.GodTossing.Type
 import           Pos.Ssc.GodTossing.Types
 import           Pos.Ssc.GodTossing.VssCertData

--- a/src/Pos/Ssc/GodTossing/LocalData/Logic.hs
+++ b/src/Pos/Ssc/GodTossing/LocalData/Logic.hs
@@ -52,10 +52,10 @@ import           Pos.Ssc.GodTossing.Toss            (GtTag (..), PureToss, TossM
                                                      TossT, TossVerFailure (..),
                                                      evalPureTossWithLogger, evalTossT,
                                                      execTossT, hasCertificate,
-                                                     hasCommitment, hasOpening, hasShares,
-                                                     isGoodSlotForTag, normalizeToss,
-                                                     tmCertificates, tmCommitments,
-                                                     tmOpenings, tmShares,
+                                                     hasCommitmentToss, hasOpeningToss,
+                                                     hasSharesToss, isGoodSlotForTag,
+                                                     normalizeToss, tmCertificates,
+                                                     tmCommitments, tmOpenings, tmShares,
                                                      verifyAndApplyGtPayload)
 import           Pos.Ssc.GodTossing.Type            (SscGodTossing)
 import           Pos.Ssc.GodTossing.Types           (GtGlobalState)
@@ -142,9 +142,9 @@ sscIsDataUseful tag id =
         (evalTossInMem $ sscIsDataUsefulDo tag)
         (pure False)
   where
-    sscIsDataUsefulDo CommitmentMsg     = not <$> hasCommitment id
-    sscIsDataUsefulDo OpeningMsg        = not <$> hasOpening id
-    sscIsDataUsefulDo SharesMsg         = not <$> hasShares id
+    sscIsDataUsefulDo CommitmentMsg     = not <$> hasCommitmentToss id
+    sscIsDataUsefulDo OpeningMsg        = not <$> hasOpeningToss id
+    sscIsDataUsefulDo SharesMsg         = not <$> hasSharesToss id
     sscIsDataUsefulDo VssCertificateMsg = not <$> hasCertificate id
     evalTossInMem
         :: ( WithLogger m

--- a/src/Pos/Ssc/GodTossing/LocalData/Logic.hs
+++ b/src/Pos/Ssc/GodTossing/LocalData/Logic.hs
@@ -51,7 +51,7 @@ import           Pos.Ssc.GodTossing.LocalData.Types (GtLocalData (..), ldEpoch,
 import           Pos.Ssc.GodTossing.Toss            (GtTag (..), PureToss, TossModifier,
                                                      TossT, TossVerFailure (..),
                                                      evalPureTossWithLogger, evalTossT,
-                                                     execTossT, hasCertificate,
+                                                     execTossT, hasCertificateToss,
                                                      hasCommitmentToss, hasOpeningToss,
                                                      hasSharesToss, isGoodSlotForTag,
                                                      normalizeToss, tmCertificates,
@@ -145,7 +145,7 @@ sscIsDataUseful tag id =
     sscIsDataUsefulDo CommitmentMsg     = not <$> hasCommitmentToss id
     sscIsDataUsefulDo OpeningMsg        = not <$> hasOpeningToss id
     sscIsDataUsefulDo SharesMsg         = not <$> hasSharesToss id
-    sscIsDataUsefulDo VssCertificateMsg = not <$> hasCertificate id
+    sscIsDataUsefulDo VssCertificateMsg = not <$> hasCertificateToss id
     evalTossInMem
         :: ( WithLogger m
            , MonadDB SscGodTossing m

--- a/src/Pos/Ssc/GodTossing/Toss/Base.hs
+++ b/src/Pos/Ssc/GodTossing/Toss/Base.hs
@@ -9,7 +9,7 @@ module Pos.Ssc.GodTossing.Toss.Base
        , hasCommitmentToss
        , hasOpeningToss
        , hasSharesToss
-       , hasCertificate
+       , hasCertificateToss
 
        -- * Basic logic
        , getParticipants
@@ -79,8 +79,8 @@ hasSharesToss :: MonadTossRead m => StakeholderId -> m Bool
 hasSharesToss id = HM.member id <$> getShares
 
 -- | Check whether there is 'VssCertificate' from given stakeholder.
-hasCertificate :: MonadTossRead m => StakeholderId -> m Bool
-hasCertificate id = HM.member id <$> getVssCertificates
+hasCertificateToss :: MonadTossRead m => StakeholderId -> m Bool
+hasCertificateToss id = HM.member id <$> getVssCertificates
 
 ----------------------------------------------------------------------------
 -- Non-trivial getters
@@ -370,7 +370,7 @@ checkCertificatesPayload
 checkCertificatesPayload epoch certs = do
     richmenSet <- getKeys <$> (note (NoRichmen epoch) =<< getRichmen epoch)
     exceptGuardM CertificateAlreadySent
-        (notM hasCertificate) (HM.keys certs)
+        (notM hasCertificateToss) (HM.keys certs)
     exceptGuardSnd CertificateNotRichmen
         ((`HS.member` richmenSet) . addressHash . vcSigningKey)
         (HM.toList certs)

--- a/src/Pos/Ssc/GodTossing/Toss/Base.hs
+++ b/src/Pos/Ssc/GodTossing/Toss/Base.hs
@@ -6,9 +6,9 @@ module Pos.Ssc.GodTossing.Toss.Base
        (
          -- * Trivial functions
          getCommitment
-       , hasCommitment
-       , hasOpening
-       , hasShares
+       , hasCommitmentToss
+       , hasOpeningToss
+       , hasSharesToss
        , hasCertificate
 
        -- * Basic logic
@@ -67,16 +67,16 @@ getCommitment :: MonadTossRead m => StakeholderId -> m (Maybe SignedCommitment)
 getCommitment id = HM.lookup id . getCommitmentsMap <$> getCommitments
 
 -- | Check whether there is a 'SignedCommitment' from given stakeholder.
-hasCommitment :: MonadTossRead m => StakeholderId -> m Bool
-hasCommitment id = HM.member id . getCommitmentsMap <$> getCommitments
+hasCommitmentToss :: MonadTossRead m => StakeholderId -> m Bool
+hasCommitmentToss id = HM.member id . getCommitmentsMap <$> getCommitments
 
 -- | Check whether there is an 'Opening' from given stakeholder.
-hasOpening :: MonadTossRead m => StakeholderId -> m Bool
-hasOpening id = HM.member id <$> getOpenings
+hasOpeningToss :: MonadTossRead m => StakeholderId -> m Bool
+hasOpeningToss id = HM.member id <$> getOpenings
 
 -- | Check whether there is 'InnerSharesMap' from given stakeholder.
-hasShares :: MonadTossRead m => StakeholderId -> m Bool
-hasShares id = HM.member id <$> getShares
+hasSharesToss :: MonadTossRead m => StakeholderId -> m Bool
+hasSharesToss id = HM.member id <$> getShares
 
 -- | Check whether there is 'VssCertificate' from given stakeholder.
 hasCertificate :: MonadTossRead m => StakeholderId -> m Bool
@@ -313,7 +313,7 @@ checkCommitmentsPayload epoch (getCommitmentsMap -> comms) = do
     exceptGuard CommitingNoParticipants
         (`HM.member` participants) (HM.keys comms)
     exceptGuardM CommitmentAlreadySent
-        (notM hasCommitment) (HM.keys comms)
+        (notM hasCommitmentToss) (HM.keys comms)
     exceptGuardSnd CommSharesOnWrongParticipants
         (checkCommitmentShares distr participants) (HM.toList comms)
 
@@ -328,9 +328,9 @@ checkOpeningsPayload
     -> m ()
 checkOpeningsPayload opens = do
     exceptGuardM OpeningAlreadySent
-        (notM hasOpening) (HM.keys opens)
+        (notM hasOpeningToss) (HM.keys opens)
     exceptGuardM OpeningWithoutCommitment
-        hasCommitment (HM.keys opens)
+        hasCommitmentToss (HM.keys opens)
     exceptGuardEntryM OpeningNotMatchCommitment
         matchCommitment (HM.toList opens)
 
@@ -353,9 +353,9 @@ checkSharesPayload epoch shares = do
     exceptGuard SharesNotRichmen
         (`HM.member` part) (HM.keys shares)
     exceptGuardM InternalShareWithoutCommitment
-        hasCommitment (concatMap HM.keys $ toList shares)
+        hasCommitmentToss (concatMap HM.keys $ toList shares)
     exceptGuardM SharesAlreadySent
-        (notM hasShares) (HM.keys shares)
+        (notM hasSharesToss) (HM.keys shares)
     exceptGuardEntryM DecrSharesNotMatchCommitment
         (checkShares epoch) (HM.toList shares)
 

--- a/src/Pos/Ssc/GodTossing/Toss/Failure.hs
+++ b/src/Pos/Ssc/GodTossing/Toss/Failure.hs
@@ -45,6 +45,7 @@ data TossVerFailure
     | CertificateInvalidTTL !(NonEmpty VssCertificate)
 
     | TossInternallError !Text
+    deriving Eq
 
 instance Buildable TossVerFailure where
     build (NotCommitmentPhase slotId) =

--- a/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
+++ b/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
@@ -1,0 +1,40 @@
+-- | Specification of Pos.Ssc.GodTossing.Toss.Base.computeSharesdistr
+
+module Test.Pos.Ssc.GodTossing.ComputeSharesSpec
+       ( spec
+       ) where
+
+import           Test.Hspec              (Spec, describe, it)
+import           Test.Hspec.QuickCheck   (prop)
+import           Universum
+
+import           Control.Monad.Except    (runExceptT)
+import qualified Data.HashMap.Strict     as HM (elems, keys)
+import           Pos.Lrc                 (RichmenStake)
+import qualified Pos.Ssc.GodTossing      as T
+import           Pos.Types               (sumCoins)
+import           Test.QuickCheck         (Property, (===), (==>))
+import           Test.QuickCheck.Monadic (assert, monadicIO)
+
+spec :: Spec
+spec = describe "computeSharesDistr" $ do
+    prop emptyRichmenStakeDesc emptyRichmenStake
+    prop allRichmenGetShareDesc allRichmenGetShares
+  where
+    emptyRichmenStakeDesc = "Outputs an empty distribution when the richmen stake is\
+    \ empty."
+    allRichmenGetShareDesc = "All richmen are awarded a share, and richmen who do not\
+    \ participate in the share distribution are awarded none"
+
+emptyRichmenStake :: RichmenStake -> Property
+emptyRichmenStake richmen = monadicIO $ do
+    let total = sumCoins $ toList richmen
+    res <- runExceptT $ T.computeSharesDistr richmen
+    pure $ (total == 0) ==> (isLeft res)
+
+allRichmenGetShares :: RichmenStake -> Property
+allRichmenGetShares richmen = monadicIO $ do
+    let inputStakeholder = Right richmen
+    outputStakeholder <- runExceptT $ T.computeSharesDistr richmen
+    pure $ ((HM.keys <$> inputStakeholder) == (HM.keys <$> outputStakeholder)) &&
+        (either (const False) (all (/= 0) . HM.elems) outputStakeholder)

--- a/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
+++ b/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
@@ -4,37 +4,37 @@ module Test.Pos.Ssc.GodTossing.ComputeSharesSpec
        ( spec
        ) where
 
-import           Test.Hspec              (Spec, describe, it)
+import           Test.Hspec              (Spec, describe)
 import           Test.Hspec.QuickCheck   (prop)
 import           Universum
 
-import           Control.Monad.Except    (runExceptT)
+import           Control.Monad.Except    (runExcept)
 import qualified Data.HashMap.Strict     as HM (elems, keys)
+import           Pos.Types.Coin          (mkCoin)
 import           Pos.Lrc                 (RichmenStake)
 import qualified Pos.Ssc.GodTossing      as T
 import           Pos.Types               (sumCoins)
-import           Test.QuickCheck         (Property, (===), (==>))
-import           Test.QuickCheck.Monadic (assert, monadicIO)
+import           Test.QuickCheck         (Property, (.&&.), (==>))
 
 spec :: Spec
 spec = describe "computeSharesDistr" $ do
     prop emptyRichmenStakeDesc emptyRichmenStake
     prop allRichmenGetShareDesc allRichmenGetShares
   where
-    emptyRichmenStakeDesc = "Outputs an empty distribution when the richmen stake is\
-    \ empty."
+    emptyRichmenStakeDesc = "Fails to calculate a share distribution when the richmen\
+    \ stake is empty."
     allRichmenGetShareDesc = "All richmen are awarded a share, and richmen who do not\
     \ participate in the share distribution are awarded none"
 
-emptyRichmenStake :: RichmenStake -> Property
-emptyRichmenStake richmen = monadicIO $ do
-    let total = sumCoins $ toList richmen
-    res <- runExceptT $ T.computeSharesDistr richmen
-    pure $ (total == 0) ==> (isLeft res)
+emptyRichmenStake :: RichmenStake -> Bool
+emptyRichmenStake richmen =
+    let zeroCoin = mkCoin 0
+        allZero = runExcept . T.computeSharesDistr . fmap (const zeroCoin) $ richmen
+    in isLeft allZero
 
 allRichmenGetShares :: RichmenStake -> Property
-allRichmenGetShares richmen = monadicIO $ do
-    let inputStakeholder = Right richmen
-    outputStakeholder <- runExceptT $ T.computeSharesDistr richmen
-    pure $ ((HM.keys <$> inputStakeholder) == (HM.keys <$> outputStakeholder)) &&
+allRichmenGetShares richmen =
+    let outputStakeholder = runExcept $ T.computeSharesDistr richmen
+    in isRight outputStakeholder ==>
+        ((Right . HM.keys $ richmen) == (HM.keys <$> outputStakeholder)) &&
         (either (const False) (all (/= 0) . HM.elems) outputStakeholder)


### PR DESCRIPTION
This commit covers the 'computeSharesDistr' function with tests,
making some necessary changes to the codebase.

The contents of the
'Toss' submodule in 'Pos/Ssc/GodTossing' were not being exported,
so it was added to the re-export list in 'Pos/Ssc/GodTossing.hs'.

However, this caused conflicts with the functions 'hasOpening',
'hasCommitment' and 'hasShares' from 'Pos.Ssc.GodTossing.Functions'.

To solve this, their counterparts from 'Pos.Ssc.GodTossing.Toss.Base'
were renamed.

Not many tests are present in this commit, I'll continue adding them in the ongoing sprint.