### PR TITLE
Feature/add test reset sl02

### DIFF
--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -138,3 +138,6 @@ importKey = postRBody ["import_key"]
 
 syncProgress :: forall eff. Aff (ajax :: AJAX | eff) SyncProgress
 syncProgress = getR ["sync_progress"]
+
+testReset :: forall eff. Aff (ajax :: AJAX | eff) Unit
+testReset = postR ["test_reset"]

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -159,3 +159,6 @@ importKey = mkEffFn1 $ fromAff <<< map encodeJson <<< B.importKey
 
 syncProgress :: forall eff. Eff (ajax :: AJAX | eff) (Promise Json)
 syncProgress = fromAff $ map encodeJson B.syncProgress
+
+testReset :: forall eff. Eff (ajax :: AJAX | eff) (Promise Unit)
+testReset = fromAff B.testReset

--- a/src/Pos/Wallet/KeyStorage.hs
+++ b/src/Pos/Wallet/KeyStorage.hs
@@ -194,9 +194,7 @@ instance (MonadIO m, MonadThrow m) =>
     addSecretKey sk =
         whenM (not . elem sk <$> use usKeys) $
             usKeys <>= [sk]
-    deleteSecretKey (fromIntegral -> i)
-        | i == 0 = throwM $ PrimaryKey "Cannot delete a primary secret key"
-        | otherwise = usKeys %= deleteAt i
+    deleteSecretKey (fromIntegral -> i) = usKeys %= deleteAt i
 
 -- | Derived instances for ancestors in monad stack
 deriving instance MonadKeys m => MonadKeys (SscHolder ssc m)

--- a/src/Pos/Wallet/Web/Api.hs
+++ b/src/Pos/Wallet/Web/Api.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP           #-}
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -21,6 +22,10 @@ import           Universum
 
 -- | Servant API which provides access to wallet.
 type WalletApi =
+#ifdef DEV_MODE
+     "api" :> "test_reset" :> Post '[JSON] (Either WalletError ())
+    :<|>
+#endif
      "api" :> "get_wallet" :> Capture "address" CAddress :> Get '[JSON] (Either WalletError CWallet)
     :<|>
      "api" :> "get_wallets" :> Get '[JSON] (Either WalletError [CWallet])

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -477,8 +477,8 @@ testResetAll :: WalletWebMode ssc m => m ()
 testResetAll = deleteAllKeys >> testReset
   where
     deleteAllKeys = do
-        keyNum <- fromIntegral . pred . length <$> getSecretKeys
-        sequence_ $ replicate keyNum $ deleteSecretKey 1
+        keyNum <- length <$> getSecretKeys
+        sequence_ $ replicate keyNum $ deleteSecretKey 0
 #endif
 
 ---------------------------------------------------------------------------

--- a/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/src/Pos/Wallet/Web/State/Acidic.hs
@@ -19,6 +19,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetUpdates (..)
        , GetNextUpdate (..)
        , GetHistoryCache (..)
+       , TestReset (..)
        , CreateWallet (..)
        , SetProfile (..)
        , SetWalletMeta (..)
@@ -70,7 +71,8 @@ tidyState = tidyExtendedState
 
 makeAcidic ''WalletStorage
     [
-      'WS.getProfile
+      'WS.testReset
+    , 'WS.getProfile
     , 'WS.getWalletMetas
     , 'WS.getWalletMeta
     , 'WS.getTxMeta

--- a/src/Pos/Wallet/Web/State/State.hs
+++ b/src/Pos/Wallet/Web/State/State.hs
@@ -20,6 +20,7 @@ module Pos.Wallet.Web.State.State
        , getHistoryCache
 
        -- * Setters
+       , testReset
        , createWallet
        , setProfile
        , setWalletMeta
@@ -127,3 +128,6 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 
 updateHistoryCache :: WebWalletModeDB m => CAddress -> HeaderHash -> Utxo -> [TxHistoryEntry] -> m ()
 updateHistoryCache cAddr h utxo = updateDisk . A.UpdateHistoryCache cAddr h utxo
+
+testReset :: WebWalletModeDB m => m ()
+testReset = updateDisk A.TestReset

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -25,9 +25,11 @@ module Pos.Wallet.Web.State.Storage
        , addUpdate
        , removeNextUpdate
        , updateHistoryCache
+       , testReset
        ) where
 
 import           Control.Lens               (at, ix, makeClassy, (%=), (.=), _Just, _head)
+import           Control.Monad.State.Class  (put)
 import           Data.Default               (Default, def)
 import           Data.SafeCopy              (base, deriveSafeCopySimple)
 import           Pos.Types                  (HeaderHash, Utxo)
@@ -120,6 +122,9 @@ removeNextUpdate = wsReadyUpdates %= drop 1
 
 updateHistoryCache :: CAddress -> HeaderHash -> Utxo -> [TxHistoryEntry] -> Update ()
 updateHistoryCache cAddr cHash utxo cTxs = wsHistoryCache . at cAddr .= Just (cHash, utxo, cTxs)
+
+testReset :: Update ()
+testReset = put def
 
 deriveSafeCopySimple 0 'base ''CProfile
 deriveSafeCopySimple 0 'base ''CHash


### PR DESCRIPTION
This cherry picks test reset from master to sl-02. There was one more problem that is fixed in master regarding how primary private key works. In master it is allowed to delete it, in sl-02 wasn't allowed so I set its allowed to delete it in `sl-02` as well (that's the last commit). With this we can normally run `testReset` in sl-02 .