### PR TITLE
[CSL-1231] Bring back optional macos travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - env: HLINT=false
     - os: osx
       osx_image: xcode8.3
+  allow_failures:
+    - os: osx
 env:
   global:
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/8bed8fb53227932886ab23e5f5f9eabe139f8e9f.tar.gz


### PR DESCRIPTION
The OSX CI was made obligatory by the commit 13e2771c6bb3a41989657603ac676e73bdcdc182 named WIP. I don't know the reason but several PRs can't be merged because OSX CI is broken.