### PR TITLE
[CSM-232] [CSM-234] Add keyfiles generation

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -380,8 +380,8 @@ library
                         Pos.Wallet.SscType
   if (flag(with-wallet) && flag(with-web))
     other-modules:      Pos.Aeson.ClientTypes
-                        Pos.Wallet.Web.ClientTypes
                         Pos.Wallet.Web.Api
+                        Pos.Wallet.Web.ClientTypes
                         Pos.Wallet.Web.Doc
                         Pos.Wallet.Web.Error
                         Pos.Wallet.Web.Server
@@ -395,6 +395,7 @@ library
                         Pos.Wallet.Web.State.Limits
                         Pos.Wallet.Web.State.State
                         Pos.Wallet.Web.State.Storage
+                        Pos.Wallet.Web.Util
 
   build-depends:        IfElse
                       , QuickCheck

--- a/core/Pos/Crypto/HD.hs
+++ b/core/Pos/Crypto/HD.hs
@@ -11,6 +11,9 @@ module Pos.Crypto.HD
        , decryptChaChaPoly
        , encryptChaChaPoly
        , toEither
+
+       , firstNonHardened
+       , isNonHardened
        ) where
 
 import           Cardano.Crypto.Wallet        (deriveXPrv, deriveXPrvHardened, deriveXPub,
@@ -66,9 +69,17 @@ deriveHDPassphrase (PublicKey pk) = HDPassphrase $
     passLen = 32
 
 -- Direct children of node are numbered from 0 to 2^32-1.
--- Child with index less or equal @maxHardened@ is a hardened child.
+-- Child with index greater or equal than @firstNonHardened@ is a non-hardened
+-- child.
+firstNonHardened :: Word32
+firstNonHardened = 2 ^ (31 :: Word32)
+
+-- Child with index less or equal than @maxHardened@ is a hardened child.
 maxHardened :: Word32
-maxHardened = 2 ^ (31 :: Word32) - 1
+maxHardened = firstNonHardened - 1
+
+isNonHardened :: Word32 -> Bool
+isNonHardened = ( >= firstNonHardened)
 
 -- | Derive public key from public key in non-hardened (normal) way.
 -- If you try to pass index more than @maxHardened@, error will be called.

--- a/core/Pos/Util/Mnemonics.hs
+++ b/core/Pos/Util/Mnemonics.hs
@@ -12,6 +12,8 @@ module Pos.Util.Mnemonics
          -- * Entropy encoding and decoding
        , toMnemonic
        , fromMnemonic
+
+       , wl
        ) where
 
 import           Crypto.Hash     (Digest, SHA256, hash)

--- a/core/Pos/Util/Mnemonics.hs
+++ b/core/Pos/Util/Mnemonics.hs
@@ -12,8 +12,6 @@ module Pos.Util.Mnemonics
          -- * Entropy encoding and decoding
        , toMnemonic
        , fromMnemonic
-
-       , wl
        ) where
 
 import           Crypto.Hash     (Digest, SHA256, hash)

--- a/src/Pos/Client/Txp/Util.hs
+++ b/src/Pos/Client/Txp/Util.hs
@@ -26,6 +26,7 @@ import qualified Data.Vector         as V
 import           Universum
 
 import           Pos.Binary          ()
+import           Pos.Core.Address    (AddressIgnoringAttributes (AddressIA))
 import           Pos.Core.Coin       (unsafeIntegerToCoin, unsafeSubCoin)
 import           Pos.Crypto          (PublicKey, RedeemSecretKey, SafeSigner,
                                       SignTag (SignTxIn), hash, redeemSign,
@@ -162,10 +163,10 @@ createMTx utxo hwdSigner outputs =
     in  uncurry (makeMPubKeyTx getSigner) <$>
         prepareInpsOuts utxo addr outputs
   where
-    signers = HM.fromList . toList $ map swap hwdSigner
+    signers = HM.fromList . toList $ map (swap . second AddressIA) hwdSigner
     getSigner addr =
         fromMaybe (error "Requested signer for unknown address") $
-        HM.lookup addr signers
+        HM.lookup (AddressIA addr) signers
 
 -- | Make a multi-transaction using given secret key and info for outputs
 createTx :: Utxo -> SafeSigner -> TxOutputs -> Either TxError TxAux

--- a/src/Pos/Genesis.hs
+++ b/src/Pos/Genesis.hs
@@ -23,41 +23,38 @@ module Pos.Genesis
        , genesisDevKeyPairs
        , genesisDevPublicKeys
        , genesisDevSecretKeys
-       , generateGenesisBackupPhrase
        , genesisDevHdwSecretKeys
 
        -- * Ssc
        , genesisLeaders
        ) where
 
