### PR TITLE
[CSL-1189] Restrict nonempty passphrase again

### DIFF
--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -196,17 +196,11 @@ instance (Bi w) => Bi (ProxySignature w a) where
 
 instance Bi PassPhrase where
     put pp = do
-        -- currently passphrase may be 32-byte long, or empty
-        -- (for unencrypted keys)
         let bs = BS.pack $ ByteArray.unpack pp
-            bl = BS.length bs
-        unless (bl `elem` [0, 32]) $ error $
-            sformat ("put@PassPhrase: expected length 0 or 32, not "%int)
-                bl
+        putAssertLength "PassPhrase" passphraseLength bs
         putByteString bs
     get = label "PassPhrase" $
-          ByteArray.pack . BS.unpack <$>
-              (getByteString passphraseLength <|> getByteString 0)
+          ByteArray.pack . BS.unpack <$> getByteString passphraseLength
 
 -------------------------------------------------------------------------------
 -- Hierarchical derivation

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -39,7 +39,7 @@ import           Pos.Crypto.Hashing    (Hash, hash)
 import           Pos.Crypto.Random     (secureRandomBS)
 import           Pos.Crypto.Signing    (ProxyCert (..), ProxySecretKey (..),
                                         PublicKey (..), SecretKey (..), Signature (..),
-                                        sign, toPublic)
+                                        emptyPass, sign, toPublic)
 import           Pos.Crypto.SignTag    (SignTag (SignProxySK), signTag)
 
 data EncryptedSecretKey = EncryptedSecretKey
@@ -64,11 +64,7 @@ instance Buildable PassPhrase where
 
 -- | Empty passphrase used in development.
 emptyPassphrase :: PassPhrase
-emptyPassphrase = PassPhrase mempty
-
-{-instance Monoid PassPhrase where
-    mempty = PassPhrase mempty
-    mappend (PassPhrase p1) (PassPhrase p2) = PassPhrase (p1 `mappend` p2)-}
+emptyPassphrase = PassPhrase emptyPass
 
 mkEncSecret :: Bi PassPhrase => PassPhrase -> CC.XPrv -> EncryptedSecretKey
 mkEncSecret pp payload = EncryptedSecretKey payload (hash pp)

--- a/core/Pos/Crypto/Signing.hs
+++ b/core/Pos/Crypto/Signing.hs
@@ -42,6 +42,7 @@ import qualified Cardano.Crypto.Wallet  as CC
 -- import qualified Cardano.Crypto.Wallet.Encrypted as CC
 -- import qualified Crypto.ECC.Edwards25519         as Ed25519
 import           Data.ByteArray         (ScrubbedBytes)
+import qualified Data.ByteArray         as BA
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Lazy   as BSL
 import           Data.Coerce            (coerce)
@@ -118,7 +119,7 @@ parseFullPublicKey s = do
     pure a
 
 emptyPass :: ScrubbedBytes
-emptyPass = mempty
+emptyPass = BA.replicate 32 0
 
 -- TODO: this is just a placeholder for actual (not ready yet) derivation
 -- of keypair from seed in cardano-crypto API

--- a/src/Pos/Crypto/Arbitrary.hs
+++ b/src/Pos/Crypto/Arbitrary.hs
@@ -14,7 +14,7 @@ import           Data.DeriveTH               (derive, makeArbitrary)
 import           Data.List.NonEmpty          (fromList)
 import           System.IO.Unsafe            (unsafePerformIO)
 import           Test.QuickCheck             (Arbitrary (..), choose, elements, generate,
-                                              oneof, vector)
+                                              vector)
 
 import           Pos.Binary.Class            (AsBinary (..), AsBinaryClass (..), Bi)
 import           Pos.Binary.Crypto           ()
@@ -215,10 +215,7 @@ instance (HashAlgorithm algo, Bi a) => Arbitrary (AbstractHash algo a) where
 ----------------------------------------------------------------------------
 
 instance Arbitrary PassPhrase where
-    arbitrary = oneof [
-        pure mempty,
-        ByteArray.pack <$> vector 32
-        ]
+    arbitrary = ByteArray.pack <$> vector 32
 
 ----------------------------------------------------------------------------
 -- HD

--- a/src/Pos/Wallet/Web/Util.hs
+++ b/src/Pos/Wallet/Web/Util.hs
@@ -7,8 +7,9 @@ module Pos.Wallet.Web.Util
 import           Universum
 
 import           Pos.Core   (Address, createHDAddressH)
-import           Pos.Crypto (EncryptedSecretKey, PassPhrase, deriveHDPassphrase,
-                             deriveHDSecretKey, encToPublic)
+import           Pos.Crypto (PassPhrase, deriveHDPassphrase, deriveHDSecretKey,
+                             encToPublic)
+import           Pos.Crypto (EncryptedSecretKey)
 
 -- TODO: move more here from Methods.hs
 


### PR DESCRIPTION
Use only 32-byte length pasphrases.
Default is set to `replicate 32 0`