### PR TITLE
[CSM-224] Avoid circular imports

### DIFF
--- a/src/Pos/Block/Logic.hs
+++ b/src/Pos/Block/Logic.hs
@@ -64,7 +64,6 @@ import           Pos.Crypto                 (SecretKey, WithHash (WithHash), has
 import           Pos.Data.Attributes        (mkAttributes)
 import           Pos.DB                     (DBError (..), MonadDB, MonadDBCore)
 import qualified Pos.DB.Block               as DB
-import qualified Pos.DB.DB                  as DB
 import qualified Pos.DB.GState              as GS
 import           Pos.Delegation.Logic       (delegationVerifyBlocks, getProxyMempool)
 import           Pos.Exception              (assertionFailed, reportFatalError)

--- a/src/Pos/Block/Network/Announce.hs
+++ b/src/Pos/Block/Network/Announce.hs
@@ -26,7 +26,6 @@ import           Pos.Context                (getNodeContext, isRecoveryMode, ncN
                                              npAttackTypes)
 import           Pos.Crypto                 (shortHashF)
 import qualified Pos.DB.Block               as DB
-import qualified Pos.DB.DB                  as DB
 import           Pos.DHT.Model              (converseToNeighbors)
 import           Pos.Security               (AttackType (..), NodeAttackedError (..),
                                              shouldIgnoreAddress)

--- a/src/Pos/DB/Block.hs
+++ b/src/Pos/DB/Block.hs
@@ -7,6 +7,8 @@ module Pos.DB.Block
        , getBlockHeader
        , getUndo
        , getBlockWithUndo
+       , getTipBlock
+       , getTipBlockHeader
 
        , deleteBlock
        , putBlock
@@ -41,6 +43,7 @@ import           Pos.Crypto                (hashHexF, shortHashF)
 import           Pos.DB.Class              (MonadDB, getBlockIndexDB, getNodeDBs)
 import           Pos.DB.Error              (DBError (DBMalformed))
 import           Pos.DB.Functions          (rocksDelete, rocksGetBi, rocksPutBi)
+import           Pos.DB.GState.Common      (getTip)
 import           Pos.DB.Types              (blockDataDir)
 import           Pos.Ssc.Class.Helpers     (SscHelpersClass)
 import           Pos.Types                 (Block, BlockHeader, GenesisBlock,
@@ -62,6 +65,20 @@ getBlockHeader
     :: (SscHelpersClass ssc, MonadDB m)
     => HeaderHash -> m (Maybe (BlockHeader ssc))
 getBlockHeader = getBi . blockIndexKey
+
+-- | Get block corresponding to tip.
+getTipBlock
+    :: (SscHelpersClass ssc, MonadDB m)
+    => m (Block ssc)
+getTipBlock = maybe onFailure pure =<< getBlock =<< getTip
+  where
+    onFailure = throwM $ DBMalformed "there is no block corresponding to tip"
+
+-- | Get BlockHeader corresponding to tip.
+getTipBlockHeader
+    :: (SscHelpersClass ssc, MonadDB m)
+    => m (BlockHeader ssc)
+getTipBlockHeader = T.getBlockHeader <$> getTipBlock
 
 -- | Get undo data for block with given hash from Block DB.
 getUndo :: (MonadDB m) => HeaderHash -> m (Maybe Undo)
@@ -265,20 +282,18 @@ getBlundThrow hash =
     maybeThrow (DBMalformed $ sformat errFmt hash) =<<
     (liftA2 (,) <$> getBlock hash <*> getUndo hash)
   where
-    errFmt = ("getBlockThrow: no blund with HeaderHash: " %shortHashF)
+    errFmt = "getBlockThrow: no blund with HeaderHash: " %shortHashF
 
 getBlockThrow
     :: (SscHelpersClass ssc, MonadDB m)
     => HeaderHash -> m (Block ssc)
 getBlockThrow hash = maybeThrow (DBMalformed $ sformat errFmt hash) =<< getBlock hash
   where
-    errFmt =
-        ("getBlockThrow: no block with HeaderHash: "%shortHashF)
+    errFmt = "getBlockThrow: no block with HeaderHash: "%shortHashF
 
 getHeaderThrow
     :: (SscHelpersClass ssc, MonadDB m)
     => HeaderHash -> m (BlockHeader ssc)
 getHeaderThrow hash = maybeThrow (DBMalformed $ sformat errFmt hash) =<< getBlockHeader hash
   where
-    errFmt =
-        ("getBlockThrow: no block header with hash: "%shortHashF)
+    errFmt = "getBlockThrow: no block header with hash: "%shortHashF

--- a/src/Pos/Delegation/Logic.hs
+++ b/src/Pos/Delegation/Logic.hs
@@ -61,7 +61,6 @@ import           Pos.DB                      (DBError (DBMalformed), MonadDB,
                                               SomeBatchOp (..))
 import qualified Pos.DB                      as DB
 import qualified Pos.DB.Block                as DB
-import qualified Pos.DB.DB                   as DB
 import qualified Pos.DB.GState               as GS
 import qualified Pos.DB.Misc                 as Misc
 import           Pos.Delegation.Class        (DelegationWrap, MonadDelegation (..),

--- a/src/Pos/Ssc/Extra/Logic.hs
+++ b/src/Pos/Ssc/Extra/Logic.hs
@@ -38,7 +38,7 @@ import           Universum
 
 import           Pos.Context             (lrcActionOnEpochReason)
 import           Pos.DB                  (MonadDB)
-import           Pos.DB.DB               (getTipBlockHeader)
+import           Pos.DB.Block            (getTipBlockHeader)
 import           Pos.Exception           (assertionFailed)
 import           Pos.Lrc.Context         (LrcContext)
 import qualified Pos.Lrc.DB              as LrcDB

--- a/src/Pos/WorkMode.hs
+++ b/src/Pos/WorkMode.hs
@@ -31,7 +31,6 @@ import           Pos.Communication.PeerState (PeerStateHolder (..), WithPeerStat
 import           Pos.Communication.Relay     (MonadRelayMem)
 import           Pos.Context                 (ContextHolder, NodeParams, WithNodeContext)
 import           Pos.DB.Class                (MonadDB, MonadDBCore)
-import           Pos.DB.DB                   ()
 import           Pos.DB.Holder               (DBHolder)
 import           Pos.DB.Limits               (MonadDBLimits)
 import           Pos.Delegation.Class        (MonadDelegation)


### PR DESCRIPTION
This is an auxiliary part of https://github.com/input-output-hk/cardano-sl/pull/304 that simply migrates two functions to avoid an issue with circular imports.

Also a couple of cosmetic changes (removed redundant parentheses).

Should be merged before https://github.com/input-output-hk/cardano-sl/pull/304.