### PR TITLE
Feature/csl1224 report logging

### DIFF
--- a/infra/Pos/Reporting/Methods.hs
+++ b/infra/Pos/Reporting/Methods.hs
@@ -7,7 +7,7 @@ module Pos.Reporting.Methods
        , sendReportNodeNologs
        , getNodeInfo
        , reportMisbehaviour
-       , reportMisbehaviourMasked
+       , reportMisbehaviourSilent
        , reportingFatal
        , sendReport
        , retrieveLogFiles
@@ -31,16 +31,16 @@ import           Formatting               (sformat, shown, stext, (%))
 import           Network.Info             (IPv4 (..), getNetworkInterfaces, ipv4)
 import           Network.Wreq             (partFile, partLBS, post)
 import           Pos.ReportServer.Report  (ReportInfo (..), ReportType (..))
-import           Serokell.Util.Exceptions (throwText)
+import           Serokell.Util.Exceptions (TextException (..))
 import           Serokell.Util.Text       (listBuilderJSON, listJson)
 import           System.Directory         (doesFileExist)
 import           System.FilePath          (takeFileName)
 import           System.Info              (arch, os)
 import           System.IO                (hClose)
 import           System.IO.Temp           (withSystemTempFile)
-import           System.Wlog              (CanLog, HasLoggerName, LoggerConfig (..),
-                                           hwFilePath, lcTree, logDebug, logError,
-                                           ltFiles, ltSubloggers, retrieveLogContent)
+import           System.Wlog              (LoggerConfig (..), WithLogger, hwFilePath,
+                                           lcTree, logDebug, logError, logInfo, ltFiles,
+                                           ltSubloggers, retrieveLogContent)
 
 import           Pos.Core.Constants       (protocolMagic)
 import           Pos.Discovery.Class      (MonadDiscovery, getPeers)
@@ -48,6 +48,7 @@ import           Pos.Exception            (CardanoFatalError)
 import           Pos.Reporting.Exceptions (ReportingError (..))
 import           Pos.Reporting.MemState   (MonadReportingMem, rcLoggingConfig,
                                            rcReportServers)
+import           Pos.Util.Util            (maybeThrow)
 
 -- TODO From Pos.Util, remove after refactoring.
 -- | Concatenates two url part using regular slash '/'.