-import           Control.Lens          (ix)
-import           Data.Default          (Default (..))
-import           Data.List             (genericLength, genericReplicate)
-import qualified Data.Map.Strict       as M
-import qualified Data.Text             as T
-import           Formatting            (int, sformat, stext, (%))
-import           Serokell.Util         (enumerate)
+import           Data.Default        (Default (..))
+import           Data.List           (genericLength, genericReplicate)
+import qualified Data.Map.Strict     as M
+import qualified Data.Text           as T
+import           Formatting          (int, sformat, (%))
+import           Serokell.Util       (enumerate)
 import           Universum
 
-import qualified Pos.Constants         as Const
-import           Pos.Core.Types        (StakeholderId)
-import           Pos.Crypto            (EncryptedSecretKey, PublicKey, SecretKey,
-                                        deterministicKeyGen, emptyPassphrase, encToPublic,
-                                        unsafeHash)
-import           Pos.Genesis.Parser    (compileGenData)
-import           Pos.Genesis.Types     (GenesisData (..), StakeDistribution (..),
-                                        getTotalStake)
-import           Pos.Lrc.FtsPure       (followTheSatoshi)
-import           Pos.Lrc.Genesis       (genesisSeed)
-import           Pos.Txp.Core.Types    (TxIn (..), TxOut (..), TxOutAux (..),
-                                        TxOutDistribution)
-import           Pos.Txp.Toil.Types    (Utxo)
-import           Pos.Types             (Address (..), Coin, SlotLeaders, applyCoinPortion,
-                                        coinToInteger, divCoin, makePubKeyAddress, mkCoin,
-                                        unsafeAddCoin, unsafeMulCoin)
-import           Pos.Util.BackupPhrase (BackupPhrase, mkBackupPhrase9, safeKeysFromPhrase)
-import           Pos.Util.Mnemonics    as Mnemonics
-import           Pos.Wallet.Web.Util   (deriveLvl2KeyPair)
+import qualified Pos.Constants       as Const
+import           Pos.Core.Types      (StakeholderId)
+import           Pos.Crypto          (EncryptedSecretKey, PublicKey, SecretKey,
+                                      deterministicKeyGen, emptyPassphrase, encToPublic,
+                                      firstNonHardened, safeDeterministicKeyGen,
+                                      unsafeHash)
+import           Pos.Genesis.Parser  (compileGenData)
+import           Pos.Genesis.Types   (GenesisData (..), StakeDistribution (..),
+                                      getTotalStake)
+import           Pos.Lrc.FtsPure     (followTheSatoshi)
+import           Pos.Lrc.Genesis     (genesisSeed)
+import           Pos.Txp.Core.Types  (TxIn (..), TxOut (..), TxOutAux (..),
+                                      TxOutDistribution)
+import           Pos.Txp.Toil.Types  (Utxo)
+import           Pos.Types           (Address (..), Coin, SlotLeaders, applyCoinPortion,
+                                      coinToInteger, divCoin, makePubKeyAddress, mkCoin,
+                                      unsafeAddCoin, unsafeMulCoin)
+import           Pos.Wallet.Web.Util (deriveLvl2KeyPair)
 
 ----------------------------------------------------------------------------
 -- Static state
@@ -98,30 +95,13 @@ genesisBalances
     | Const.isDevelopment = mempty
     | otherwise           = gdBootstrapBalances compileGenData
 
-generateGenesisBackupPhrase :: Int -> BackupPhrase
-generateGenesisBackupPhrase i =
-    let unique = fromMaybe (error "Mnemonics dictionary it too small for Genesis")
-               $ Mnemonics.wl ^? ix i
-    in mkBackupPhrase9
-        [ "avocado"
-        , "avoid"
-        , "awake"
-        , "aware"
-        , "away"
-        , "awesome"
-        , "awful"
-        , "awkward"
-        , toText unique
-        ]
-
 generateHdwGenesisSecretKey :: Int -> EncryptedSecretKey
 generateHdwGenesisSecretKey =
-    fst .
-    either failed identity .
-    safeKeysFromPhrase emptyPassphrase .
-    generateGenesisBackupPhrase
-  where
-    failed = error . sformat ("safeKeysFromPhrase failed in Genesis: "%stext)
+    snd .
+    fromMaybe (error "safeDeterministicKeyGen failed in Genesis") .
+    flip safeDeterministicKeyGen emptyPassphrase .
+    encodeUtf8 .
+    T.take 32 . sformat ("My 32-byte hdw seed #" %int % "                  ")
 
 -- | List of 'SecretKey's in genesis for HD wallets.
 genesisDevHdwSecretKeys :: [EncryptedSecretKey]
