### PR TITLE
Benchmarking: include transaction provenance

### DIFF
--- a/infra/Pos/Communication/Relay/Class.hs
+++ b/infra/Pos/Communication/Relay/Class.hs
@@ -6,15 +6,16 @@ module Pos.Communication.Relay.Class
        , askRelayMem
        ) where
 
-import qualified Control.Monad.Ether.Implicit   as Ether
-import           Node.Message                   (Message)
-import           Serokell.Util.Verify           (VerificationRes)
+import qualified Control.Monad.Ether.Implicit     as Ether
+import           Node.Message                     (Message)
+import           Serokell.Util.Verify             (VerificationRes)
 import           Universum
 
-import           Pos.Communication.Limits.Types (MessageLimited)
-import           Pos.Communication.Relay.Types  (RelayContext)
-import           Pos.Communication.Types.Relay  (DataMsg, InvOrData, MempoolMsg,
-                                                 ReqMsg (..))
+import           Pos.Communication.Limits.Types   (MessageLimited)
+import           Pos.Communication.Types.Protocol (NodeId)
+import           Pos.Communication.Relay.Types    (RelayContext)
+import           Pos.Communication.Types.Relay    (DataMsg, InvOrData, MempoolMsg,
+                                                   ReqMsg (..))
 
 -- | Typeclass for general Inv/Req/Dat framework. It describes monads,
 -- that store data described by tag, where "key" stands for node
