### PR TITLE
[WIP] Removing dependency on headers in Pos.Update

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -393,16 +393,15 @@ library
                       , base
                       , base58-bytestring
                       , base64-bytestring
-                      , temporary >= 1.2.0.4
                       , binary
                       , binary-conduit >= 1.2.4.1
                       , binary-orphans
                       , bytestring
                       , cardano-report-server >= 0.1.0
                       , cardano-sl-core
-                      , cardano-sl-update
-                      , cardano-sl-infra
                       , cardano-sl-db
+                      , cardano-sl-infra
+                      , cardano-sl-update
                       , cereal
                       , concurrent-extra
                       , conduit >= 1.2.8
@@ -462,6 +461,7 @@ library
                       , stm-containers
                       , tagged
                       , template-haskell
+                      , temporary >= 1.2.0.4
                       , text
                       , text-format
                       , th-lift-instances

--- a/core/Pos/Core.hs
+++ b/core/Pos/Core.hs
@@ -4,6 +4,7 @@ module Pos.Core
 
 import           Pos.Core.Address   as X
 import           Pos.Core.Block     as X
+import           Pos.Core.Class     as X
 import           Pos.Core.Coin      as X
 import           Pos.Core.Constants as X
 import           Pos.Core.Script    as X ()

--- a/core/Pos/Core/Block.hs
+++ b/core/Pos/Core/Block.hs
@@ -8,9 +8,15 @@ module Pos.Core.Block
        , GenericBlockHeader (..)
        , GenericBlock (..)
 
-       -- * Lenses
+       -- * Classes for overloaded accessors
        , HasPrevBlock (..)
 
+       -- * Classes for headers
+       , IsHeader (..)
+       , IsGenesisHeader (..)
+       , IsMainHeader (..)
+
+       -- * Lenses
        , gbBody
        , gbHeader
        , gbExtra
@@ -133,6 +139,38 @@ makeLenses ''GenericBlock
 
 class HasPrevBlock s where
     prevBlockL :: Lens' s HeaderHash
+
+{- | A class that lets subpackages use some fields from headers without
+depending on cardano-sl:
+
+  * 'difficultyL'
+  * 'epochIndexL'
+  * 'prevBlockL'
+-}
+class (HasDifficulty header, HasEpochIndex header, HasPrevBlock header) =>
+      IsHeader header
+
+{- | A class for genesis headers. Currently provides the same data:
+
+  * 'difficultyL'
+  * 'epochIndexL'
+  * 'prevBlockL'
+-}
+class IsHeader header => IsGenesisHeader header
+
+{- | A class for main headers. Provides:
+
+  * 'difficultyL'
+  * 'epochIndexL'
+  * 'prevBlockL'
+  * 'headerSlot'
+  * 'headerLeaderKey'
+-}
+class IsHeader header => IsMainHeader header where
+    -- | Id of the slot for which this block was generated.
+    headerSlot :: Lens' header SlotId
+    -- | Public key of slot leader.
+    headerLeaderKey :: Lens' header PublicKey
 
 -- | Lens from 'GenericBlock' to 'BodyProof'.
 gbBodyProof :: Lens' (GenericBlock b) (BodyProof b)

--- a/core/Pos/Core/Block.hs
+++ b/core/Pos/Core/Block.hs
@@ -140,6 +140,9 @@ makeLenses ''GenericBlock
 class HasPrevBlock s where
     prevBlockL :: Lens' s HeaderHash
 
+instance HasPrevBlock (Some HasPrevBlock) where
+    prevBlockL = liftLensSome prevBlockL
+
 {- | A class that lets subpackages use some fields from headers without
 depending on cardano-sl:
 

--- a/core/Pos/Core/Block.hs
+++ b/core/Pos/Core/Block.hs
@@ -149,8 +149,12 @@ depending on cardano-sl:
   * 'difficultyL'
   * 'epochIndexL'
   * 'prevBlockL'
+  * 'headerHashG'
 -}
