### PR TITLE
[CSL-969] Add helpers to work with `scrypt`

### DIFF
--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -66,10 +66,6 @@ instance Buildable PassPhrase where
 emptyPassphrase :: PassPhrase
 emptyPassphrase = PassPhrase mempty
 
-{-instance Monoid PassPhrase where
-    mempty = PassPhrase mempty
-    mappend (PassPhrase p1) (PassPhrase p2) = PassPhrase (p1 `mappend` p2)-}
-
 mkEncSecret :: Bi PassPhrase => PassPhrase -> CC.XPrv -> EncryptedSecretKey
 mkEncSecret pp payload = EncryptedSecretKey payload (hash pp)
 

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -1,0 +1,44 @@
+-- | Wrapper over scrypt library
+
+module Pos.Crypto.Scrypt
+    ( S.ScryptParams
+    , S.Salt (..)
+    , S.Pass (..)
+    , S.EncryptedPass (..)
+
+    , S.scryptParams
+    , S.scryptParamsLen
+
+    , mkSalt
+    , genSalt
+    , encryptPassIO
+    , encryptPassWithSalt
+    , verifyPass
+    ) where
+
+import           Universum
+
+import qualified Crypto.Scrypt     as S
+
+import           Pos.Binary.Class  (Bi, encodeStrict)
+import           Pos.Crypto.Random (secureRandomBS)
+
+mkSalt :: Bi salt => salt -> S.Salt
+mkSalt = S.Salt . encodeStrict
+
+genSalt :: MonadIO m => m S.Salt
+genSalt = liftIO $ S.Salt <$> secureRandomBS 32
+
+mkPass :: Bi pass => pass -> S.Pass
+mkPass = S.Pass . encodeStrict
+
+encryptPassIO :: (Bi pass, MonadIO m) => S.ScryptParams -> pass -> m S.EncryptedPass
+encryptPassIO params passphrase =
+    genSalt <&> \salt -> encryptPassWithSalt params salt passphrase
+
+encryptPassWithSalt :: Bi pass => S.ScryptParams -> S.Salt -> pass -> S.EncryptedPass
+encryptPassWithSalt params salt passphrase =
+    S.encryptPass params salt (mkPass passphrase)
+
+verifyPass :: Bi pass => S.ScryptParams -> pass -> S.EncryptedPass -> Bool
+verifyPass params passphrase = fst . S.verifyPass params (mkPass passphrase)

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -6,8 +6,8 @@ module Pos.Crypto.Scrypt
     , S.Pass (..)
     , S.EncryptedPass (..)
 
-    , S.scryptParams
-    , S.scryptParamsLen
+    , ScryptParamsBuilder (..)
+    , mkScryptParams
 
     , mkSalt
     , genSalt
@@ -19,9 +19,31 @@ module Pos.Crypto.Scrypt
 import           Universum
 
 import qualified Crypto.Scrypt     as S
+import           Data.Default      (Default (..))
 
 import           Pos.Binary.Class  (Bi, encodeStrict)
 import           Pos.Crypto.Random (secureRandomBS)
+
+-- | This corresponds to 'ScryptParams' datatype.
+-- These parameters influence on resulting hash length, memory and time
+-- consumption. See documentation for exact details.
+data ScryptParamsBuilder = ScryptParamsBuilder
+    { spLogN    :: Word
+    , spR       :: Word
+    , spP       :: Word
+    , spHashLen :: Word
+    }
+
+mkScryptParams :: ScryptParamsBuilder -> Maybe S.ScryptParams
+mkScryptParams ScryptParamsBuilder {..} =
+    S.scryptParamsLen
+        (fromIntegral spLogN)
+        (fromIntegral spR)
+        (fromIntegral spP)
+        (fromIntegral spHashLen)
+
+instance Default ScryptParamsBuilder where
+    def = ScryptParamsBuilder { spLogN = 14, spR = 8, spP = 1, spHashLen = 64 }
 
 mkSalt :: Bi salt => salt -> S.Salt
 mkSalt = S.Salt . encodeStrict

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -18,20 +18,21 @@ module Pos.Crypto.Scrypt
 
 import           Universum
 
-import qualified Crypto.Scrypt     as S
-import           Data.Default      (Default (..))
+import qualified Crypto.Scrypt              as S
+import           Data.Default               (Default (..))
+import           Serokell.Data.Memory.Units (Byte)
 
-import           Pos.Binary.Class  (Bi, encodeStrict)
-import           Pos.Crypto.Random (secureRandomBS)
+import           Pos.Binary.Class           (Bi, encodeStrict)
+import           Pos.Crypto.Random          (secureRandomBS)
 
 -- | This corresponds to 'ScryptParams' datatype.
--- These parameters influence on resulting hash length, memory and time
--- consumption. See documentation for exact details.
+-- See <https://hackage.haskell.org/package/scrypt-0.5.0/docs/Crypto-Scrypt.html
+-- hashing parameters description> for more details; briefly explained below.
 data ScryptParamsBuilder = ScryptParamsBuilder
-    { spLogN    :: Word
-    , spR       :: Word
-    , spP       :: Word
-    , spHashLen :: Word
+    { spLogN    :: Word  -- ^ Influences memory & time usage (exponentially)
+    , spR       :: Word  -- ^ Influences memory & time usage
+    , spP       :: Word  -- ^ Influences only time usage
+    , spHashLen :: Byte  -- ^ Length of resulting hash
     }
 
 mkScryptParams :: ScryptParamsBuilder -> Maybe S.ScryptParams
@@ -42,6 +43,7 @@ mkScryptParams ScryptParamsBuilder {..} =
         (fromIntegral spP)
         (fromIntegral spHashLen)
 
+-- | Corresponds to 'S.defaultParams'
 instance Default ScryptParamsBuilder where
     def = ScryptParamsBuilder { spLogN = 14, spR = 8, spP = 1, spHashLen = 64 }
 

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -53,6 +53,7 @@ library
                        Pos.Crypto.SafeSigning
                        Pos.Crypto.Signing
                        Pos.Crypto.SignTag
+                       Pos.Crypto.Scrypt
                        Pos.Crypto.SecretSharing
                        Pos.Crypto.RedeemSigning
 
@@ -130,6 +131,7 @@ library
                      , quickcheck-instances
                      , random
                      , safecopy
+                     , scrypt >= 0.5
                      , semigroups
                      , serokell-util
                      , tagged


### PR DESCRIPTION
It was intended to change replace hashing of passphrase for secret key, but it will be done under CSL-1169 + some other issue, only helpers remained