### PR TITLE
[CSL-1105] Split slotting implementations akin to Discovery

### DIFF
--- a/infra/Pos/Communication/Protocol.hs
+++ b/infra/Pos/Communication/Protocol.hs
@@ -16,6 +16,7 @@ module Pos.Communication.Protocol
        , worker
        , worker'
        , localWorker
+       , localSpecs
        , toAction
        , unpackLSpecs
        , hoistMkListeners
@@ -232,7 +233,10 @@ localOnNewSlotWorker
 localOnNewSlotWorker b h = (ActionSpec $ \__vI __sA -> onNewSlot b h, mempty)
 
 localWorker :: m () -> (WorkerSpec m, OutSpecs)
-localWorker h = (ActionSpec $ \__vI __sA -> h, mempty)
+localWorker = localSpecs
+
+localSpecs :: m a -> (ActionSpec m a, OutSpecs)
+localSpecs h = (ActionSpec $ \__vI __sA -> h, mempty)
 
 checkingInSpecs
     :: WithLogger m

--- a/infra/Pos/Slotting.hs
+++ b/infra/Pos/Slotting.hs
@@ -3,15 +3,15 @@
 module Pos.Slotting
        ( module Pos.Slotting.Class
        , module Pos.Slotting.Error
+       , module Pos.Slotting.Impl
        , module Pos.Slotting.MemState
-       , module Pos.Slotting.Ntp
        , module Pos.Slotting.Types
        , module Pos.Slotting.Util
        ) where
 
 import           Pos.Slotting.Class
 import           Pos.Slotting.Error
+import           Pos.Slotting.Impl
 import           Pos.Slotting.MemState
-import           Pos.Slotting.Ntp
 import           Pos.Slotting.Types
 import           Pos.Slotting.Util

--- a/infra/Pos/Slotting/Class.hs
+++ b/infra/Pos/Slotting/Class.hs
@@ -6,8 +6,9 @@ module Pos.Slotting.Class
        ( MonadSlots (..)
        ) where
 
-import           Control.Monad.Trans   (MonadTrans)
 import           Universum
+
+import           Control.Monad.Trans   (MonadTrans)
 
 import           Pos.Core.Types        (SlotId (..), Timestamp)
 import           Pos.Slotting.MemState (MonadSlotsData)
@@ -31,8 +32,6 @@ class MonadSlotsData m => MonadSlots m where
 
     currentTimeSlotting :: m Timestamp
 
-    slottingWorkers :: [m ()]
-
     default getCurrentSlot :: (MonadTrans t, MonadSlots m', t m' ~ m) =>
         m (Maybe SlotId)
     getCurrentSlot = lift getCurrentSlot
@@ -44,10 +43,6 @@ class MonadSlotsData m => MonadSlots m where
     default currentTimeSlotting :: (MonadTrans t, MonadSlots m', t m' ~ m) =>
         m Timestamp
     currentTimeSlotting = lift currentTimeSlotting
-
-    default slottingWorkers :: (MonadTrans t, MonadSlots m', t m' ~ m) =>
-        [m ()]
-    slottingWorkers = map lift slottingWorkers
 
     default getCurrentSlotInaccurate :: (MonadTrans t, MonadSlots m', t m' ~ m) =>
         m SlotId