@@ -130,11 +110,11 @@ genesisDevHdwSecretKeys =
 
 -- | First index in derivation path for HD account, which is put to genesis utxo
 walletGenesisIndex :: Word32
-walletGenesisIndex = 0
+walletGenesisIndex = firstNonHardened
 
 -- | Second index in derivation path for HD account, which is put to genesis utxo
 accountGenesisIndex :: Word32
-accountGenesisIndex = 0
+accountGenesisIndex = firstNonHardened
 
 genesisDevHdwAccountSecretKeys :: [EncryptedSecretKey]
 genesisDevHdwAccountSecretKeys =
@@ -218,8 +198,10 @@ bitcoinDistributionImpl ratio coins (coinIdx, coin) =
 -- | Genesis 'Utxo'.
 genesisUtxo :: StakeDistribution -> Utxo
 genesisUtxo sd =
-    M.fromList . zipWith zipF (stakeDistribution sd) $
-    genesisAddresses <> allTailAddresses
+    M.fromList $
+        zipWith zipF (stakeDistribution sd)
+            (genesisAddresses <> tailAddresses)
+     <> map (zipF hwdDistr) hdwAddresses
   where
     zipF (coin, distr) addr =
         ( TxIn (unsafeHash addr) 0
@@ -227,10 +209,10 @@ genesisUtxo sd =
         )
     tailAddresses = map (makePubKeyAddress . fst . generateGenesisKeyPair)
         [Const.genesisN ..]
-    tailHdwAddresses = makePubKeyAddress . encToPublic <$>
-        genesisDevHdwAccountSecretKeys
-    allTailAddresses =
-        concat $ zipWith (\a b -> [a, b]) tailAddresses tailHdwAddresses
+    hdwAddresses =
+        take Const.genesisN $
+        makePubKeyAddress . encToPublic <$> genesisDevHdwAccountSecretKeys
+    hwdDistr = (mkCoin 50000, [])  -- TODO: manage
 
 genesisDelegation :: HashMap StakeholderId [StakeholderId]
 genesisDelegation = mempty

--- a/src/Pos/Util/BackupPhrase.hs
+++ b/src/Pos/Util/BackupPhrase.hs
@@ -16,7 +16,7 @@ import qualified Prelude
 import           Universum
 
 import           Crypto.Hash         (Blake2b_256)
-import           Pos.Binary          (Bi, encodeStrict)
+import           Pos.Binary          (Bi (..), encodeStrict, label)
 import           Pos.Crypto          (AbstractHash, EncryptedSecretKey, PassPhrase,
                                       SecretKey, VssKeyPair, deterministicKeyGen,
                                       deterministicVssKeyGen, safeDeterministicKeyGen,
@@ -28,6 +28,10 @@ import           Pos.Util.Mnemonics  (fromMnemonic, toMnemonic)
 newtype BackupPhrase = BackupPhrase
     { bpToList :: [Text]
     } deriving (Eq, Generic)
+
+instance Bi BackupPhrase where
+    put BackupPhrase{..} = put bpToList
+    get = label "BackupPhrase" $ BackupPhrase <$> get
 
 -- | Number of words in backup phrase
 backupPhraseWordsNum :: Int

--- a/src/Pos/Util/UserSecret.hs
+++ b/src/Pos/Util/UserSecret.hs
@@ -21,6 +21,8 @@ module Pos.Util.UserSecret
        , takeUserSecret
        , writeUserSecret
        , writeUserSecretRelease
+
+       , ensureModeIs600
        ) where
 
 import           Control.Exception    (onException)

--- a/src/Pos/Wallet/Web/Api.hs
+++ b/src/Pos/Wallet/Web/Api.hs
@@ -111,6 +111,7 @@ type RenameWalletSet = API
 type ImportKey = API
     :> "walletSets"
     :> "keys"
+    :> QueryParam "passphrase" CPassPhrase
     :> ReqBody '[JSON] Text
     :> Post '[JSON] (Either WalletError CWalletSet)
 

--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -50,12 +50,17 @@ module Pos.Wallet.Web.ClientTypes
       , txContainsTitle
       , toCUpdateInfo
       , walletAddrByAccount
+      , mkDefCWSetMeta
+      , WalletUserSecret (..)
+      , readWalletUserSecret
+      , writeWalletUserSecret
       ) where
 
 import           Universum
 
 import           Control.Arrow          ((&&&))
 import qualified Data.ByteString.Lazy   as LBS
