### PR TITLE
[CSM-317] Fix changing password

### DIFF
--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -66,10 +66,10 @@ import           Pos.Core                         (Address (..), Coin, addressF,
                                                    makeRedeemAddress, mkCoin, sumCoins,
                                                    unsafeAddCoin, unsafeIntegerToCoin,
                                                    unsafeSubCoin)
-import           Pos.Crypto                       (EncryptedSecretKey, PassPhrase,
-                                                   aesDecrypt, changeEncPassphrase,
-                                                   checkPassMatches, deriveAesKeyBS,
-                                                   emptyPassphrase, encToPublic, hash,
+import           Pos.Crypto                       (PassPhrase, aesDecrypt,
+                                                   changeEncPassphrase, checkPassMatches,
+                                                   deriveAesKeyBS, emptyPassphrase,
+                                                   encToPublic, hash,
                                                    redeemDeterministicKeyGen,
                                                    redeemToPublic, withSafeSigner,
                                                    withSafeSigner)
@@ -85,9 +85,9 @@ import           Pos.Util                         (maybeThrow)
 import           Pos.Util.BackupPhrase            (toSeed)
 import qualified Pos.Util.Modifier                as MM
 import           Pos.Util.Servant                 (decodeCType, encodeCType)
-import           Pos.Util.UserSecret              (UserSecretDecodingError (..),
-                                                   readUserSecret, usWalletSet,
-                                                   UserSecret)
+import           Pos.Util.UserSecret              (UserSecret,
+                                                   UserSecretDecodingError (..),
+                                                   readUserSecret, usWalletSet)
 import           Pos.Wallet.KeyStorage            (addSecretKey, deleteSecretKey,
                                                    getSecretKeys)
 import           Pos.Wallet.Redirect              (WalletRedirects)
@@ -129,29 +129,26 @@ import           Pos.Wallet.Web.Server.Sockets    (ConnectionsVar, MonadWalletWe
                                                    WalletWebSockets, closeWSConnections,
                                                    getWalletWebSockets, initWSConnections,
                                                    notifyAll, upgradeApplicationWS)
-import           Pos.Wallet.Web.State             (AddressLookupMode (Deleted, Ever, Existing),
+import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing),
                                                    WalletWebDB, WebWalletModeDB,
-                                                   addOnlyNewTxMeta, addRemovedAccount,
-                                                   addUpdate, addWAddress, closeState,
-                                                   createAccount, createWallet,
-                                                   getAccountMeta, getAccountWAddresses,
-                                                   getHistoryCache, getNextUpdate,
-                                                   getProfile, getTxMeta, getWAddressIds,
-                                                   getWalletAddresses, getWalletMeta,
-                                                   getWalletPassLU, openState,
-                                                   removeAccount, removeNextUpdate,
-                                                   removeWAddress, removeWallet,
+                                                   addOnlyNewTxMeta, addUpdate,
+                                                   addWAddress, closeState, createAccount,
+                                                   createWallet, getAccountMeta,
+                                                   getAccountWAddresses, getHistoryCache,
+                                                   getNextUpdate, getProfile, getTxMeta,
+                                                   getWAddressIds, getWalletAddresses,
+                                                   getWalletMeta, getWalletPassLU,
+                                                   openState, removeAccount,
+                                                   removeNextUpdate, removeWallet,
                                                    setAccountMeta, setProfile,
                                                    setWalletMeta, setWalletPassLU,
                                                    setWalletTxMeta, testReset,
-                                                   totallyRemoveWAddress,
                                                    updateHistoryCache)
 import           Pos.Wallet.Web.State.Storage     (WalletStorage)
 import           Pos.Wallet.Web.Tracking          (BlockLockMode, MonadWalletTracking,
                                                    selectAccountsFromUtxoLock,
                                                    syncWSetsWithGStateLock,
                                                    txMempoolToModifier)
