### PR TITLE
[CSL-928] Make UnsignedVarInt decode fail for non-normalized varints

### DIFF
--- a/core/Pos/Binary/Class.hs
+++ b/core/Pos/Binary/Class.hs
@@ -171,20 +171,25 @@ putUnsignedVarInt n
           putUnsignedVarInt $ shiftR n 7
 {-# INLINE putUnsignedVarInt #-}
 
-getUnsignedVarInt' :: (Num a, Bits a) => Get a
-getUnsignedVarInt' = getWord8 >>= go
+getUnsignedVarInt' :: (Integral a, Bits a) => Get a
+getUnsignedVarInt' = do
+    (bytes, i) <- getWord8 >>= go
+    let iBytes = runPut $ putUnsignedVarInt i
+    if BSL.pack bytes /= iBytes
+       then fail $ "Ambigious varInt bytes: " ++ show bytes
+       else return i
   where
     go n | testBit n 7 = do
-             m <- getWord8 >>= go
-             return $ shiftL m 7 .|. clearBit (fromIntegral n) 7
-         | otherwise = return $ fromIntegral n
+             (bs, m) <- getWord8 >>= go
+             return (n:bs, shiftL m 7 .|. clearBit (fromIntegral n) 7)
+         | otherwise = return ([n], fromIntegral n)
 {-# INLINE getUnsignedVarInt' #-}
 
 putSignedVarInt :: (ZZEncode a b, Integral b, Bits b) => a -> Put
 putSignedVarInt x = putUnsignedVarInt (zzEncode x)
 {-# INLINE putSignedVarInt #-}
 
-getSignedVarInt' :: (ZZEncode a b, Num b, Bits b) => Get a
+getSignedVarInt' :: (ZZEncode a b, Integral b, Bits b) => Get a
 getSignedVarInt' = zzDecode <$> getUnsignedVarInt'
 {-# INLINE getSignedVarInt' #-}
 


### PR DESCRIPTION
Fix for CSL-928: allow only unambigious varint decode/encode