--- a/infra/Pos/Slotting/Impl.hs
+++ b/infra/Pos/Slotting/Impl.hs
@@ -1,0 +1,3 @@
+-- | This module re-exports slotting implementations.
+
+{-# OPTIONS_GHC -F -pgmF autoexporter #-}

--- a/infra/Pos/Slotting/Impl/Simple.hs
+++ b/infra/Pos/Slotting/Impl/Simple.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Simple implementation of slotting.
+
+module Pos.Slotting.Impl.Simple
+       ( SimpleSlottingMode
+       , SimpleSlotsRedirect
+       , runSimpleSlotsRedirect
+       ) where
+
+import           Universum
+
+import           Control.Monad.Trans.Identity (IdentityT (..))
+import           Data.Coerce                  (coerce)
+import qualified Ether
+import           Mockable                     (CurrentTime, Mockable, currentTime)
+import           NTP.Example                  ()
+
+import           Pos.Core.Types               (SlotId (..), Timestamp (..))
+import           Pos.Slotting.Class           (MonadSlots (..))
+import           Pos.Slotting.Impl.Util       (approxSlotUsingOutdated, slotFromTimestamp)
+import           Pos.Slotting.MemState.Class  (MonadSlotsData (..))
+import           Pos.Slotting.Types           (SlottingData (..))
+
+----------------------------------------------------------------------------
+-- Mode
+----------------------------------------------------------------------------
+
+type SimpleSlottingMode m = (Mockable CurrentTime m, MonadSlotsData m)
+
+----------------------------------------------------------------------------
+-- MonadSlots implementation
+----------------------------------------------------------------------------
+
+data SimpleSlotsRedirectTag
+
+type SimpleSlotsRedirect =
+    Ether.TaggedTrans SimpleSlotsRedirectTag IdentityT
+
+runSimpleSlotsRedirect :: SimpleSlotsRedirect m a -> m a
+runSimpleSlotsRedirect = coerce
+
+instance (SimpleSlottingMode m, t ~ IdentityT) =>
+         MonadSlots (Ether.TaggedTrans SimpleSlotsRedirectTag t m) where
+    getCurrentSlot = simpleGetCurrentSlot
+    getCurrentSlotBlocking = simpleGetCurrentSlotBlocking
+    getCurrentSlotInaccurate = simpleGetCurrentSlotInaccurate
+    currentTimeSlotting = simpleCurrentTimeSlotting
+
+----------------------------------------------------------------------------
+-- Implementation
+----------------------------------------------------------------------------
+
+simpleGetCurrentSlot :: SimpleSlottingMode m => m (Maybe SlotId)
+simpleGetCurrentSlot = simpleCurrentTimeSlotting >>= slotFromTimestamp
+
+simpleGetCurrentSlotBlocking :: SimpleSlottingMode m => m SlotId
+simpleGetCurrentSlotBlocking = do
+    penult <- sdPenultEpoch <$> getSlottingData
+    simpleGetCurrentSlot >>= \case
+        Just slot -> pure slot
+        Nothing -> do
+            waitPenultEpochEquals (penult + 1)
+            simpleGetCurrentSlotBlocking
+
+simpleGetCurrentSlotInaccurate :: SimpleSlottingMode m => m SlotId
+simpleGetCurrentSlotInaccurate = do
+    penult <- sdPenultEpoch <$> getSlottingData
+    simpleGetCurrentSlot >>= \case
+        Just slot -> pure slot
+        Nothing -> simpleCurrentTimeSlotting >>= approxSlotUsingOutdated penult
+
+simpleCurrentTimeSlotting :: SimpleSlottingMode m => m Timestamp
+simpleCurrentTimeSlotting = Timestamp <$> currentTime

--- a/infra/Pos/Slotting/Impl/Sum.hs
+++ b/infra/Pos/Slotting/Impl/Sum.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE RankNTypes   #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Sum of slotting implementations.
+
+module Pos.Slotting.Impl.Sum
+       ( SlottingContextSum (..)
+       , MonadSlottingSum
+       , SlotsRedirect
+       , runSlotsRedirect
+       , askSlottingContextSum
+
+       -- * Workers
+       , SlottingWorkerModeSum
+       , slottingWorkers
+       ) where
+
+import           Universum
+
+import           Control.Monad.Trans.Identity (IdentityT (..))
+import           Data.Coerce                  (coerce)
+import qualified Ether
+
+import           Pos.Slotting.Class           (MonadSlots (..))
+import           Pos.Slotting.Impl.Ntp        (NtpMode, NtpSlottingVar, NtpWorkerMode,
+                                               ntpWorkers, runNtpSlotsRedirect)
+import           Pos.Slotting.Impl.Simple     (SimpleSlottingMode, runSimpleSlotsRedirect)
+
+-- | Sum of all contexts used by slotting implementations.
+data SlottingContextSum
+    = SCSimple
+    | SCNtp NtpSlottingVar
+
+-- | Monad which combines all 'MonadSlots' implementations (and
+-- uses only one of them).
+type MonadSlottingSum = Ether.MonadReader' SlottingContextSum
+
+data SlotsRedirectTag
+
+type SlotsRedirect =
+    Ether.TaggedTrans SlotsRedirectTag IdentityT
+
+runSlotsRedirect :: SlotsRedirect m a -> m a
+runSlotsRedirect = coerce
+
+askSlottingContextSum :: MonadSlottingSum m => m SlottingContextSum
+askSlottingContextSum = Ether.ask'
+
+type SlottingModeSum m = (NtpMode m, SimpleSlottingMode m)
+
+instance (MonadSlottingSum m, SlottingModeSum m, t ~ IdentityT) =>
+         MonadSlots (Ether.TaggedTrans SlotsRedirectTag t m) where
+    getCurrentSlot = helper getCurrentSlot
+    getCurrentSlotBlocking = helper getCurrentSlotBlocking
+    getCurrentSlotInaccurate = helper getCurrentSlotInaccurate
+    currentTimeSlotting = helper currentTimeSlotting
+
+helper ::
+       (MonadSlottingSum m, SlottingModeSum m, t ~ IdentityT)
+    => (forall n. MonadSlots n =>
+                      n a)
+    -> Ether.TaggedTrans SlotsRedirectTag t m a
+helper action =
+    Ether.ask' >>= \case
+        SCSimple -> runSimpleSlotsRedirect action
+        SCNtp var -> Ether.runReaderT' (runNtpSlotsRedirect action) var
+
+type SlottingWorkerModeSum m = NtpWorkerMode m
+
+-- | Get all slotting workers using 'SlottingContextSum'.
+slottingWorkers :: SlottingWorkerModeSum m => SlottingContextSum -> [m ()]
+slottingWorkers SCSimple    = []
+slottingWorkers (SCNtp var) = ntpWorkers var

--- a/infra/Pos/Slotting/Impl/Util.hs
+++ b/infra/Pos/Slotting/Impl/Util.hs
@@ -1,0 +1,63 @@
+-- | Utilities used by slotting implementations.
+
+module Pos.Slotting.Impl.Util
+       ( approxSlotUsingOutdated
+       , slotFromTimestamp
+       ) where
+
+import           Universum
+
+import           Data.Time.Units             (convertUnit)
+import           NTP.Example                 ()
+
+import qualified Pos.Core.Constants          as C
+import           Pos.Core.Slotting           (flattenEpochIndex, unflattenSlotId)
+import           Pos.Core.Types              (EpochIndex, SlotId (..), Timestamp (..),
+                                              mkLocalSlotIndex)
+import           Pos.Util.Util               (leftToPanic)
+
+import           Pos.Slotting.MemState.Class (MonadSlotsData (..))
+import           Pos.Slotting.Types          (EpochSlottingData (..), SlottingData (..))
+
+-- | Approximate current slot using outdated slotting data.
+approxSlotUsingOutdated :: MonadSlotsData m => EpochIndex -> Timestamp -> m SlotId
+approxSlotUsingOutdated penult t = do
+    SlottingData {..} <- getSlottingData
+    pure $
+        if | t < esdStart sdLast -> SlotId (penult + 1) minBound
+           | otherwise           -> outdatedEpoch t (penult + 1) sdLast
+  where
+    outdatedEpoch (Timestamp curTime) epoch EpochSlottingData {..} =
+        let duration = convertUnit esdSlotDuration
+            start = getTimestamp esdStart in
+        unflattenSlotId $
+        flattenEpochIndex epoch + fromIntegral ((curTime - start) `div` duration)
+
+-- | Compute current slot from current timestamp based on data
+-- provided by 'MonadSlotsData'.
+slotFromTimestamp
+    :: MonadSlotsData m
+    => Timestamp -> m (Maybe SlotId)
+slotFromTimestamp approxCurTime = do
+    SlottingData {..} <- getSlottingData
+    let tryEpoch = computeSlotUsingEpoch approxCurTime
+    let penultRes = tryEpoch sdPenultEpoch sdPenult
+    let lastRes = tryEpoch (succ sdPenultEpoch) sdLast
+    return $ penultRes <|> lastRes
+
+computeSlotUsingEpoch
+    :: Timestamp
+    -> EpochIndex
+    -> EpochSlottingData
+    -> Maybe SlotId
+computeSlotUsingEpoch (Timestamp curTime) epoch EpochSlottingData {..}
+    | curTime < start = Nothing
+    | curTime < start + duration * C.epochSlots = Just $ SlotId epoch localSlot
+    | otherwise = Nothing
+  where
+    localSlotNumeric = fromIntegral $ (curTime - start) `div` duration
+    localSlot =
+        leftToPanic "computeSlotUsingEpoch: " $
+        mkLocalSlotIndex localSlotNumeric
+    duration = convertUnit esdSlotDuration
+    start = getTimestamp esdStart

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -21,14 +21,18 @@ library
 
                         -- Slotting
                         Pos.Slotting
+                        Pos.Slotting.Class
                         Pos.Slotting.Constants
+                        Pos.Slotting.Impl
+                        Pos.Slotting.Impl.Ntp
+                        Pos.Slotting.Impl.Simple
+                        Pos.Slotting.Impl.Sum
+                        Pos.Slotting.Impl.Util
                         Pos.Slotting.MemState
                         Pos.Slotting.MemState.Class
                         Pos.Slotting.MemState.Holder
                         Pos.Slotting.Types
-                        Pos.Slotting.Class
                         Pos.Slotting.Error
-                        Pos.Slotting.Ntp
                         Pos.Slotting.Util
 
                         Pos.Discovery

--- a/src/Pos/Context/Context.hs
+++ b/src/Pos/Context/Context.hs
@@ -58,6 +58,7 @@ import           Pos.Lrc.Context               (LrcContext)
 import           Pos.Reporting.MemState        (ReportingContext (..), rcLoggingConfig,
                                                 rcReportServers)
 import           Pos.Shutdown.Types            (ShutdownContext (..))
+import           Pos.Slotting                  (SlottingContextSum)
 import           Pos.Ssc.Class.Types           (MonadSscContext, Ssc (SscNodeContext),
                                                 SscContextTag)
 import           Pos.Txp.Settings              (TxpGlobalSettings)
@@ -111,6 +112,8 @@ data NodeContext ssc = NodeContext
     -- ^ Context needed for LRC
     , ncDiscoveryContext    :: !DiscoveryContextSum
     -- ^ Context needed for Discovery.
+    , ncSlottingContext     :: !SlottingContextSum
+    -- ^ Context needed for Slotting.
     , ncBlkSemaphore        :: !BlkSemaphore
     -- ^ Semaphore which manages access to block application.
     -- Stored hash is a hash of last applied block.
@@ -164,6 +167,7 @@ makeLensesFor
     [ ("ncUpdateContext", "ncUpdateContextL")
     , ("ncLrcContext", "ncLrcContextL")
     , ("ncDiscoveryContext", "ncDiscoveryContextL")
+    , ("ncSlottingContext", "ncSlottingContextL")
     , ("ncSscContext", "ncSscContextL")
     , ("ncNodeParams", "ncNodeParamsL")
     , ("ncInvPropagationQueue", "ncInvPropagationQueueL")
@@ -217,6 +221,7 @@ type instance TagsK (NodeContext ssc) =
   Type ':
   Type ':
   Type ':
+  Type ':
   '[]
 
 return []
@@ -231,6 +236,7 @@ type instance Tags (NodeContext ssc) =
   UpdateContext          :::
   LrcContext             :::
   DiscoveryContextSum    :::
+  SlottingContextSum     :::
   NodeParams             :::
   UpdateParams           :::
   SecurityParams         :::
@@ -266,6 +272,9 @@ instance HasLens LrcContext (NodeContext ssc) LrcContext where
 
 instance HasLens DiscoveryContextSum (NodeContext ssc) DiscoveryContextSum where
     lensOf = ncDiscoveryContextL
+
+instance HasLens SlottingContextSum (NodeContext ssc) SlottingContextSum where
+    lensOf = ncSlottingContextL
 
 instance HasLens NodeParams (NodeContext ssc) NodeParams where
     lensOf = ncNodeParamsL

--- a/src/Pos/Launcher/Launcher.hs
+++ b/src/Pos/Launcher/Launcher.hs
@@ -16,6 +16,7 @@ import           Pos.Launcher.Param         (NodeParams (..))
 import           Pos.Launcher.Runner        (runRealMode)
 import           Pos.Launcher.Scenario      (runNode)
 import           Pos.Security               (SecurityWorkersClass)
+import           Pos.Slotting               (SlottingContextSum)
 import           Pos.Ssc.Class              (SscConstraint)
 import           Pos.Ssc.Class.Types        (SscParams)
 import           Pos.WorkMode               (RealMode)
@@ -29,10 +30,17 @@ runNodeReal
     :: forall ssc.
        (SscConstraint ssc, SecurityWorkersClass ssc)
     => DiscoveryContextSum
+    -> SlottingContextSum
     -> Transport (RealMode ssc)
     -> ([WorkerSpec (RealMode ssc)], OutSpecs)
     -> NodeParams
     -> SscParams ssc
     -> Production ()
-runNodeReal discCtx transport plugins np sscnp =
-    runRealMode discCtx transport np sscnp (runNode @ssc plugins)
+runNodeReal discCtx slottingCtx transport plugins np sscnp =
+    runRealMode
+        discCtx
+        slottingCtx
+        transport
+        np
+        sscnp
+        (runNode @ssc slottingCtx plugins)

--- a/src/Pos/Wallet/Web/Server/Full/R.hs
+++ b/src/Pos/Wallet/Web/Server/Full/R.hs
@@ -26,6 +26,7 @@ import           Pos.Discovery                     (DiscoveryContextSum)
 import           Pos.Genesis                       (genesisDevSecretKeys)
 import           Pos.Launcher.Param                (NodeParams (..))
 import           Pos.Launcher.Runner               (runRealBasedMode)
+import           Pos.Slotting                      (SlottingContextSum)
 import           Pos.Ssc.Class                     (SscConstraint, SscParams)
 import           Pos.Wallet.KeyStorage             (addSecretKey)
 import           Pos.Wallet.Redirect               (liftWalletRedirects,
@@ -46,6 +47,7 @@ runWRealMode
     => WalletState
     -> ConnectionsVar
     -> DiscoveryContextSum
+    -> SlottingContextSum
     -> Transport WalletRealWebMode
     -> NodeParams
     -> SscParams WalletSscType

--- a/src/Pos/WorkMode.hs
+++ b/src/Pos/WorkMode.hs
@@ -17,8 +17,9 @@ module Pos.WorkMode
 import           Universum
 
 import           Control.Monad.Base             (MonadBase)
-import           Control.Monad.Fix
+import           Control.Monad.Fix              (MonadFix)
 import           Control.Monad.Morph            (hoist)
+import           Control.Monad.Trans.Control    (MonadBaseControl (..))
 import qualified Control.Monad.Trans.Lift.Local as Lift
 import           Control.Monad.Trans.Resource   (MonadResource, ResourceT)
 import           Data.Coerce
@@ -44,9 +45,9 @@ import           Pos.DB.DB                      (GStateCoreRedirect)
 import           Pos.Delegation.Class           (DelegationVar)
 import           Pos.Discovery                  (DiscoveryRedirect, MonadDiscovery)
 import           Pos.Slotting.Class             (MonadSlots)
+import           Pos.Slotting.Impl              (SlotsRedirect)
 import           Pos.Slotting.MemState          (MonadSlotsData, SlottingVar)
 import           Pos.Slotting.MemState.Holder   (SlotsDataRedirect)
-import           Pos.Slotting.Ntp               (NtpSlottingVar, SlotsRedirect)
 import           Pos.Ssc.Class.Helpers          (SscHelpersClass)
 import           Pos.Ssc.Extra                  (SscMemTag, SscState)
 import           Pos.Txp.MemState               (GenericTxpLocalData, TxpHolderTag)
@@ -71,7 +72,6 @@ type RealMode' ssc =
     Ether.ReadersT
         ( Tagged NodeDBs NodeDBs
         , Tagged SlottingVar SlottingVar
-        , Tagged (Bool, NtpSlottingVar) (Bool, NtpSlottingVar)
         , Tagged SscMemTag (SscState ssc)
         , Tagged TxpHolderTag (GenericTxpLocalData TxpExtra_TMP)
         , Tagged DelegationVar DelegationVar
@@ -82,7 +82,7 @@ type RealMode' ssc =
     ResourceT Production
     )))))))))))
 
