### PR TITLE
[CSM-151] Fix paper vend redeem validation

### DIFF
--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -185,4 +185,4 @@ isValidRedeemCode code = either (const false) (const $ endsWithEqual && 44 == le
 
 -- Valid postvend code is base58 encoded 32byte data
 isValidPostVendRedeemCode :: String -> Boolean
-isValidPostVendRedeemCode code = maybe false (const $ 44 == length code) $ B58.decode code
+isValidPostVendRedeemCode code = maybe false (const true) $ B58.decode code


### PR DESCRIPTION
Remove constraint that base58 paper vend redeem code should be 44 chars long

@volhovM and I thought it should be 44 chars long which is wrong (we have 43 chars codes)