### PR TITLE
[CSL-981] Fix tcp timeouts in yaml config (ms vs mcs)

### DIFF
--- a/core/constants-dev.yaml
+++ b/core/constants-dev.yaml
@@ -23,8 +23,8 @@ defaultPeers: []
 kademliaDumpInterval: 4
 neighboursSendThreshold: 2
 networkDiameter: 3
-networkConnectionTimeout: 2000
-networkReceiveTimeout: 5000
+networkConnectionTimeout: 1000000 # 1 sec
+networkReceiveTimeout: 5000000 # 5 sec
 
 ## P2P Security
 mdNoBlocksSlotThreshold: 3 # should be less than 2 * k

--- a/core/constants-prod.yaml
+++ b/core/constants-prod.yaml
@@ -23,8 +23,8 @@ defaultPeers: []
 kademliaDumpInterval: 4
 neighboursSendThreshold: 2
 networkDiameter: 10
-networkConnectionTimeout: 2000
-networkReceiveTimeout: 5000
+networkConnectionTimeout: 1000000 # 1 sec
+networkReceiveTimeout: 5000000 # 5 sec
 
 ## P2P Security
 mdNoBlocksSlotThreshold: 45 # should be less than 2 * k

--- a/core/constants-wallet-prod.yaml
+++ b/core/constants-wallet-prod.yaml
@@ -23,8 +23,8 @@ defaultPeers: []
 kademliaDumpInterval: 4
 neighboursSendThreshold: 2
 networkDiameter: 10
-networkConnectionTimeout: 2000
-networkReceiveTimeout: 5000
+networkConnectionTimeout: 1000000 # 1 sec
+networkReceiveTimeout: 5000000 # 5 sec
 
 ## P2P Security
 mdNoBlocksSlotThreshold: 45 # should be less than 2 * k


### PR DESCRIPTION
Here are definitions from `Constants.hs` (main repo and infra):
```
networkConnectionTimeout :: Microsecond
networkConnectionTimeout = ms . fromIntegral . ccNetworkConnectionTimeout $ compileConfig
...
networkReceiveTimeout :: Microsecond
networkReceiveTimeout = ms . fromIntegral . ccNetworkReceiveTimeout $ infraConstants
```
Values in `.yaml` config were ~10^3, so several milliseconds as parsed/used.
