### PR TITLE
[CSL-1004] Node catchup improvements

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -577,7 +577,8 @@ executable cardano-node
   ghc-options:         -threaded -rtsopts
                        -Wall
                        -fno-warn-orphans
-                       -with-rtsopts=-N
+                       -- -N1 for improved CPU utilisation until we manage to reduce it, see [CSL-1004]
+                       -with-rtsopts=-N1
                        -O2
   default-extensions:   DeriveDataTypeable
                         DeriveGeneric

--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -429,7 +429,7 @@ library
                       , concurrent-extra
                       , conduit >= 1.2.8
                       , containers
-                      , cryptonite >= 0.19 && <= 0.22
+                      , cryptonite >= 0.19 && <= 0.23
                       , cryptonite-openssl >= 0.5
                       , data-default
                       , deepseq

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -89,7 +89,7 @@ library
                       -- this constraint, first check that all code in
                       -- Pos.Binary.Class that has been ripped from 'binary'
                       -- hasn't changed upstream.
-                     , binary == 0.8.3.*
+                     , binary == 0.8.5.*
                      , bytestring
                      , cardano-crypto
                      , cereal

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -374,6 +374,7 @@ createTransport addrInfo = do
                    Just $ fromIntegral Const.networkConnectionTimeout
              , TCP.tcpNewQDisc = fairQDisc $ \_ -> return Nothing
              , TCP.tcpCheckPeerHost = True
+             , TCP.tcpNoDelay = True
              })
     transportE <-
         liftIO $ TCP.createTransport addrInfo tcpParams

--- a/stack.yaml
+++ b/stack.yaml
@@ -83,7 +83,9 @@ extra-deps:
 - concurrent-extra-0.7.0.10       # not yet in lts-8
 - derive-2.6.2
 - purescript-bridge-0.8.0.1
-- cryptonite-0.22
+- foundation-0.0.8
+- memory-0.14.5
+- cryptonite-0.23
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8
 - servant-0.10                    # servant-multipart supports version servant-10 only
 - servant-server-0.10             # so it triggers another dependencies to be v10

--- a/stack.yaml
+++ b/stack.yaml
@@ -82,6 +82,7 @@ extra-deps:
 - log-warper-1.1.1
 - concurrent-extra-0.7.0.10       # not yet in lts-8
 - derive-2.6.2
+- binary-0.8.5.1
 - purescript-bridge-0.8.0.1
 - foundation-0.0.8
 - memory-0.14.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,8 +47,8 @@ packages:
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:
-    git: https://github.com/avieth/network-transport-tcp
-    commit: ca42a954a15792f5ea8dc203e56fac8175b99c33
+    git: https://github.com/serokell/network-transport-tcp
+    commit: 83aa8748f613e5309653c925fff43693b4f0c618
   extra-dep: true
 - location:
     git: https://github.com/avieth/network-transport


### PR DESCRIPTION
This is the first set of improvements to improve block retrieval speed (especially for nodes "catching up" their blockchain).

See the commit messages for details.

In my measurements, these changes improve node retrieval speed by 30-40% on localhost networking, and on an older commit against a remote cluster (so that localhost was not CPU bound) which was 10 ms away improved a total retrieval time from ~120 to ~45 seconds.

After these changes, block retrieval is still slower than desired, but at least the bottleneck is now CPU usage, instead of `cardano-node` sitting around at low network speed and low CPU usage.

---

Special QA needs:

* Compatibility:
  * [ ] I have only tested this on Linux so far, check that it works as expected on OSX and Windows.
* Network performance: `TCP_QUICKACK` is Linux-only; while changing the behaviour on only 1 side of the TCP connection may already bring an improvement, I still need somebody to
  * [ ] check if the [corresponding Windows registry setting `TcpAckFrequency`](https://support.microsoft.com/en-gb/help/328890/new-registry-entry-for-controlling-the-tcp-acknowledgment-ack-behavior-in-windows-xp-and-in-windows-server-2003) brings an improvement when set to `1` (from the default, `2`).
  * [ ] check if the corresponding setting on OSX (seems to be [`sudo sysctl -w net.inet.tcp.delayed_ack=0`](http://www.shabangs.net/osx/speed-up-macos-x-file-transferring-over-network/)) brings a performance improvement
* Non-network performance: The change to `-N1` may hurt performance for parts of `cardano-node` that scale nicely to multiple threads (apparently catchup is not such a part currently). Need to check if we're making some non-catchup use case slower.

---

**Don't merge before #318.**