### PR TITLE
[CSL-728] Fix and add new tests for 'computeSharesDistr'

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -232,6 +232,7 @@ library
                         Pos.Genesis.Parser
 
                         -- LRC
+                        Pos.Lrc.Arbitrary
                         Pos.Lrc.Consumer
                         Pos.Lrc.Consumers
                         Pos.Lrc.DB

--- a/src/Pos/Lrc.hs
+++ b/src/Pos/Lrc.hs
@@ -2,13 +2,15 @@
 
 module Pos.Lrc
        (
-         module Pos.Lrc.Consumer
+         module Pos.Lrc.Arbitrary
+       , module Pos.Lrc.Consumer
        , module Pos.Lrc.Consumers
        , module Pos.Lrc.Logic
        , module Pos.Lrc.FollowTheSatoshi
        , module Pos.Lrc.Types
        ) where
 
+import           Pos.Lrc.Arbitrary
 import           Pos.Lrc.Consumer
 import           Pos.Lrc.Consumers
 import           Pos.Lrc.FollowTheSatoshi

--- a/src/Pos/Lrc/Arbitrary.hs
+++ b/src/Pos/Lrc/Arbitrary.hs
@@ -1,0 +1,73 @@
+-- | Arbitrary instances for Lrc types.
+
+module Pos.Lrc.Arbitrary
+       ( InvalidRichmenStake (..)
+       , ValidRichmenStake (..)
+       ) where
+
+import           Universum
+
+import qualified Data.HashMap.Strict as HM
+import           Pos.Constants       (genesisMpcThd)
+import           Pos.Lrc.Types       (RichmenStake)
+import           Pos.Types.Address   (StakeholderId)
+import           Pos.Types.Core      (Coin, coinPortionDenominator, getCoinPortion,
+                                      mkCoin, unsafeGetCoin)
+import           Test.QuickCheck     (Arbitrary (..), Gen, choose)
+
+-- | Wrapper over 'RichmenStake'. Its 'Arbitrary' instance enforces that the stake
+-- distribution inside must be valid, i.e. all of the coins are non-zero and every
+-- stakeholder has sufficient coins to participate.
+newtype ValidRichmenStake = Valid
+    { getValid :: RichmenStake
+    } deriving (Show, Eq)
+
+instance Arbitrary ValidRichmenStake where
+    arbitrary = Valid <$> genRichmenStake
+
+-- | Wrapper over 'RichmenStake'. Its 'Arbitrary' instance enforces that the stake
+-- distribution inside must be invalid, i.e. one of the stakeholders does not have
+-- sufficient coins to participate.
+newtype InvalidRichmenStake = Invalid
+    { getInvalid :: RichmenStake
+    } deriving (Show, Eq)
+
+instance Arbitrary InvalidRichmenStake where
+    arbitrary = Invalid <$> do
+        validRichmenStake <- genRichmenStake
+        poorMan <- arbitrary
+        return $ HM.insert poorMan (mkCoin 0) validRichmenStake
+
+genRichmenStake
+    :: Gen RichmenStake
+genRichmenStake = do
+    -- Total number of coins in the 'RichmenStake' hashmap that will be returned. May not
+    -- be exactly accurate because of a possible early return in 'fun' (see comment).
+    totalCoins <- mkCoin <$> choose (1, unsafeGetCoin maxBound)
+    let toD = fromIntegral @Word64 @Double
+        -- Minimum percentage of stake required to participate in MPC protocol.
+        mpcThreshold = toD (getCoinPortion genesisMpcThd) / (toD coinPortionDenominator)
+        -- Since each participant must have 'mpcThreshold' percent of stake to
+        -- participate, this number designates the maximum allowed number of stakeholders
+        -- with which 'computeSharesDistr' can be successfully called.
+        maxRichmen :: Word64
+        maxRichmen = floor $ 1 / mpcThreshold
+        -- Given the total number of coins in a 'RichmenStake' hashmap, 'maxRichmen'
+        -- dictates that there is a minimum amount of stake each holder must have so that
+        -- 'computeSharesDistr' can be successful.
+        minStake :: Word64
+        minStake = ceiling $ mpcThreshold * (fromIntegral $ unsafeGetCoin totalCoins)
+        -- Stops either when 'maxRichmen' richmen have been reached, or when presently
+        -- available stake is below mpc threshold, in which case it is discarded
+        -- and the stakeholder list is returned as is.
+        fun :: Word64 -> Word64 -> [(StakeholderId, Coin)] -> Gen RichmenStake
+        fun coinAccum richmenNum participants
+            | coinAccum < minStake = return $ HM.fromList participants
+            | richmenNum == 0 = return $ HM.fromList participants
+            | otherwise = do
+                richman <- arbitrary
+                word <- choose (minStake, coinAccum)
+                fun (coinAccum - word)
+                    (richmenNum - 1)
+                    ((richman, mkCoin word) : participants)
+    fun (unsafeGetCoin totalCoins) maxRichmen []

