### PR TITLE
[CSL-775] Fix double initialization of logging

### DIFF
--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -246,7 +246,6 @@ allocateNodeContext ::
     -> m $ NodeContext ssc
 allocateNodeContext np@NodeParams {..} sscnp = do
     ncLoggerConfig <- getRealLoggerConfig $ bpLoggingParams npBaseParams
-    setupLoggers $ bpLoggingParams npBaseParams
     ncBlkSemaphore <- BlkSemaphore <$> newEmptyMVar
     ucUpdateSemaphore <- newEmptyMVar
     lcLrcSync <- mkLrcSyncData >>= newTVarIO


### PR DESCRIPTION
During refactoring I accidentally put logging initialization into two places.