### PR TITLE
[CSL-984] Eliminate time-slave and time-lord

### DIFF
--- a/core/Pos/Core/Constants.hs
+++ b/core/Pos/Core/Constants.hs
@@ -80,14 +80,20 @@ isDevelopment = True
 isDevelopment = False
 #endif
 
+-- | In development there's a system start.
+--   TBD why not 0? Judging by other uses of system start, only positive
+--   numbers are OK. Is that true?
+defaultDevelopmentSysStart :: Timestamp
+defaultDevelopmentSysStart = Timestamp $ sec 1
+
 -- | System start time embeded into binary.
-staticSysStart :: Maybe Timestamp
+staticSysStart :: Timestamp
 staticSysStart
-    | isDevelopment = Nothing
-    | st > 0        = Just $ Timestamp $ sec st
+    | isDevelopment = defaultDevelopmentSysStart
+    | st > 0        = Timestamp $ sec st
     -- If several local nodes are started within 20 sec,
     -- they'll have same start time
-    | otherwise     = Just $ Timestamp $ sec $
+    | otherwise     = Timestamp $ sec $
           (after3Mins `div` divider + alignment) * divider
   where
     st = ccProductionNetworkStartTime coreConstants

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -110,6 +110,7 @@ function node_cmd {
   local stake_distr=$5
   local wallet_args=$6
   local kademlia_dump_path=$7
+  local system_start=$8
   local st=''
   local reb=''
   local ssc_algo=''
@@ -159,6 +160,7 @@ function node_cmd {
   echo -n " $report_server "
   echo -n " $wallet_args "
   echo -n " --kademlia-dump-path  $(dump_path $kademlia_dump_path)"
+  echo -n " --system-start $system_start"
   # echo -n " --monitor-port $monitor_port +RTS -T -RTS "
   echo ''
 }

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -36,6 +36,11 @@ if [[ "$TPS" != "" ]]; then
   panesCnt=$((n+1))
 fi
 
+# System start time in seconds (time since epoch).
+system_start=`date +%s`
+
+echo "Using system start time "$system_start
+
 i=0
 while [[ $i -lt $panesCnt ]]; do
   im=$((i%4))
@@ -81,7 +86,7 @@ while [[ $i -lt $panesCnt ]]; do
   fi
 
   if [[ $i -lt $n ]]; then
-    tmux send-keys "$(node_cmd $i "$time_lord" "$dht_conf" "$stats" "$stake_distr" "$wallet_args" "$kademlia_dump_path")" C-m
+    tmux send-keys "$(node_cmd $i "$time_lord" "$dht_conf" "$stats" "$stake_distr" "$wallet_args" "$kademlia_dump_path" "$system_start")" C-m
   else
     tmux send-keys "NODE_COUNT=$n $base/bench/runSmartGen.sh 0 -R 1 -N 2 -t $TPS -S 3 --init-money 100000 --recipients-share 0" C-m
   fi

--- a/src/Pos/CLI.hs
+++ b/src/Pos/CLI.hs
@@ -22,6 +22,7 @@ module Pos.CLI
        , webPortOption
        , walletPortOption
        , ipPortOption
+       , sysStartParser
 
        , readPeersFile
        ) where
@@ -30,6 +31,7 @@ import           Control.Lens                         (zoom, (?=))
 import           Formatting                           (build, formatToString, shown, (%))
 import           Options.Applicative.Builder.Internal (HasMetavar, HasName)
 import qualified Options.Applicative.Simple           as Opt
+import           Serokell.Util                        (sec)
 import           Serokell.Util.OptParse               (fromParsec)
 import           System.Wlog                          (LoggerConfig (..),
                                                        Severity (Info, Warning),
@@ -41,9 +43,10 @@ import qualified Text.Parsec.String                   as P
 import           Universum
 
 import           Pos.Binary.Core                      ()
-import           Pos.Constants                        (isDevelopment)
+import           Pos.Constants                        (isDevelopment, staticSysStart)
 import           Pos.Core                             (Address (..), AddressHash,
                                                        decodeTextAddress)
+import           Pos.Core.Types                       (Timestamp (..))
 import           Pos.Crypto                           (PublicKey)
 import           Pos.DHT.Model.Types                  (DHTNode (..), dhtKeyParser,
                                                        dhtNodeParser)
@@ -122,6 +125,7 @@ data CommonArgs = CommonArgs
     , bitcoinDistr       :: !(Maybe (Int, Int))
     , richPoorDistr      :: !(Maybe (Int, Int, Integer, Double))
     , expDistr           :: !Bool
+    , sysStart           :: !Timestamp
     } deriving Show
 
 commonArgsParser :: String -> Opt.Parser CommonArgs