--- a/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
+++ b/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
@@ -9,21 +9,33 @@ import           Test.Hspec.QuickCheck   (prop)
 import           Universum
 
 import           Control.Monad.Except    (runExcept)
-import qualified Data.HashMap.Strict     as HM (elems, keys)
-import           Pos.Types.Coin          (mkCoin)
-import           Pos.Lrc                 (RichmenStake)
+import qualified Data.HashMap.Strict     as HM
+import           Pos.Constants           (genesisMpcThd)
+import           Pos.Types.Coin          (mkCoin, sumCoins)
+import           Pos.Types.Core          (coinPortionDenominator, getCoinPortion)
+import           Pos.Lrc                 (InvalidRichmenStake (..), RichmenStake,
+                                          ValidRichmenStake (..))
 import qualified Pos.Ssc.GodTossing      as T
-import           Test.QuickCheck         (Property, (==>))
 
 spec :: Spec
 spec = describe "computeSharesDistr" $ do
     prop emptyRichmenStakeDesc emptyRichmenStake
-    -- prop allRichmenGetShareDesc allRichmenGetShares
+    prop allRichmenGetShareDesc allRichmenGetShares
+    prop invalidStakeErrorsDesc invalidStakeErrors
+    prop totalStakeZeroDesc totalStakeIsZero
+    prop validRichmenStakeWorksDesc validRichmenStakeWorks
   where
     emptyRichmenStakeDesc = "Fails to calculate a share distribution when the richmen\
     \ stake is empty."
-    allRichmenGetShareDesc = "All richmen are awarded a share, and richmen who do not\
-    \ participate in the share distribution are awarded none"
+    allRichmenGetShareDesc = "All richmen are awarded a non-zero share, and richmen who\
+    \ do not participate in the share distribution are awarded none"
+    invalidStakeErrorsDesc = "If the stake distribution has a 'StakeholderId' with\
+    \ insufficient stake to participate in the distribution of shares, the distribution\
+    \ fails to be calculated."
+    totalStakeZeroDesc = "If the total stake is zero, then the distribution fails to be\
+    \ calculated"
+    validRichmenStakeWorksDesc = "Given a valid distribution of stake, calculating the\
+    \ distribution of shares successfully works."
 
 emptyRichmenStake :: RichmenStake -> Bool
 emptyRichmenStake richmen =
@@ -31,9 +43,26 @@ emptyRichmenStake richmen =
         allZero = runExcept . T.computeSharesDistr . fmap (const zeroCoin) $ richmen
     in isLeft allZero
 
-allRichmenGetShares :: RichmenStake -> Property
-allRichmenGetShares richmen =
+allRichmenGetShares :: ValidRichmenStake -> Bool
+allRichmenGetShares (getValid -> richmen) =
     let outputStakeholder = runExcept $ T.computeSharesDistr richmen
-    in isRight outputStakeholder ==>
-        ((Right . HM.keys $ richmen) == (HM.keys <$> outputStakeholder)) &&
-        (either (const False) (all (/= 0) . HM.elems) outputStakeholder)
+    in ((Right . HM.keys $ richmen) == (HM.keys <$> outputStakeholder)) &&
+        (either (const False) (all (/= 0)) outputStakeholder)
+
+validRichmenStakeWorks :: ValidRichmenStake -> Bool
+validRichmenStakeWorks (getValid -> richmen) =
+    let outputStakeholder = runExcept $ T.computeSharesDistr richmen
+        totalCoins = sumCoins $ HM.elems richmen
+        mpcThreshold = toRational (getCoinPortion genesisMpcThd) / (toRational coinPortionDenominator)
+        minStake = mkCoin . ceiling $ (fromIntegral totalCoins) * mpcThreshold
+    in (isRight outputStakeholder) ==
+       (all (\x -> x >= minStake && x > (mkCoin 0)) richmen)
+
+totalStakeIsZero :: ValidRichmenStake -> Bool
+totalStakeIsZero (getValid -> richmen) =
+    let zeroStake = fmap (const $ mkCoin 0) richmen
+    in isLeft $ runExcept $ T.computeSharesDistr zeroStake
+
+invalidStakeErrors :: InvalidRichmenStake -> Bool
+invalidStakeErrors (getInvalid -> richmen) =
+    isLeft $ runExcept $ T.computeSharesDistr richmen


### PR DESCRIPTION
Due to tests in 'master' being broken over [CSL-728], they were previously
disabled. In the meantime, a fix was developed, along with more complete
tests for 'computeSharesDistr'.