-import           Pos.Wallet.Web.Util              (deriveLvl2KeyPair)
 import           Pos.Web.Server                   (serveImpl)
 
 ----------------------------------------------------------------------------
@@ -322,9 +319,9 @@ servantHandlers sendActions =
     :<|>
      deleteWallet
     :<|>
-     importWallet sendActions
+     importWallet
     :<|>
-     changeWalletPassphrase sendActions
+     changeWalletPassphrase
     :<|>
 
      getAccount
@@ -821,21 +818,6 @@ renameWSet cid newName = do
     setWalletMeta cid meta{ cwName = newName }
     getWallet cid
 
--- | Creates account address with same derivation path for new wallet.
-rederiveAccountAddress
-    :: WalletWebMode m
-    => EncryptedSecretKey -> PassPhrase -> CWAddressMeta -> m CWAddressMeta
-rederiveAccountAddress newSK newPass CWAddressMeta{..} = do
-    (accAddr, _) <- maybeThrow badPass $
-        deriveLvl2KeyPair newPass newSK cwamWalletIndex cwamAccountIndex
-    return CWAddressMeta
-        { cwamWId      = encToCId newSK
-        , cwamId        = addressToCId accAddr
-        , ..
-        }
-  where
-    badPass = RequestError "Passphrase doesn't match"
-
 data AccountsSnapshot = AccountsSnapshot
     { asExisting :: [CWAddressMeta]
     , asDeleted  :: [CWAddressMeta]
@@ -853,86 +835,19 @@ instance Buildable AccountsSnapshot where
             asExisting
             asDeleted
 
--- | Clones existing accounts of wallet with new passphrase and returns
--- list of old accounts
-cloneWalletSetWithPass
-    :: WalletWebMode m
-    => EncryptedSecretKey
-    -> PassPhrase
-    -> CId Wal
-    -> m (AccountsSnapshot, AccountsSnapshot)
-cloneWalletSetWithPass newSK newPass wid = do
-    accIds <- getWalletAccountIds wid
-    fmap mconcat . forM accIds $ \accId@AccountId{..} -> do
-        wMeta <- getAccountMeta accId >>= maybeThrow noWMeta
-        setAccountMeta accId wMeta
-        (oldDeleted, newDeleted) <-
-            unzip <$> cloneAccounts accId Deleted addRemovedAccount
-        (oldExisting, newExisting) <-
-            unzip <$> cloneAccounts accId Existing addWAddress
-        let oldAddrMeta =
-                AccountsSnapshot
-                {asExisting = oldExisting, asDeleted = oldDeleted}
-            newAddrMeta =
-                AccountsSnapshot
-                {asExisting = newExisting, asDeleted = newDeleted}
-        logDebug $
-            sformat
-                ("Cloned wallet accounts: "%build%"\n\t-> "%build)
-                oldAddrMeta
-                newAddrMeta
-        return (oldAddrMeta, newAddrMeta)
-  where
-    noWMeta = InternalError "Can't get wallet meta (inconsistent db)"
-    cloneAccounts oldAccId lookupMode addToDB = do
-        accAddrs <- getAccountAddrsOrThrow lookupMode oldAccId
-        forM accAddrs $ \accAddr@CWAddressMeta {..} -> do
-            newAcc <- rederiveAccountAddress newSK newPass accAddr
-            _ <- addToDB newAcc
-            return (accAddr, newAcc)
-
-moveMoneyToClone
-    :: WalletWebMode m
-    => SendActions m
-    -> PassPhrase
-    -> CId Wal
-    -> [CWAddressMeta]
-    -> [CWAddressMeta]
-    -> m ()
-moveMoneyToClone sa oldPass wid oldAddrMeta newAddrMeta = do
-    let ms = WalletMoneySource wid
-    dist <-
-        forM (zip oldAddrMeta newAddrMeta) $ \(oldAcc, newAcc) ->
-            (cwamId newAcc, ) <$> getWAddressBalance oldAcc
-    whenNotNull dist $ \dist' ->
-        unless (all ((== mkCoin 0) . snd) dist) $
-        void $
-        sendMoney sa oldPass ms dist'
-
 changeWalletPassphrase
     :: WalletWebMode m
-    => SendActions m -> CId Wal -> PassPhrase -> PassPhrase -> m ()
-changeWalletPassphrase sa wid oldPass newPass = do
+    => CId Wal -> PassPhrase -> PassPhrase -> m ()
+changeWalletPassphrase wid oldPass newPass = do
     oldSK <- getSKByAddr wid
 
     -- 'cloneWalletSetWithPass' will work badly if accounts / addresses ids
     -- don't actually change
     unless (isJust $ checkPassMatches newPass oldSK) $ do
         newSK <- maybeThrow badPass $ changeEncPassphrase oldPass newPass oldSK
-
-        addSecretKey newSK
-        oldAddrMeta <- (`E.onException` deleteSK newPass) $ do
-            (oldAddrMeta, newAddrMeta) <- cloneWalletSetWithPass newSK newPass wid
-                `E.onException` do
-                    logError "Failed to clone wallet"
-            moveMoneyToClone sa oldPass wid (asExisting oldAddrMeta) (asExisting newAddrMeta)
-                `E.onException` do
-                    logError "Money transmition to new wallet failed"
-                    mapM_ totallyRemoveWAddress $ asDeleted <> asExisting $ newAddrMeta
-            return oldAddrMeta
-        mapM_ removeWAddress $ asExisting oldAddrMeta
-        setWalletPassLU wid =<< liftIO getPOSIXTime
         deleteSK oldPass
+        addSecretKey newSK
+        setWalletPassLU wid =<< liftIO getPOSIXTime
   where
     badPass = RequestError "Invalid old passphrase given"
     deleteSK passphrase = do
@@ -1048,18 +963,17 @@ reportingElectroncrash celcrash = do
 
 importWallet
     :: WalletWebMode m
-    => SendActions m
-    -> PassPhrase
+    => PassPhrase
     -> Text
     -> m CWallet
-importWallet sa passphrase (toString -> fp) = do
+importWallet passphrase (toString -> fp) = do
     secret <-
         rewrapToWalletError isDoesNotExistError noFile $
         rewrapToWalletError (\UserSecretDecodingError{} -> True) decodeFailed $
         readUserSecret fp
     wSecret <- maybeThrow noWalletSecret (secret ^. usWalletSet)
     wId <- cwId <$> importWalletSecret emptyPassphrase wSecret
-    changeWalletPassphrase sa wId emptyPassphrase passphrase
+    changeWalletPassphrase wId emptyPassphrase passphrase
     getWallet wId
   where
     noWalletSecret = RequestError "This key doesn't contain HD wallet info"

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -841,8 +841,6 @@ changeWalletPassphrase
 changeWalletPassphrase wid oldPass newPass = do
     oldSK <- getSKByAddr wid
 
-    -- 'cloneWalletSetWithPass' will work badly if accounts / addresses ids
-    -- don't actually change
     unless (isJust $ checkPassMatches newPass oldSK) $ do
         newSK <- maybeThrow badPass $ changeEncPassphrase oldPass newPass oldSK
         deleteSK oldPass

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/input-output-hk/cardano-crypto
-    commit: 96adbd5aa9a906859deddf170f8762a9ed85c0c9
+    commit: 84f8c358463bbf6bb09168aac5ad990faa9d310a
   extra-dep: true
 # We're using forked version of 'swagger2' package because of bug in haddock package.
 # Now we don't build Haddock-docs for this 'swagger2' package, and when that bug will


### PR DESCRIPTION
New version of `cardano-crypto`, where bug with password changing has been fixed, is used.
Cumbersome workaround with copying the wallet is removed as redundant.

Testing via CLI in dev mode has shown that CSM-314 has been fixed by this too, but more profound testing with Daedalus is planned.