@@ -146,7 +150,14 @@ commonArgsParser peerHelpMsg = do
     richPoorDistr <- if isDevelopment then rnpDistrOptional  else pure Nothing
     expDistr      <- if isDevelopment then expDistrOption    else pure False
     --
+    sysStart      <- sysStartParser
     pure CommonArgs{..}
+
+sysStartParser :: Opt.Parser Timestamp
+sysStartParser = Opt.option (Timestamp . sec <$> Opt.auto) $
+    Opt.long    "system-start" <>
+    Opt.metavar "TIMESTAMP" <>
+    Opt.value   staticSysStart
 
 templateParser :: (HasName f, HasMetavar f) => String -> String -> String -> Opt.Mod f a
 templateParser long metavar help =

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -4,23 +4,24 @@ module Main where
 
 import           Data.List             ((!!))
 import           Data.Maybe            (fromJust)
-import           Mockable              (Production)
+import           Mockable              (Production, currentTime)
 import           Node                  (hoistSendActions)
-import           Serokell.Util         (sec)
 import           System.Wlog           (LoggerName, WithLogger, logInfo)
+import           Formatting            ((%), sformat, shown)
 import           Universum
 
 import           Pos.Binary            ()
+import           Pos.Core.Types        (Timestamp (..))
 import qualified Pos.CLI               as CLI
 import           Pos.Communication     (ActionSpec (..), OutSpecs, WorkerSpec, worker)
-import           Pos.Constants         (isDevelopment, staticSysStart)
+import           Pos.Constants         (isDevelopment)
 import           Pos.Crypto            (SecretKey, VssKeyPair, keyGen, vssKeyGen)
 import           Pos.Genesis           (genesisDevSecretKeys, genesisStakeDistribution,
                                         genesisUtxo)
 import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
                                         NodeParams (..), RealModeResources,
                                         bracketResources, runNodeProduction, runNodeStats,
