### PR TITLE
[CSL-1042] Do not treat exceptions like UnknownBlockForLrc or OutdatedSlottingData as errors while we're in recovery

### DIFF
--- a/infra/Pos/Communication/Protocol.hs
+++ b/infra/Pos/Communication/Protocol.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -30,8 +31,8 @@ import qualified Data.HashMap.Strict              as HM
 import qualified Data.List.NonEmpty               as NE
 import qualified Data.Text.Buildable              as B
 import           Formatting                       (bprint, build, sformat, (%))
-import           Mockable                         (Delay, Fork, Mockable, SharedAtomic,
-                                                   Throw, throw)
+import           Mockable                         (Delay, Fork, Mockable, Mockables,
+                                                   SharedAtomic, Throw, throw)
 import qualified Node                             as N
 import           Node.Message                     (Message (..), MessageName (..),
                                                    messageName')
@@ -190,18 +191,10 @@ worker' outSpecs h =
 
 
 type OnNewSlotComm m =
-    ( MonadIO m
-    , MonadSlots m
-    , MonadMask m
-    , WithLogger m
-    , Mockable Fork m
-    , Mockable Delay m
+    ( LocalOnNewSlotComm m
     , Mockable Throw m
     , WithPeerState m
     , Mockable SharedAtomic m
-    , MonadReportingMem m
-    , MonadShutdownMem m
-    , MonadDiscovery m
     )
 
 type LocalOnNewSlotComm m =
@@ -209,8 +202,7 @@ type LocalOnNewSlotComm m =
     , MonadSlots m
     , MonadMask m
     , WithLogger m
-    , Mockable Fork m
-    , Mockable Delay m
+    , Mockables m [Fork, Delay]
     , MonadReportingMem m
     , MonadShutdownMem m
     , MonadDiscovery m

--- a/infra/Pos/Communication/Protocol.hs
+++ b/infra/Pos/Communication/Protocol.hs
@@ -204,6 +204,18 @@ type OnNewSlotComm m =
     , MonadDiscovery m
     )
 
+type LocalOnNewSlotComm m =
+    ( MonadIO m
+    , MonadSlots m
+    , MonadMask m
+    , WithLogger m
+    , Mockable Fork m
+    , Mockable Delay m
+    , MonadReportingMem m
+    , MonadShutdownMem m
+    , MonadDiscovery m
+    )
+
 onNewSlot'
     :: OnNewSlotComm m
     => Bool -> Bool -> (SlotId -> WorkerSpec m, outSpecs) -> (WorkerSpec m, outSpecs)
@@ -223,16 +235,8 @@ onNewSlotWithLoggingWorker
 onNewSlotWithLoggingWorker b outs = onNewSlot' True b . workerHelper outs
 
 localOnNewSlotWorker
-    :: ( MonadIO m
-       , MonadSlots m
-       , MonadMask m
-       , WithLogger m
-       , Mockable Fork m
-       , Mockable Delay m
-       , MonadReportingMem m
-       , MonadShutdownMem m
-       , MonadDiscovery m
-       ) => Bool -> (SlotId -> m ()) -> (WorkerSpec m, OutSpecs)
+    :: LocalOnNewSlotComm m
+    => Bool -> (SlotId -> m ()) -> (WorkerSpec m, OutSpecs)
 localOnNewSlotWorker b h = (ActionSpec $ \__vI __sA -> onNewSlot b h, mempty)
 
 localWorker :: m () -> (WorkerSpec m, OutSpecs)

--- a/src/Pos/Block/Worker.hs
+++ b/src/Pos/Block/Worker.hs
@@ -25,7 +25,7 @@ import           Pos.Block.Network.Retrieval (retrievalWorker)
 import           Pos.Communication.Protocol  (OutSpecs, SendActions, Worker', WorkerSpec,
                                               onNewSlotWorker)
 import           Pos.Constants               (networkDiameter)
-import           Pos.Context                 (npPublicKey)
+import           Pos.Context                 (npPublicKey, recoveryCommGuard)
 import           Pos.Core.Address            (addressHash)
 import           Pos.Crypto                  (ProxySecretKey (pskDelegatePk, pskIssuerPk, pskOmega))
 import           Pos.DB.Class                (MonadDBCore)
@@ -65,7 +65,7 @@ blkWorkers =
 
 -- Action which should be done when new slot starts.
 blkOnNewSlot :: WorkMode ssc m => (WorkerSpec m, OutSpecs)
-blkOnNewSlot = onNewSlotWorker True announceBlockOuts blkOnNewSlotImpl
+blkOnNewSlot = recoveryCommGuard $ onNewSlotWorker True announceBlockOuts blkOnNewSlotImpl
 
 blkOnNewSlotImpl
     :: WorkMode ssc m

--- a/src/Pos/Context/Functions.hs
+++ b/src/Pos/Context/Functions.hs
@@ -23,20 +23,20 @@ module Pos.Context.Functions
        , recoveryCommGuard
        ) where
 
