### PR TITLE
[CSL-1201] Guard the state modifying STM action with a mutex

### DIFF
--- a/src/Pos/Block/Logic/Internal.hs
+++ b/src/Pos/Block/Logic/Internal.hs
@@ -23,6 +23,7 @@ module Pos.Block.Logic.Internal
 import           Universum
 
 import           Control.Lens            (each, _Wrapped)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Ether
 import           Formatting              (sformat, (%))
 import           Paths_cardano_sl        (version)
@@ -107,6 +108,7 @@ type BlockApplyMode ssc m
        -- Needed for error reporting.
        , MonadReportingMem m
        , MonadDiscovery m
+       , MonadBaseControl IO m
        )
 
 -- | Applies a definitely valid prefix of blocks. This function is unsafe,

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -31,6 +31,7 @@ import           Universum
 import           Control.Lens                 (makeLenses, (%=))
 import           Control.Monad.Loops          (unfoldrM)
 import           Control.Monad.Trans          (MonadTrans)
+import           Control.Monad.Trans.Control  (MonadBaseControl)
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Control.Monad.Trans.Maybe    (MaybeT (..))
 import           Data.Coerce                  (coerce)
@@ -193,6 +194,7 @@ instance
     , MonadSlots m
     , Ether.MonadReader' GenesisUtxo m
     , MonadTxpMem TxpExtra_TMP m
+    , MonadBaseControl IO m
     , t ~ IdentityT
     ) => MonadTxHistory (Ether.TaggedTrans TxHistoryRedirectTag t m)
   where

--- a/src/Pos/Explorer/Txp/Local.hs
+++ b/src/Pos/Explorer/Txp/Local.hs
@@ -8,6 +8,7 @@ module Pos.Explorer.Txp.Local
 import           Universum
 
 import           Control.Monad.Except  (MonadError (..))
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Default          (def)
 import qualified Data.HashMap.Strict   as HM
 import qualified Data.List.NonEmpty    as NE
@@ -38,6 +39,7 @@ import           Pos.Explorer.Txp.Toil (ExplorerExtra, ExplorerExtraTxp (..),
 
 type ETxpLocalWorkMode m =
     ( MonadIO m
+    , MonadBaseControl IO m
     , MonadDBRead m
     , MonadGState m
     , MonadTxpMem ExplorerExtra m
@@ -144,7 +146,7 @@ eTxProcessTransaction itw@(txId, TxAux {taTx = UnsafeTx {..}}) = do
 --   2. Remove invalid transactions from MemPool
 --   3. Set new tip to txp local data
 eTxNormalize
-    :: (MonadIO m, MonadDBRead m, MonadGState m, MonadTxpMem ExplorerExtra m) => m ()
+    :: (MonadIO m, MonadBaseControl IO m, MonadDBRead m, MonadGState m, MonadTxpMem ExplorerExtra m) => m ()
 eTxNormalize = do
     utxoTip <- GS.getTip
     localTxs <- getLocalTxsMap

--- a/txp/Pos/Txp/Logic/Local.hs
+++ b/txp/Pos/Txp/Logic/Local.hs
@@ -7,6 +7,7 @@ module Pos.Txp.Logic.Local
        ) where
 
 import           Control.Monad.Except (MonadError (..))
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Default         (Default (def))
 import qualified Data.List.NonEmpty   as NE
 import qualified Data.Map             as M (fromList)
@@ -28,6 +29,7 @@ import           Pos.Txp.Toil         (GenericToilModifier (..), MonadUtxoRead (
 
 type TxpLocalWorkMode m =
     ( MonadIO m
+    , MonadBaseControl IO m
     , MonadDBRead m
     , MonadGState m
     , MonadTxpMem () m
@@ -92,7 +94,7 @@ txProcessTransaction itw@(txId, txAux) = do
 -- | 2. Remove invalid transactions from MemPool
 -- | 3. Set new tip to txp local data
 txNormalize
-    :: (MonadIO m, MonadDBRead m, MonadGState m, MonadTxpMem () m) => m ()
+    :: (MonadIO m, MonadBaseControl IO m, MonadDBRead m, MonadGState m, MonadTxpMem () m) => m ()
 txNormalize = do
     utxoTip <- GS.getTip
     localTxs <- getLocalTxs

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -68,8 +68,10 @@ library
                      , formatting
                      , hashable
                      , lens
+                     , lifted-base
                      , log-warper
                      , mtl
+                     , monad-control
                      , neat-interpolation
                      , plutus-prototype
                      , rocksdb


### PR DESCRIPTION
Backported from `feature/csl-971-build-simpler-benchmark`, but uses bracket instead of calling takeMVar/putMVar directly to be more robust.

I'd use MonadMask (since it's used in other places), but unfortunately there is also usage of ExceptT, and these two are incompatible.