### PR TITLE
Disable library gold linking when build for explorer

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -438,7 +438,8 @@ library
                        -O2
 
   -- linker speed up for linux
-  if os(linux)
+  -- for explorer linking see https://ghc.haskell.org/trac/ghc/ticket/13810
+  if os(linux) && !flag(with-explorer)
     ghc-options:       -optl-fuse-ld=gold
     ld-options:        -fuse-ld=gold
 


### PR DESCRIPTION
Without this fix, explorer doesn't compile due to a bug in GHC