-import qualified Control.Concurrent.STM     as STM
-import           Data.Time                  (diffUTCTime, getCurrentTime)
-import           Data.Time.Units            (Microsecond, fromMicroseconds)
+import qualified Control.Concurrent.STM           as STM
+import           Data.Time                        (diffUTCTime, getCurrentTime)
+import           Data.Time.Units                  (Microsecond, fromMicroseconds)
 import qualified Ether
 import           Universum
 
-import           Pos.Communication.Protocol (ActionSpec (..), OutSpecs, WorkerSpec)
-import           Pos.Context.Context        (BlkSemaphore (..), GenesisLeaders (..),
-                                             GenesisUtxo (..), MonadRecoveryHeader,
-                                             RecoveryHeaderTag, StartTime (..))
-import           Pos.Lrc.Context            (lrcActionOnEpoch, lrcActionOnEpochReason,
-                                             waitLrc)
-import           Pos.Txp.Toil.Types         (Utxo)
-import           Pos.Types                  (HeaderHash, SlotLeaders)
+import           Pos.Communication.Types.Protocol (ActionSpec (..), OutSpecs, WorkerSpec)
+import           Pos.Context.Context              (BlkSemaphore (..), GenesisLeaders (..),
+                                                   GenesisUtxo (..), MonadRecoveryHeader,
+                                                   RecoveryHeaderTag, StartTime (..))
+import           Pos.Lrc.Context                  (lrcActionOnEpoch,
+                                                   lrcActionOnEpochReason, waitLrc)
+import           Pos.Txp.Toil.Types               (Utxo)
+import           Pos.Types                        (HeaderHash, SlotLeaders)
 
 ----------------------------------------------------------------------------
 -- Genesis
@@ -86,8 +86,8 @@ recoveryInProgress = do
     var <- Ether.ask @RecoveryHeaderTag
     isJust <$> atomically (STM.tryReadTMVar var)
 
