### PR TITLE
[CSM-222] Enable utxo filtering in tx history derivation

### DIFF
--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -72,7 +72,7 @@ import           Servant.Multipart         (FileData, FromMultipart (..), lookup
 
 import           Pos.Aeson.Types           ()
 import           Pos.Binary.Class          (decodeFull, encodeStrict)
-import           Pos.Client.Txp.History    (TxHistoryEntry (..))
+import           Pos.Client.Txp.History    (TxHistoryEntry (..), _thInputAddrs)
 import           Pos.Core.Coin             (mkCoin)
 import           Pos.Core.Types            (ScriptVersion)
 import           Pos.Crypto                (EncryptedSecretKey, PassPhrase, encToPublic,
@@ -180,7 +180,7 @@ mkCTxs
     -> CTxMeta            -- ^ Transaction metadata
     -> [CWAddressMeta]    -- ^ Addresses of wallet
     -> Either Text CTxs
-mkCTxs diff THEntry {..} meta wAddrMetas = do
+mkCTxs diff thEntry@THEntry {..} meta wAddrMetas = do
     ctInputAddrsNe <-
         nonEmpty ctInputAddrs
         `whenNothing` throwError "No input addresses in tx!"
@@ -221,7 +221,7 @@ mkCTxs diff THEntry {..} meta wAddrMetas = do
   where
     ctId = txIdToCTxId _thTxId
     outputs = toList $ _txOutputs _thTx
-    ctInputAddrs = map addressToCId _thInputAddrs
+    ctInputAddrs = map addressToCId (_thInputAddrs thEntry)
     ctOutputAddrs = map addressToCId _thOutputAddrs
     ctConfirmations = maybe 0 fromIntegral $ (diff -) <$> _thDifficulty
     ctMeta = meta

--- a/txp/Pos/Txp/Toil/Utxo/Util.hs
+++ b/txp/Pos/Txp/Toil/Utxo/Util.hs
@@ -23,9 +23,10 @@ filterUtxoByAddr addr = M.filter (`addrBelongsTo` addr)
 
 -- | Select only TxOuts for given addresses
 filterUtxoByAddrs :: [Address] -> Utxo -> Utxo
-filterUtxoByAddrs addrs =
+filterUtxoByAddrs addrs utxo =
     let addrSet = HS.fromList $ map AddressIA addrs
-    in  M.filter (`addrBelongsToSet` addrSet)
+    in traceShow ("Filtering: by " <> show addrs <> "\n\t: " <> show utxo <> "\n") $
+       M.filter (`addrBelongsToSet` addrSet) utxo
 
 -- | Convert 'Utxo' to map from 'StakeholderId' to stake.
 utxoToStakes :: Utxo -> HashMap StakeholderId Coin


### PR DESCRIPTION
Since, unlike previously, now we provide input addresses of transactions, derivation requires two-phase lookup.

First lookup fetches main info and input addresses from genesis utxo.
Second lookup adds input addresses which did not come from genesis.

Note that initial filtering of genesis utxo wasn't enabled:
https://github.com/input-output-hk/cardano-sl/blob/422a40062b3e8cfbab6ac5e46d1cadf0bcebedac/src/Pos/Client/Txp/History.hs#L196
but it seems not to impact performance much.

Tested on sending chains of length 2 (A -> B -> A, chains of length 1 were working with bad filtering).