### PR TITLE
[CSM-169] Added function(s) for iterating all blocks matching predicate.

### DIFF
--- a/src/Pos/DB/Block.hs
+++ b/src/Pos/DB/Block.hs
@@ -16,6 +16,7 @@ module Pos.DB.Block
        -- * Load data
        , loadBlundsWhile
        , loadBlundsByDepth
+       , loadBlundsMatching
        , loadBlocksWhile
        , loadHeadersWhile
        , loadHeadersByDepth
@@ -102,6 +103,31 @@ loadDataWhile getter predicate start = NewestFirst <$> doIt start
                 then (d :) <$> doIt prev
                 else pure []
 
+-- Return all blocks that match the given predicate. It is repetetive,
+-- but it's also already pretty generic.
+loadDataMatching
+    :: forall m a .
+       (Monad m, HasPrevBlock a)
+    => (HeaderHash -> m a)
+    -> (a -> Bool)
+    -> HeaderHash
+    -> m (NewestFirst [] a)
+loadDataMatching getter predicate start = NewestFirst <$> doIt start []
+  where
+    doIt :: HeaderHash -> [HeaderHash] -> m [a]
+    doIt h acc
+        -- When we reach the genesis block, return the accumulator.
+        | h == genesisHash = sequence $ getter <$> acc
+        -- Otherwise iterate back from the top block (called tip) and add all
+        -- blocks (hash) to accumulator satisfying the predicate.
+        | otherwise = do
+            d <- getter h
+            let prev = d ^. prevBlockL
+            if predicate d
+                then doIt prev (h : acc)
+                else doIt prev acc
+
+
 -- For depth 'd' load blocks that have depth < 'd'. Given header
 -- (newest one) is assumed to have depth 0.
 loadDataByDepth
@@ -134,6 +160,13 @@ loadDataByDepth getter extraPredicate depth h = do
         getter
         (\a -> a ^. difficultyL >= targetDifficulty && extraPredicate a)
         prev
+
+-- | Load blunds starting from block with header hash equal to given hash
+-- and returns all blunds for which @predicate@ is true.
+loadBlundsMatching
+    :: (SscHelpersClass ssc, MonadDB m)
+    => (Block ssc -> Bool) -> HeaderHash -> m (NewestFirst [] (Blund ssc))
+loadBlundsMatching predicate = loadDataMatching getBlundThrow (predicate . fst)
 
 -- | Load blunds starting from block with header hash equal to given hash
 -- and while @predicate@ is true.

--- a/src/Pos/DB/Block.hs
+++ b/src/Pos/DB/Block.hs
@@ -103,7 +103,7 @@ loadDataWhile getter predicate start = NewestFirst <$> doIt start
                 then (d :) <$> doIt prev
                 else pure []
 
--- Return all blocks that match the given predicate. It is repetetive,
+-- | Return all blocks that match the given predicate. It is repetetive,
 -- but it's also already pretty generic.
 loadDataMatching
     :: forall m a .
@@ -112,19 +112,19 @@ loadDataMatching
     -> (a -> Bool)
     -> HeaderHash
     -> m (NewestFirst [] a)
-loadDataMatching getter predicate start = NewestFirst <$> doIt start []
+loadDataMatching getter predicate start = NewestFirst <$> doIt start (pure [])
   where
-    doIt :: HeaderHash -> [HeaderHash] -> m [a]
+    doIt :: HeaderHash ->  m [a] -> m [a]
     doIt h acc
         -- When we reach the genesis block, return the accumulator.
-        | h == genesisHash = sequence $ getter <$> acc
+        | h == genesisHash = acc
         -- Otherwise iterate back from the top block (called tip) and add all
         -- blocks (hash) to accumulator satisfying the predicate.
         | otherwise = do
             d <- getter h
             let prev = d ^. prevBlockL
             if predicate d
-                then doIt prev (h : acc)
+                then doIt prev ((:) <$> pure d <*> acc)
                 else doIt prev acc
 
 

--- a/src/Pos/DB/DB.hs
+++ b/src/Pos/DB/DB.hs
@@ -8,6 +8,7 @@ module Pos.DB.DB
        , getTip
        , getTipBlock
        , getTipBlockHeader
+       , loadBlundsFromTipMatching
        , loadBlundsFromTipWhile
        , loadBlundsFromTipByDepth
        , sanityCheckDB
@@ -26,7 +27,8 @@ import           Pos.Block.Types                  (Blund)
 import           Pos.Context.Class                (WithNodeContext)
 import           Pos.Context.Functions            (genesisLeadersM)
 import           Pos.DB.Block                     (getBlock, loadBlundsByDepth,
-                                                   loadBlundsWhile, prepareBlockDB)
+                                                   loadBlundsWhile, prepareBlockDB,
+                                                   loadBlundsMatching)
 import           Pos.DB.Class                     (MonadDB)
 import           Pos.DB.Error                     (DBError (DBMalformed))
 import           Pos.DB.Functions                 (openDB)
@@ -90,7 +92,13 @@ getTipBlockHeader
     => m (BlockHeader ssc)
 getTipBlockHeader = getBlockHeader <$> getTipBlock
 
--- | Load blunds from BlockDB starting from tip and while the @condition@ is
+-- | Load blunds from BlockDB starting from tip and matching the @condition@.
+loadBlundsFromTipMatching
+    :: (SscHelpersClass ssc, MonadDB m)
+    => (Block ssc -> Bool) -> m (NewestFirst [] (Blund ssc))
+loadBlundsFromTipMatching condition = getTip >>= loadBlundsMatching condition
+
+-- | Load blunds from BlockDB starting from tip and matching the @condition@ is
 -- true.
 loadBlundsFromTipWhile
     :: (SscHelpersClass ssc, MonadDB m)


### PR DESCRIPTION
Added functions that support the (naive) way of fetching blocks by epoch/slot proposed by @gromakovsky.