### PR TITLE
AppVeyor: copy artifact assets back to repo dir

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,6 +98,7 @@ test_script:
 after_test:
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
+ - xcopy /q /s /e /r /k /i /v /h /y "%WORK_DIR%\daedalus" C:\projects\cardano-sl\daedalus
 
 artifacts:
   - path: daedalus/


### PR DESCRIPTION
Fix was already merged into `cardano-sl-0.4`, but needs to get to `master` too: https://github.com/input-output-hk/cardano-sl/pull/259

Without this change, AppVeyor builds don't include all the necessary assets in the output artifact zip.