### PR TITLE
Upgrade to cryptonite-0.23 (fixes 4GB alloc issue)

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -431,7 +431,7 @@ library
                       , concurrent-extra
                       , conduit >= 1.2.8
                       , containers
-                      , cryptonite >= 0.19 && <= 0.22
+                      , cryptonite >= 0.23 && <= 0.23
                       , cryptonite-openssl >= 0.5
                       , data-default
                       , deepseq

--- a/stack.yaml
+++ b/stack.yaml
@@ -74,6 +74,8 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
+- foundation-0.0.8
+- memory-0.14.5
 - universum-0.3
 - time-units-1.0.0
 - serokell-util-0.1.5.0
@@ -83,7 +85,7 @@ extra-deps:
 - concurrent-extra-0.7.0.10       # not yet in lts-8
 - derive-2.6.2
 - purescript-bridge-0.8.0.1
-- cryptonite-0.22
+- cryptonite-0.23
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8
 - servant-0.10                    # servant-multipart supports version servant-10 only
 - servant-server-0.10             # so it triggers another dependencies to be v10


### PR DESCRIPTION
Reference:

bug/csl982-mem-optimization

https://issues.serokell.io/issue/CSL-982