### PR TITLE
[CSM-260] Catch from wallet endpoints automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 - if [[ "$HLINT" == "true" ]]; then
     nix-shell -p haskellPackages.hlint moreutils --run "util-scripts/lint.sh --nix | ts";
   else
-    nix-shell -p moreutils --run "./util-scripts/travis.sh | ts";
+    nix-shell -p moreutils expect --run "unbuffer ./util-scripts/travis.sh | ts";
   fi
 
 deploy:

--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -985,6 +985,7 @@ executable cardano-swagger
                      , cardano-sl
                      , lens
                      , swagger2
+                     , servant
                      , servant-server
                      , servant-multipart
                      , servant-swagger

--- a/src/Pos/Wallet/Web/Error.hs
+++ b/src/Pos/Wallet/Web/Error.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators   #-}
 
 -- | Types describing runtime errors related to Wallet.
 
@@ -7,13 +8,18 @@ module Pos.Wallet.Web.Error
        , _InternalError
        , _RequestError
        , rewrapToWalletError
+       , catchEndpointErrors
        ) where
 
 import           Control.Lens        (makePrisms)
-import           Control.Monad.Catch (Handler (..), catches)
+import           Control.Monad.Catch (Handler (..), catches, handleAll, try, tryJust)
 import qualified Data.Text.Buildable
-import           Formatting          (bprint, stext, (%))
+import           Formatting          (bprint, sformat, shown, stext, (%))
+import           Servant.Server      (err500)
+import           System.Wlog         (CanLog, logError, usingLoggerName)
 import           Universum
+
+import           Pos.Constants       (isDevelopment)
 
 data WalletError
     -- | Reasonable error for given request
@@ -34,6 +40,25 @@ instance Buildable WalletError where
 
 rewrapToWalletError :: MonadCatch m => m a -> m a
 rewrapToWalletError = flip catches
-     [ Handler $ \e@(RequestError _)    -> throwM e
-     , Handler $ \(SomeException e) -> throwM . RequestError $ show e
+     [ Handler $ \e@(RequestError _) -> throwM e
+     , Handler $ \(SomeException e)  -> throwM . RequestError $ show e
      ]
+
+-- | Catches all errors, and either returns them on client, or
+-- just logs error.
+-- It has such strange type, because it's used to modify servant handler
+-- in general case (see 'Pos.Wallet.Web.Api').
+catchEndpointErrors
+    :: (MonadCatch m, CanLog m)
+    => m a -> m (Either WalletError a)
+catchEndpointErrors action = catchOtherError $ tryWalletError action
+  where
+    tryWalletError
+        | isDevelopment = try
+        | otherwise     = tryJust $ \e -> (e ^? _RequestError) $> e
+    catchOtherError = handleAll $ \e -> do
+        usingLoggerName logName $
+            logError $ sformat ("Uncaught error in wallet method: "%shown) e
+        throwM err500
+    logName = "wallet-api" <> "handler"
+

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -48,7 +48,7 @@ import           Servant.API                      ((:<|>) ((:<|>)),
                                                    FromHttpApiData (parseUrlPiece))
 import           Servant.Multipart                (fdFilePath)
 import           Servant.Server                   (Handler, Server, ServerT, err403,
-                                                   err500, runHandler, serve)
+                                                   runHandler, serve)
 import           Servant.Utils.Enter              ((:~>) (..), enter)
 import           System.Wlog                      (logDebug, logError, logInfo)
 
@@ -118,8 +118,7 @@ import           Pos.Wallet.Web.ClientTypes       (Acc, CAccount (..),
                                                    mkCCoin, mkCTx, mkCTxId, toCUpdateInfo,
                                                    toCWalletAddress, txContainsTitle,
                                                    txIdToCTxId, walletAddrByAccount)
