### PR TITLE
[CSL-1031] Emergency NAT patch

### DIFF
--- a/infra/Pos/Util/TimeWarp.hs
+++ b/infra/Pos/Util/TimeWarp.hs
@@ -13,14 +13,14 @@ module Pos.Util.TimeWarp
        , addrParserNoWildcard
        ) where
 
-import qualified Data.ByteString.Char8 as BS8
-import           Data.Time.Units       (Microsecond)
-import           Mockable              (realTime)
-import qualified Network.Transport.TCP as TCP
-import           Node                  (NodeId (..))
-import qualified Serokell.Util.Parse   as P
-import qualified Text.Parsec.Char      as P
-import qualified Text.Parsec.String    as P
+import qualified Data.ByteString.Char8          as BS8
+import           Data.Time.Units                (Microsecond)
+import           Mockable                       (realTime)
+import qualified Network.Transport.TCP.Internal as TCP
+import           Node                           (NodeId (..))
+import qualified Serokell.Util.Parse            as P
+import qualified Text.Parsec.Char               as P
+import qualified Text.Parsec.String             as P
 import           Universum
 
 -- | @"127.0.0.1"@.

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -374,7 +374,7 @@ createTransport ip port = do
              , TCP.tcpNewQDisc = fairQDisc $ \_ -> return Nothing
              })
     transportE <-
-        liftIO $ TCP.createTransport "0.0.0.0" (show port) ((,) ip) tcpParams
+        liftIO $ TCP.createTransport (TCP.Addressable (TCP.TCPAddrInfo "0.0.0.0" (show port) ((,) ip))) tcpParams
     case transportE of
         Left e -> do
             logError $ sformat ("Error creating TCP transport: " % shown) e

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,12 +43,12 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 17b68653edfcbb72ad92a6b0ecbff82d3b42c4ef
+    commit: 31e2102cd9b4cd882aabe664cbfab90eb3336ad3
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:
     git: https://github.com/avieth/network-transport-tcp
-    commit: 15847920ac1a32ada237e5a00ac4f56f3ca421a7
+    commit: ca42a954a15792f5ea8dc203e56fac8175b99c33
   extra-dep: true
 - location:
     git: https://github.com/avieth/network-transport


### PR DESCRIPTION
Bumps nt-tcp and time-warp revisions so that peers which claim 0.0.0.0
or 127.0.0.1 as their hosts will be treated as unaddressable.

This mitigates the self-inflicted denial-of-service observed when many
preconfigured wallet programs try to talk to the network, each claiming
the very same address. nt-tcp is designed to admit at most one TCP
socket per pair of EndPoints, which are identified by their addresses.

This is a temporary patch, which will make existing client executables
play well with the network. It should be obsoleted soon by a major
update. The revision of nt-tcp which is chosen will certainly not be
admitted upstream.