### PR TITLE
Fix/csm 152 fix wallet rest api calls

### DIFF
--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -134,10 +134,10 @@ updateTransaction :: forall eff. CAddress -> CTxId -> CTxMeta -> Aff (ajax :: AJ
 updateTransaction addr ctxId = postRBody ["txs", "payments", _address addr, _ctxIdValue ctxId]
 
 getHistory :: forall eff. CAddress -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-getHistory addr skip limit = getR ["txs", "histories", _address addr, show skip, show limit]
+getHistory addr skip limit = getR ["txs", "histories", _address addr, "?skip=",show skip, "&skip=",show limit]
 
 searchHistory :: forall eff. CAddress -> String -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search, show skip, show limit]
+searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search, "?skip=",show skip, "&skip=",show limit]
 --------------------------------------------------------------------------------
 -- UPDATES ---------------------------------------------------------------------
 nextUpdate :: forall eff. Aff (ajax :: AJAX | eff) CUpdateInfo

--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -134,10 +134,10 @@ updateTransaction :: forall eff. CAddress -> CTxId -> CTxMeta -> Aff (ajax :: AJ
 updateTransaction addr ctxId = postRBody ["txs", "payments", _address addr, _ctxIdValue ctxId]
 
 getHistory :: forall eff. CAddress -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-getHistory addr skip limit = getR ["txs", "histories", _address addr, "?skip=",show skip, "&limit=",show limit]
+getHistory addr skip limit = getR ["txs", "histories", _address addr <> "?skip=" <> show skip <> "&limit=" <> show limit]
 
 searchHistory :: forall eff. CAddress -> String -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search, "?skip=",show skip, "&limit=",show limit]
+searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search <> "?skip=" <> show skip <> "&limit=" <> show limit]
 --------------------------------------------------------------------------------
 -- UPDATES ---------------------------------------------------------------------
 nextUpdate :: forall eff. Aff (ajax :: AJAX | eff) CUpdateInfo

--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -134,10 +134,10 @@ updateTransaction :: forall eff. CAddress -> CTxId -> CTxMeta -> Aff (ajax :: AJ
 updateTransaction addr ctxId = postRBody ["txs", "payments", _address addr, _ctxIdValue ctxId]
 
 getHistory :: forall eff. CAddress -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-getHistory addr skip limit = getR ["txs", "histories", _address addr, "?skip=",show skip, "&skip=",show limit]
+getHistory addr skip limit = getR ["txs", "histories", _address addr, "?skip=",show skip, "&limit=",show limit]
 
 searchHistory :: forall eff. CAddress -> String -> Int -> Int -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search, "?skip=",show skip, "&skip=",show limit]
+searchHistory addr search skip limit = getR ["txs", "histories", _address addr, search, "?skip=",show skip, "&limit=",show limit]
 --------------------------------------------------------------------------------
 -- UPDATES ---------------------------------------------------------------------
 nextUpdate :: forall eff. Aff (ajax :: AJAX | eff) CUpdateInfo


### PR DESCRIPTION
There is a different behavior when calling from _Daedalus_ client, **skip** and **limit** are now optional.
The wallet api should reflect that.