### PR TITLE
[CSL-861] Sort out unknown data checks

### DIFF
--- a/src/Pos/Txp/Settings/Global.hs
+++ b/src/Pos/Txp/Settings/Global.hs
@@ -47,8 +47,12 @@ type TxpBlund = (TxpBlock, TxpUndo)
 data TxpGlobalSettings = TxpGlobalSettings
     { -- | Verify a chain of payloads from blocks and return txp undos
       -- for each payload.
+      --
+      -- First argument determines whether it should be checked that
+      -- all data from transactions is known (script versions,
+      -- attributes, addresses, witnesses).
       tgsVerifyBlocks :: forall m. TxpGlobalVerifyMode m =>
-                         OldestFirst NE TxpBlock -> m (OldestFirst NE TxpUndo)
+                         Bool -> OldestFirst NE TxpBlock -> m (OldestFirst NE TxpUndo)
     , -- | Apply chain of /definitely/ valid blocks to Txp's GState.
       tgsApplyBlocks :: forall m . TxpGlobalApplyMode m =>
                         OldestFirst NE TxpBlund -> m SomeBatchOp

--- a/src/Pos/Txp/Toil/Failure.hs
+++ b/src/Pos/Txp/Toil/Failure.hs
@@ -7,6 +7,7 @@ module Pos.Txp.Toil.Failure
 import qualified Data.Text.Buildable
 import           Formatting                 (bprint, build, int, stext, (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
+import           Serokell.Util.Base16       (base16F)
 import           Serokell.Util.Verify       (formatAllErrors)
 import           Universum
 
@@ -27,6 +28,7 @@ data ToilVerFailure
     | ToilInvalidInputs ![Text] -- [CSL-814] TODO: make it more informative
     | ToilTooLargeTx { ttltSize  :: !Byte
                      , ttltLimit :: !Byte}
+    | ToilUnknownAttributes !ByteString
     deriving (Show, Eq)
 
 instance Buildable ToilVerFailure where
@@ -51,3 +53,5 @@ instance Buildable ToilVerFailure where
     build (ToilTooLargeTx {..}) =
         bprint ("transaction's size exceeds limit "%
                 "("%memory%" > "%memory%")") ttltSize ttltLimit
+    build (ToilUnknownAttributes bs) =
+        bprint ("transaction has unknown attributes: "%base16F) bs

--- a/src/Pos/Txp/Toil/Logic.hs
+++ b/src/Pos/Txp/Toil/Logic.hs
@@ -48,10 +48,15 @@ type GlobalToilMode m = ( MonadUtxo m
 -- Note: transactions must be topsorted to pass check.
 -- Warning: this function may apply some transactions and fail
 -- eventually. Use it only on temporary data.
+--
+-- If the first argument is 'True', all data (script versions,
+-- witnesses, addresses, attributes) must be known. Otherwise unknown
+-- data is just ignored.
 verifyToil
     :: (GlobalToilMode m, MonadError ToilVerFailure m)
-    => [TxAux] -> m TxpUndo
-verifyToil = mapM (verifyAndApplyTx False . withTxId)
+    => Bool -> [TxAux] -> m TxpUndo
+verifyToil verifyAllIsKnown =
+    mapM (verifyAndApplyTx verifyAllIsKnown . withTxId)
 
 -- | Apply transactions from one block. They must be valid (for
 -- example, it implies topological sort).
@@ -79,7 +84,6 @@ type LocalToilMode m = ( MonadUtxo m
                       )
 
 -- CHECK: @processTx
--- #processWithPureChecks
 -- | Verify one transaction and also add it to mem pool and apply to utxo
 -- if transaction is valid.
 processTx

--- a/src/Pos/Types/Block/Functions.hs
+++ b/src/Pos/Types/Block/Functions.hs
@@ -25,7 +25,7 @@ module Pos.Types.Block.Functions
        , verifyHeaders
        ) where
 
-import           Control.Lens               (folded, iconcatMap, imap, ix)
+import           Control.Lens               (ix)
 import           Data.Default               (Default (def))
 import           Data.List                  (groupBy)
 import           Data.Tagged                (untag)
@@ -38,29 +38,24 @@ import           Pos.Binary.Block.Types     ()
 import qualified Pos.Binary.Class           as Bi
 import           Pos.Binary.Core            ()
 import           Pos.Binary.Update          ()
-import           Pos.Constants              (epochSlots, lastKnownBlockVersion)
-import           Pos.Core                   (BlockVersion, ChainDifficulty, EpochIndex,
-                                             EpochOrSlot, HasDifficulty (..),
-                                             HasEpochIndex (..), HasEpochOrSlot (..),
-                                             HasHeaderHash (..), HeaderHash,
-                                             ProxySKEither, SlotId (..), SlotLeaders,
-                                             prevBlockL)
-import           Pos.Core.Address           (Address (..), addressHash)
+import           Pos.Constants              (epochSlots)
+import           Pos.Core                   (ChainDifficulty, EpochIndex, EpochOrSlot,
+                                             HasDifficulty (..), HasEpochIndex (..),
+                                             HasEpochOrSlot (..), HasHeaderHash (..),
+                                             HeaderHash, ProxySKEither, SlotId (..),
+                                             SlotLeaders, addressHash, prevBlockL)
 import           Pos.Core.Block             (Blockchain (..), GenericBlock (..),
                                              GenericBlockHeader (..), gbBody, gbBodyProof,
-                                             gbHeader, gbhExtra)
+                                             gbHeader)
 import           Pos.Crypto                 (Hash, SecretKey, SignTag (SignMainBlock),
                                              checkSig, proxySign, proxyVerify,
                                              pskIssuerPk, pskOmega, sign, toPublic,
                                              unsafeHash)
 import           Pos.Data.Attributes        (mkAttributes)
-import           Pos.Script                 (isKnownScriptVersion, scrVersion)
 import           Pos.Ssc.Class.Helpers      (SscHelpersClass (..))
-import           Pos.Txp.Core.Types         (Tx (..), TxInWitness (..), TxOut (..))
 import           Pos.Types.Block.Instances  (Body (..), ConsensusData (..), blockLeaders,
-                                             blockMpc, blockProxySKs, blockTxs,
-                                             getBlockHeader, getBlockHeader,
-                                             headerLeaderKey, headerSlot, mbWitnesses,
+                                             blockMpc, blockProxySKs, getBlockHeader,
+                                             getBlockHeader, headerLeaderKey, headerSlot,
                                              mcdDifficulty, mcdLeaderKey, mcdSignature,
                                              mcdSlot)
 import           Pos.Types.Block.Types      (BiSsc, Block, BlockHeader,
@@ -70,7 +65,7 @@ import           Pos.Types.Block.Types      (BiSsc, Block, BlockHeader,
                                              GenesisExtraHeaderData (..), MainBlock,
                                              MainBlockHeader, MainBlockchain,
                                              MainExtraBodyData (..), MainExtraHeaderData,
-                                             MainToSign (..), mehBlockVersion)
+                                             MainToSign (..))
 import           Pos.Update.Core            (BlockVersionData (..))
 import           Pos.Util.Chrono            (NewestFirst (..), OldestFirst)
 
@@ -420,13 +415,6 @@ data VerifyBlockParams ssc = VerifyBlockParams
       -- ^ Verifies ssc payload with 'sscVerifyPayload'.
     , vbpVerifyProxySKs :: !Bool
       -- ^ Check that's number of sks is limited (1000 for now).
-    , vbpVerifyVersions :: !(Maybe BlockVersion)
-      -- ^ Verify that there are no unknown script, address or witness
-      -- versions anywhere in the block. The check is only done if
-      -- 'vbpVerifyVersions' is 'Just' and the current adopted BlockVersion
-      -- (passed in the 'Just') is higher (or equal) than the version of the
-      -- block we're checking, because in this case there really shouldn't be
-      -- anything unparseable in the block.
     , vbpMaxSize        :: !Byte
     -- ^ Maximal block size.
     }
@@ -439,7 +427,6 @@ instance Default (VerifyBlockParams ssc) where
         , vbpVerifyGeneric = False
         , vbpVerifySsc = False
         , vbpVerifyProxySKs = False
-        , vbpVerifyVersions = Nothing
         , vbpMaxSize = 1000000000 -- TODO: get rid of this module
         }
 
