### PR TITLE
Improve clean util script

### DIFF
--- a/util-scripts/clean.sh
+++ b/util-scripts/clean.sh
@@ -1,4 +1,4 @@
 stack clean --full --nix
 rm -rf .stack-wok
 stack --nix clean cardano-sl
-rm -rf run/* wallet-db/ *key daedalus/src/Generated/ db-abc/* node-*
+rm -rf run/* wallet-db/ *key daedalus/src/Generated/ db-abc/* node-* daedalus/.psci_modules/ daedalus/.pulp-cache/ daedalus/node_modules/ daedalus/bower_components/ daedalus/output/


### PR DESCRIPTION
This PR improves `clean.sh` util script which should fix this issue:

```
Unable to find a suitable version for purescript-eff, please choose one by typing one of the numbers below:
    1) purescript-eff#^1.0.0 which resolved to 1.0.0 and is required by purescript-console#1.0.0, purescript-eff-functions#1.0.0, purescript-exceptions#1.0.0, purescript-now#1.0.0, purescript-refs#1.0.0, purescript-st#1.0.0, purescript-var#0.2.0, purescript-websocket-simple#0.5.0
    2) purescript-eff#^2.0.0 which resolved to 2.0.0 and is required by purescript-console#2.0.0, purescript-eff-functions#2.0.0, purescript-exceptions#2.0.0, purescript-now#2.0.0, purescript-refs#2.0.0, purescript-refs#2.0.0, purescript-st#2.0.0, purescript-var#1.0.0, purescript-websocket-simple#1.0.1

Prefix the choice with ! to persist it to bower.json
? Answer 
```