-newtype RealMode ssc a = RealMode (RealMode' ssc a)
+newtype RealMode ssc a = RealMode { unRealMode :: RealMode' ssc a }
   deriving
     ( Functor
     , Applicative
@@ -94,6 +94,11 @@ newtype RealMode ssc a = RealMode (RealMode' ssc a)
     , MonadMask
     , MonadFix
     )
+
+instance MonadBaseControl IO (RealMode ssc) where
+    type StM (RealMode ssc) a = StM (RealMode' ssc) a
+    liftBaseWith f = RealMode $ liftBaseWith $ \q -> f (q . unRealMode)
+    restoreM s = RealMode $ restoreM s
 
 type instance ThreadId (RealMode ssc) = ThreadId Production
 type instance Promise (RealMode ssc) = Promise Production
@@ -196,7 +201,7 @@ deriving instance HasLoggerName (ServiceMode)
 deriving instance WithPeerState (ServiceMode)
 
 instance PowerLift m ServiceMode' => PowerLift m (ServiceMode) where
-  powerLift = ServiceMode . powerLift
+    powerLift = ServiceMode . powerLift
 
 instance
     ( Mockable d (ServiceMode')

--- a/src/Pos/WorkMode/Class.hs
+++ b/src/Pos/WorkMode/Class.hs
@@ -15,6 +15,7 @@ module Pos.WorkMode.Class
 import           Universum
 
 import           Control.Monad.Catch         (MonadMask)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Ether
 import           Mockable                    (MonadMockable)
 import           System.Wlog                 (WithLogger)
@@ -60,6 +61,7 @@ type TxpExtra_TMP = ()
 -- | Bunch of constraints to perform work for real world distributed system.
 type WorkMode ssc m
     = ( MinWorkMode m
+      , MonadBaseControl IO m
       , MonadMask m
       , MonadSlots m
       , MonadDB m

--- a/src/smart-generator/Main.hs
+++ b/src/smart-generator/Main.hs
@@ -36,6 +36,7 @@ import           Pos.Launcher               (BaseParams (..), LoggingParams (..)
                                              NodeParams (..), bracketResources, initLrc,
                                              runNode', runRealMode, stakesDistr)
 import           Pos.Security               (SecurityParams (..), SecurityWorkersClass)
+import           Pos.Slotting               (SlottingContextSum (SCSimple))
 import           Pos.Ssc.Class              (SscConstraint, SscParams)
 import           Pos.Ssc.GodTossing         (GtParams (..), SscGodTossing)
 import           Pos.Ssc.NistBeacon         (SscNistBeacon)
@@ -105,7 +106,7 @@ runSmartGen
     -> GenOptions
     -> Production ()
 runSmartGen transport peers np@NodeParams{..} sscnp opts@GenOptions{..} =
-  runRealMode (DCStatic peers) transport np sscnp $ (,sendTxOuts <> wOuts) . ActionSpec $ \vI sendActions -> do
+  runRealMode (DCStatic peers) slottingCtx transport np sscnp $ (,sendTxOuts <> wOuts) . ActionSpec $ \vI sendActions -> do
     initLrc
     let getPosixMs = round . (*1000) <$> liftIO getPOSIXTime
         initTx = initTransaction opts
@@ -230,7 +231,8 @@ runSmartGen transport peers np@NodeParams{..} sscnp opts@GenOptions{..} =
 
       return (newTPS, newStep)
   where
-    (workers', wOuts) = allWorkers
+    slottingCtx = SCSimple
+    (workers', wOuts) = allWorkers slottingCtx
 
 -----------------------------------------------------------------------------
 -- Main


### PR DESCRIPTION
Previously we had slotting implementation based on `ReaderT (Bool, NtpSlottingVar)`. It was bad for two reasons:
• `(Bool, NtpSlottingVar) doesn't make sense, it should be `Maybe NtpSlottingVar` or something equivalent.
• We couldn't use simple slotting separately. But we want to use it in tests.
Also it was strange to see simple slotting in NTP module.

In order to fix it I've chosen approach similar to `Discovery` implementations. So we have different transformers and we have a wrapper which stores sum of all contexts and chooses the appropriate one. Also I removed workers from type class, because otherwise I wouldn't be able to get all workers without monadic context and because workers require much more constraints. There is a function which chooses appropriate workers based on contexts sum.

Note that I had to add `SlottingContextSum` as an argument in many places. I don't like it and I think nobody does. I will improve it within another issue. So please don't complain about this argument.