### PR TITLE
[CSL-1019] Remove delay after ntpSingleShot in mkNtpSlottingVar

### DIFF
--- a/infra/Pos/Slotting/Ntp.hs
+++ b/infra/Pos/Slotting/Ntp.hs
@@ -303,7 +303,6 @@ mkNtpSlottingVar = do
     singleShot settings = unless C.isDevelopment $ do
         logInfo $ "Waiting for response from NTP servers"
         ntpSingleShot settings
-        delay C.ntpResponseTimeout
 
 runNtpSlotting :: NtpSlottingVar -> NtpSlotting m a -> m a
 runNtpSlotting var = usingReaderT var . getNtpSlotting


### PR DESCRIPTION
It doesn't make any sense to have it there.
`ntpSingleShot' waits exactly this amount of time internally.