### PR TITLE
Akegalj/csm89 remove tx desc title

### DIFF
--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -174,28 +174,23 @@ updateProfile = postRBody $ noQueryParam ["profile"]
 newPayment :: forall eff. Maybe CPassPhrase -> CAccountId -> CId Addr -> CCoin -> Aff (ajax :: AJAX | eff) CTx
 newPayment pass addrFrom addrTo amount = postR $ queryParams ["txs", "payments", walletAddressToUrl addrFrom, _address addrTo, _ccoin amount] [qParam "passphrase" $ _passPhrase <$> pass]
 
-newPaymentExtended :: forall eff. Maybe CPassPhrase -> CAccountId -> CId Addr -> CCoin -> String -> String -> Aff (ajax :: AJAX | eff) CTx
-newPaymentExtended pass addrFrom addrTo amount title desc = postR $ queryParams ["txs", "payments", walletAddressToUrl  addrFrom, _address addrTo, _ccoin amount, title, desc] [qParam "passphrase" $ _passPhrase <$> pass]
-
 updateTransaction :: forall eff. CAccountId -> CTxId -> CTxMeta -> Aff (ajax :: AJAX | eff) Unit
 updateTransaction addr ctxId = postRBody $ noQueryParam ["txs", "payments", walletAddressToUrl addr, _ctxIdValue ctxId]
 
-searchHistory
+getHistory
   :: forall eff.
      Maybe (CId Wal)
   -> Maybe CAccountId
   -> Maybe (CId Addr)
-  -> Maybe String
   -> Maybe Int
   -> Maybe Int
   -> Aff (ajax :: AJAX | eff) (Tuple (Array CTx) Int)
-searchHistory walletId accountId addr search skip limit =
+getHistory walletId accountId addr skip limit =
   getR $ queryParams
   ["txs", "histories"]
   [ qParam "walletId" $ _address <$> walletId
   , qParam "accountId" $ walletAddressToUrl <$> accountId
   , qParam "address" $ _address <$> addr
-  , qParam "search" search
   , qParam "skip" $ show <$> skip
   , qParam "limit" $ show <$> limit
   ]

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -12,7 +12,7 @@ import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Ref (newRef, REF)
 import Control.Monad.Error.Class (throwError)
 import Control.Promise (Promise, fromAff)
-import Daedalus.Types (getProfileLocale, mkBackupPhrase, mkCAccountId, mkCAccountInit, mkCAccountMeta, mkCCoin, mkCId, mkCInitialized, mkCPaperVendWalletRedeem, mkCPassPhrase, mkCProfile, mkCTxId, mkCTxMeta, mkCWalletInit, mkCWalletMeta, mkCWalletRedeem)
+import Daedalus.Types (getProfileLocale, mkBackupPhrase, mkCAccountId, mkCAccountInit, mkCAccountMeta, mkCCoin, mkCId, mkCInitialized, mkCPaperVendWalletRedeem, mkCPassPhrase, mkCProfile, mkCTxId, mkCTxMeta, mkCWalletInit, mkCWalletMeta, mkCWalletRedeem, optionalString)
 import Daedalus.WS (WSConnection(WSNotConnected), mkWSState, ErrorCb, NotifyCb, openConn)
 import Data.Argonaut (Json)
 import Data.Argonaut.Generic.Aeson (encodeJson)
