### PR TITLE
Fix AppVeyor artifact path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,9 +98,10 @@ test_script:
 after_test:
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
+ - xcopy /q /s /e /r /k /i /v /h /y "%WORK_DIR%\daedalus" C:\projects\cardano-sl\daedalus
 
 artifacts:
-  - path: "%WORK_DIR%\daedalus\"
+  - path: daedalus/
     name: CardanoSL
     type: zip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,7 +100,7 @@ after_test:
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
 
 artifacts:
-  - path: daedalus/
+  - path: "%WORK_DIR%\daedalus\"
     name: CardanoSL
     type: zip
 


### PR DESCRIPTION
Since build 0.4.4258 the artifact zip hasn't included all the
assets. When paths were restructured to account for Windows' path
length limit, the artifact target path was missed.