-import           Pos.Wallet.Web.Error             (WalletError (..), rewrapToWalletError,
-                                                   _RequestError)
+import           Pos.Wallet.Web.Error             (WalletError (..), rewrapToWalletError)
 import           Pos.Wallet.Web.Secret            (WalletUserSecret (..))
 import           Pos.Wallet.Web.Server.Sockets    (ConnectionsVar, MonadWalletWebSockets,
                                                    WalletWebSockets, closeWSConnection,
@@ -299,121 +298,79 @@ servantHandlers
     => SendActions m
     -> ServerT WalletApi m
 servantHandlers sendActions =
-     catchWalletError testResetAll
+     testResetAll
     :<|>
 
-     apiGetWSet
+     getWSet
     :<|>
-     apiGetWSets
+     getWSets
     :<|>
-     apiNewWSet
+     newWSet
     :<|>
-     apiRestoreWSet
+     newWSet
     :<|>
-     apiRenameWSet
+     renameWSet
     :<|>
-     apiDeleteWSet
+     deleteWSet
     :<|>
-     apiImportWSet
+     importWSet
     :<|>
-     apiChangeWSetPassphrase
-    :<|>
-
-     apiGetWallet
-    :<|>
-     apiGetWallets
-    :<|>
-     apiUpdateWallet
-    :<|>
-     apiNewWallet
-    :<|>
-     apiDeleteWallet
+     changeWSetPassphrase sendActions
     :<|>
 
-     apiNewAccount
+     getWallet
+    :<|>
+     getWallets
+    :<|>
+     updateWallet
+    :<|>
+     newWallet RandomSeed
+    :<|>
+     deleteWallet
     :<|>
 
-     apiIsValidAddress
+     newAccount RandomSeed
     :<|>
 
-     apiGetUserProfile
-    :<|>
-     apiUpdateUserProfile
+     isValidAddress
     :<|>
 
-     apiTxsPayments
+     getUserProfile
     :<|>
-     apiTxsPaymentsExt
-    :<|>
-     apiUpdateTransaction
-    :<|>
-     apiGetHistory
-    :<|>
-     apiSearchHistory
+     updateUserProfile
     :<|>
 
-     apiNextUpdate
+     send sendActions
     :<|>
-     apiApplyUpdate
+     sendExtended sendActions
     :<|>
-
-     apiRedeemAda
+     updateTransaction
     :<|>
-     apiRedeemAdaPaperVend
+     getHistory
     :<|>
-
-     apiReportingInitialized
-    :<|>
-     apiReportingElectroncrash
+     searchHistory
     :<|>
 
-     apiSettingsSlotDuration
+     nextUpdate
     :<|>
-     apiSettingsSoftwareVersion
+     applyUpdate
     :<|>
-     apiSettingsSyncProgress
-  where
-    -- TODO: can we with Traversable map catchWalletError over :<|>
-    -- TODO: add logging on error
-    apiGetWSet                  = catchWalletError ... getWSet
-    apiGetWSets                 = catchWalletError ... getWSets
-    apiNewWSet                  = catchWalletError ... newWSet
-    apiRestoreWSet              = catchWalletError ... newWSet
-    apiRenameWSet               = catchWalletError ... renameWSet
-    apiDeleteWSet               = catchWalletError ... deleteWSet
-    apiImportWSet               = catchWalletError ... importWSet
-    apiChangeWSetPassphrase     = catchWalletError ... changeWSetPassphrase sendActions
-    apiGetWallet                = catchWalletError ... getWallet
-    apiGetWallets               = catchWalletError ... getWallets
-    apiUpdateWallet             = catchWalletError ... updateWallet
-    apiNewWallet                = catchWalletError ... newWallet RandomSeed
-    apiDeleteWallet             = catchWalletError ... deleteWallet
-    apiNewAccount               = catchWalletError ... newAccount RandomSeed
-    apiIsValidAddress           = catchWalletError ... isValidAddress
-    apiGetUserProfile           = catchWalletError ... getUserProfile
-    apiUpdateUserProfile        = catchWalletError ... updateUserProfile
-    apiTxsPayments              = catchWalletError ... send sendActions
-    apiTxsPaymentsExt           = catchWalletError ... sendExtended sendActions
-    apiUpdateTransaction        = catchWalletError ... updateTransaction
-    apiGetHistory               = catchWalletError ... getHistory
-    apiSearchHistory            = catchWalletError ... searchHistory
-    apiNextUpdate               = catchWalletError ... nextUpdate
-    apiApplyUpdate              = catchWalletError ... applyUpdate
-    apiRedeemAda                = catchWalletError ... redeemAda sendActions
-    apiRedeemAdaPaperVend       = catchWalletError ... redeemAdaPaperVend sendActions
-    apiReportingInitialized     = catchWalletError ... reportingInitialized
-    apiReportingElectroncrash   = catchWalletError ... reportingElectroncrash
-    apiSettingsSlotDuration     = catchWalletError ... (fromIntegral <$> blockchainSlotDuration)
-    apiSettingsSoftwareVersion  = catchWalletError ... pure curSoftwareVersion
-    apiSettingsSyncProgress     = catchWalletError ... syncProgress
 
-    catchWalletError action     = catchOtherError $ tryWalletError action
-    tryWalletError
-        | isDevelopment = try
-        | otherwise     = E.tryJust $ \e -> (e ^? _RequestError) $> e
-    catchOtherError = E.handleAll $ \e -> do
-        logError $ sformat ("Uncaught error in wallet method: "%shown) e
-        throwM err500
+     redeemAda sendActions
+    :<|>
+     redeemAdaPaperVend sendActions
+    :<|>
+
+     reportingInitialized
+    :<|>
+     reportingElectroncrash
+    :<|>
+
+     (blockchainSlotDuration <&> fromIntegral)
+    :<|>
+     pure curSoftwareVersion
+    :<|>
+     syncProgress
 
 -- getAddresses :: WalletWebMode m => m [CAddress]
 -- getAddresses = map addressToCAddress <$> myAddresses

--- a/src/wallet-web-api-swagger/Main.hs
+++ b/src/wallet-web-api-swagger/Main.hs
@@ -50,6 +50,7 @@ import qualified Pos.Wallet.Web                     as W
 
 import qualified Description                        as D
 
+
 main :: IO ()
 main = do
     BSL8.writeFile jsonFile $ encode swaggerSpecForWalletApi
@@ -133,6 +134,9 @@ instance ToParamSchema W.CPassPhrase
 instance {-# OVERLAPPING #-} (Typeable a, ToSchema a) => ToSchema (Either W.WalletError a) where
     declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
         & mapped . name ?~ show (typeRep (Proxy @(Either W.WalletError a)))
+
+instance HasSwagger v => HasSwagger (W.WalletVerb v) where
+    toSwagger _ = toSwagger (Proxy @v)
 
 -- | Wallet API operations.
 walletOp


### PR DESCRIPTION
Allows to apply `catchWalletError` only in single place