@@ -586,6 +586,20 @@ updateTransaction = mkEffFn3 \wId ctxId ctmDate -> fromAff $
 -- |       ctAmount: [Object] } ],
 -- |   2 ]
 -- | ```
+
+getHistory :: forall eff. EffFn5 (ajax :: AJAX, err :: EXCEPTION | eff) Foreign Foreign Foreign Int Int (Promise Json)
+getHistory = mkEffFn5 \wIdF acIdF addressIdF skip limit -> do
+    wId <- optionalString wIdF "walletId"
+    acId <- optionalString acIdF "accountId"
+    addressId <- optionalString addressIdF "addressId"
+    fromAff <<< map encodeJson $ do
+        B.getHistory
+            (mkCId <$> wId)
+            (mkCAccountId <$> acId)
+            (mkCId <$> addressId)
+            (Just skip)
+            (Just limit)
+
 getHistoryByAccount :: forall eff. EffFn3 (ajax :: AJAX | eff) String Int Int (Promise Json)
 getHistoryByAccount = mkEffFn3 \wId skip limit -> fromAff <<< map encodeJson $
     B.getHistory

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -601,10 +601,10 @@ getHistory = mkEffFn5 \wIdF acIdF addressIdF skip limit -> do
             (Just limit)
 
 getHistoryByAccount :: forall eff. EffFn3 (ajax :: AJAX | eff) String Int Int (Promise Json)
-getHistoryByAccount = mkEffFn3 \wId skip limit -> fromAff <<< map encodeJson $
+getHistoryByAccount = mkEffFn3 \acId skip limit -> fromAff <<< map encodeJson $
     B.getHistory
     Nothing
-    (Just $ mkCAccountId wId)
+    (Just $ mkCAccountId acId)
     Nothing
     (Just skip)
     (Just limit)

--- a/daedalus/src/Daedalus/Types.purs
+++ b/daedalus/src/Daedalus/Types.purs
@@ -27,6 +27,7 @@ module Daedalus.Types
        , walletAddressToUrl
        , mkCWalletInit
        , mkCWalletAssurance
+       , optionalString
        ) where
 
 import Prelude

--- a/daedalus/src/Daedalus/Types.purs
+++ b/daedalus/src/Daedalus/Types.purs
@@ -202,11 +202,9 @@ _ctxIdValue (CT.CTxId tx) = _hash tx
 mkCTxId :: String -> CT.CTxId
 mkCTxId = CT.CTxId <<< CHash
 
-mkCTxMeta :: String -> String -> Number -> CT.CTxMeta
-mkCTxMeta title description date =
-    CT.CTxMeta { ctmTitle: title
-               , ctmDescription: description
-               , ctmDate: mkTime date
+mkCTxMeta :: Number -> CT.CTxMeta
+mkCTxMeta date =
+    CT.CTxMeta { ctmDate: mkTime date
                }
 
 mkCProfile :: String -> CT.CProfile

--- a/src/Pos/Wallet/Web/Api.hs
+++ b/src/Pos/Wallet/Web/Api.hs
@@ -39,9 +39,8 @@ module Pos.Wallet.Web.Api
        , UpdateProfile
 
        , NewPayment
-       , NewPaymentExt
        , UpdateTx
-       , SearchHistory
+       , GetHistory
 
        , NextUpdate
        , ApplyUpdate
@@ -242,18 +241,6 @@ type NewPayment =
     :> Capture "amount" Coin
     :> WRes Post CTx
 
-type NewPaymentExt =
-       "txs"
-    :> "payments"
-    :> CQueryParam "passphrase" CPassPhrase
-    :> CCapture "from" CAccountId
-    :> Capture "to" (CId Addr)
-    :> Capture "amount" Coin
-    :> Capture "title" Text
-    :> Capture "description" Text
-    :> WRes Post CTx
-
-
 type UpdateTx =
        "txs"
     :> "payments"
@@ -262,13 +249,12 @@ type UpdateTx =
     :> ReqBody '[JSON] CTxMeta
     :> WRes Post ()
 
-type SearchHistory =
+type GetHistory =
        "txs"
     :> "histories"
     :> QueryParam "walletId" (CId Wal)
     :> CQueryParam "accountId" CAccountId
     :> QueryParam "address" (CId Addr)
-    :> QueryParam "search" Text
     :> QueryParam "skip" Word
     :> QueryParam "limit" Word
     :> WRes Get ([CTx], Word)
@@ -407,14 +393,10 @@ type WalletApi = ApiPrefix :> (
     -- to support many2many
      NewPayment
     :<|>
-    -- TODO: for now we only support one2one sending. We should extend this
-    -- to support many2many
-     NewPaymentExt
-    :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx
     :<|>
-     SearchHistory
+     GetHistory
     :<|>
      -------------------------------------------------------------------------
      -- Updates

--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -47,7 +47,6 @@ module Pos.Wallet.Web.ClientTypes
       , mkCTxs
       , mkCTxId
       , txIdToCTxId
-      , txContainsTitle
       , toCUpdateInfo
       , addrMetaToAccount
       ) where
@@ -415,9 +414,7 @@ instance Default CProfile where
 
 -- | meta data of transactions
 data CTxMeta = CTxMeta
-    { ctmTitle       :: Text
-    , ctmDescription :: Text
-    , ctmDate        :: POSIXTime
+    { ctmDate        :: POSIXTime
     } deriving (Show, Generic)
 
 -- | Client transaction (CTx)
@@ -433,9 +430,6 @@ data CTx = CTx
     , ctOutputAddrs   :: [CId Addr]
     , ctIsOutgoing    :: Bool
     } deriving (Show, Generic, Typeable)
-
-txContainsTitle :: Text -> CTx -> Bool
-txContainsTitle search = isInfixOf (toLower search) . toLower . ctmTitle . ctMeta
 
 -- TODO [CSM-288] Rename?
 -- | In case of A -> A tranaction, we have to return two similar 'CTx's:

--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -59,7 +59,7 @@ import qualified Data.ByteString.Lazy      as LBS
 import           Data.Default              (Default, def)
 import           Data.Hashable             (Hashable (..))
 import qualified Data.Set                  as S
-import           Data.Text                 (Text, isInfixOf, splitOn, toLower)
+import           Data.Text                 (Text, splitOn)
 import           Data.Text.Buildable       (build)
 import           Data.Time.Clock.POSIX     (POSIXTime)
 import           Data.Typeable             (Typeable)

--- a/src/wallet-web-api-swagger/Main.hs
+++ b/src/wallet-web-api-swagger/Main.hs
@@ -196,9 +196,8 @@ swaggerSpecForWalletApi = toSwagger W.walletApi
     & wop @W.UpdateProfile          . description ?~ D.updateProfile
 
     & wop @W.NewPayment             . description ?~ D.newPayment
-    & wop @W.NewPaymentExt          . description ?~ D.newPaymentExt
     & wop @W.UpdateTx               . description ?~ D.updateTx
-    & wop @W.SearchHistory          . description ?~ D.searchHistory
+    & wop @W.GetHistory             . description ?~ D.getHistory
 
     & wop @W.NextUpdate             . description ?~ D.nextUpdate
     & wop @W.ApplyUpdate            . description ?~ D.applyUpdate

--- a/util-scripts/build.sh
+++ b/util-scripts/build.sh
@@ -135,9 +135,9 @@ else
 fi
 
 if [[ $ram == true ]]; then
-  ghc_opts="$ghc_opts -Wwarn +RTS -A2G -n4m -RTS"
+  ghc_opts="$ghc_opts -Werror +RTS -A2G -n4m -RTS"
 else
-  ghc_opts="$ghc_opts -Wwarn +RTS -A256m -n2m -RTS"
+  ghc_opts="$ghc_opts -Werror +RTS -A256m -n2m -RTS"
 fi
 
 xperl='$|++; s/(.*) Compiling\s([^\s]+)\s+\(\s+([^\/]+).*/\1 \2/p'


### PR DESCRIPTION
This implements both:
 * https://issues.serokell.io/issue/CSM-89
 * https://issues.serokell.io/issue/CSM-295

The resulting changes are:
 * getHistory has first three parameters optional
    - `getHistory(wId, null, null, 1, 10)` if you want to search with wallet
    - `getHistory(null, accId, null, 1, 10)` if you want to search with account
    - `getHistory(null, accId, addressId, 1, 10)` if you want to search specific address
    - `getHistory(wId, null, addressId, 1, 10)` if you want to search specific address
    - `getHistory` - any other combination will throw an error
 * `getHistoryByWallet(wId, 1, 10)` - search only by wallet
 * `getHistoryByAccount(acId, 1, 10)` - search only by account
 * `getHistoryByAddress(acId, addressId, 1, 10)` - search  by account and address within
 * `searchHistory*` - removed - based on https://input-output-rnd.slack.com/archives/G2FTCSW69/p1497548495263461
      > We dont have search in the UI ;)
      by @DominikGuzei 
 * `newPaymentExtended` - removed
 * `updateTransaction` - removed title and desc

by @Pastafarianist
Also, note that `getHistory` is working like:
 * If you specify only `accountId`, then it will work
 * If you specify only `walletId`, it will also work
 * If you specify either of those things and `addressId`, it will work provided that the address belongs to whatever you specify, otherwise it will throw an error

> To UI guys: please note the quirky behavior of getHistory. This is an implementation detail and if needed, I can fix it.