-
-
+-- | This function is helper for workers.
+-- It doesn't run a worker if the node is in recovery mode.
 recoveryCommGuard
     :: (MonadIO m, MonadRecoveryHeader ssc m)
     => (WorkerSpec m, OutSpecs) -> (WorkerSpec m, OutSpecs)

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -61,9 +61,13 @@ lrcOnNewSlotWorker = recoveryCommGuard $ localOnNewSlotWorker True $ \SlotId {..
     when (getSlotIndex siSlot < slotSecurityParam) $
         lrcSingleShot siEpoch `catch` onLrcError
   where
+    -- Here we log it as a warning and report an error, even though it
+    -- can happen there we don't know recent blocks. That's because if
+    -- we don't know them, we should be in recovery mode and this
+    -- worker should be turned off.
     onLrcError e@UnknownBlocksForLrc = do
         reportError e
-        logInfo
+        logWarning
             "LRC worker can't do anything, because recent blocks aren't known"
     onLrcError e = reportError e >> throwM e
     reportError e =

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -26,6 +26,7 @@ import           Pos.Block.Logic.Internal   (applyBlocksUnsafe, rollbackBlocksUn
 import           Pos.Block.Logic.Util       (withBlkSemaphore_)
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
 import           Pos.Constants              (slotSecurityParam)
+import           Pos.Context                (recoveryCommGuard)
 import           Pos.Core                   (Coin)
 import           Pos.DB.Class               (MonadDBCore)
 import qualified Pos.DB.DB                  as DB
@@ -55,7 +56,7 @@ import           Pos.WorkMode.Class         (WorkMode)
 lrcOnNewSlotWorker
     :: (SscWorkersClass ssc, WorkMode ssc m, MonadDBCore m)
     => (WorkerSpec m, OutSpecs)
-lrcOnNewSlotWorker = localOnNewSlotWorker True $ \SlotId {..} ->
+lrcOnNewSlotWorker = recoveryCommGuard $ localOnNewSlotWorker True $ \SlotId {..} ->
     when (siSlot < slotSecurityParam) $
     (lrcSingleShot siEpoch `catch` reportError) `catch` onLrcError
   where

--- a/src/Pos/Ssc/GodTossing/Workers.hs
+++ b/src/Pos/Ssc/GodTossing/Workers.hs
@@ -37,7 +37,8 @@ import           Pos.Communication.Types          (InvOrDataTK)
 import           Pos.Constants                    (mpcSendInterval, slotSecurityParam,
                                                    vssMaxTTL)
 import           Pos.Context                      (SscContextTag, lrcActionOnEpochReason,
-                                                   npPublicKey, npSecretKey)
+                                                   npPublicKey, npSecretKey,
+                                                   recoveryCommGuard)
 import           Pos.Crypto                       (SecretKey, VssKeyPair, VssPublicKey,
                                                    randomNumber, runSecureRandom)
 import           Pos.Crypto.SecretSharing         (toVssPublicKey)
@@ -88,7 +89,7 @@ instance SscWorkersClass SscGodTossing where
 onNewSlotSsc
     :: (WorkMode SscGodTossing m)
     => (WorkerSpec m, OutSpecs)
-onNewSlotSsc = onNewSlotWorker True outs $ \slotId sendActions -> do
+onNewSlotSsc = recoveryCommGuard $ onNewSlotWorker True outs $ \slotId sendActions -> do
     richmen <- lrcActionOnEpochReason (siEpoch slotId)
         "couldn't get SSC richmen"
         getRichmenSsc

--- a/src/Pos/Update/Worker.hs
+++ b/src/Pos/Update/Worker.hs
@@ -9,6 +9,7 @@ import           Universum
 
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
 import           Pos.Constants              (curSoftwareVersion)
+import           Pos.Context                (recoveryCommGuard)
 import           Pos.Types                  (SoftwareVersion (..))
 import           Pos.Update.DB              (getConfirmedProposals)
 import           Pos.Update.Download        (downloadUpdate)
@@ -19,7 +20,7 @@ import           Pos.WorkMode.Class         (WorkMode)
 usWorkers :: WorkMode ssc m => ([WorkerSpec m], OutSpecs)
 usWorkers =
     first pure $
-    localOnNewSlotWorker True $ \s ->
+    recoveryCommGuard $ localOnNewSlotWorker True $ \s ->
         processNewSlot s >> void (fork checkForUpdate)
 
 checkForUpdate :: WorkMode ssc m => m ()

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -31,7 +31,7 @@ import qualified Pos.CLI                    as CLI
 import           Pos.Communication          (ActionSpec (..), NodeId, OutSpecs,
                                              WorkerSpec, worker, wrapActionSpec)
 import           Pos.Constants              (isDevelopment)
-import           Pos.Context                (MonadNodeContext)
+import           Pos.Context                (MonadNodeContext, recoveryCommGuard)
 import           Pos.Core.Types             (Timestamp (..))
 import           Pos.DHT.Model              (dhtNodeToNodeId)
 import           Pos.DHT.Real               (KademliaDHTInstance (..),
@@ -91,7 +91,8 @@ action peerHolder args@Args {..} transport = do
     let vssSK = fromJust $ npUserSecret currentParams ^. usVss
     let gtParams = gtSscParams args vssSK
     let wDhtWorkers :: WorkMode ssc m => KademliaDHTInstance -> ([WorkerSpec m], OutSpecs)
-        wDhtWorkers = first (map $ wrapActionSpec $ "worker" <> "dht") . dhtWorkers
+        wDhtWorkers = (\(ws, outs) -> (map (fst . recoveryCommGuard . (, outs)) ws, outs)) . -- TODO simplify
+                      first (map $ wrapActionSpec $ "worker" <> "dht") . dhtWorkers
 
 #ifdef WITH_WEB
     when enableWallet $ do


### PR DESCRIPTION
* Don't run `onNewSlot` workers when node is in recovery mode