### PR TITLE
[TW-134] 0.0.0.0 is neither default nor valid host

### DIFF
--- a/infra/Pos/Util/TimeWarp.hs
+++ b/infra/Pos/Util/TimeWarp.hs
@@ -10,6 +10,7 @@ module Pos.Util.TimeWarp
        , addressToNodeId'
        , nodeIdToAddress
        , addrParser
+       , addrParserNoWildcard
        ) where
 
 import qualified Data.ByteString.Char8 as BS8
@@ -50,3 +51,11 @@ nodeIdToAddress (NodeId ep) = do
 -- | Parsed for network address in format @host:port@.
 addrParser :: P.Parser NetworkAddress
 addrParser = (,) <$> (encodeUtf8 <$> P.host) <*> (P.char ':' *> P.port)
+
+-- | Parses an IPv4 NetworkAddress where the host is not 0.0.0.0.
+addrParserNoWildcard :: P.Parser NetworkAddress
+addrParserNoWildcard = do
+  (host, port) <- addrParser
+  if host == BS8.pack "0.0.0.0"
+  then empty
+  else return (host, port)

--- a/src/Pos/CLI.hs
+++ b/src/Pos/CLI.hs
@@ -50,7 +50,8 @@ import           Pos.DHT.Model.Types                  (DHTNode (..), dhtKeyParse
 import           Pos.Security.CLI                     (AttackTarget (..), AttackType (..))
 import           Pos.Ssc.SscAlgo                      (SscAlgo (..))
 import           Pos.Util                             ()
-import           Pos.Util.TimeWarp                    (NetworkAddress, addrParser)
+import           Pos.Util.TimeWarp                    (NetworkAddress, addrParser,
+                                                       addrParserNoWildcard)
 
 -- | Parse 'DHTNode's from a file (nodes should be separated by newlines).
 readPeersFile :: FilePath -> IO [DHTNode]
@@ -271,7 +272,7 @@ walletPortOption portNum help =
 
 ipPortOption :: NetworkAddress -> Opt.Parser NetworkAddress
 ipPortOption na =
-    Opt.option (fromParsec addrParser) $
+    Opt.option (fromParsec addrParserNoWildcard) $
             Opt.long "listen"
          <> Opt.metavar "IP:PORT"
          <> Opt.help helpMsg
@@ -281,4 +282,5 @@ ipPortOption na =
     helpMsg = "Ip and port on which to listen. "
         <> "Please mind that you need to specify actual accessible "
         <> "ip of host, at which node is run,"
-        <> " otherwise work of CSL is not guaranteed."
+        <> " otherwise work of CSL is not guaranteed. "
+        <> "0.0.0.0 is not accepted as a valid host."

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -45,7 +45,7 @@ import           Network.Transport.Concrete  (concrete)
 import qualified Network.Transport.TCP       as TCP
 import           Node                        (Node, NodeAction (..),
                                               defaultNodeEnvironment, hoistSendActions,
-                                              node)
+                                              node, simpleNodeEndPoint)
 import           Node.Util.Monitor           (setupMonitor, stopMonitor)
 import           Serokell.Util               (sec)
 import qualified STMContainers.Map           as SM
@@ -274,7 +274,7 @@ runServer transport packedLS_M (OutSpecs wouts) withNode afterNode (ActionSpec a
         listeners = listeners' ourVerInfo
     stdGen <- liftIO newStdGen
     logInfo $ sformat ("Our verInfo "%build) ourVerInfo
-    node (concrete transport) stdGen BiP (ourPeerId, ourVerInfo) defaultNodeEnvironment $ \__node ->
+    node (simpleNodeEndPoint (concrete transport)) stdGen BiP (ourPeerId, ourVerInfo) defaultNodeEnvironment $ \__node ->
         NodeAction listeners $ \sendActions -> do
             t <- withNode __node
             action ourVerInfo sendActions `finally` afterNode t

--- a/src/node/NodeOptions.hs
+++ b/src/node/NodeOptions.hs
@@ -94,7 +94,7 @@ argsParser = do
         help    (show backupPhraseWordsNum ++
                  "-word phrase to recover the wallet")
     ipPort <-
-        CLI.ipPortOption ("0.0.0.0", 3000)
+        CLI.ipPortOption ("127.0.0.1", 3000)
     supporterNode <- switch $
         long "supporter" <>
         help "Launch DHT supporter instead of full node"

--- a/src/smart-generator/GenOptions.hs
+++ b/src/smart-generator/GenOptions.hs
@@ -93,7 +93,7 @@ optionsParser = do
     goCommonArgs <-
         CLI.commonArgsParser "Initial DHT peer (may be many)"
     goIpPort <-
-        CLI.ipPortOption ("0.0.0.0", 24962)
+        CLI.ipPortOption ("127.0.0.1", 24962)
     return GenOptions{..}
 
 optsInfo :: ParserInfo GenOptions

--- a/src/wallet/WalletOptions.hs
+++ b/src/wallet/WalletOptions.hs
@@ -80,7 +80,7 @@ optionsParser = do
         help "If the DB already exist, discard its contents and \
              \create new one from scratch"
     woIpPort <-
-        CLI.ipPortOption ("0.0.0.0", 24961)   -- truly random value
+        CLI.ipPortOption ("127.0.0.1", 24961)
     woKeyFilePath <- strOption $
         long    "keys-path" <>
         metavar "FILEPATH" <>

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 2943e7814b9f78b9ef68c9bdc96820ed32a0fdf3
+    commit: e0a48924e7e308f1164168a81f67c0f25eaabda1
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,7 +44,7 @@ packages:
 # These two are needed for time-warp-nt
 - location:
     git: https://github.com/avieth/network-transport-tcp
-    commit: 1739cc6d5c73257201e5551088f4ba56d5ede15c
+    commit: 15847920ac1a32ada237e5a00ac4f56f3ca421a7
   extra-dep: true
 - location:
     git: https://github.com/avieth/network-transport


### PR DESCRIPTION
A node must not advertise its external address as 0.0.0.0.
First, because the host at which it is reached is assumed by time-warp
to match the host at which it claims to be reachable (the one in the
EndPointAddress).
Second, because with an upcoming patch to network-transport-tcp, any
EndPoint's reported host must match the host which its peer determines
from the TCP connection. This is a security measure, to prevent an easy
DOS attack where any node can deny service to another by claiming the
other's host.