### PR TITLE
[CSL-886] Fix handlerspec

### DIFF
--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -103,9 +103,9 @@ instance Buildable PeerId where
     build (PeerId bs) = bprint base16F bs
 
 data HandlerSpec
-  = ConvHandler { hsReplyType :: MessageName }
-  | OneMsgHandler
-  | UnknownHandler Word8 ByteString
+    = ConvHandler { hsReplyType :: MessageName}
+    | OneMsgHandler
+    | UnknownHandler Word8 ByteString
     deriving (Show, Generic, Eq)
 
 convH :: (Message snd, Message rcv) => Proxy snd -> Proxy rcv -> (MessageName, HandlerSpec)
@@ -135,8 +135,7 @@ data VerInfo = VerInfo
     , vIBlockVersion :: BlockVersion
     , vIInHandlers   :: HandlerSpecs
     , vIOutHandlers  :: HandlerSpecs
-    }
-  deriving (Eq, Generic, Show)
+    } deriving (Eq, Generic, Show)
 
 instance Buildable VerInfo where
     build VerInfo {..} = bprint ("VerInfo { magic="%hex%", blockVersion="

--- a/src/Pos/Binary/Communication.hs
+++ b/src/Pos/Binary/Communication.hs
@@ -14,9 +14,10 @@ import           Formatting                       (int, sformat, (%))
 import           Node.Message                     (MessageName (..))
 
 import           Pos.Binary.Class                 (Bi (..), UnsignedVarInt (..),
-                                                   decodeOrFail, encodeStrict,
-                                                   getRemainingByteString, getWithLength,
-                                                   putWithLength)
+                                                   decodeFull, encodeStrict,
+                                                   getRemainingByteString,
+                                                   getSmallWithLength, getWithLength,
+                                                   putSmallWithLength, putWithLength)
 import           Pos.Block.Network.Types          (MsgBlock (..), MsgGetBlocks (..),
                                                    MsgGetHeaders (..), MsgHeaders (..))
 import           Pos.Communication.Types          (SysStartRequest (..),
@@ -132,17 +133,20 @@ instance Bi VoteMsgTag where
 instance Bi HandlerSpec where
     put OneMsgHandler = putWord8 0
     put (ConvHandler (MessageName m)) =
-        case decodeOrFail $ BSL.fromStrict m of
-            Right (_, _, UnsignedVarInt a) | a < 64 -> putWord8 (0x40 .|. (fromIntegral (a :: Word) .&. 0x3f))
-            _ -> putWord8 0x01 <> putWithLength (put m)
+        case decodeFull $ BSL.fromStrict m of
+            Right (UnsignedVarInt a)
+                | a < 64 -> putWord8 (0x40 .|. (fromIntegral (a :: Word) .&. 0x3f))
+            _ -> putWord8 1 >> putSmallWithLength (put m)
     put (UnknownHandler t b) =
-        putWord8 t <>
-        putWithLength (putByteString b)
+        putWord8 t >> putSmallWithLength (putByteString b)
     get = label "HandlerSpec" $ getWord8 >>= \case
         0                        -> pure OneMsgHandler
-        0x1                      -> getWithLength (ConvHandler <$> get)
-        t | (t .&. 0xc0) == 0x40 -> pure $ ConvHandler $ MessageName $ encodeStrict $ UnsignedVarInt (fromIntegral (t .&. 0x3f) :: Word)
-          | otherwise            -> getWithLength (UnknownHandler t <$> getRemainingByteString)
+        1                        -> getSmallWithLength (ConvHandler <$> get)
+        t | (t .&. 0xc0) == 0x40 ->
+            pure . ConvHandler . MessageName . encodeStrict $
+            UnsignedVarInt (fromIntegral (t .&. 0x3f) :: Word)
+          | otherwise            ->
+            getSmallWithLength (UnknownHandler t <$> getRemainingByteString)
 
 instance Bi VerInfo where
     put VerInfo {..} = put vIMagic

--- a/test/Test/Pos/Arbitrary/Infra/Communication.hs
+++ b/test/Test/Pos/Arbitrary/Infra/Communication.hs
@@ -27,7 +27,7 @@ instance Arbitrary HandlerSpec where
     arbitrary = oneof
         [ ConvHandler <$> arbitrary
         , pure OneMsgHandler
-        , UnknownHandler <$> choose (2, 255) <*> arbitrary
+        , UnknownHandler <$> choose (128, 255) <*> arbitrary
         ]
 
 derive makeArbitrary ''VerInfo


### PR DESCRIPTION
The problem was in two things:
1. `Arbitrary` for `UnknownHandler` was having wrong range of first byte.
2. `decodeOrFail` was used instead of `decodeFull` in `HandlerSpec` binary instance.

I've also replaced `get/putWithLength` to `get/putSmallWithLength` because it saves us 2-3 bytes per message and also length of handler won't be bigger than 2^14 (which is upper bound for "small" lists).