@@ -456,7 +443,6 @@ verifyBlock VerifyBlockParams {..} blk =
         , maybeEmpty (flip verifyHeader (getBlockHeader blk)) vbpVerifyHeader
         , verifySsc
         , verifyProxySKs
-        , maybeEmpty verifyVersions vbpVerifyVersions
         , checkSize
         ]
   where
@@ -494,57 +480,11 @@ verifyBlock VerifyBlockParams {..} blk =
               , "Block contains psk(s) that have non-matching epoch index")
             ]
         | otherwise = mempty
-    verifyVersions bv = case blk of
-        Left _        -> mempty
-        Right mainBlk ->
-            let effectiveBlockVersion =
-                    bv `min`
-                    (mainBlk ^. gbHeader . gbhExtra . mehBlockVersion)
-            in if lastKnownBlockVersion >= effectiveBlockVersion
-                   then checkNoUnknownVersions mainBlk
-                   else mempty
     checkSize = verifyGeneric [
       (Bi.biSize blk <= vbpMaxSize,
        sformat ("block's size exceeds limit ("%memory%" > "%memory%")")
        (Bi.biSize blk) vbpMaxSize)
       ]
-
--- | Check that the block contains no 'UnknownAddressType' and
--- 'UnknownWitnessType' and that all script versions are known.
-checkNoUnknownVersions :: MainBlock ssc -> VerificationRes
-checkNoUnknownVersions blk = mconcat $ map toVerRes $ concat [
-    iconcatMap checkTx (blk ^.. blockTxs . folded),
-    iconcatMap checkWitness (blk ^. gbBody . mbWitnesses) ]
-  where
-    toVerRes (Right _) = VerSuccess
-    toVerRes (Left e)  = VerFailure [sformat build e]
-
-    -- Check a transaction
-    checkTx txI UnsafeTx{..} = imap (checkOutput txI) $ toList _txOutputs
-    -- Check an output
-    checkOutput txI outI TxOut{..} = case txOutAddress of
-        UnknownAddressType t _ -> Left $
-            sformat ("Output #"%int%" of tx #"%int%
-                     " has UnknownAddressType "%int) outI txI t
-        _ -> Right ()
-
-    -- Check an array of witnesses
-    checkWitness txI wit = imap (checkSingleWitness txI) (toList wit)
-    -- Check a single witness
-    checkSingleWitness txI witI wit = case wit of
-        UnknownWitnessType t _ -> Left $
-            sformat ("Witness #"%int%" of tx #"%int%
-                     " has UnknownWitnessType "%int) witI txI t
-        ScriptWitness{..}
-            | not (isKnownScriptVersion (scrVersion twValidator)) -> Left $
-              sformat ("Validator of witness #"%int%" of tx #"%int%
-                       " has unknown script version "%int)
-                      witI txI (scrVersion twValidator)
-            | not (isKnownScriptVersion (scrVersion twRedeemer)) -> Left $
-              sformat ("Redeemer of witness #"%int%" of tx #"%int%
-                       " has unknown script version "%int)
-                      witI txI (scrVersion twRedeemer)
-        _ -> Right ()
 
 -- CHECK: @verifyBlocks
 -- Verifies a sequence of blocks.
