### PR TITLE
[CSM-197] Add genesis key to the set of spending keys in dev mode

### DIFF
--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -14,7 +14,8 @@ import           Pos.Binary            ()
 import qualified Pos.CLI               as CLI
 import           Pos.Communication     (ActionSpec (..), OutSpecs, WorkerSpec, worker)
 import           Pos.Constants         (isDevelopment, staticSysStart)
-import           Pos.Crypto            (SecretKey, VssKeyPair, keyGen, vssKeyGen)
+import           Pos.Crypto            (SecretKey, VssKeyPair, keyGen, noPassEncrypt,
+                                        vssKeyGen)
 import           Pos.Genesis           (genesisDevSecretKeys, genesisStakeDistribution,
                                         genesisUtxo)
 import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
@@ -33,8 +34,8 @@ import           Pos.Update.Context    (ucUpdateSemaphore)
 import           Pos.Update.Params     (UpdateParams (..))
 import           Pos.Util              (inAssertMode, mappendPair)
 import           Pos.Util.BackupPhrase (keysFromPhrase)
-import           Pos.Util.UserSecret   (UserSecret, peekUserSecret, usPrimKey, usVss,
-                                        writeUserSecret)
+import           Pos.Util.UserSecret   (UserSecret, peekUserSecret, usKeys, usPrimKey,
+                                        usVss, writeUserSecret)
 import           Pos.WorkMode          (ProductionMode, RawRealMode, StatsMode)
 #ifdef WITH_WEB
 import           Pos.Web               (serveWebBase, serveWebGT)
@@ -135,7 +136,9 @@ userSecretWithGenesisKey Args{..} userSecret
           Nothing -> fetchPrimaryKey userSecret
           Just i -> do
               let sk = genesisDevSecretKeys !! i
-                  us = userSecret & usPrimKey .~ Just sk
+                  us = userSecret
+                       & usPrimKey .~ Just sk
+                       & usKeys %~ (noPassEncrypt sk :)
               writeUserSecret us
               return (sk, us)
     | otherwise = fetchPrimaryKey userSecret


### PR DESCRIPTION
It will enable access to genesis funds for testing in dev mode in much simpler way than it was before.