### PR TITLE
[CSL-993] Sort out work with balances (aka stakes)

### DIFF
--- a/db/Pos/DB/GState/Balances.hs
+++ b/db/Pos/DB/GState/Balances.hs
@@ -5,9 +5,9 @@
 module Pos.DB.GState.Balances
        ( BalanceIter
          -- * Getters
-       , getTotalFtsStake
-       , getFtsStake
-       , getFtsSumMaybe
+       , getRealTotalStake
+       , getRealStake
+       , getRealStakeSumMaybe
 
        , ftsStakeKey
        , ftsSumKey
@@ -49,19 +49,30 @@ ftsSumKey = "b/ftssum"
 -- Getters
 ----------------------------------------------------------------------------
 
--- | Get total amount of stake to be used for follow-the-satoshi. It's
--- different from total amount of coins in the system.
-getTotalFtsStake :: MonadDB m => m Coin
-getTotalFtsStake =
-    maybeThrow (DBMalformed "no total FTS stake in GState DB") =<< getFtsSumMaybe
+-- | Get real total amount of stake to be used for follow-the-satoshi
+-- and other procedures which use stake of some stakeholder.
+--
+-- Word `real` is essential here, because there is also apparent stake
+-- during bootstrap era.
+--
+-- It's different from total amount of spendable coins in the system,
+-- because spending is done using Utxo. For example, one can send
+-- coins to script address and not include it into transaction
+-- distribution.
+getRealTotalStake :: MonadDB m => m Coin
+getRealTotalStake =
+    maybeThrow (DBMalformed "no total FTS stake in GState DB") =<< getRealStakeSumMaybe
 
--- | Get stake owne by given stakeholder (according to rules used for FTS).
-getFtsStake :: MonadDB m => StakeholderId -> m (Maybe Coin)
-getFtsStake = gsGetBi . ftsStakeKey
+-- | Get real stake owned by given stakeholder (according to rules
+-- used for FTS and similar procedures). Word `real` is essential
+-- here. See documentation of 'getRealTotalStake' for some
+-- explanation.
+getRealStake :: MonadDB m => StakeholderId -> m (Maybe Coin)
+getRealStake = gsGetBi . ftsStakeKey
 
 ----------------------------------------------------------------------------
 -- Details
 ----------------------------------------------------------------------------
 
-getFtsSumMaybe :: MonadDB m => m (Maybe Coin)
-getFtsSumMaybe = gsGetBi ftsSumKey
+getRealStakeSumMaybe :: MonadDB m => m (Maybe Coin)
+getRealStakeSumMaybe = gsGetBi ftsSumKey

--- a/src/Pos/DB/GState/GState.hs
+++ b/src/Pos/DB/GState/GState.hs
@@ -17,7 +17,7 @@ import           Pos.Context.Class      (WithNodeContext (getNodeContext))
 import           Pos.Context.Context    (ncSystemStart)
 import           Pos.Context.Functions  (genesisUtxoM)
 import           Pos.DB.Class           (MonadDB (getNodeDBs, usingReadOptions))
-import           Pos.DB.GState.Balances (getTotalFtsStake)
+import           Pos.DB.GState.Balances (getRealTotalStake)
 import           Pos.DB.GState.Common   (prepareGStateCommon)
 import           Pos.DB.Types           (DB (..), NodeDBs (..), Snapshot (..), gStateDB,
                                          usingSnapshot)
@@ -46,7 +46,7 @@ sanityCheckGStateDB
     => m ()
 sanityCheckGStateDB = do
     sanityCheckBalances
-    sanityCheckUtxo =<< getTotalFtsStake
+    sanityCheckUtxo =<< getRealTotalStake
 
 usingGStateSnapshot :: (MonadDB m, MonadMask m) => m a -> m a
 usingGStateSnapshot action = do

--- a/src/Pos/Lrc/Logic.hs
+++ b/src/Pos/Lrc/Logic.hs
@@ -16,7 +16,7 @@ import           Universum
 
 import           Pos.Crypto.Signing  (pskDelegatePk)
 import           Pos.DB.Class        (MonadDB)
-import           Pos.DB.GState       (getFtsStake, isIssuerByAddressHash,
+import           Pos.DB.GState       (getEffectiveStake, isIssuerByAddressHash,
                                       runPskMapIterator)
 import           Pos.Lrc.Core        (findDelegationStakes, findRichmenStake)
 import           Pos.Lrc.Types       (FullRichmenData, RichmenStake)
@@ -34,7 +34,7 @@ findDelRichUsingPrecomp
 findDelRichUsingPrecomp precomputed t = do
     delIssMap <- computeDelIssMap
     (old, new) <- runListHolderT @(StakeholderId, [StakeholderId])
-                      (findDelegationStakes isIssuerByAddressHash getFtsStake t)
+                      (findDelegationStakes isIssuerByAddressHash getEffectiveStake t)
                       (HM.toList delIssMap)
     -- attention: order of new and precomputed is important
     -- we want to use new balances (computed from delegated) of precomputed richmen

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -168,7 +168,7 @@ issuersComputationDo epochId = do
   where
     unionHSs = foldl' (flip HS.union) mempty
     putIsStake :: IssuersStakes -> StakeholderId -> m IssuersStakes
-    putIsStake hm id = GS.getFtsStake id >>= \case
+    putIsStake hm id = GS.getEffectiveStake id >>= \case
         Nothing ->
            hm <$ (logWarning $ sformat ("Stake for issuer "%build% " not found") id)
         Just stake -> pure $ HM.insert id stake hm
@@ -176,7 +176,7 @@ issuersComputationDo epochId = do
 leadersComputationDo :: WorkMode ssc m => EpochIndex -> SharedSeed -> m ()
 leadersComputationDo epochId seed =
     unlessM (isJust <$> getLeaders epochId) $ do
-        totalStake <- GS.getTotalFtsStake
+        totalStake <- GS.getEffectiveTotalStake
         leaders <- GS.runBalanceIterator $ followTheSatoshiM seed totalStake
         putLeaders epochId leaders
 
@@ -185,7 +185,7 @@ richmenComputationDo
        WorkMode ssc m
     => EpochIndex -> [LrcConsumer m] -> m ()
 richmenComputationDo epochIdx consumers = unless (null consumers) $ do
-    total <- GS.getTotalFtsStake
+    total <- GS.getEffectiveTotalStake
     consumersAndThds <-
         zip consumers <$> mapM (flip lcThreshold total) consumers
     let minThreshold :: Maybe Coin

--- a/src/Pos/Txp/Toil/DBTxp.hs
+++ b/src/Pos/Txp/Toil/DBTxp.hs
@@ -27,6 +27,7 @@ import           Universum
 import           Pos.Context                 (WithNodeContext)
 import           Pos.DB.Class                (MonadDB)
 import qualified Pos.DB.GState               as GS
+import           Pos.DB.GState.Balances      (getRealStake, getRealTotalStake)
 import           Pos.Delegation.Class        (MonadDelegation)
 import           Pos.Slotting                (MonadSlots, MonadSlotsData)
 import           Pos.Ssc.Extra               (MonadSscMem)
@@ -105,8 +106,8 @@ instance (Monad m, MonadDB m) => MonadUtxoRead (DBTxp m) where
     utxoGet = GS.getTxOut
 
 instance (Monad m, MonadDB m) => MonadBalancesRead (DBTxp m) where
-    getTotalStake = GS.getTotalFtsStake
-    getStake = GS.getFtsStake
+    getTotalStake = getRealTotalStake
+    getStake = getRealStake
 
 instance (Monad m, MonadDB m) => MonadToilEnv (DBTxp m) where
     getToilEnv = ToilEnv . bvdMaxTxSize <$> getAdoptedBVData


### PR DESCRIPTION
Now there are two versions of functions which get balances from DB with
different names: with `effective` word in name and with `real` word in name.
Real corresponds to stake which is modified by transactions and is stored
in DB.
Effective is same is real if we are not in bootstrap era, otherwise it's taken
from predefined constants.
This commit also fixes a bug where effective stake was used is 'MonadBalances'
implementation.