### PR TITLE
[CSL-1057] Fix TxpUndo construction

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl
-version:             0.4.1
+version:             0.4.3
 synopsis:            Cardano SL main implementation
 description:         Please see README.md
 license:             MIT

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-core
-version:             0.4.1
+version:             0.4.3
 synopsis:            Cardano SL - core
 description:         Cardano SL - core
 license:             MIT

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-db
-version:             0.4.1
+version:             0.4.3
 synopsis:            Cardano SL - basic DB interfaces
 description:         Cardano SL - basic DB interfaces
 license:             MIT

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-infra
-version:             0.4.1
+version:             0.4.3
 synopsis:            Cardano SL - infrastructural
 description:         Cardano SL - infrastructural
 license:             MIT

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-lrc
-version:             0.4.1
+version:             0.4.3
 synopsis:            Cardano SL - Leaders and Richmen computation
 description:         Cardano SL - Leaders and Richmen computation
 license:             MIT

--- a/src/Pos/Block/Logic.hs
+++ b/src/Pos/Block/Logic.hs
@@ -776,7 +776,7 @@ createMainBlockFinish slotId pSk prevHeader = do
     (pModifier,verUndo) <- runExceptT (usVerifyBlocks (one (toUpdateBlock (Right blk)))) >>= \case
         Left _ -> throwError "Couldn't get pModifier while creating MainBlock"
         Right o -> pure o
-    let blockUndo = Undo (reverse $ foldl' prependToUndo [] localTxs)
+    let blockUndo = Undo (reverse $ foldl' prependToUndo [] sortedTxs)
                          pskUndo
                          (verUndo ^. _Wrapped . _neHead)
     () <- (blockUndo `deepseq` blk) `deepseq` pure ()


### PR DESCRIPTION
This commit also sets version to 0.4.3, because:
1. It's a potentially critical bugfix.
2. We already have 0.4.2 tag even though .cabal version is 0.4.3 (facepalm) which
   is ridiculous but true :(