### PR TITLE
[CSM-201] getLocale is broken after testReset

### DIFF
--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -241,6 +241,11 @@ data CProfile = CProfile
     { cpLocale      :: Text
     } deriving (Show, Generic, Typeable)
 
+-- | Added default instance for `testReset`, we need an inital state for
+-- @CProfile@
+instance Default CProfile where
+    def = CProfile mempty
+
 ----------------------------------------------------------------------------
 -- Transactions
 ----------------------------------------------------------------------------

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -152,8 +152,6 @@ walletServer
     -> WalletWebHandler m (WalletWebHandler m :~> Handler)
     -> WalletWebHandler m (Server WalletApi)
 walletServer sendActions nat = do
-    whenM (isNothing <$> getProfile) $
-        createUserProfile >>= setProfile
     ws    <- lift getWalletState
     socks <- getWalletWebSockets
     let sendActions' = hoistSendActions
@@ -166,7 +164,6 @@ walletServer sendActions nat = do
   where
     insertAddressMeta cAddr =
         getWalletMeta cAddr >>= createWallet cAddr . fromMaybe def
-    createUserProfile = pure $ CProfile mempty
 
 ----------------------------------------------------------------------------
 -- Notifier
@@ -333,9 +330,7 @@ servantHandlers sendActions =
 --   where gb addr = (,) (addressToCAddress addr) <$> getBalance addr
 
 getUserProfile :: WalletWebMode ssc m => m CProfile
-getUserProfile = getProfile >>= maybe noProfile pure
-  where
-    noProfile = throwM $ Internal "No user profile"
+getUserProfile = getProfile
 
 updateUserProfile :: WalletWebMode ssc m => CProfile -> m CProfile
 updateUserProfile profile = setProfile profile >> getUserProfile

--- a/src/Pos/Wallet/Web/State/State.hs
+++ b/src/Pos/Wallet/Web/State/State.hs
@@ -79,7 +79,7 @@ updateDisk e = getWalletWebState >>= flip A.update e
 getWalletMetas :: WebWalletModeDB m => m [CWalletMeta]
 getWalletMetas = queryDisk A.GetWalletMetas
 
-getProfile :: WebWalletModeDB m => m (Maybe CProfile)
+getProfile :: WebWalletModeDB m => m (CProfile)
 getProfile = queryDisk A.GetProfile
 
 getWalletMeta :: WebWalletModeDB m => CAddress -> m (Maybe CWalletMeta)

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -47,7 +47,7 @@ type TransactionHistory = HashMap CTxId CTxMeta
 data WalletStorage = WalletStorage
     {
       _wsWalletMetas  :: !(HashMap CAddress (CWalletMeta, TransactionHistory))
-    , _wsProfile      :: !(Maybe CProfile)
+    , _wsProfile      :: !CProfile
     , _wsReadyUpdates :: [CUpdateInfo]
     , _wsHistoryCache :: !(HashMap CAddress (HeaderHash, Utxo, [TxHistoryEntry]))
     }
@@ -58,8 +58,8 @@ instance Default WalletStorage where
     def =
         WalletStorage
         {
-          _wsWalletMetas = mempty
-        , _wsProfile = mzero
+          _wsWalletMetas  = mempty
+        , _wsProfile      = def
         , _wsReadyUpdates = mempty
         , _wsHistoryCache = mempty
         }
@@ -67,11 +67,11 @@ instance Default WalletStorage where
 type Query a = forall m. (MonadReader WalletStorage m) => m a
 type Update a = forall m. ({-MonadThrow m, -}MonadState WalletStorage m) => m a
 
-getProfile :: Query (Maybe CProfile)
+getProfile :: Query CProfile
 getProfile = view wsProfile
 
 setProfile :: CProfile -> Update ()
-setProfile profile = wsProfile .= Just profile
+setProfile profile = wsProfile .= profile
 
 getWalletMetas :: Query [CWalletMeta]
 getWalletMetas = toList . map fst <$> view wsWalletMetas


### PR DESCRIPTION
Fixed - https://issues.serokell.io/issue/CSM-201

Also made `CProfile` not optional.
Before:
```haskell
data WalletStorage = WalletStorage
    {
      _wsWalletMetas  :: !(HashMap CAddress (CWalletMeta, TransactionHistory))
    , _wsProfile      :: !(Maybe CProfile)
    , _wsReadyUpdates :: [CUpdateInfo]
    , _wsHistoryCache :: !(HashMap CAddress (HeaderHash, Utxo, [TxHistoryEntry]))
    }
```

After:
```haskell
    , _wsProfile      :: !CProfile
```