@@ -59,6 +60,13 @@ import           Pos.Reporting.MemState   (MonadReportingMem, rcLoggingConfig,
     lhs' = reverse $ dropWhile isSlash $ reverse lhs
     rhs' = dropWhile isSlash rhs
 
+type ReportingMode m =
+       ( MonadIO m
+       , MonadMask m
+       , MonadReportingMem m
+       , WithLogger m
+       )
+
 ----------------------------------------------------------------------------
 -- Node-specific
 ----------------------------------------------------------------------------
@@ -67,19 +75,21 @@ import           Pos.Reporting.MemState   (MonadReportingMem, rcLoggingConfig,
 -- retrieving all logger files from it. List of servers is also taken
 -- from node's configuration.
 sendReportNode
-    :: (MonadIO m, MonadMask m, MonadReportingMem m)
+    :: (ReportingMode m)
     => Version -> ReportType -> m ()
 sendReportNode version reportType = do
-    logConfig <- Ether.asks' (view rcLoggingConfig)
-    let allFiles = map snd $ retrieveLogFiles logConfig
-    logFile <- maybe
-        (throwText "sendReportNode: can't find any .pub file in logconfig")
-        pure
-        (head $ filter (".pub" `isSuffixOf`) allFiles)
-    logContent <-
-        takeGlobalSize charsConst <$>
-        retrieveLogContent logFile (Just 5000)
-    sendReportNodeImpl (reverse logContent) version reportType
+    noServers <- null <$> Ether.asks' (view rcReportServers)
+    if noServers then onNoServers else do
+        logConfig <- Ether.asks' (view rcLoggingConfig)
+        let allFiles = map snd $ retrieveLogFiles logConfig
+        logFile <-
+            maybeThrow (TextException onNoPubfiles)
+                       (head $ filter (".pub" `isSuffixOf`) allFiles)
+        logContent <-
+            takeGlobalSize charsConst <$>
+            retrieveLogContent logFile (Just 5000)
+        sendReportNodeImpl (reverse logContent) version reportType
+
   where
     -- 2 megabytes, assuming we use chars which are ASCII mostly
     charsConst :: Int
@@ -89,24 +99,31 @@ sendReportNode version reportType = do
     takeGlobalSize curLimit (t:xs) =
         let delta = curLimit - length t
         in bool [] (t:(takeGlobalSize delta xs)) (delta > 0)
+    onNoServers =
+        logInfo $ "sendReportNode: not sending report " <>
+                  "because no reporting servers are specified"
+    onNoPubfiles = "sendReportNode: can't find any .pub file in logconfig. " <>
+        "Most probably public logging is misconfigured. Either set reporting " <>
+        "servers to [] or include .pub files in log config"
 
 -- | Same as 'sendReportNode', but doesn't attach any logs.
-sendReportNodeNologs
-    :: (MonadIO m, MonadMask m, MonadReportingMem m)
-    => Version -> ReportType -> m ()
+sendReportNodeNologs :: (ReportingMode m) => Version -> ReportType -> m ()
 sendReportNodeNologs = sendReportNodeImpl []
 
 sendReportNodeImpl
-    :: (MonadIO m, MonadMask m, MonadReportingMem m)
+    :: (ReportingMode m)
     => [Text] -> Version -> ReportType -> m ()
 sendReportNodeImpl rawLogs version reportType = do
     servers <- Ether.asks' (view rcReportServers)
+    when (null servers) onNoServers
     errors <- fmap lefts $ forM servers $ try .
         sendReport [] rawLogs reportType "cardano-node" version . toString
     whenNotNull errors $ throwSE . NE.head
   where
+    onNoServers =
+        logInfo $ "sendReportNodeImpl: not sending report " <>
+                  "because no reporting servers are specified"
     throwSE (e :: SomeException) = throwM e
-
 
 -- checks if ipv4 is from local range
 ipv4Local :: Word32 -> Bool
@@ -130,19 +147,11 @@ getNodeInfo = do
         not $ ipv4Local w || w == 0 || w == 16777343 -- the last is 127.0.0.1
     outputF = ("{ nodeParams: '"%stext%"', otherNodes: "%listJson%" }")
 
-type ReportingWorkMode m =
-       ( MonadIO m
-       , MonadMask m
-       , MonadReportingMem m
-       , HasLoggerName m
-       , MonadDiscovery m
-       , CanLog m
-       )
 
 -- | Reports misbehaviour given reason string. Effectively designed
 -- for 'WorkMode' context.
 reportMisbehaviour
-    :: forall m . ReportingWorkMode m
+    :: (ReportingMode m, MonadDiscovery m)
     => Version -> Text -> m ()
 reportMisbehaviour version reason = do
     logError $ "Reporting misbehaviour \"" <> reason <> "\""
@@ -151,16 +160,12 @@ reportMisbehaviour version reason = do
   where
     misbehF = stext%", nodeInfo: "%stext
 
+-- FIXME catch and squelch *all* exceptions? Probably a bad idea.
 -- | Report misbehaviour, but catch all errors inside
---
---   FIXME very misleading name. Suggests reporting misbehaviours while
---   asynchronous exceptions are masked.
---
---   FIXME catch and squelch *all* exceptions? Probably a bad idea.
-reportMisbehaviourMasked
-    :: forall m . ReportingWorkMode m
+reportMisbehaviourSilent
+    :: forall m . (ReportingMode m, MonadDiscovery m)
     => Version -> Text -> m ()
-reportMisbehaviourMasked version reason =
+reportMisbehaviourSilent version reason =
     reportMisbehaviour version reason `catch` handler
   where
     handler :: SomeException -> m ()
@@ -173,7 +178,7 @@ reportMisbehaviourMasked version reason =
 -- happens and rethrow. Errors related to reporting itself are caught,
 -- logged and ignored.
 reportingFatal
-    :: forall m a . ReportingWorkMode m
+    :: forall m a . (ReportingMode m, MonadDiscovery m)
     => Version -> m a -> m a
 reportingFatal version action =
     action `catch` handler1 `catch` handler2

--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -35,7 +35,7 @@ import           Pos.Core               (FlatSlotId, SlotId (..), Timestamp (..)
 import           Pos.Discovery.Class    (MonadDiscovery)
 import           Pos.Exception          (CardanoException)
 import           Pos.Reporting.MemState (MonadReportingMem)
-import           Pos.Reporting.Methods  (reportMisbehaviourMasked, reportingFatal)
+import           Pos.Reporting.Methods  (reportMisbehaviourSilent, reportingFatal)
 import           Pos.Shutdown           (MonadShutdownMem, runIfNotShutdown)
 import           Pos.Slotting.Class     (MonadSlots (..))
 import           Pos.Slotting.Error     (SlottingError (..))
@@ -115,7 +115,7 @@ onNewSlotImpl withLogging startImmediately action =
     workerHandler e = do
         let msg = sformat ("Error occurred in 'onNewSlot' worker itself: " %build) e
         logError $ msg
-        reportMisbehaviourMasked version msg
+        reportMisbehaviourSilent version msg
         delay =<< getLastKnownSlotDuration
         onNewSlotImpl withLogging startImmediately action
 

--- a/src/Pos/Block/Logic/Creation.hs
+++ b/src/Pos/Block/Logic/Creation.hs
@@ -57,7 +57,7 @@ import           Pos.Delegation.Types       (DlgPayload (getDlgPayload), ProxySK
 import           Pos.Exception              (assertionFailed, reportFatalError)
 import qualified Pos.Lrc.DB                 as LrcDB
 import           Pos.Lrc.Error              (LrcError (..))
-import           Pos.Reporting              (reportMisbehaviourMasked, reportingFatal)
+import           Pos.Reporting              (reportMisbehaviourSilent, reportingFatal)
 import           Pos.Ssc.Class              (Ssc (..), SscHelpersClass (sscDefaultPayload, sscStripPayload))
 import           Pos.Ssc.Extra              (sscGetLocalPayload, sscResetLocal)
 import           Pos.Txp.Core               (TxAux (..), mkTxPayload, topsortTxs)
@@ -251,7 +251,7 @@ createMainBlockFinish slotId pske prevHeader = do
     fallbackCreateBlock :: Text -> ExceptT Text m (MainBlock ssc, Undo, PollModifier)
     fallbackCreateBlock er = do
         logError $ sformat ("We've created bad main block: "%stext) er
-        lift $ reportMisbehaviourMasked version $
+        lift $ reportMisbehaviourSilent version $
             sformat ("We've created bad main block: "%build) er
         logDebug $ "Creating empty block"
         clearMempools

--- a/src/Pos/Block/Network/Logic.hs
+++ b/src/Pos/Block/Network/Logic.hs
@@ -62,7 +62,7 @@ import qualified Pos.DB.DB                  as DB
 import           Pos.Discovery              (converseToNeighbors)
 import           Pos.Exception              (cardanoExceptionFromException,
                                              cardanoExceptionToException)
-import           Pos.Reporting.Methods      (reportMisbehaviourMasked)
+import           Pos.Reporting.Methods      (reportMisbehaviourSilent)
 import           Pos.Ssc.Class              (SscHelpersClass, SscWorkersClass)
 import           Pos.Util                   (inAssertMode, _neHead, _neLast)
 import           Pos.Util.Chrono            (NE, NewestFirst (..), OldestFirst (..))
@@ -494,7 +494,7 @@ applyWithRollback nodeId sendActions toApply lca toRollback = do
     reportRollback =
         unlessM recoveryInProgress $ do
             logDebug "Reporting rollback happened"
-            reportMisbehaviourMasked version $
+            reportMisbehaviourSilent version $
                 sformat reportF nodeId toRollbackHashes toApplyHashes
     panicBrokenLca = error "applyWithRollback: nothing after LCA :<"
     toApplyAfterLca =

--- a/src/Pos/Launcher/Scenario.hs
+++ b/src/Pos/Launcher/Scenario.hs
@@ -29,7 +29,7 @@ import qualified Pos.DB.GState      as GS
 import           Pos.Delegation     (initDelegation)
 import           Pos.Lrc.Context    (LrcSyncData (..), lcLrcSync)
 import qualified Pos.Lrc.DB         as LrcDB
-import           Pos.Reporting      (reportMisbehaviourMasked)
+import           Pos.Reporting      (reportMisbehaviourSilent)
 import           Pos.Security       (SecurityWorkersClass)
 import           Pos.Shutdown       (waitForWorkers)
 import           Pos.Slotting       (getCurrentSlot, waitSystemStart)
@@ -77,7 +77,7 @@ runNode' plugins' = ActionSpec $ \vI sendActions -> do
     -- FIXME shouldn't this kill the whole program?
     reportHandler (SomeException e) = do
         loggerName <- getLoggerName
-        reportMisbehaviourMasked version $
+        reportMisbehaviourSilent version $
             sformat ("Worker/plugin with logger name "%shown%
                     " failed with exception: "%shown)
             loggerName e

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -46,7 +46,7 @@ import           Pos.Lrc.Error              (LrcError (..))
 import           Pos.Lrc.Fts                (followTheSatoshiM)
 import           Pos.Lrc.Logic              (findAllRichmenMaybe)
 import           Pos.Lrc.Mode               (LrcMode)
-import           Pos.Reporting              (reportMisbehaviourMasked)
+import           Pos.Reporting              (reportMisbehaviourSilent)
 import           Pos.Slotting               (MonadSlots)
 import           Pos.Ssc.Class              (SscHelpersClass, SscWorkersClass)
 import           Pos.Ssc.Extra              (MonadSscMem, sscCalculateSeed)
@@ -74,7 +74,7 @@ lrcOnNewSlotWorker = recoveryCommGuard $ localOnNewSlotWorker True $ \SlotId {..
             "LRC worker can't do anything, because recent blocks aren't known"
     onLrcError e = reportError e >> throwM e
     reportError e =
-        reportMisbehaviourMasked version $ "Lrc worker failed with error: " <> show e
+        reportMisbehaviourSilent version $ "Lrc worker failed with error: " <> show e
 
 -- | 'LrcModeFull' contains all constraints necessary to launch LRC.
 type LrcModeFull ssc m =

--- a/src/Pos/Security/Workers.hs
+++ b/src/Pos/Security/Workers.hs
@@ -35,7 +35,7 @@ import           Pos.Crypto                 (PublicKey)
 import           Pos.DB                     (DBError (DBMalformed))
 import           Pos.DB.Block               (MonadBlockDB, blkGetHeader)
 import           Pos.DB.DB                  (getTipHeader, loadBlundsFromTipByDepth)
-import           Pos.Reporting.Methods      (reportMisbehaviourMasked, reportingFatal)
+import           Pos.Reporting.Methods      (reportMisbehaviourSilent, reportingFatal)
 import           Pos.Security.Class         (SecurityWorkersClass (..))
 import           Pos.Shutdown               (runIfNotShutdown)
 import           Pos.Slotting               (getCurrentSlot, getLastKnownSlotDuration,
@@ -138,7 +138,7 @@ checkForReceivedBlocksWorkerImpl sendActions = afterDelay $ do
                 "Eclipse attack was discovered, mdNoBlocksSlotThreshold: " <>
                 show (mdNoBlocksSlotThreshold :: Int)
         when (nonTrivialUptime && not isRecovery) $
-            reportMisbehaviourMasked version reason
+            reportMisbehaviourSilent version reason
 
 
 checkForIgnoredCommitmentsWorker

--- a/util-scripts/clean.sh
+++ b/util-scripts/clean.sh
@@ -1,5 +1,0 @@
-stack clean --full --nix
-rm -rf .stack-work
-stack --nix clean cardano-sl
-rm -rf run/* wallet-db* wdb-* *key daedalus/src/Generated/ db-abc* node-* daedalus/.psci_modules/ daedalus/.pulp-cache/ daedalus/node_modules/ daedalus/bower_components/ daedalus/output/ db-qanet*
-rm -rf kademlia-abc.dump


### PR DESCRIPTION
This introduces the small reporting fix: if no servers are specified we won't try to retrieve `.pub` logs so we won't fail if they are not present (the setting used in QA cluster).
I've also removed util-scripts dir as it's redundant after scripts refactoring and renamed a `reportMisbehaviorMasked` into `reportMisbehaviorSilent` as recommended in the TODO.