### PR TITLE
[CSL-1239] Show full leaders list only once

### DIFF
--- a/src/Pos/Block/Worker.hs
+++ b/src/Pos/Block/Worker.hs
@@ -98,16 +98,26 @@ blkOnNewSlotImpl (slotId@SlotId {..}) sendActions = do
   where
     onNoLeader =
         logWarning "Couldn't find a leader for current slot among known ones"
-    logLeadersF = if siSlot == minBound then logInfo else logDebug
-    logLeadersFS = if siSlot == minBound then logInfoS else logDebugS
+    logOnEpochFS = if siSlot == minBound then logInfoS else logDebugS
+    logOnEpochF = if siSlot == minBound then logInfo else logDebug
     onKnownLeader leaders leader = do
         ourPk <- getOurPublicKey
         let ourPkHash = addressHash ourPk
         logNoticeS "This is a test debug message which shouldn't be sent to the logging server."
-        logLeadersFS $ sformat ("Our pk: "%build%", our pkHash: "%build) ourPk ourPkHash
-        logLeadersF $ sformat ("Slot leaders: "%listJson) $
-                      map (bprint pairF) (zip [0 :: Int ..] $ toList leaders)
-        logLeadersF $ sformat ("Current slot leader: "%build) leader
+        logOnEpochFS $ sformat ("Our pk: "%build%", our pkHash: "%build) ourPk ourPkHash
+        logOnEpochF $ sformat ("Current slot leader: "%build) leader
+
+
+        let -- position, how many to drop, list. This is to show some
+            -- of leaders before and after current slot, but not all
+            -- of them.
+            dropAround :: Int -> Int -> [a] -> [a]
+            dropAround p s = take (2*s + 1) . drop (max 0 (p - s))
+            strLeaders = map (bprint pairF) (zip [0 :: Int ..] $ toList leaders)
+        if siSlot == minBound
+            then logInfo $ sformat ("Full slot leaders: "%listJson) strLeaders
+            else logDebug $ sformat ("Trimmed leaders: "%listJson) $
+                            dropAround (fromIntegral $ fromEnum $ siSlot) 10 strLeaders
 
         proxyCerts <- getProxySecretKeys -- TODO rename it with "light" suffix
         let validCerts =


### PR DESCRIPTION
* Full leader list is shown once per epoch with INFO
* Every other slot s we show [s-10..s+10] window of leaders with DEBUG verbosity