### PR TITLE
Chore/csm 162 improve util scripts for daedalus bridge

### DIFF
--- a/util-scripts/build-daedalus-bridge.sh
+++ b/util-scripts/build-daedalus-bridge.sh
@@ -1,7 +1,4 @@
-stack clean --full
-rm -rf .stack-wok
-stack clean cardano-sl
-rm -rf run/* wallet-db/ *key daedalus/src/Generated/
+./util-scripts/clean.sh
 stack build
 stack exec -- cardano-wallet-hs2purs
 cd daedalus && npm install && npm run build:prod && npm link

--- a/util-scripts/start-dev.sh
+++ b/util-scripts/start-dev.sh
@@ -1,0 +1,1 @@
+WALLET_TEST=1 ./scripts/launch.sh


### PR DESCRIPTION
This PR fixes the broken `util-scripts/build-daedalus-bridge.sh` by re-using the existing `clean.sh` script instead of custom logic. It also adds a new simple script to launch cardano nodes in dev mode for our convenience.