### PR TITLE
Feature/csl1168 forbid rerevoking psks

### DIFF
--- a/src/Pos/Delegation/Logic.hs
+++ b/src/Pos/Delegation/Logic.hs
@@ -605,11 +605,16 @@ delegationVerifyBlocks blocks = do
                              "match the one in current allowed heavy psks set")
                             pSig
             (BlockPSignatureLight pSig) -> do
-                let pskIPk = pskIssuerPk $ pdPsk pSig
+                let psk = pdPsk pSig
+                let pskIPk = pskIssuerPk psk
                 unless (pskIPk == issuer) $ throwError $
                     sformat ("light proxy signature's "%build%" issuer "%
                              build%" doesn't match block slot leader "%build)
                             pSig pskIPk issuer
+                unless (pskIPk == pskDelegatePk psk) $ throwError $
+                    sformat ("using revoke light proxy signatures to sign block "%
+                             "is forbidden: "%build)
+                            psk
             _ -> pass
 
         ------------- [Payload] -------------


### PR DESCRIPTION
* Now you can't post revocation cert if you have nothing to revoke
* You can now also revoke even if you don't have money (not a richman anymore)
* It's forbidden to sign blocks with revoke certificates