+import qualified Data.ByteString.Lazy   as BSL
 import           Data.Default           (Default, def)
 import           Data.Hashable          (Hashable (..))
 import           Data.Text              (Text, isInfixOf, toLower)
@@ -68,12 +73,14 @@ import qualified Prelude
 import qualified Serokell.Util.Base16   as Base16
 import           Servant.Multipart      (FileData, FromMultipart (..), lookupFile,
                                          lookupInput)
+import           System.IO              (withFile)
+import           System.Wlog            (WithLogger)
 
 import           Pos.Aeson.Types        ()
-import           Pos.Binary.Class       (decodeFull, encodeStrict)
+import           Pos.Binary.Class       (Bi (..), decodeFull, encode, encodeStrict, label)
 import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Core.Types         (ScriptVersion)
-import           Pos.Crypto             (PassPhrase, hashHexF)
+import           Pos.Crypto             (EncryptedSecretKey, PassPhrase, hashHexF)
 import           Pos.Txp.Core.Types     (Tx (..), TxId, TxOut, txOutAddress, txOutValue)
 import           Pos.Types              (Address (..), BlockVersion, ChainDifficulty,
                                          Coin, SoftwareVersion, decodeTextAddress,
@@ -81,7 +88,8 @@ import           Pos.Types              (Address (..), BlockVersion, ChainDiffic
 import           Pos.Update.Core        (BlockVersionData (..), StakeholderVotes,
                                          UpdateProposal (..), isPositiveVote)
 import           Pos.Update.Poll        (ConfirmedProposalState (..))
-import           Pos.Util.BackupPhrase  (BackupPhrase, mkBackupPhrase12)
+import           Pos.Util.BackupPhrase  (BackupPhrase)
+import           Pos.Util.UserSecret    (ensureModeIs600)
 
 
 data SyncProgress = SyncProgress
@@ -300,24 +308,8 @@ data CWalletSetMeta = CWalletSetMeta
     , cwsBackupPhrase :: !BackupPhrase
     } deriving (Show, Eq, Generic)
 
-instance Default BackupPhrase where
-    def = mkBackupPhrase12
-        [ "transfer"
-        , "uniform"
-        , "grunt"
-        , "excess"
-        , "six"
-        , "veteran"
-        , "vintage"
-        , "warm"
-        , "confirm"
-        , "vote"
-        , "nephew"
-        , "allow"
-        ]
-
-instance Default CWalletSetMeta where
-    def = CWalletSetMeta "Personal Wallet Set" def
+mkDefCWSetMeta :: BackupPhrase -> CWalletSetMeta
+mkDefCWSetMeta = CWalletSetMeta "Personal Wallet Set"
 
 -- | Client Wallet Set (CW)
 data CWalletSet = CWalletSet
@@ -449,6 +441,46 @@ toCUpdateInfo ConfirmedProposalState {..} =
         cuiPositiveStake    = mkCCoin cpsPositiveStake
         cuiNegativeStake    = mkCCoin cpsNegativeStake
     in CUpdateInfo {..}
+
+----------------------------------------------------------------------------
+-- UserSecret
+----------------------------------------------------------------------------
+
+-- | Describes HD wallets keyfile content
+data WalletUserSecret = WalletUserSecret
+    { wusRootKey      :: EncryptedSecretKey  -- ^ root key of wallet set
+    , wusWSetName     :: Text                -- ^ name of wallet set
+    , wusBackupPhrase :: BackupPhrase        -- ^ backup phrase of wallet set
+    , wusWallets      :: [(Word32, Text)]    -- ^ coordinates and names wallets
+    , wusAccounts     :: [(Word32, Word32)]  -- ^ coordinates of accounts
+    }
+
+instance Bi WalletUserSecret where
+    put WalletUserSecret{..} = do
+        put wusRootKey
+        put wusWSetName
+        put wusBackupPhrase
+        put wusWallets
+        put wusAccounts
+    get = label "WalletUserSecret" $ do
+        wusRootKey <- get
+        wusWSetName <- get
+        wusBackupPhrase <- get
+        wusWallets <- get
+        wusAccounts <- get
+        return WalletUserSecret{..}
+
+readWalletUserSecret
+    :: (MonadIO m, WithLogger m)
+    => FilePath -> m (Either Text WalletUserSecret)
+readWalletUserSecret path = do
+    ensureModeIs600 path
+    liftIO $ first toText . decodeFull <$> BSL.readFile path
+
+writeWalletUserSecret :: MonadIO m => FilePath -> WalletUserSecret -> m ()
+writeWalletUserSecret path secret = do
+    liftIO $ withFile path WriteMode $ \handle ->
+        BSL.hPut handle (encode secret)
 
 ----------------------------------------------------------------------------
 -- Reportin

--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -50,7 +50,6 @@ module Pos.Wallet.Web.ClientTypes
       , txContainsTitle
       , toCUpdateInfo
       , walletAddrByAccount
-      , mkDefCWSetMeta
       , WalletUserSecret (..)
       , readWalletUserSecret
       , writeWalletUserSecret
@@ -304,12 +303,12 @@ data CWalletRedeem = CWalletRedeem
 
 -- | Meta data of 'CWalletSet'
 data CWalletSetMeta = CWalletSetMeta
-    { cwsName         :: !Text
-    , cwsBackupPhrase :: !BackupPhrase
+    { cwsName :: !Text
     } deriving (Show, Eq, Generic)
 
-mkDefCWSetMeta :: BackupPhrase -> CWalletSetMeta
-mkDefCWSetMeta = CWalletSetMeta "Personal Wallet Set"
+
+instance Default CWalletSetMeta where
+  def = CWalletSetMeta "Personal Wallet Set"
 
 -- | Client Wallet Set (CW)
 data CWalletSet = CWalletSet
@@ -323,6 +322,7 @@ data CWalletSet = CWalletSet
 -- | Query data for wallet set creation
 data CWalletSetInit = CWalletSetInit
     { cwsInitMeta     :: !CWalletSetMeta
+    , cwsBackupPhrase :: !BackupPhrase
     } deriving (Eq, Show, Generic)
 
 class WithDerivationPath a where
@@ -448,24 +448,21 @@ toCUpdateInfo ConfirmedProposalState {..} =
 
 -- | Describes HD wallets keyfile content
 data WalletUserSecret = WalletUserSecret
-    { wusRootKey      :: EncryptedSecretKey  -- ^ root key of wallet set
-    , wusWSetName     :: Text                -- ^ name of wallet set
-    , wusBackupPhrase :: BackupPhrase        -- ^ backup phrase of wallet set
-    , wusWallets      :: [(Word32, Text)]    -- ^ coordinates and names wallets
-    , wusAccounts     :: [(Word32, Word32)]  -- ^ coordinates of accounts
+    { wusRootKey  :: EncryptedSecretKey  -- ^ root key of wallet set
+    , wusWSetName :: Text                -- ^ name of wallet set
+    , wusWallets  :: [(Word32, Text)]    -- ^ coordinates and names wallets
+    , wusAccounts :: [(Word32, Word32)]  -- ^ coordinates of accounts
     }
 
 instance Bi WalletUserSecret where
     put WalletUserSecret{..} = do
         put wusRootKey
         put wusWSetName
-        put wusBackupPhrase
         put wusWallets
         put wusAccounts
     get = label "WalletUserSecret" $ do
         wusRootKey <- get
         wusWSetName <- get
-        wusBackupPhrase <- get
         wusWallets <- get
         wusAccounts <- get
         return WalletUserSecret{..}

--- a/src/Pos/Wallet/Web/Doc.hs
+++ b/src/Pos/Wallet/Web/Doc.hs
@@ -53,7 +53,8 @@ import           Pos.Wallet.Web.ClientTypes (Acc, CAccount (..), CAccountAddress
                                              CWalletRedeem (..), CWalletSet (..),
                                              CWalletSetInit (..), CWalletSetInit (..),
                                              CWalletSetMeta (..), SyncProgress, WS,
-                                             addressToCAddress, mkCCoin, mkCTxId)
+                                             addressToCAddress, mkCCoin, mkCTxId,
+                                             mkDefCWSetMeta)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 
 
@@ -458,7 +459,7 @@ instance ToSample CWalletSetInit where
     toSamples Proxy = singleSample sample
       where
         sample = CWalletSetInit
-            { cwsInitMeta = def
+            { cwsInitMeta = mkDefCWSetMeta backupPhrase
             }
 
 instance ToSample CWalletAddress where

--- a/src/Pos/Wallet/Web/Doc.hs
+++ b/src/Pos/Wallet/Web/Doc.hs
@@ -53,8 +53,7 @@ import           Pos.Wallet.Web.ClientTypes (Acc, CAccount (..), CAccountAddress
                                              CWalletRedeem (..), CWalletSet (..),
                                              CWalletSetInit (..), CWalletSetInit (..),
                                              CWalletSetMeta (..), SyncProgress, WS,
-                                             addressToCAddress, mkCCoin, mkCTxId,
-                                             mkDefCWSetMeta)
+                                             addressToCAddress, mkCCoin, mkCTxId)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 
 
@@ -441,7 +440,7 @@ instance ToSample CWalletSet where
       where
         sample = CWalletSet
             { cwsAddress       = cWalletSetAddressSample
-            , cwsWSetMeta      = CWalletSetMeta "Personal Wallet Set" backupPhrase
+            , cwsWSetMeta      = CWalletSetMeta "Personal Wallet Set"
             , cwsWalletsNumber = 3
             , cwsHasPassphrase = True
             , cwsPassphraseLU  = 1493331655090351
@@ -459,7 +458,8 @@ instance ToSample CWalletSetInit where
     toSamples Proxy = singleSample sample
       where
         sample = CWalletSetInit
-            { cwsInitMeta = mkDefCWSetMeta backupPhrase
+            { cwsInitMeta     = def
+            , cwsBackupPhrase = backupPhrase
             }
 
 instance ToSample CWalletAddress where

--- a/src/Pos/Wallet/Web/Util.hs
+++ b/src/Pos/Wallet/Web/Util.hs
@@ -1,0 +1,26 @@
+-- | Different utils for wallets
+
+module Pos.Wallet.Web.Util
+    ( deriveLvl2KeyPair
+    ) where
+
+import           Universum
+
+import           Pos.Core   (Address, createHDAddressH)
+import           Pos.Crypto (PassPhrase, deriveHDPassphrase, deriveHDSecretKey,
+                             encToPublic)
+import           Pos.Crypto (EncryptedSecretKey)
+
+-- TODO: move more here from Methods.hs
+
+-- | Makes account secret key for given wallet set.
+deriveLvl2KeyPair
+    :: PassPhrase
+    -> EncryptedSecretKey  -- ^ key of wallet set
+    -> Word32              -- ^ wallet derivation index
+    -> Word32              -- ^ account derivation index
+    -> (Address, EncryptedSecretKey)
+deriveLvl2KeyPair passphrase wsKey walletIndex accIndex =
+    let wKey   = deriveHDSecretKey passphrase wsKey walletIndex
+        hdPass = deriveHDPassphrase $ encToPublic wsKey
+    in  createHDAddressH passphrase hdPass wKey [walletIndex] accIndex

--- a/src/keygen/Main.hs
+++ b/src/keygen/Main.hs
@@ -20,7 +20,9 @@ import           Pos.Binary           (decodeFull, encode)
 import           Pos.Core             (coinToInteger, mkCoin, unsafeAddCoin,
                                        unsafeIntegerToCoin)
 import           Pos.Genesis          (GenesisData (..), StakeDistribution (..),
-                                       genesisDevSecretKeys, getTotalStake)
+                                       generateGenesisBackupPhrase,
+                                       genesisDevHdwSecretKeys, genesisDevSecretKeys,
+                                       getTotalStake)
 import           Pos.Types            (addressDetailedF, addressHash, makePubKeyAddress,
                                        makeRedeemAddress)
 
@@ -30,7 +32,8 @@ import           KeygenOptions        (AvvmStakeOptions (..), FakeAvvmOptions (.
                                        KeygenOptions (..), TestStakeOptions (..),
                                        optsInfo)
 import           Testnet              (genTestnetStakes, generateFakeAvvm,
-                                       generateKeyfile, rearrangeKeyfile)
+                                       generateHdwKeyfile, generateKeyfile,
+                                       rearrangeKeyfile)
 
 replace :: FilePath -> FilePath -> FilePath -> FilePath
 replace a b = toString . (T.replace `on` toText) a b . toText
@@ -122,6 +125,9 @@ dumpKeys pat = do
     liftIO $ createDirectoryIfMissing True keysDir
     for_ (zip [1..] genesisDevSecretKeys) $ \(i :: Int, k) ->
         generateKeyfile False (Just k) $ applyPattern pat i
+    for_ (zip [1..] genesisDevHdwSecretKeys) $ \(i :: Int, k) ->
+        let bp = generateGenesisBackupPhrase i
+        in  generateHdwKeyfile k bp $ applyPattern (pat <> ".hd") i
 
 reassignBalances :: GenesisData -> GenesisData
 reassignBalances GenesisData{..} = GenesisData
@@ -172,4 +178,3 @@ genGenesisBin KeygenOptions{..} = do
             if length binGenesis < 10*1024
                 then putText "Printing GenesisData:\n\n" >> print genData
                 else putText "genesis.bin is bigger than 10k, won't print it\n"
-

--- a/src/keygen/Main.hs
+++ b/src/keygen/Main.hs
@@ -20,7 +20,6 @@ import           Pos.Binary           (decodeFull, encode)
 import           Pos.Core             (coinToInteger, mkCoin, unsafeAddCoin,
                                        unsafeIntegerToCoin)
 import           Pos.Genesis          (GenesisData (..), StakeDistribution (..),
-                                       generateGenesisBackupPhrase,
                                        genesisDevHdwSecretKeys, genesisDevSecretKeys,
                                        getTotalStake)
 import           Pos.Types            (addressDetailedF, addressHash, makePubKeyAddress,
@@ -126,8 +125,7 @@ dumpKeys pat = do
     for_ (zip [1..] genesisDevSecretKeys) $ \(i :: Int, k) ->
         generateKeyfile False (Just k) $ applyPattern pat i
     for_ (zip [1..] genesisDevHdwSecretKeys) $ \(i :: Int, k) ->
-        let bp = generateGenesisBackupPhrase i
-        in  generateHdwKeyfile k bp $ applyPattern (pat <> ".hd") i
+        generateHdwKeyfile k $ applyPattern (pat <> ".hd") i
 
 reassignBalances :: GenesisData -> GenesisData
 reassignBalances GenesisData{..} = GenesisData

--- a/src/keygen/Testnet.hs
+++ b/src/keygen/Testnet.hs
@@ -6,29 +6,28 @@ module Testnet
        , rearrangeKeyfile
        ) where
 
-import qualified Serokell.Util.Base64  as B64
-import           Serokell.Util.Verify  (VerificationRes (..), formatAllErrors,
-                                        verifyGeneric)
-import           System.Random         (randomRIO)
-import           System.Wlog           (WithLogger)
+import qualified Serokell.Util.Base64 as B64
+import           Serokell.Util.Verify (VerificationRes (..), formatAllErrors,
+                                       verifyGeneric)
+import           System.Random        (randomRIO)
+import           System.Wlog          (WithLogger)
 import           Universum
 
-import           Pos.Binary            (asBinary)
-import qualified Pos.Constants         as Const
-import           Pos.Crypto            (EncryptedSecretKey, PublicKey, RedeemPublicKey,
-                                        SecretKey, keyGen, noPassEncrypt,
-                                        redeemDeterministicKeyGen, secureRandomBS,
-                                        toPublic, toVssPublicKey, vssKeyGen)
-import           Pos.Genesis           (StakeDistribution (..), accountGenesisIndex,
-                                        walletGenesisIndex)
-import           Pos.Ssc.GodTossing    (VssCertificate, mkVssCertificate)
-import           Pos.Types             (coinPortionToDouble, unsafeIntegerToCoin)
-import           Pos.Util.BackupPhrase (BackupPhrase)
-import           Pos.Util.UserSecret   (initializeUserSecret, takeUserSecret, usKeys,
-                                        usPrimKey, usVss, writeUserSecretRelease)
-import           Pos.Wallet.Web        (WalletUserSecret (..), writeWalletUserSecret)
+import           Pos.Binary           (asBinary)
+import qualified Pos.Constants        as Const
+import           Pos.Crypto           (EncryptedSecretKey, PublicKey, RedeemPublicKey,
+                                       SecretKey, keyGen, noPassEncrypt,
+                                       redeemDeterministicKeyGen, secureRandomBS,
+                                       toPublic, toVssPublicKey, vssKeyGen)
+import           Pos.Genesis          (StakeDistribution (..), accountGenesisIndex,
+                                       walletGenesisIndex)
+import           Pos.Ssc.GodTossing   (VssCertificate, mkVssCertificate)
+import           Pos.Types            (coinPortionToDouble, unsafeIntegerToCoin)
+import           Pos.Util.UserSecret  (initializeUserSecret, takeUserSecret, usKeys,
+                                       usPrimKey, usVss, writeUserSecretRelease)
+import           Pos.Wallet.Web       (WalletUserSecret (..), writeWalletUserSecret)
 
-import           KeygenOptions         (TestStakeOptions (..))
+import           KeygenOptions        (TestStakeOptions (..))
 
 rearrangeKeyfile :: (MonadIO m, MonadFail m, WithLogger m) => FilePath -> m ()
 rearrangeKeyfile fp = do
@@ -61,8 +60,8 @@ generateKeyfile isPrim mbSk fp = do
 
 generateHdwKeyfile
     :: (MonadIO m, MonadFail m, WithLogger m)
-    => EncryptedSecretKey -> BackupPhrase -> FilePath -> m ()
-generateHdwKeyfile wusRootKey wusBackupPhrase fp = do
+    => EncryptedSecretKey -> FilePath -> m ()
+generateHdwKeyfile wusRootKey fp = do
     let wusWSetName = "Genesis wallet set"
         wusWallets  = [(walletGenesisIndex, "Genesis wallet")]
         wusAccounts = [(walletGenesisIndex, accountGenesisIndex)]

--- a/src/keygen/Testnet.hs
+++ b/src/keygen/Testnet.hs
@@ -1,30 +1,34 @@
 module Testnet
        ( generateKeyfile
+       , generateHdwKeyfile
        , generateFakeAvvm
        , genTestnetStakes
        , rearrangeKeyfile
        ) where
 
-import qualified Serokell.Util.Base64 as B64
-import           Serokell.Util.Verify (VerificationRes (..), formatAllErrors,
-                                       verifyGeneric)
-import           System.Random        (randomRIO)
-import           System.Wlog          (WithLogger)
+import qualified Serokell.Util.Base64  as B64
+import           Serokell.Util.Verify  (VerificationRes (..), formatAllErrors,
+                                        verifyGeneric)
+import           System.Random         (randomRIO)
+import           System.Wlog           (WithLogger)
 import           Universum
 
-import           Pos.Binary           (asBinary)
-import qualified Pos.Constants        as Const
-import           Pos.Crypto           (PublicKey, RedeemPublicKey, SecretKey, keyGen,
-                                       noPassEncrypt, redeemDeterministicKeyGen,
-                                       secureRandomBS, toPublic, toVssPublicKey,
-                                       vssKeyGen)
-import           Pos.Genesis          (StakeDistribution (..))
-import           Pos.Ssc.GodTossing   (VssCertificate, mkVssCertificate)
-import           Pos.Types            (coinPortionToDouble, unsafeIntegerToCoin)
-import           Pos.Util.UserSecret  (initializeUserSecret, takeUserSecret, usKeys,
-                                       usPrimKey, usVss, writeUserSecretRelease)
+import           Pos.Binary            (asBinary)
+import qualified Pos.Constants         as Const
+import           Pos.Crypto            (EncryptedSecretKey, PublicKey, RedeemPublicKey,
+                                        SecretKey, keyGen, noPassEncrypt,
+                                        redeemDeterministicKeyGen, secureRandomBS,
+                                        toPublic, toVssPublicKey, vssKeyGen)
+import           Pos.Genesis           (StakeDistribution (..), accountGenesisIndex,
+                                        walletGenesisIndex)
+import           Pos.Ssc.GodTossing    (VssCertificate, mkVssCertificate)
+import           Pos.Types             (coinPortionToDouble, unsafeIntegerToCoin)
+import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.UserSecret   (initializeUserSecret, takeUserSecret, usKeys,
+                                        usPrimKey, usVss, writeUserSecretRelease)
+import           Pos.Wallet.Web        (WalletUserSecret (..), writeWalletUserSecret)
 
-import           KeygenOptions        (TestStakeOptions (..))
+import           KeygenOptions         (TestStakeOptions (..))
 
 rearrangeKeyfile :: (MonadIO m, MonadFail m, WithLogger m) => FilePath -> m ()
 rearrangeKeyfile fp = do
@@ -54,6 +58,15 @@ generateKeyfile isPrim mbSk fp = do
     let vssPk = asBinary $ toVssPublicKey vss
         vssCert = mkVssCertificate sk vssPk expiry
     return (toPublic sk, vssCert)
+
+generateHdwKeyfile
+    :: (MonadIO m, MonadFail m, WithLogger m)
+    => EncryptedSecretKey -> BackupPhrase -> FilePath -> m ()
+generateHdwKeyfile wusRootKey wusBackupPhrase fp = do
+    let wusWSetName = "Genesis wallet set"
+        wusWallets  = [(walletGenesisIndex, "Genesis wallet")]
+        wusAccounts = [(walletGenesisIndex, accountGenesisIndex)]
+    writeWalletUserSecret fp WalletUserSecret{..}
 
 generateFakeAvvm :: MonadIO m => FilePath -> m RedeemPublicKey
 generateFakeAvvm fp = do


### PR DESCRIPTION
This PR adds new format of `UserSecret`, used for wallets - now (`WalletUserSecret`) it keeps whole db walletset structure.

Also it adds to genesis utxo `Const.genesisN` keys with 50000 money (very naive, but I hope it fits for now), and enable generation of hd keyfiles by `keygen`. Generated keyfiles can be successfully imported and used as source of money :money_mouth_face: 