@@ -565,12 +505,9 @@ verifyBlocks
     => Maybe SlotId
     -> BlockVersionData
     -> Maybe SlotLeaders
-    -> Maybe BlockVersion           -- ^ @Just <$> getAdoptedBV@ if it's
-                                    --   an incoming sequence of blocks
-                                    --   (see issue #25 on Github)
     -> OldestFirst f (Block ssc)
     -> VerificationRes
-verifyBlocks curSlotId bvd initLeaders mbBV = view _3 . foldl' step start
+verifyBlocks curSlotId bvd initLeaders = view _3 . foldl' step start
   where
     start :: (Maybe SlotLeaders, Maybe (BlockHeader ssc), VerificationRes)
     start = (initLeaders, Nothing, mempty)
@@ -598,7 +535,6 @@ verifyBlocks curSlotId bvd initLeaders mbBV = view _3 . foldl' step start
                 , vbpVerifyGeneric = True
                 , vbpVerifySsc = True
                 , vbpVerifyProxySKs = True
-                , vbpVerifyVersions = mbBV
                 , vbpMaxSize = bvdMaxBlockSize bvd
                 }
         in (newLeaders, Just $ getBlockHeader blk, res <> verifyBlock vbp blk)


### PR DESCRIPTION
There was some mess with unknown data checks. Some checks were done in `Txp`, some checks in `Pos.Types.Block.Functions`. Currently they are all done in `Txp` and are configured by a single boolean flag in `VTxContext`. They are performed if we are verifying block and our software is aware of adopted protocol version. Also they are performed when we are verifying transaction in isolation (received through relay). They are not performed if adopted version is not fully known to our software.

I have also fixed a predicate to determine whether we know protocol version. There is a big comment which explains this stuff.

Some final notes:
1. I cherry-picked a commit by @neongreen from CSL-976 branch because there are some changes which overlap with my changes and I don't want to do an unpleasant merge. Depending on how soon CSL-976 will be merged, I will either rebase on master and remove that cherry-picked commit or @neongreen will do it in his branch.
2. I am 99% sure that other checks regarding unknown data are still missing. There is CSL-938 about it. So within scope of this task I didn't care about that. I am planning to do it soon but as a separate task.