@@ -45,16 +46,16 @@ class ( Buildable tag
     verifyDataContents :: contents -> m VerificationRes
 
     -- | Handle inv msg and return whether it's useful or not
-    handleInv :: tag -> key -> m Bool
+    handleInv :: NodeId -> tag -> key -> m Bool
 
     -- | Handle req msg and return (Just data) in case requested data can be provided
-    handleReq :: tag -> key -> m (Maybe contents)
+    handleReq :: NodeId -> tag -> key -> m (Maybe contents)
 
     -- | Handle mempool msg and return all keys we want to send
-    handleMempool :: tag -> m [key]
+    handleMempool :: NodeId -> tag -> m [key]
 
     -- | Handle data msg and return True if message is to be propagated
-    handleData :: contents -> m Bool
+    handleData :: NodeId -> contents -> m Bool
 
 type MonadRelayMem = Ether.MonadReader RelayContext
 

--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -51,9 +51,10 @@ import           Pos.Communication.Limits.Types     (LimitedLength, LimitedLengt
 import           Pos.Communication.MessagePart      (MessagePart)
 import           Pos.Communication.PeerState        (WithPeerState)
 import           Pos.Communication.Protocol         (ConversationActions (..),
-                                                     ListenerSpec, NodeId, OutSpecs,
-                                                     SendActions (..), WorkerSpec,
-                                                     listenerConv, mergeLs, worker)
+                                                     ListenerSpec, NodeId,
+                                                     OutSpecs, SendActions (..),
+                                                     WorkerSpec, listenerConv,
+                                                     mergeLs, worker)
 import           Pos.Communication.Relay.Class      (MonadRelayMem, Relay (..),
                                                      askRelayMem)
 import           Pos.Communication.Relay.Types      (RelayContext (..), RelayProxy (..),
@@ -90,12 +91,13 @@ handleInvL
        , MinRelayWorkMode m
        )
     => RelayProxy key tag contents
+    -> NodeId
     -> InvMsg key tag
     -> m (Maybe key)
-handleInvL proxy msg@(InvMsg{..}) =
+handleInvL proxy __nodeId msg@(InvMsg{..}) =
     processMessage Nothing "Inventory" imTag verifyInvTag $ do
         let _ = invCatchType proxy msg
-        invRes <- handleInv imTag imKey
+        invRes <- handleInv __nodeId imTag imKey
         if invRes then
             Just imKey <$ logDebug (sformat
               ("We'll request data "%build%" for key "%build%", because it's useful")
@@ -118,7 +120,7 @@ handleReqL
     -> m (ListenerSpec m, OutSpecs)
 handleReqL proxy = reifyMsgLimit (Proxy @(ReqMsg key tag)) $
   \(_ :: Proxy s) -> return $ listenerConv $
-    \_ __peerId ConversationActions{..} ->
+    \_ __nodeId ConversationActions{..} ->
     let handlingLoop = do
             mbMsg <- fmap (withLimitedLength @s) <$> recv
             whenJust mbMsg $ \msg@ReqMsg{..} -> do
@@ -130,7 +132,7 @@ handleReqL proxy = reifyMsgLimit (Proxy @(ReqMsg key tag)) $
                         logHaveData = logDebug $ sformat
                             ("We have data "%build%" for key "%build)
                             rmTag rmKey
-                    dtMB <- handleReq rmTag rmKey
+                    dtMB <- handleReq __nodeId rmTag rmKey
                     case dtMB of
                         Nothing -> logNoData
                         Just dt -> logHaveData >> send (constructDataMsg dt)
@@ -153,11 +155,11 @@ handleMempoolL
     -> m (ListenerSpec m, OutSpecs)
 handleMempoolL proxy = reifyMsgLimit (Proxy @(MempoolMsg tag)) $
   \(_ :: Proxy s) -> return $ listenerConv $
-    \_ __peerId ConversationActions{..} ->
+    \_ __nodeId ConversationActions{..} ->
     whenJustM recv $ \(withLimitedLength @s -> msg@MempoolMsg{..}) -> do
       let _ = mempoolCatchType proxy msg
       processMessage () "Mempool" mmTag verifyMempoolTag $ do
-          res <- handleMempool mmTag
+          res <- handleMempool __nodeId mmTag
           case nonEmpty res of
               Nothing -> logDebug $ sformat
                   ("We don't have mempool data "%build) mmTag
@@ -182,13 +184,14 @@ handleDataL
        , RelayWorkMode m
        )
     => RelayProxy key tag contents
+    -> NodeId
     -> DataMsg contents
     -> m ()
-handleDataL proxy msg@(DataMsg {..}) =
+handleDataL proxy __nodeId msg@(DataMsg {..}) =
     processMessage () "Data" dmContents verifyDataContents $ do
         let _ = dataCatchType proxy msg
         dmKey <- contentsToKey dmContents
-        ifM (handleData dmContents)
+        ifM (handleData __nodeId dmContents)
             (handleDataLDo dmKey) $
                 logDebug $ sformat
                     ("Ignoring data "%build%" for key "%build) dmContents dmKey
@@ -246,7 +249,7 @@ relayListeners proxy =
         [handleReqL proxy, handleMempoolL proxy, invDataListener]
   where
     invDataListener = reifyMsgLimit (Proxy @(InvOrData tag key contents)) $
-      \(_ :: Proxy s) -> return $ listenerConv $ \_ __peerId
+      \(_ :: Proxy s) -> return $ listenerConv $ \_ __nodeId
         (ConversationActions{..}::(ConversationActions
                                   (ReqMsg key tag)
                                   (SmartLimit s (InvOrData tag key contents))
@@ -255,12 +258,12 @@ relayListeners proxy =
             inv' <- recv
             whenJust (withLimitedLength <$> inv') $ expectInv $
                 \inv@InvMsg{..} -> do
-                    useful <- handleInvL proxy inv
+                    useful <- handleInvL proxy __nodeId inv
                     whenJust useful $ \ne -> do
                         send $ ReqMsg imTag ne
                         dt' <- recv
                         whenJust (withLimitedLength <$> dt') $ expectData $
-                            \dt -> handleDataL proxy dt
+                            \dt -> handleDataL proxy __nodeId dt
 
 relayStubListeners
     :: ( WithLogger m
@@ -355,7 +358,7 @@ relayWorkers allOutSpecs =
         -> ConversationActions
              (InvOrData tag1 key1 contents1) (ReqMsg key1 tag1) m
         -> m ()
-    convHandler inv __peerId ConversationActions{..} = send inv
+    convHandler inv __nodeId ConversationActions{..} = send inv
 
     handleWE e = do
         logError $ sformat ("relayWorker: error caught "%shown) e

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -89,6 +89,7 @@ library
   build-depends:        aeson
                       , base
                       , parsec
+                      , base64-bytestring
                       , binary
                       , bytestring
                       , cardano-sl-core

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -53,7 +53,7 @@ import           Pos.Txp                   (MonadUtxoRead, Tx (..), TxAux, TxDis
                                             TxpHolder, Utxo, UtxoStateT, applyTxToUtxo,
                                             evalUtxoStateT, filterUtxoByAddr, getLocalTxs,
                                             runUtxoStateT, topsortTxs, txOutAddress,
-                                            utxoGet)
+                                            utxoGet, TransactionProvenance (..))
 import           Pos.Types                 (Address, Block, ChainDifficulty, HeaderHash,
                                             blockTxas, difficultyL, prevBlockL)
 import           Pos.Util                  (ether, maybeThrow)
@@ -236,7 +236,7 @@ instance ( MonadDB m
         maybe (error "deriveAddrHistory: Nothing") pure mres
 
 #ifdef WITH_EXPLORER
-    saveTx txw = () <$ runExceptT (eTxProcessTransaction txw)
+    saveTx txw = () <$ runExceptT (eTxProcessTransaction History txw)
 #else
-    saveTx txw = () <$ runExceptT (txProcessTransaction txw)
+    saveTx txw = () <$ runExceptT (txProcessTransaction History txw)
 #endif

--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -67,6 +67,7 @@ data Backpressure = Backpressure
     }
     deriving Show
 
+noBackpressure :: Backpressure
 noBackpressure = Backpressure
     { bpressLevelOne = (maxBound, 0)
     , bpressLevelTwo = (maxBound, 0)

--- a/src/Pos/Ssc/GodTossing/Listeners.hs
+++ b/src/Pos/Ssc/GodTossing/Listeners.hs
@@ -62,11 +62,11 @@ instance WorkMode SscGodTossing m =>
     verifyMempoolTag   _ = pure VerSuccess
     verifyDataContents _ = pure VerSuccess
 
-    handleInv = sscIsDataUseful
-    handleReq tag addr =
+    handleInv _ = sscIsDataUseful
+    handleReq _ tag addr =
         toContents tag addr . view ldModifier <$> sscRunLocalQuery ask
-    handleMempool _ = pure []
-    handleData dat = do
+    handleMempool _ _ = pure []
+    handleData _ dat = do
         addr <- contentsToKey dat
         -- [CSL-685] TODO: Add here malicious emulation for network addresses
         -- when TW will support getting peer address properly

--- a/src/Pos/Txp/MemState/Types.hs
+++ b/src/Pos/Txp/MemState/Types.hs
@@ -65,6 +65,7 @@ data MemPoolModifyReason =
     | CreateBlock
       -- | Include a transaction. It came from this peer.
     | ProcessTransaction TransactionProvenance
+    | Custom Text
     | Unknown
     deriving Show
 

--- a/src/Pos/Txp/MemState/Types.hs
+++ b/src/Pos/Txp/MemState/Types.hs
@@ -7,19 +7,21 @@ module Pos.Txp.MemState.Types
        , GenericTxpLocalDataPure
        , TxpLocalData
        , TxpLocalDataPure
+       , TransactionProvenance (..)
        , MemPoolModifyReason (..)
        , TxpMetrics (..)
        , ignoreTxpMetrics
        ) where
 
-import           GHC.Base               (Int, IO)
+import           GHC.Base                         (Int, IO)
 import           Universum
-import           Data.Aeson.TH          (deriveJSON, defaultOptions)
-import           Data.Time.Units        (Microsecond)
-import           System.Wlog            (LoggerNameBox)
+import           Data.Aeson.TH                    (deriveJSON, defaultOptions)
+import           Data.Time.Units                  (Microsecond)
+import           System.Wlog                      (LoggerNameBox)
 
-import           Pos.Core.Types         (HeaderHash)
-import           Pos.Txp.Toil.Types     (MemPool, UndoMap, UtxoModifier)
+import           Pos.Communication.Types.Protocol (PeerId)
+import           Pos.Core.Types                   (HeaderHash)
+import           Pos.Txp.Toil.Types               (MemPool, UndoMap, UtxoModifier)
 
 -- | LocalData of transactions processing.
 -- There are two invariants which must hold for local data
@@ -50,14 +52,19 @@ type TxpLocalData = GenericTxpLocalData ()
 -- | Pure version of TxpLocalData.
 type TxpLocalDataPure = GenericTxpLocalDataPure ()
 
+data TransactionProvenance = FromPeer PeerId | History
+  deriving Show
+
+$(deriveJSON defaultOptions ''TransactionProvenance)
+
 -- | Enumeration of all reasons for modifying the mempool.
 data MemPoolModifyReason =
       -- | Apply a block created by someone else.
       ApplyBlock
       -- | Apply a block created by us.
     | CreateBlock
-      -- | Include a transaction.
-    | ProcessTransaction
+      -- | Include a transaction. It came from this peer.
+    | ProcessTransaction TransactionProvenance
     | Unknown
     deriving Show
 

--- a/src/Pos/Txp/Network/Listeners.hs
+++ b/src/Pos/Txp/Network/Listeners.hs
@@ -58,16 +58,16 @@ instance ( WorkMode ssc m
     verifyMempoolTag   _ = pure VerSuccess
     verifyDataContents _ = pure VerSuccess
 
-    handleInv _ txId = not . HM.member txId  . _mpLocalTxs <$> getMemPool
+    handleInv _ _ txId = not . HM.member txId  . _mpLocalTxs <$> getMemPool
 
-    handleReq _ txId =
+    handleReq _ _ txId =
         fmap toContents . HM.lookup txId . _mpLocalTxs <$> getMemPool
       where
         toContents (tx, tw, td) = TxMsgContents tx tw td
 
-    handleMempool _ = HM.keys . _mpLocalTxs <$> getMemPool
+    handleMempool _ _ = HM.keys . _mpLocalTxs <$> getMemPool
 
-    handleData (TxMsgContents tx tw td) = handleTxDo (hash tx, (tx, tw, td))
+    handleData _ (TxMsgContents tx tw td) = handleTxDo (hash tx, (tx, tw, td))
 
 -- Real tx processing
 -- CHECK: @handleTxDo

--- a/src/Pos/Txp/Network/Listeners.hs
+++ b/src/Pos/Txp/Network/Listeners.hs
@@ -17,7 +17,7 @@ import           Pos.Binary.Communication   ()
 import           Pos.Binary.Relay           ()
 import           Pos.Communication.Limits   ()
 import           Pos.Communication.Message  ()
-import           Pos.Communication.Protocol (ListenerSpec, OutSpecs)
+import           Pos.Communication.Protocol (ListenerSpec, OutSpecs, NodeId (..))
 import           Pos.Communication.Relay    (Relay (..), RelayProxy (..), relayListeners,
                                              relayStubListeners)
 import           Pos.Crypto                 (hash)
@@ -28,7 +28,7 @@ import           Pos.Explorer.Txp.Local     (eTxProcessTransaction)
 #else
 import           Pos.Txp.Logic              (txProcessTransaction)
 #endif
-import           Pos.Txp.MemState           (getMemPool)
+import           Pos.Txp.MemState           (getMemPool, TransactionProvenance (..))
 import           Pos.Txp.Network.Types      (TxMsgContents (..), TxMsgTag (..))
 import           Pos.Txp.Toil.Types         (MemPool (..))
 import           Pos.Util.JsonLog           (MonadJL (..), JLEvent (..), JLTxR (..))
@@ -67,20 +67,22 @@ instance ( WorkMode ssc m
 
     handleMempool _ _ = HM.keys . _mpLocalTxs <$> getMemPool
 
-    handleData _ (TxMsgContents tx tw td) = handleTxDo (hash tx, (tx, tw, td))
+    handleData peer (TxMsgContents tx tw td) = handleTxDo peer (hash tx, (tx, tw, td))
 
 -- Real tx processing
 -- CHECK: @handleTxDo
 -- #txProcessTransaction
 handleTxDo
     :: WorkMode ssc m
-    => (TxId, TxAux) -> m Bool
-handleTxDo tx = do
+    => NodeId
+    -> (TxId, TxAux)
+    -> m Bool
+handleTxDo (NodeId (peer, _)) tx = do
     ts <- currentTime
 #ifdef WITH_EXPLORER
-    res <- runExceptT $ eTxProcessTransaction tx
+    res <- runExceptT $ eTxProcessTransaction (FromPeer peer) tx
 #else
-    res <- runExceptT $ txProcessTransaction tx
+    res <- runExceptT $ txProcessTransaction (FromPeer peer) tx
 #endif
     let txId = fst tx
     let json me = jlLog $ JLTxReceived $ JLTxR

--- a/src/Pos/Txp/Worker.hs
+++ b/src/Pos/Txp/Worker.hs
@@ -116,7 +116,7 @@ getTxMempoolInvs sendActions node = do
                       Nothing -> return []
                       Just (Right _) -> throw UnexpectedData
                       Just (Left inv@InvMsg{..}) -> do
-                          useful <- handleInvL txProxy inv
+                          useful <- handleInvL txProxy node inv
                           case useful of
                               Nothing  -> getInvs
                               Just key -> (key:) <$> getInvs
@@ -147,7 +147,7 @@ requestTxs sendActions node txIds = do
                     dt' <- recv
                     case withLimitedLength <$> dt' of
                         Nothing -> error "didn't get an answer to Req"
-                        Just x  -> expectData (handleDataL txProxy) x
+                        Just x  -> expectData (handleDataL txProxy node) x
             for_ txIds $ \id ->
                 getTx id `catch` handler id
     logInfo $ sformat

--- a/src/Pos/Update/Network/Listeners.hs
+++ b/src/Pos/Update/Network/Listeners.hs
@@ -62,10 +62,10 @@ instance UpdateMode m =>
     verifyMempoolTag   _ = pure VerSuccess
     verifyDataContents _ = pure VerSuccess
 
-    handleInv _ = isProposalNeeded
-    handleReq _ = getLocalProposalNVotes
-    handleMempool _ = pure []
-    handleData (proposal, votes) = do
+    handleInv _ _ = isProposalNeeded
+    handleReq _ _ = getLocalProposalNVotes
+    handleMempool _ _ = pure []
+    handleData _ (proposal, votes) = do
         res <- processProposal proposal
         logProp res
         let processed = isRight res
@@ -95,10 +95,10 @@ instance UpdateMode m =>
     verifyMempoolTag _ = pure VerSuccess
     verifyDataContents UpdateVote{..} = pure VerSuccess
 
-    handleInv _ (id, pk, dec) = isVoteNeeded id pk dec
-    handleReq _ (id, pk, dec) = getLocalVote id pk dec
-    handleMempool _ = pure []
-    handleData uv = do
+    handleInv _ _ (id, pk, dec) = isVoteNeeded id pk dec
+    handleReq _ _ (id, pk, dec) = getLocalVote id pk dec
+    handleMempool _ _ = pure []
+    handleData _ uv = do
         res <- processVote uv
         logProcess res
         pure $ isRight res

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 7a3e082bcd387da9c7ebeb691d8165a9961c5432
+    commit: 32bce17217e710e3e26210c660e05a1954b137cf
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
When the mempool is modified to include a transaction, the provenance of that transaction is given: either from some peer (their PeerId is given) or due to the client history system.

Also included a bump of time-warp-nt to tip of master.