-class (HasDifficulty header, HasEpochIndex header, HasPrevBlock header) =>
+class (HasDifficulty header
+      ,HasEpochIndex header
+      ,HasPrevBlock header
+      ,HasHeaderHash header) =>
       IsHeader header
 
 {- | A class for genesis headers. Currently provides the same data:

--- a/core/Pos/Core/Block.hs
+++ b/core/Pos/Core/Block.hs
@@ -12,8 +12,8 @@ module Pos.Core.Block
        , HasPrevBlock (..)
 
        -- * Classes for headers
-       , IsHeader (..)
-       , IsGenesisHeader (..)
+       , IsHeader
+       , IsGenesisHeader
        , IsMainHeader (..)
 
        -- * Lenses
@@ -143,6 +143,9 @@ class HasPrevBlock s where
 instance HasPrevBlock (Some HasPrevBlock) where
     prevBlockL = liftLensSome prevBlockL
 
+-- | Lens from 'GenericBlock' to 'BodyProof'.
+gbBodyProof :: Lens' (GenericBlock b) (BodyProof b)
+gbBodyProof = gbHeader . gbhBodyProof
 {- | A class that lets subpackages use some fields from headers without
 depending on cardano-sl:
 
@@ -175,10 +178,6 @@ class IsHeader header => IsGenesisHeader header
 -}
 class IsHeader header => IsMainHeader header where
     -- | Id of the slot for which this block was generated.
-    headerSlot :: Lens' header SlotId
+    headerSlotL :: Lens' header SlotId
     -- | Public key of slot leader.
-    headerLeaderKey :: Lens' header PublicKey
-
--- | Lens from 'GenericBlock' to 'BodyProof'.
-gbBodyProof :: Lens' (GenericBlock b) (BodyProof b)
-gbBodyProof = gbHeader . gbhBodyProof
+    headerLeaderKeyL :: Lens' header PublicKey

--- a/core/Pos/Core/Block.hs
+++ b/core/Pos/Core/Block.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
@@ -8,14 +7,6 @@ module Pos.Core.Block
        ( Blockchain (..)
        , GenericBlockHeader (..)
        , GenericBlock (..)
-
-       -- * Classes for overloaded accessors
-       , HasPrevBlock (..)
-
-       -- * Classes for headers
-       , IsHeader
-       , IsGenesisHeader
-       , IsMainHeader (..)
 
        -- * Lenses
        , gbBody
@@ -28,14 +19,10 @@ module Pos.Core.Block
        , gbhBodyProof
        ) where
 
-import           Control.Lens       (makeLenses)
+import           Control.Lens   (makeLenses)
 import           Universum
 
-import           Pos.Core.Types     (HasBlockVersion (..), HasDifficulty (..),
-                                     HasEpochIndex (..), HasHeaderHash (..),
-                                     HasSoftwareVersion (..), HeaderHash, SlotId)
-import           Pos.Crypto.Signing (PublicKey)
-import           Pos.Util.Util      (Some, applySome, liftLensSome)
+import           Pos.Core.Types (HeaderHash)
 
 ----------------------------------------------------------------------------
 -- GenericBlock
@@ -142,85 +129,6 @@ deriving instance
 makeLenses ''GenericBlockHeader
 makeLenses ''GenericBlock
 
-class HasPrevBlock s where
-    prevBlockL :: Lens' s HeaderHash
-
-instance HasPrevBlock (Some HasPrevBlock) where
-    prevBlockL = liftLensSome prevBlockL
-
 -- | Lens from 'GenericBlock' to 'BodyProof'.
 gbBodyProof :: Lens' (GenericBlock b) (BodyProof b)
 gbBodyProof = gbHeader . gbhBodyProof
-
-----------------------------------------------------------------------------
--- Classes for headers
-----------------------------------------------------------------------------
-
-#define SOME_LENS_CLASS(HAS, LENS, CL)                       \
-    instance HAS (Some CL) where LENS = liftLensSome LENS
-#define SOME_FUNC_CLASS(HAS, FUNC, CL)                       \
-    instance HAS (Some CL) where FUNC = applySome FUNC
-
--- Add (..) to export list when IsHeader or IsGenesisHeader get any methods
-
-{- | A class that lets subpackages use some fields from headers without
-depending on cardano-sl:
-
-  * 'difficultyL'
-  * 'epochIndexL'
-  * 'prevBlockL'
-  * 'headerHashG'
--}
-class (HasDifficulty header
-      ,HasEpochIndex header
-      ,HasPrevBlock header
-      ,HasHeaderHash header) =>
-      IsHeader header
-
-SOME_LENS_CLASS(HasDifficulty, difficultyL, IsHeader)
-SOME_LENS_CLASS(HasEpochIndex, epochIndexL, IsHeader)
-SOME_LENS_CLASS(HasPrevBlock,  prevBlockL,  IsHeader)
-SOME_FUNC_CLASS(HasHeaderHash, headerHash,  IsHeader)
-
-instance IsHeader (Some IsHeader)
-
--- | A class for genesis headers. Currently doesn't provide any data beyond
--- what 'IsHeader' provides.
-class IsHeader header => IsGenesisHeader header
-
-SOME_LENS_CLASS(HasDifficulty, difficultyL, IsGenesisHeader)
-SOME_LENS_CLASS(HasEpochIndex, epochIndexL, IsGenesisHeader)
-SOME_LENS_CLASS(HasPrevBlock,  prevBlockL,  IsGenesisHeader)
-SOME_FUNC_CLASS(HasHeaderHash, headerHash,  IsGenesisHeader)
-
-instance IsHeader        (Some IsGenesisHeader)
-instance IsGenesisHeader (Some IsGenesisHeader)
-
-{- | A class for main headers. In addition to 'IsHeader', provides:
-
-  * 'headerSlotL'
-  * 'headerLeaderKeyL'
-  * 'blockVersionL'
-  * 'softwareVersionL'
--}
-class (IsHeader header
-      ,HasBlockVersion header
-      ,HasSoftwareVersion header) =>
-      IsMainHeader header
-  where
-    -- | Id of the slot for which this block was generated.
-    headerSlotL :: Lens' header SlotId
-    -- | Public key of slot leader.
-    headerLeaderKeyL :: Lens' header PublicKey
-
-SOME_LENS_CLASS(HasDifficulty,      difficultyL,      IsMainHeader)
-SOME_LENS_CLASS(HasEpochIndex,      epochIndexL,      IsMainHeader)
-SOME_LENS_CLASS(HasPrevBlock,       prevBlockL,       IsMainHeader)
-SOME_FUNC_CLASS(HasHeaderHash,      headerHash,       IsMainHeader)
-SOME_LENS_CLASS(HasBlockVersion,    blockVersionL,    IsMainHeader)
-SOME_LENS_CLASS(HasSoftwareVersion, softwareVersionL, IsMainHeader)
-
-instance IsHeader     (Some IsMainHeader)
-instance IsMainHeader (Some IsMainHeader) where
-    headerSlotL = liftLensSome headerSlotL
-    headerLeaderKeyL = liftLensSome headerLeaderKeyL

--- a/core/Pos/Core/Class.hs
+++ b/core/Pos/Core/Class.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE CPP             #-}
+-- needed for stylish-haskell :(
+{-# LANGUAGE TemplateHaskell #-}
+
+module Pos.Core.Class
+       (
+       -- * Classes for overloaded accessors
+         HasPrevBlock (..)
+       , HasDifficulty (..)
+       , HasBlockVersion (..)
+       , HasSoftwareVersion (..)
+       , HasHeaderHash (..)
+       , headerHashG
+       , HasEpochIndex (..)
+       , HasEpochOrSlot (..)
+       , epochOrSlotG
+
+       -- * Classes for headers
+       , IsHeader
+       , IsGenesisHeader
+       , IsMainHeader (..)
+       ) where
+
+import           Control.Lens   (Getter, to)
+import           Universum
+
+import           Pos.Core.Types (BlockVersion, ChainDifficulty, EpochIndex,
+                                 EpochOrSlot (..), HeaderHash, SlotId, SoftwareVersion)
+import           Pos.Crypto     (PublicKey)
+import           Pos.Util.Util  (Some, applySome, liftLensSome)
+
+#define SOME_LENS_CLASS(HAS, LENS, CL)                       \
+    instance HAS (Some CL) where LENS = liftLensSome LENS
+#define SOME_FUNC_CLASS(HAS, FUNC, CL)                       \
+    instance HAS (Some CL) where FUNC = applySome FUNC
+
+----------------------------------------------------------------------------
+-- Classes for overloaded accessors
+----------------------------------------------------------------------------
+
+-- HasPrevBlock
+class HasPrevBlock s where
+    prevBlockL :: Lens' s HeaderHash
+
+SOME_LENS_CLASS(HasPrevBlock, prevBlockL, HasPrevBlock)
+
+-- HasDifficulty
+class HasDifficulty a where
+    difficultyL :: Lens' a ChainDifficulty
+
+SOME_LENS_CLASS(HasDifficulty, difficultyL, HasDifficulty)
+
+-- HasBlockVersion
+class HasBlockVersion a where
+    blockVersionL :: Lens' a BlockVersion
+
+SOME_LENS_CLASS(HasBlockVersion, blockVersionL, HasBlockVersion)
+
+-- HasSoftwareVersion
+class HasSoftwareVersion a where
+    softwareVersionL :: Lens' a SoftwareVersion
+
+SOME_LENS_CLASS(HasSoftwareVersion, softwareVersionL, HasSoftwareVersion)
+
+-- HasHeaderHash
+class HasHeaderHash a where
+    headerHash :: a -> HeaderHash
+
+SOME_FUNC_CLASS(HasHeaderHash, headerHash, HasHeaderHash)
+
+headerHashG :: HasHeaderHash a => Getter a HeaderHash
+headerHashG = to headerHash
+
+-- HasEpochIndex
+class HasEpochIndex a where
+    epochIndexL :: Lens' a EpochIndex
+
+SOME_LENS_CLASS(HasEpochIndex, epochIndexL, HasEpochIndex)
+
+-- HasEpochOrSlot
+class HasEpochOrSlot a where
+    getEpochOrSlot :: a -> EpochOrSlot
+
+SOME_FUNC_CLASS(HasEpochOrSlot, getEpochOrSlot, HasEpochOrSlot)
+
+epochOrSlotG :: HasEpochOrSlot a => Getter a EpochOrSlot
+epochOrSlotG = to getEpochOrSlot
+
+instance HasEpochOrSlot EpochIndex where
+    getEpochOrSlot = EpochOrSlot . Left
+instance HasEpochOrSlot SlotId where
+    getEpochOrSlot = EpochOrSlot . Right
+
+----------------------------------------------------------------------------
+-- Classes for headers
+----------------------------------------------------------------------------
+
+-- Add (..) to export list when IsHeader or IsGenesisHeader get any methods
+
+{- | A class that lets subpackages use some fields from headers without
+depending on cardano-sl:
+
+  * 'difficultyL'
+  * 'epochIndexL'
+  * 'prevBlockL'
+  * 'headerHashG'
+-}
+class (HasDifficulty header
+      ,HasEpochIndex header
+      ,HasPrevBlock header
+      ,HasHeaderHash header) =>
+      IsHeader header
+
+SOME_LENS_CLASS(HasDifficulty, difficultyL, IsHeader)
+SOME_LENS_CLASS(HasEpochIndex, epochIndexL, IsHeader)
+SOME_LENS_CLASS(HasPrevBlock,  prevBlockL,  IsHeader)
+SOME_FUNC_CLASS(HasHeaderHash, headerHash,  IsHeader)
+
+instance IsHeader (Some IsHeader)
+
+-- | A class for genesis headers. Currently doesn't provide any data beyond
+-- what 'IsHeader' provides.
+class IsHeader header => IsGenesisHeader header
+
+SOME_LENS_CLASS(HasDifficulty, difficultyL, IsGenesisHeader)
+SOME_LENS_CLASS(HasEpochIndex, epochIndexL, IsGenesisHeader)
+SOME_LENS_CLASS(HasPrevBlock,  prevBlockL,  IsGenesisHeader)
+SOME_FUNC_CLASS(HasHeaderHash, headerHash,  IsGenesisHeader)
+
+instance IsHeader        (Some IsGenesisHeader)
+instance IsGenesisHeader (Some IsGenesisHeader)
+
+{- | A class for main headers. In addition to 'IsHeader', provides:
+
+  * 'headerSlotL'
+  * 'headerLeaderKeyL'
+  * 'blockVersionL'
+  * 'softwareVersionL'
+-}
+class (IsHeader header
+      ,HasBlockVersion header
+      ,HasSoftwareVersion header) =>
+      IsMainHeader header
+  where
+    -- | Id of the slot for which this block was generated.
+    headerSlotL :: Lens' header SlotId
+    -- | Public key of slot leader.
+    headerLeaderKeyL :: Lens' header PublicKey
+
+SOME_LENS_CLASS(HasDifficulty,      difficultyL,      IsMainHeader)
+SOME_LENS_CLASS(HasEpochIndex,      epochIndexL,      IsMainHeader)
+SOME_LENS_CLASS(HasPrevBlock,       prevBlockL,       IsMainHeader)
+SOME_FUNC_CLASS(HasHeaderHash,      headerHash,       IsMainHeader)
+SOME_LENS_CLASS(HasBlockVersion,    blockVersionL,    IsMainHeader)
+SOME_LENS_CLASS(HasSoftwareVersion, softwareVersionL, IsMainHeader)
+
+instance IsHeader     (Some IsMainHeader)
+instance IsMainHeader (Some IsMainHeader) where
+    headerSlotL = liftLensSome headerSlotL
+    headerLeaderKeyL = liftLensSome headerLeaderKeyL

--- a/core/Pos/Core/Slotting.hs
+++ b/core/Pos/Core/Slotting.hs
@@ -10,9 +10,10 @@ module Pos.Core.Slotting
 
 import           Universum
 
+import           Pos.Core.Class     (HasEpochOrSlot (..), getEpochOrSlot)
 import           Pos.Core.Constants (epochSlots, slotSecurityParam)
 import           Pos.Core.Types     (EpochIndex (..), EpochOrSlot (..), FlatSlotId,
-                                     HasEpochOrSlot (..), SlotId (..))
+                                     SlotId (..), epochOrSlot)
 
 -- | Flatten 'SlotId' (which is basically pair of integers) into a single number.
 flattenSlotId :: SlotId -> FlatSlotId
@@ -25,7 +26,7 @@ flattenEpochIndex EpochIndex {..} = getEpochIndex * epochSlots
 -- | Transforms some 'HasEpochOrSlot' to a single number.
 flattenEpochOrSlot :: (HasEpochOrSlot a) => a -> FlatSlotId
 flattenEpochOrSlot =
-    either flattenEpochIndex flattenSlotId . _getEpochOrSlot
+    epochOrSlot flattenEpochIndex flattenSlotId . getEpochOrSlot
 
 -- | Construct 'SlotId' from a flattened variant.
 unflattenSlotId :: FlatSlotId -> SlotId

--- a/core/Pos/Core/Types.hs
+++ b/core/Pos/Core/Types.hs
@@ -21,8 +21,10 @@ module Pos.Core.Types
         -- * Version
        , ApplicationName (..)
        , BlockVersion (..)
+       , HasBlockVersion (..)
        , NumSoftwareVersion
        , SoftwareVersion (..)
+       , HasSoftwareVersion (..)
 
        -- * HeaderHash related types and functions
        , BlockHeaderStub
@@ -184,6 +186,12 @@ instance Hashable BlockVersion
 
 instance NFData BlockVersion
 instance NFData SoftwareVersion
+
+class HasBlockVersion a where
+    blockVersionL :: Lens' a BlockVersion
+
+class HasSoftwareVersion a where
+    softwareVersionL :: Lens' a SoftwareVersion
 
 ----------------------------------------------------------------------------
 -- HeaderHash

--- a/core/Pos/Core/Types.hs
+++ b/core/Pos/Core/Types.hs
@@ -16,20 +16,16 @@ module Pos.Core.Types
 
         -- * ChainDifficulty
        , ChainDifficulty (..)
-       , HasDifficulty (..)
 
         -- * Version
        , ApplicationName (..)
        , BlockVersion (..)
-       , HasBlockVersion (..)
        , NumSoftwareVersion
        , SoftwareVersion (..)
-       , HasSoftwareVersion (..)
 
        -- * HeaderHash related types and functions
        , BlockHeaderStub
        , HeaderHash
-       , HasHeaderHash (..)
        , headerHashF
 
        , ProxySigLight
@@ -54,12 +50,10 @@ module Pos.Core.Types
 
         -- * Slotting
        , EpochIndex (..)
-       , HasEpochIndex (..)
        , FlatSlotId
        , LocalSlotIndex (..)
        , SlotId (..)
        , EpochOrSlot (..)
-       , HasEpochOrSlot (..)
        , slotIdF
        , epochOrSlot
 
@@ -69,7 +63,6 @@ module Pos.Core.Types
        , ScriptVersion
        ) where
 
-import           Control.Lens         (Getter, to)
 import           Crypto.Hash          (Blake2s_224)
 import           Data.Data            (Data)
 import           Data.Default         (Default (..))
@@ -82,16 +75,14 @@ import           Data.Time.Units      (Microsecond)
 import           Formatting           (Format, bprint, build, formatToString, int, ords,
                                        shown, stext, (%))
 import qualified PlutusCore.Program   as PLCore
-import           Prelude              (show)
+import qualified Prelude
 import           Serokell.AcidState   ()
 import           Serokell.Util.Base16 (formatBase16)
-import           Universum            hiding (show)
+import           Universum
 
 import           Pos.Crypto           (AbstractHash, Hash, ProxySecretKey, ProxySignature,
                                        PublicKey)
 import           Pos.Data.Attributes  (Attributes)
-import           Pos.Util.Util        (Some (..), applySome, liftLensSome)
-
 
 -- | Timestamp is a number which represents some point in time. It is
 -- used in MonadSlots and its meaning is up to implementation of this
@@ -139,13 +130,6 @@ newtype ChainDifficulty = ChainDifficulty
     { getChainDifficulty :: Word64
     } deriving (Show, Eq, Ord, Num, Enum, Real, Integral, Generic, Buildable, Typeable, NFData)
 
--- | Type class for something that has 'ChainDifficulty'.
-class HasDifficulty a where
-    difficultyL :: Lens' a ChainDifficulty
-
-instance HasDifficulty (Some HasDifficulty) where
-    difficultyL = liftLensSome difficultyL
-
 ----------------------------------------------------------------------------
 -- Version
 ----------------------------------------------------------------------------
@@ -191,18 +175,6 @@ instance Hashable BlockVersion
 instance NFData BlockVersion
 instance NFData SoftwareVersion
 
-class HasBlockVersion a where
-    blockVersionL :: Lens' a BlockVersion
-
-instance HasBlockVersion (Some HasBlockVersion) where
-    blockVersionL = liftLensSome blockVersionL
-
-class HasSoftwareVersion a where
-    softwareVersionL :: Lens' a SoftwareVersion
-
-instance HasSoftwareVersion (Some HasSoftwareVersion) where
-    softwareVersionL = liftLensSome softwareVersionL
-
 ----------------------------------------------------------------------------
 -- HeaderHash
 ----------------------------------------------------------------------------
@@ -215,15 +187,6 @@ data BlockHeaderStub
 -- | Specialized formatter for 'HeaderHash'.
 headerHashF :: Format r (HeaderHash -> r)
 headerHashF = build
-
--- | Class for something that has 'HeaderHash'.
-class HasHeaderHash a where
-    headerHash :: a -> HeaderHash
-    headerHashG :: Getter a HeaderHash
-    headerHashG = to headerHash
-
-instance HasHeaderHash (Some HasHeaderHash) where
-    headerHash = applySome headerHash
 
 ----------------------------------------------------------------------------
 -- Proxy signatures and delegation
@@ -350,13 +313,6 @@ instance Buildable EpochIndex where
 -- instance Buildable (EpochIndex,EpochIndex) where
 --     build = bprint ("epochIndices: "%pairF)
 
--- | Class for something that has 'EpochIndex'.
-class HasEpochIndex a where
-    epochIndexL :: Lens' a EpochIndex
-
-instance HasEpochIndex (Some HasEpochIndex) where
-    epochIndexL = liftLensSome epochIndexL
-
 -- | Index of slot inside a concrete epoch.
 newtype LocalSlotIndex = LocalSlotIndex
     { getSlotIndex :: Word16
@@ -403,22 +359,6 @@ instance Ord EpochOrSlot where
 
 instance Buildable EpochOrSlot where
     build = either Buildable.build Buildable.build . unEpochOrSlot
-
-class HasEpochOrSlot a where
-    _getEpochOrSlot :: a -> Either EpochIndex SlotId
-    getEpochOrSlot :: a -> EpochOrSlot
-    getEpochOrSlot = EpochOrSlot . _getEpochOrSlot
-    epochOrSlotG :: Getter a EpochOrSlot
-    epochOrSlotG = to getEpochOrSlot
-
-instance HasEpochOrSlot (Some HasEpochOrSlot) where
-    _getEpochOrSlot = applySome _getEpochOrSlot
-
-instance HasEpochOrSlot EpochIndex where
-    _getEpochOrSlot = Left
-
-instance HasEpochOrSlot SlotId where
-    _getEpochOrSlot = Right
 
 instance NFData SlotId
 

--- a/core/Pos/Core/Types.hs
+++ b/core/Pos/Core/Types.hs
@@ -90,6 +90,7 @@ import           Universum            hiding (show)
 import           Pos.Crypto           (AbstractHash, Hash, ProxySecretKey, ProxySignature,
                                        PublicKey)
 import           Pos.Data.Attributes  (Attributes)
+import           Pos.Util.Util        (Some (..), applySome, liftLensSome)
 
 
 -- | Timestamp is a number which represents some point in time. It is
@@ -142,6 +143,9 @@ newtype ChainDifficulty = ChainDifficulty
 class HasDifficulty a where
     difficultyL :: Lens' a ChainDifficulty
 
+instance HasDifficulty (Some HasDifficulty) where
+    difficultyL = liftLensSome difficultyL
+
 ----------------------------------------------------------------------------
 -- Version
 ----------------------------------------------------------------------------
@@ -190,8 +194,14 @@ instance NFData SoftwareVersion
 class HasBlockVersion a where
     blockVersionL :: Lens' a BlockVersion
 
+instance HasBlockVersion (Some HasBlockVersion) where
+    blockVersionL = liftLensSome blockVersionL
+
 class HasSoftwareVersion a where
     softwareVersionL :: Lens' a SoftwareVersion
+
+instance HasSoftwareVersion (Some HasSoftwareVersion) where
+    softwareVersionL = liftLensSome softwareVersionL
 
 ----------------------------------------------------------------------------
 -- HeaderHash
@@ -211,6 +221,9 @@ class HasHeaderHash a where
     headerHash :: a -> HeaderHash
     headerHashG :: Getter a HeaderHash
     headerHashG = to headerHash
+
+instance HasHeaderHash (Some HasHeaderHash) where
+    headerHash = applySome headerHash
 
 ----------------------------------------------------------------------------
 -- Proxy signatures and delegation
@@ -341,6 +354,9 @@ instance Buildable EpochIndex where
 class HasEpochIndex a where
     epochIndexL :: Lens' a EpochIndex
 
+instance HasEpochIndex (Some HasEpochIndex) where
+    epochIndexL = liftLensSome epochIndexL
+
 -- | Index of slot inside a concrete epoch.
 newtype LocalSlotIndex = LocalSlotIndex
     { getSlotIndex :: Word16
@@ -394,6 +410,9 @@ class HasEpochOrSlot a where
     getEpochOrSlot = EpochOrSlot . _getEpochOrSlot
     epochOrSlotG :: Getter a EpochOrSlot
     epochOrSlotG = to getEpochOrSlot
+
+instance HasEpochOrSlot (Some HasEpochOrSlot) where
+    _getEpochOrSlot = applySome _getEpochOrSlot
 
 instance HasEpochOrSlot EpochIndex where
     _getEpochOrSlot = Left

--- a/core/Pos/Util/Util.hs
+++ b/core/Pos/Util/Util.hs
@@ -1,18 +1,71 @@
-{-# LANGUAGE CPP             #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Pos.Util.Util
        (
-       -- Instances
+       -- * Existential types
+         Some(..)
+       , Some1(..)
+       , applySome
+       , liftLensSome
+       , liftGetterSome
+
+       -- * Instances
        -- ** Lift Byte
        -- ** FromJSON Byte
        -- ** ToJSON Byte
        ) where
 
+import           Control.Lens               (ALens', Getter, Getting, cloneLens, to)
 import           Data.Aeson                 (FromJSON (..), ToJSON (..))
 import           Language.Haskell.TH.Syntax (Lift (..))
+import qualified Prelude
 import           Serokell.Data.Memory.Units (Byte, fromBytes, toBytes)
 import           Universum
+
+----------------------------------------------------------------------------
+-- Some
+----------------------------------------------------------------------------
+
+-- | Turn any constraint into an existential type! Example:
+--
+-- @
+-- foo :: Some Show -> String
+-- foo (Some s) = show s
+-- @
+data Some c where
+    Some :: c a => a -> Some c
+
+instance Show (Some Show) where
+    show (Some s) = show s
+
+-- | Like 'Some', but for @* -> *@ types – for instance, @Some1 Functor ()@
+data Some1 c a where
+    Some1 :: c f => f a -> Some1 c a
+
+instance Functor (Some1 Functor) where
+    fmap f (Some1 x) = Some1 (fmap f x)
+
+-- | Apply a function requiring the constraint
+applySome :: (forall a. c a => a -> r) -> (Some c -> r)
+applySome f (Some x) = f x
+
+-- | Turn a lens into something operating on 'Some'. Useful for many types
+-- like 'HasDifficulty', 'IsHeader', etc.
+liftLensSome :: (forall a. c a => ALens' a b)
+             -> Lens' (Some c) b
+liftLensSome l =
+    \f (Some a) -> Some <$> cloneLens l f a
+
+-- | Like 'liftLensSome', but for getters.
+liftGetterSome :: (forall a. c a => Getting b a b) -> Getter (Some c) b
+liftGetterSome l = \f (Some a) -> Some <$> to (view l) f a
+
+----------------------------------------------------------------------------
+-- Instances
+----------------------------------------------------------------------------
 
 instance Lift Byte where
     lift x = let b = toBytes x in [|fromBytes b :: Byte|]

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:     Pos.Core
                        Pos.Core.Address
                        Pos.Core.Block
+                       Pos.Core.Class
                        Pos.Core.Coin
                        Pos.Core.Constants
                        Pos.Core.Constants.Type

--- a/src/Pos/Block/Network/Retrieval.hs
+++ b/src/Pos/Block/Network/Retrieval.hs
@@ -54,7 +54,8 @@ import           Pos.Shutdown               (runIfNotShutdown)
 import           Pos.Ssc.Class              (Ssc, SscWorkersClass)
 import           Pos.Types                  (Block, BlockHeader, HasHeaderHash (..),
                                              HeaderHash, blockHeader, difficultyL,
-                                             gbHeader, prevBlockL, verifyHeaders)
+                                             gbHeader, headerHashG, prevBlockL,
+                                             verifyHeaders)
 import           Pos.Util                   (NE, NewestFirst (..), OldestFirst (..),
                                              inAssertMode, _neHead, _neLast)
 import           Pos.WorkMode               (WorkMode)

--- a/src/Pos/Block/Types.hs
+++ b/src/Pos/Block/Types.hs
@@ -12,7 +12,7 @@ import           Formatting            (bprint, build, (%))
 import           Serokell.Util.Text    (listJson)
 import           Universum
 
-import           Pos.Core.Types        (HasDifficulty (..), HasHeaderHash (..),
+import           Pos.Core              (HasDifficulty (..), HasHeaderHash (..),
                                         ProxySKHeavy)
 import           Pos.Txp.Core.Types    (TxsUndo)
 import           Pos.Types.Block       (BiSsc, Block)

--- a/src/Pos/Types.hs
+++ b/src/Pos/Types.hs
@@ -3,6 +3,7 @@
 module Pos.Types
        ( module Pos.Core.Address
        , module Pos.Core.Block
+       , module Pos.Core.Class
        , module Pos.Core.Coin
        , module Pos.Core.Slotting
        , module Pos.Core.Types
@@ -14,6 +15,7 @@ module Pos.Types
 import           Pos.Binary.Core      ()
 import           Pos.Core.Address
 import           Pos.Core.Block
+import           Pos.Core.Class
 import           Pos.Core.Coin
 import           Pos.Core.Slotting
 import           Pos.Core.Types

--- a/src/Pos/Types/Block/Functions.hs
+++ b/src/Pos/Types/Block/Functions.hs
@@ -4,8 +4,8 @@
 -- | Functions related to blocks and headers.
 
 module Pos.Types.Block.Functions
-       ( blockDifficulty
-       , headerDifficulty
+       ( blockDifficultyIncrement
+       , headerDifficultyIncrement
        , mkGenericBlock
        , mkGenericHeader
        , mkMainBlock
@@ -78,13 +78,13 @@ import           Pos.Update.Core            (UpdatePayload)
 import           Pos.Util                   (NewestFirst (..), OldestFirst)
 
 -- | Difficulty of the BlockHeader. 0 for genesis block, 1 for main block.
-headerDifficulty :: BlockHeader ssc -> ChainDifficulty
-headerDifficulty (Left _)  = 0
-headerDifficulty (Right _) = 1
+headerDifficultyIncrement :: BlockHeader ssc -> ChainDifficulty
+headerDifficultyIncrement (Left _)  = 0
+headerDifficultyIncrement (Right _) = 1
 
 -- | Difficulty of the Block, which is determined from header.
-blockDifficulty :: Block ssc -> ChainDifficulty
-blockDifficulty = headerDifficulty . getBlockHeader
+blockDifficultyIncrement :: Block ssc -> ChainDifficulty
+blockDifficultyIncrement = headerDifficultyIncrement . getBlockHeader
 
 -- | Predefined 'Hash' of 'GenesisBlock'.
 genesisHash :: Hash a
@@ -350,7 +350,7 @@ verifyHeader VerifyHeaderParams {..} h =
     --   * Epoch/slot are consistent.
     relatedToPrevHeader prevHeader =
         [ checkDifficulty
-              (prevHeader ^. difficultyL + headerDifficulty h)
+              (prevHeader ^. difficultyL + headerDifficultyIncrement h)
               (h ^. difficultyL)
         , checkHash
               (headerHash prevHeader)
@@ -368,7 +368,7 @@ verifyHeader VerifyHeaderParams {..} h =
     --  * Epoch/slot are consistent.
     relatedToNextHeader nextHeader =
         [ checkDifficulty
-              (nextHeader ^. difficultyL - headerDifficulty nextHeader)
+              (nextHeader ^. difficultyL - headerDifficultyIncrement nextHeader)
               (h ^. difficultyL)
         , checkHash (headerHash h) (nextHeader ^. prevBlockL)
         , checkSlot (getEpochOrSlot h) (getEpochOrSlot nextHeader)

--- a/src/Pos/Types/Block/Functions.hs
+++ b/src/Pos/Types/Block/Functions.hs
@@ -48,11 +48,11 @@ import           Pos.Core                   (BlockVersion, ChainDifficulty, Epoc
                                              HasEpochIndex (..), HasEpochOrSlot (..),
                                              HasHeaderHash (..), HeaderHash,
                                              ProxySKEither, ProxySKHeavy, SlotId (..),
-                                             SlotId, SlotLeaders)
+                                             SlotId, SlotLeaders, prevBlockL)
 import           Pos.Core.Address           (Address (..), addressHash)
 import           Pos.Core.Block             (Blockchain (..), GenericBlock (..),
                                              GenericBlockHeader (..), gbBody, gbBodyProof,
-                                             gbHeader, gbhExtra, prevBlockL)
+                                             gbHeader, gbhExtra)
 import           Pos.Crypto                 (Hash, SecretKey, checkSig, proxySign,
                                              proxyVerify, pskIssuerPk, pskOmega, sign,
                                              toPublic, unsafeHash)

--- a/src/Pos/Types/Block/Instances.hs
+++ b/src/Pos/Types/Block/Instances.hs
@@ -50,8 +50,10 @@ import           Universum
 import           Pos.Binary.Class      (Bi)
 import           Pos.Core.Block        (Blockchain (..), GenericBlock (..),
                                         GenericBlockHeader (..), HasPrevBlock (..),
-                                        gbBody, gbHeader, gbhConsensus, gbhPrevBlock)
-import           Pos.Core.Types        (ChainDifficulty, EpochIndex (..),
+                                        gbBody, gbHeader, gbhConsensus, gbhPrevBlock,
+                                        gbhExtra)
+import           Pos.Core.Types        (HasBlockVersion(..), HasSoftwareVersion(..),
+                                        ChainDifficulty, EpochIndex (..),
                                         HasDifficulty (..), HasEpochIndex (..),
                                         HasEpochOrSlot (..), HasHeaderHash (..),
                                         HeaderHash, ProxySKHeavy, SlotId (..),
@@ -65,7 +67,8 @@ import           Pos.Types.Block.Types (BiHeader, BiSsc, Block, BlockHeader,
                                         BlockSignature, GenesisBlock, GenesisBlockHeader,
                                         GenesisBlockchain, MainBlock, MainBlockHeader,
                                         MainBlockchain, MainExtraBodyData,
-                                        MainExtraHeaderData)
+                                        MainExtraHeaderData, mehBlockVersion,
+                                        mehSoftwareVersion)
 import           Pos.Update.Core.Types (UpdatePayload, UpdateProof, UpdateProposal,
                                         mkUpdateProof)
 
@@ -529,3 +532,23 @@ instance (BHeaderHash b ~ HeaderHash) =>
 instance (HasPrevBlock s, HasPrevBlock s') =>
          HasPrevBlock (Either s s') where
     prevBlockL = choosing prevBlockL prevBlockL
+
+----------------------------------------------------------------------------
+-- Has*Version
+----------------------------------------------------------------------------
+
+instance HasBlockVersion MainExtraHeaderData where
+    blockVersionL = mehBlockVersion
+instance HasSoftwareVersion MainExtraHeaderData where
+    softwareVersionL = mehSoftwareVersion
+
+instance HasBlockVersion (MainBlockHeader ssc) where
+    blockVersionL = gbhExtra . blockVersionL
+instance HasSoftwareVersion (MainBlockHeader ssc) where
+    softwareVersionL = gbhExtra . softwareVersionL
+
+instance HasBlockVersion (MainBlock ssc) where
+    blockVersionL = gbHeader . blockVersionL
+instance HasSoftwareVersion (MainBlock ssc) where
+    softwareVersionL = gbHeader . softwareVersionL
+

--- a/src/Pos/Types/Block/Instances.hs
+++ b/src/Pos/Types/Block/Instances.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+-- needed for stylish-haskell :(
+{-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -48,17 +50,16 @@ import           Serokell.Util         (Color (Magenta), colorize, listJson)
 import           Universum
 
 import           Pos.Binary.Class      (Bi)
-import           Pos.Core.Block        (IsHeader, IsGenesisHeader, IsMainHeader(..),
-                                        Blockchain (..), GenericBlock (..),
-                                        GenericBlockHeader (..), HasPrevBlock (..),
-                                        gbBody, gbHeader, gbhConsensus, gbhPrevBlock,
-                                        gbhExtra)
-import           Pos.Core.Types        (HasBlockVersion(..), HasSoftwareVersion(..),
-                                        ChainDifficulty, EpochIndex (..),
+import           Pos.Core              (Blockchain (..), ChainDifficulty, EpochIndex (..),
+                                        EpochOrSlot (..), GenericBlock (..),
+                                        GenericBlockHeader (..), HasBlockVersion (..),
                                         HasDifficulty (..), HasEpochIndex (..),
                                         HasEpochOrSlot (..), HasHeaderHash (..),
-                                        HeaderHash, ProxySKHeavy, SlotId (..),
-                                        SlotLeaders, slotIdF)
+                                        HasPrevBlock (..), HasSoftwareVersion (..),
+                                        HeaderHash, IsGenesisHeader, IsHeader,
+                                        IsMainHeader (..), ProxySKHeavy, SlotId (..),
+                                        SlotLeaders, gbBody, gbHeader, gbhConsensus,
+                                        gbhExtra, gbhPrevBlock, slotIdF)
 import           Pos.Crypto            (Hash, PublicKey, hash, hashHexF, unsafeHash)
 import           Pos.Merkle            (MerkleRoot, MerkleTree, mtRoot)
 import           Pos.Ssc.Class.Helpers (SscHelpersClass (..))
@@ -428,20 +429,20 @@ instance (HasEpochIndex a, HasEpochIndex b) =>
 ----------------------------------------------------------------------------
 
 instance HasEpochOrSlot (MainBlockHeader ssc) where
-    _getEpochOrSlot = Right . _mcdSlot . _gbhConsensus
+    getEpochOrSlot = EpochOrSlot . Right . _mcdSlot . _gbhConsensus
 
 instance HasEpochOrSlot (GenesisBlockHeader ssc) where
-    _getEpochOrSlot = Left . _gcdEpoch . _gbhConsensus
+    getEpochOrSlot = EpochOrSlot . Left . _gcdEpoch . _gbhConsensus
 
 instance HasEpochOrSlot (MainBlock ssc) where
-    _getEpochOrSlot = _getEpochOrSlot . _gbHeader
+    getEpochOrSlot = getEpochOrSlot . _gbHeader
 
 instance HasEpochOrSlot (GenesisBlock ssc) where
-    _getEpochOrSlot = _getEpochOrSlot . _gbHeader
+    getEpochOrSlot = getEpochOrSlot . _gbHeader
 
 instance (HasEpochOrSlot a, HasEpochOrSlot b) =>
          HasEpochOrSlot (Either a b) where
-    _getEpochOrSlot = either _getEpochOrSlot _getEpochOrSlot
+    getEpochOrSlot = either getEpochOrSlot getEpochOrSlot
 
 ----------------------------------------------------------------------------
 -- HasHeaderHash

--- a/src/Pos/Update/Logic/Global.hs
+++ b/src/Pos/Update/Logic/Global.hs
@@ -37,7 +37,8 @@ import           Pos.Update.Poll      (BlockVersionState, ConfirmedProposalState
                                        execRollT, processGenesisBlock,
                                        recordBlockIssuance, rollbackUS, runDBPoll,
                                        runPollT, verifyAndApplyUSPayload, verifyBlockSize)
-import           Pos.Util             (NE, NewestFirst, OldestFirst, inAssertMode)
+import           Pos.Util             (NE, NewestFirst, OldestFirst, Some (..),
+                                       inAssertMode)
 import qualified Pos.Util.Modifier    as MM
 
 type USGlobalApplyMode ssc m = ( WithLogger m
@@ -114,7 +115,7 @@ verifyBlock (Right blk) =
     execRollT $ do
         verifyAndApplyUSPayload
             True
-            (Right $ blk ^. gbHeader)
+            (Right $ Some (blk ^. gbHeader))
             (blk ^. gbBody . mbUpdatePayload)
         -- Block issuance can't affect verification and application of US
         -- payload, so it's fine to separate it. Note, however, that it's

--- a/src/Pos/Update/Logic/Global.hs
+++ b/src/Pos/Update/Logic/Global.hs
@@ -116,11 +116,10 @@ verifyBlock (Right blk) =
             True
             (Right $ blk ^. gbHeader)
             (blk ^. gbBody . mbUpdatePayload)
-        -- Block issuance can't affect verification and application of US payload,
-        -- so it's fine to separate it.
-        -- Note, however, that it's important to do it after
-        -- 'verifyAndApplyUSPayload', because there we assume that block
-        -- version is confirmed.
+        -- Block issuance can't affect verification and application of US
+        -- payload, so it's fine to separate it. Note, however, that it's
+        -- important to do it after 'verifyAndApplyUSPayload', because there
+        -- we assume that block version is confirmed.
         let leaderPk = blk ^. gbHeader . gbhConsensus . mcdLeaderKey
         recordBlockIssuance
             (addressHash leaderPk)

--- a/src/Pos/Update/Poll/Logic/Apply.hs
+++ b/src/Pos/Update/Poll/Logic/Apply.hs
@@ -21,16 +21,15 @@ import           Universum
 import           Pos.Constants                 (blkSecurityParam, genesisUpdateImplicit,
                                                 genesisUpdateProposalThd,
                                                 genesisUpdateVoteThd)
-import           Pos.Crypto                    (hash, shortHashF)
-import           Pos.Ssc.Class                 (Ssc)
-import           Pos.Types                     (ChainDifficulty, Coin, EpochIndex,
-                                                HeaderHash, MainBlockHeader,
+import           Pos.Core                      (ChainDifficulty, Coin, EpochIndex,
+                                                HeaderHash, IsMainHeader (..),
                                                 SlotId (siEpoch), SoftwareVersion (..),
                                                 addressHash, applyCoinPortion,
-                                                coinToInteger, difficultyL, epochIndexL,
-                                                flattenSlotId, gbhExtra, headerHash,
-                                                headerSlot, mehBlockVersion, sumCoins,
-                                                unflattenSlotId, unsafeIntegerToCoin)
+                                                blockVersionL, coinToInteger, difficultyL,
+                                                epochIndexL, flattenSlotId, headerHashG,
+                                                sumCoins, unflattenSlotId,
+                                                unsafeIntegerToCoin)
+import           Pos.Crypto                    (hash, shortHashF)
 import           Pos.Update.Core               (UpId, UpdatePayload (..),
                                                 UpdateProposal (..), UpdateVote (..))
 import           Pos.Update.Poll.Class         (MonadPoll (..), MonadPollRead (..))
@@ -46,6 +45,7 @@ import           Pos.Update.Poll.Types         (ConfirmedProposalState (..),
                                                 ProposalState (..),
                                                 UndecidedProposalState (..),
                                                 UpsExtra (..), psProposal)
+import           Pos.Util.Util                 (Some (..))
 
 type ApplyMode m = (MonadError PollVerFailure m, MonadPoll m)
 
@@ -60,8 +60,8 @@ type ApplyMode m = (MonadError PollVerFailure m, MonadPoll m)
 -- When it is 'Right header', it means that payload from block with
 -- given header is applied.
 verifyAndApplyUSPayload
-    :: forall ssc m . (ApplyMode m, Ssc ssc)
-    => Bool -> Either SlotId (MainBlockHeader ssc) -> UpdatePayload -> m ()
+    :: ApplyMode m
+    => Bool -> Either SlotId (Some IsMainHeader) -> UpdatePayload -> m ()
 verifyAndApplyUSPayload considerPropThreshold slotOrHeader UpdatePayload {..} = do
     -- First of all, we verify data from header.
     either (const pass) verifyHeader slotOrHeader
@@ -78,8 +78,9 @@ verifyAndApplyUSPayload considerPropThreshold slotOrHeader UpdatePayload {..} = 
     -- Then we also apply votes from other groups.
     -- ChainDifficulty is needed, because proposal may become approved
     -- and then we'll need to track whether it becomes confirmed.
-    let cd = (,) <$> either (const Nothing) (Just . view difficultyL) slotOrHeader
-                 <*> either (const Nothing) (Just . headerHash) slotOrHeader
+    let cd = case slotOrHeader of
+            Left  _ -> Nothing
+            Right h -> Just (h ^. difficultyL, h ^. headerHashG)
     mapM_ (verifyAndApplyVotesGroup cd) otherGroups
     -- If we are applying payload from block, we also check implicit
     -- agreement rule and depth of decided proposals (they can become
@@ -88,20 +89,20 @@ verifyAndApplyUSPayload considerPropThreshold slotOrHeader UpdatePayload {..} = 
         Left _ -> pass
         Right mainBlk -> do
             applyImplicitAgreement
-                (mainBlk ^. headerSlot)
+                (mainBlk ^. headerSlotL)
                 (mainBlk ^. difficultyL)
-                (headerHash mainBlk)
+                (mainBlk ^. headerHashG)
             applyDepthCheck
-                (headerHash mainBlk)
+                (mainBlk ^. headerHashG)
                 (mainBlk ^. difficultyL)
 
 -- Here we verify all US-related data from header.
 verifyHeader
-    :: (MonadError PollVerFailure m, MonadPoll m)
-    => MainBlockHeader __ -> m ()
+    :: (MonadError PollVerFailure m, MonadPoll m, IsMainHeader mainHeader)
+    => mainHeader -> m ()
 verifyHeader header = do
     lastAdopted <- getAdoptedBV
-    let versionInHeader = header ^. gbhExtra ^. mehBlockVersion
+    let versionInHeader = header ^. blockVersionL
     unlessM (canCreateBlockBV versionInHeader) $
         throwError
             PollWrongHeaderBlockVersion
@@ -137,10 +138,9 @@ resolveVoteStake epoch totalStake UpdateVote {..} = do
 -- If all checks pass, proposal is added. It can be in undecided or decided
 -- state (if it has enough voted stake at once).
 verifyAndApplyProposal
-    :: forall ssc m.
-       (MonadError PollVerFailure m, MonadPoll m, Ssc ssc)
+    :: (MonadError PollVerFailure m, MonadPoll m)
     => Bool
-    -> Either SlotId (MainBlockHeader ssc)
+    -> Either SlotId (Some IsMainHeader)
     -> [UpdateVote]
     -> UpdateProposal
     -> m ()

--- a/src/Pos/Update/Poll/Logic/Apply.hs
+++ b/src/Pos/Update/Poll/Logic/Apply.hs
@@ -152,7 +152,8 @@ verifyAndApplyProposal considerThreshold slotOrHeader votes up@UpdateProposal {.
     -- Here we verify consistency with regards to data from 'BlockVersionState'
     -- and update relevant state if necessary.
     verifyAndApplyProposalBVS upId up
-    -- Then we verify that protocol version from proposal can follow last adopted software version.
+    -- Then we verify that protocol version from proposal can follow last
+    -- adopted software version.
     verifyBlockVersion upId up
     -- We also verify that software version is expected one.
     verifySoftwareVersion upId up

--- a/src/Pos/Update/Poll/Logic/Normalize.hs
+++ b/src/Pos/Update/Poll/Logic/Normalize.hs
@@ -15,9 +15,9 @@ import           System.Wlog                 (logWarning)
 import           Universum
 
 import           Pos.Constants               (genesisUpdateProposalThd)
+import           Pos.Core                    (Coin, EpochIndex, IsMainHeader, SlotId,
+                                              applyCoinPortion)
 import           Pos.Crypto                  (PublicKey, hash)
-import           Pos.Ssc.Class               (Ssc)
-import           Pos.Types                   (Coin, EpochIndex, SlotId, applyCoinPortion)
 import           Pos.Update.Core             (LocalVotes, UpId, UpdateProposals,
                                               UpdateVote (..))
 import           Pos.Update.Poll.Class       (MonadPoll (..), MonadPollRead (..))
@@ -33,23 +33,23 @@ import           Pos.Util                    (getKeys)
 -- state, i. e. remove everything that is invalid. Valid data is
 -- applied.  This function doesn't consider 'genesisUpdateProposalThd'.
 normalizePoll
-    :: forall ssc m . (MonadPoll m, Ssc ssc)
+    :: MonadPoll m
     => SlotId
     -> UpdateProposals
     -> LocalVotes
     -> m (UpdateProposals, LocalVotes)
 normalizePoll slot proposals votes =
-    (,) <$> normalizeProposals @ssc slot proposals <*> normalizeVotes votes
+    (,) <$> normalizeProposals slot proposals <*> normalizeVotes votes
 
 -- Apply proposals which can be applied and put them in result.
 -- Disregard other proposals.
 normalizeProposals
-    :: forall ssc m . (MonadPoll m, Ssc ssc)
+    :: MonadPoll m
     => SlotId -> UpdateProposals -> m UpdateProposals
 normalizeProposals slotId (toList -> proposals) =
     HM.fromList . map (\x->(hash x, x)) . map fst . catRights proposals <$>
     forM proposals
-        (runExceptT . verifyAndApplyProposal @ssc False (Left slotId) [])
+        (runExceptT . verifyAndApplyProposal False (Left slotId) [])
 
 -- Apply votes which can be applied and put them in result.
 -- Disregard other votes.

--- a/src/Pos/Util.hs
+++ b/src/Pos/Util.hs
@@ -8,10 +8,9 @@
 
 module Pos.Util
        (
---         export it when it actually reexports something apart from instances
---         module Pos.Util.Util
+         module Pos.Util.Util
        -- * Stuff for testing and benchmarking
-         module Pos.Util.Arbitrary
+       , module Pos.Util.Arbitrary
        , module Pos.Util.TimeLimit
 
        -- * Various
@@ -105,7 +104,7 @@ import           Pos.Binary.Class                 (Bi)
 import           Pos.Util.Arbitrary
 import           Pos.Util.NotImplemented          ()
 import           Pos.Util.TimeLimit
-import           Pos.Util.Util                    ()
+import           Pos.Util.Util
 
 mappendPair :: (Monoid a, Monoid b) => (a, b) -> (a, b) -> (a, b)
 mappendPair = (uncurry (***)) . (mappend *** mappend)


### PR DESCRIPTION
In this PR:

* Created classes `IsHeader`, `IsMainHeader` and `IsGenesisHeader`
* Removed dependency on `MainBlockHeader` in `Pos.Update.Poll.Logic.*`

The rest will be done after this PR is merged because I don't want to have to keep up with `master` endlessly.

@gromakovsky should I move `Pos.Update.Poll.Logic` to `update/` in this PR? If yes, pick a module name. (`Pos.Update.Core.Poll.Logic`?)