### PR TITLE
Add some flags to util-scripts/build.sh

### DIFF
--- a/util-scripts/build.sh
+++ b/util-scripts/build.sh
@@ -8,10 +8,11 @@ set -o pipefail
 #   build.sh core|db|update|infra|sl   build only a specific project
 #   build.sh -c                        stack clean
 #
-# * Do `touch .no-nix` if you want builds without Nix,
-#     or pass the --no-nix flag.
-# * Do `touch .ram` if you have lots of RAM and want to make builds faster,
-#     or pass the --ram flag.
+# * Pass --no-nix if you want builds without Nix,
+#     or do `touch .no-nix`.
+# * Pass --ram if you have lots of RAM and want to make builds faster,
+#     or do `touch .ram`.
+# * Pass --prod if you want to compile in production mode.
 
 # This script builds the project in a way that is convenient for developers.
 # Specifically, it does the following:
@@ -33,6 +34,7 @@ spec_prj=''
 
 no_nix=false
 ram=false
+prod=false
 
 if [ -e .no-nix ]; then
   no_nix=true
@@ -55,6 +57,9 @@ do
   # --ram = use more RAM
   elif [[ $var == "--ram" ]]; then
     ram=true
+  # --prod = compile in production mode
+  elif [[ $var == "--prod" ]]; then
+    prod=true
   # project name = build only the project
   elif [[ $var == "sl" ]]; then
     spec_prj="sl"
@@ -71,6 +76,11 @@ norun='--no-run-tests --no-run-benchmarks'
 
 if [[ $no_nix == true ]]; then
   commonargs="$commonargs --no-nix"
+fi
+
+if [[ $prod == true ]]; then
+  commonargs="$commonargs --flag cardano-sl-core:-dev-mode"
+  export CSL_SYSTEM_TAG=linux64
 fi
 
 if [[ $ram == true ]]; then

--- a/util-scripts/build.sh
+++ b/util-scripts/build.sh
@@ -80,7 +80,7 @@ else
 fi
 
 xperl='$|++; s/(.*) Compiling\s([^\s]+)\s+\(\s+([^\/]+).*/\1 \2/p'
-xgrep="(^.*warning.*$|^.*error.*$|^    .*$|^.*can't find source.*$|^Module imports form a cycle.*$|^  which imports.*$)|"
+xgrep="((^.*warning.*$|^.*error.*$|^    .*$|^.*can't find source.*$|^Module imports form a cycle.*$|^  which imports.*$)|^)"
 
 if [[ $clean == true ]]; then
   echo "Cleaning cardano-sl"

--- a/util-scripts/build.sh
+++ b/util-scripts/build.sh
@@ -8,7 +8,10 @@ set -o pipefail
 #   build.sh core|db|update|infra|sl   build only a specific project
 #   build.sh -c                        stack clean
 #
-# Do `touch .no-nix` if you want builds without Nix.
+# * Do `touch .no-nix` if you want builds without Nix,
+#     or pass the --no-nix flag.
+# * Do `touch .ram` if you have lots of RAM and want to make builds faster,
+#     or pass the --ram flag.
 
 # This script builds the project in a way that is convenient for developers.
 # Specifically, it does the following:
@@ -28,6 +31,16 @@ clean=false
 
 spec_prj=''
 
+no_nix=false
+ram=false
+
+if [ -e .no-nix ]; then
+  no_nix=true
+fi
+if [ -e .ram ]; then
+  ram=true
+fi
+
 for var in "$@"
 do
   # -t = run tests
@@ -36,6 +49,12 @@ do
   # -c = clean
   elif [[ $var == "-c" ]]; then
     clean=true
+  # --no-nix = don't use Nix
+  elif [[ $var == "--no-nix" ]]; then
+    no_nix=true
+  # --ram = use more RAM
+  elif [[ $var == "--ram" ]]; then
+    ram=true
   # project name = build only the project
   elif [[ $var == "sl" ]]; then
     spec_prj="sl"
@@ -47,12 +66,17 @@ do
   fi
 done
 
-# TODO: how can --ghc-options be moved into commonargs?
 commonargs='--test --no-haddock-deps --bench --jobs=4'
 norun='--no-run-tests --no-run-benchmarks'
 
-if [ -e .no-nix ]; then
+if [[ $no_nix == true ]]; then
   commonargs="$commonargs --no-nix"
+fi
+
+if [[ $ram == true ]]; then
+  ghc_opts="-Wwarn +RTS -A2G -n4m -RTS"
+else
+  ghc_opts="-Wwarn +RTS -A256m -n2m -RTS"
 fi
 
 xperl='$|++; s/(.*) Compiling\s([^\s]+)\s+\(\s+([^\/]+).*/\1 \2/p'
@@ -85,13 +109,13 @@ echo "Going to build: $to_build"
 for prj in $to_build; do
   echo "Building $prj"
   stack build                               \
-      --ghc-options="-Wwarn +RTS -A256m -n2m -RTS" \
+      --ghc-options="$ghc_opts"             \
       $commonargs $norun                    \
       --dependencies-only                   \
       $args                                 \
       $prj
   stack build                               \
-      --ghc-options="-Wwarn +RTS -A256m -n2m -RTS" \
+      --ghc-options="$ghc_opts"             \
       $commonargs $norun                    \
       --fast                                \
       $args                                 \
@@ -103,7 +127,7 @@ done
 
 if [[ $test == true ]]; then
   stack build                               \
-      --ghc-options="-Wwarn +RTS -A256m -n2m -RTS" \
+      --ghc-options="$ghc_opts"             \
       $commonargs                           \
       --no-run-benchmarks                   \
       --fast                                \


### PR DESCRIPTION
* `--ram` to increase build speed on computers with lots of RAM (at least 2–3 free GBs)
* `--prod` to build in production mode

Also it probably fixes `build.sh` on macOS, but not sure.