-                                        runTimeLordReal, runTimeSlaveReal, stakesDistr)
+                                        stakesDistr)
 import           Pos.Shutdown          (triggerShutdown)
 import           Pos.Ssc.Class         (SscConstraint)
 import           Pos.Ssc.GodTossing    (GtParams (..), SscGodTossing,
@@ -28,7 +29,6 @@ import           Pos.Ssc.GodTossing    (GtParams (..), SscGodTossing,
 import           Pos.Ssc.NistBeacon    (SscNistBeacon)
 import           Pos.Ssc.SscAlgo       (SscAlgo (..))
 import           Pos.Statistics        (getNoStatsT, getStatsMap, runStatsT')
-import           Pos.Types             (Timestamp (Timestamp))
 import           Pos.Update.Context    (ucUpdateSemaphore)
 import           Pos.Update.Params     (UpdateParams (..))
 import           Pos.Util              (inAssertMode, mappendPair)
@@ -46,23 +46,6 @@ import           Pos.Wallet.Web        (walletServeWebFull, walletServerOuts)
 import           Pos.Util.Context      (askContext)
 
 import           NodeOptions           (Args (..), getNodeOptions)
-
-getSystemStart
-    :: SscConstraint ssc
-    => Proxy ssc -> RealModeResources -> Args -> Production Timestamp
-getSystemStart sscProxy inst args
-    | noSystemStart args > 0 = pure $ Timestamp $ sec $ noSystemStart args
-    | otherwise =
-        case staticSysStart of
-            Nothing ->
-                if timeLord args
-                    then runTimeLordReal (loggingParams "time-lord" args)
-                    else do params <- liftIO $ baseParams "time-slave" args
-                            runTimeSlaveReal
-                                sscProxy
-                                inst
-                                params
-            Just systemStart -> return systemStart
 
 loggingParams :: LoggerName -> Args -> LoggingParams
 loggingParams tag Args{..} =
@@ -89,9 +72,10 @@ baseParams loggingTag args@Args {..} = do
 
 action :: Args -> RealModeResources -> Production ()
 action args@Args {..} res = do
-    systemStart <- case CLI.sscAlgo commonArgs of
-                       GodTossingAlgo -> getSystemStart (Proxy :: Proxy SscGodTossing) res args
-                       NistBeaconAlgo -> getSystemStart (Proxy :: Proxy SscNistBeacon) res args
+    let systemStart = CLI.sysStart commonArgs
+    logInfo $ sformat ("System start time is " % shown) systemStart
+    t <- currentTime
+    logInfo $ sformat ("Current time is " % shown) (Timestamp t)
     currentParams <- getNodeParams args systemStart
     let vssSK = fromJust $ npUserSecret currentParams ^. usVss
         gtParams = gtSscParams args vssSK

--- a/src/node/NodeOptions.hs
+++ b/src/node/NodeOptions.hs
@@ -53,7 +53,6 @@ data Args = Args
 #endif
 #endif
     , commonArgs                :: !CLI.CommonArgs
-    , noSystemStart             :: !Int
     , updateLatestPath          :: !FilePath
     , updateWithPackage         :: !Bool
     , monitorPort               :: !(Maybe Int)
@@ -152,10 +151,6 @@ argsParser = do
 #endif
     commonArgs <-
         CLI.commonArgsParser peerHelpMsg
-    noSystemStart <- option auto $
-        long    "system-start" <>
-        metavar "TIMESTAMP" <>
-        value   (-1)
     updateLatestPath <- strOption $
         long    "update-latest-path" <>
         metavar "FILEPATH" <>

--- a/src/smart-generator/Main.hs
+++ b/src/smart-generator/Main.hs
@@ -30,8 +30,7 @@ import           Pos.Genesis                 (genesisUtxo)
 import           Pos.Launcher                (BaseParams (..), LoggingParams (..),
                                               NodeParams (..), RealModeResources,
                                               bracketResources, initLrc, runNode',
-                                              runProductionMode, runTimeSlaveReal,
-                                              stakesDistr)
+                                              runProductionMode, stakesDistr)
 import           Pos.Ssc.Class               (SscConstraint, SscParams)
 import           Pos.Ssc.GodTossing          (GtParams (..), SscGodTossing)
 import           Pos.Ssc.NistBeacon          (SscNistBeacon)
@@ -251,14 +250,8 @@ main = do
             }
 
     bracketResources baseParams $ \res -> do
-        let timeSlaveParams =
-                baseParams
-                { bpLoggingParams = logParams { lpRunnerTag = "time-slave" }
-                }
 
-        systemStart <- case CLI.sscAlgo goCommonArgs of
-            GodTossingAlgo -> runTimeSlaveReal (Proxy :: Proxy SscGodTossing) res timeSlaveParams
-            NistBeaconAlgo -> runTimeSlaveReal (Proxy :: Proxy SscNistBeacon) res timeSlaveParams
+        let systemStart = CLI.sysStart goCommonArgs
 
         let params =
                 NodeParams


### PR DESCRIPTION
The system start time is given as a command-line option.

Launch script is updated to use the current time for all of the nodes.

Getting the system start in the old style was clumsy: it involved spawning a `node` temporarily, with stub listeners, and made necessary a hack in which nodes would try to splice in `0` and then `1` as the `EndPointId` of the peer, because it would be `1` if and only if the thing was originally a time-slave but had found the time. Now there's only one `node` spawned. `EndPointAddress`es are still hacked together from the Kademlia addresses but the situation is slightly better.

There's certainly more fat that could be trimmed (sys start workers and listeners, stub listeners, etc.) but I can do that if/once this patch is accepted.

Some context: I'm in the process of abstracting the discovery mechanism (we don't want to assume that some DHT is used) and this change is a small preliminary step. It means that there is one definite `NodeId` for each process, which is a useful fact for the discovery system.