### PR TITLE
[CSM-148] All transactions have the same date and time

### DIFF
--- a/core/Pos/Core/Timestamp.hs
+++ b/core/Pos/Core/Timestamp.hs
@@ -3,14 +3,16 @@
 module Pos.Core.Timestamp
        ( Timestamp (..)
        , timestampF
+       , getCurrentTimestamp
        ) where
 
 import           Universum
 
-import           Data.Text.Buildable (Buildable)
-import qualified Data.Text.Buildable as Buildable
-import           Data.Time.Units     (Microsecond)
-import           Formatting          (Format, build)
+import           Data.Text.Buildable   (Buildable)
+import qualified Data.Text.Buildable   as Buildable
+import           Data.Time.Clock.POSIX (getPOSIXTime)
+import           Data.Time.Units       (Microsecond)
+import           Formatting            (Format, build)
 import qualified Prelude
 
 -- | Timestamp is a number which represents some point in time. It is
@@ -39,3 +41,7 @@ instance NFData Timestamp where
 -- | Specialized formatter for 'Timestamp' data type.
 timestampF :: Format r (Timestamp -> r)
 timestampF = build
+
+-- Get the current time as a timestamp
+getCurrentTimestamp :: IO Timestamp
+getCurrentTimestamp = Timestamp . round . (*1000000) <$> getPOSIXTime

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -41,17 +41,18 @@ import           Data.Tagged                  (Tagged (..))
 import qualified Ether
 import           System.Wlog                  (WithLogger)
 
-import           Pos.Block.Core               (Block, mainBlockTxPayload)
+import           Pos.Block.Core               (Block, mainBlockSlot, mainBlockTxPayload)
 import           Pos.Constants                (blkSecurityParam)
 import           Pos.Context.Context          (GenesisUtxo (..))
 import           Pos.Core                     (Address, ChainDifficulty, HeaderHash,
-                                               difficultyL, prevBlockL)
+                                               Timestamp (..), difficultyL, prevBlockL)
 import           Pos.Crypto                   (WithHash (..), withHash)
-import           Pos.DB                       (MonadRealDB, MonadDBRead)
+import           Pos.DB                       (MonadDBRead, MonadRealDB)
 import qualified Pos.DB.Block                 as DB
 import           Pos.DB.Error                 (DBError (..))
 import qualified Pos.DB.GState                as GS
-import           Pos.Slotting                 (MonadSlots)
+import           Pos.Slotting                 (MonadSlots, SlottingData (..),
+                                               getSlotStartPure)
 import           Pos.Ssc.Class                (SscHelpersClass)
 #ifdef WITH_EXPLORER
 import           Pos.Explorer.Txp.Local       (eTxProcessTransaction)
@@ -96,6 +97,7 @@ data TxHistoryEntry = THEntry
     , _thDifficulty  :: !(Maybe ChainDifficulty)
     , _thInputAddrs  :: ![Address]  -- TODO: remove in favor of _thInputs
     , _thOutputAddrs :: ![Address]
+    , _thTimestamp   :: !(Maybe Timestamp)
     } deriving (Show, Eq, Generic)
 
 makeLenses ''TxHistoryEntry
@@ -123,7 +125,7 @@ getRelatedTxs (HS.fromList -> addrs) txs = do
         return $ do
             guard . not . null $
                 HS.fromList (incomings ++ outgoings) `HS.intersection` addrs
-            return $ THEntry txId tx inputs Nothing incomings outgoings
+            return $ THEntry txId tx inputs Nothing incomings outgoings Nothing
 
 -- | Given a full blockchain, derive address history and Utxo
 -- TODO: Such functionality will still be useful for merging
@@ -142,7 +144,16 @@ deriveAddrHistoryPartial
     -> [Address]
     -> [Block ssc]
     -> TxSelectorT m [TxHistoryEntry]
-deriveAddrHistoryPartial hist addrs chain =
+deriveAddrHistoryPartial hist addrs chain = deriveAddrHistoryPartialWithTimestamp hist addrs chain Nothing
+
+deriveAddrHistoryPartialWithTimestamp
+    :: (Monad m)
+    => [TxHistoryEntry]
+    -> [Address]
+    -> [Block ssc]
+    -> Maybe SlottingData
+    -> TxSelectorT m [TxHistoryEntry]
+deriveAddrHistoryPartialWithTimestamp hist addrs chain maybeSd =
     DL.toList <$> foldrM updateAll (DL.fromList hist) chain
   where
     updateAll (Left _) hst = pure hst
@@ -152,7 +163,9 @@ deriveAddrHistoryPartial hist addrs chain =
                    map mapper $ flattenTxPayload (blk ^. mainBlockTxPayload)
         let difficulty = blk ^. difficultyL
             txs' = map (thDifficulty .~ Just difficulty) txs
-        return $ DL.fromList txs' <> hst
+        let maybeTimestamp = maybeSd >>= getSlotStartPure (blk ^. mainBlockSlot)
+            txs'' = map (thTimestamp .~ maybeTimestamp) txs'
+        return $ DL.fromList txs'' <> hst
 
 ----------------------------------------------------------------------------
 -- MonadTxHistory
@@ -219,10 +232,12 @@ instance
         let cachedHashes = drop blkSecurityParam hashList
             nonCachedHashes = take blkSecurityParam hashList
 
+        sd <- GS.getSlottingData
+
         let blockFetcher h txs = do
                 blk <- lift . lift . DB.runBlockDBRedirect $ DB.blkGetBlock @ssc h >>=
                        maybeThrow (DBMalformed "A block mysteriously disappeared!")
-                deriveAddrHistoryPartial txs addrs [blk]
+                deriveAddrHistoryPartialWithTimestamp txs addrs [blk] (Just sd)
             localFetcher blkTxs = do
                 let mp (txid, TxAux {..}) =
                       (WithHash taTx txid, taWitness, taDistribution)

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -263,7 +263,9 @@ setWalletTxHistory cWalId cTxs = mapM_ (uncurry $ addWalletTxHistory cWalId) cTx
 -- FIXME: this will be removed later (temporary solution)
 addOnlyNewTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
 addOnlyNewTxMeta cWalId cTxId cTxMeta =
-    wsTxHistory . ix cWalId . at cTxId %= Just . fromMaybe cTxMeta
+    -- Double nested HashMap update (if either or both of cWalId, cTxId don't exist, they will be created)
+    -- TODO: There is probably a better lens operator for this
+    wsTxHistory . at cWalId %= Just . (execState (at cTxId ?= cTxMeta)) . fromMaybe HM.empty
 
 -- NOTE: sets transaction meta only for transactions ids that are already seen
 setWalletTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -53,8 +53,8 @@ module Pos.Wallet.Web.State.Storage
 
 import           Universum
 
-import           Control.Lens               (at, ix, makeClassy, makeLenses, (%=), (.=),
-                                             (<<.=), (?=), _head, non', _Empty)
+import           Control.Lens               (at, ix, makeClassy, makeLenses, non', (%=),
+                                             (.=), (<<.=), (?=), _Empty, _head)
 import           Control.Monad.State.Class  (put)
 import           Data.Default               (Default, def)
 import qualified Data.HashMap.Strict        as HM
@@ -62,6 +62,7 @@ import           Data.SafeCopy              (base, deriveSafeCopySimple)
 
 import           Pos.Client.Txp.History     (TxHistoryEntry)
 import           Pos.Constants              (genesisHash)
+import           Pos.Core.Types             (Timestamp)
 import           Pos.Txp                    (Utxo)
 import           Pos.Types                  (HeaderHash)
 import           Pos.Util.BackupPhrase      (BackupPhrase)
@@ -315,6 +316,7 @@ deriveSafeCopySimple 0 'base ''CWalletAssurance
 deriveSafeCopySimple 0 'base ''CAccountMeta
 deriveSafeCopySimple 0 'base ''CWalletMeta
 deriveSafeCopySimple 0 'base ''CTxId
+deriveSafeCopySimple 0 'base ''Timestamp
 deriveSafeCopySimple 0 'base ''TxHistoryEntry
 deriveSafeCopySimple 0 'base ''CTxMeta
 deriveSafeCopySimple 0 'base ''CUpdateInfo

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -54,7 +54,7 @@ module Pos.Wallet.Web.State.Storage
 import           Universum
 
 import           Control.Lens               (at, ix, makeClassy, makeLenses, (%=), (.=),
-                                             (<<.=), (?=), _head)
+                                             (<<.=), (?=), _head, non', _Empty)
 import           Control.Monad.State.Class  (put)
 import           Data.Default               (Default, def)
 import qualified Data.HashMap.Strict        as HM
@@ -264,8 +264,7 @@ setWalletTxHistory cWalId cTxs = mapM_ (uncurry $ addWalletTxHistory cWalId) cTx
 addOnlyNewTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
 addOnlyNewTxMeta cWalId cTxId cTxMeta =
     -- Double nested HashMap update (if either or both of cWalId, cTxId don't exist, they will be created)
-    -- TODO: There is probably a better lens operator for this
-    wsTxHistory . at cWalId %= Just . (execState (at cTxId ?= cTxMeta)) . fromMaybe HM.empty
+    wsTxHistory . at cWalId . non' _Empty . at cTxId %= Just . fromMaybe cTxMeta
 
 -- NOTE: sets transaction meta only for transactions ids that are already seen
 setWalletTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -255,7 +255,7 @@ setWalletSyncTip cWalId hh = wsWalletInfos . ix cWalId . wiSyncTip .= hh
 
 addWalletTxHistory :: CId Wal -> CTxId -> CTxMeta -> Update ()
 addWalletTxHistory cWalId cTxId cTxMeta =
-    wsTxHistory . ix cWalId . at cTxId ?= cTxMeta
+    wsTxHistory . at cWalId . non' _Empty . at cTxId ?= cTxMeta
 
 setWalletTxHistory :: CId Wal -> [(CTxId, CTxMeta)] -> Update ()
 setWalletTxHistory cWalId cTxs = mapM_ (uncurry $ addWalletTxHistory cWalId) cTxs


### PR DESCRIPTION
Initialise the transaction history metadata for a particular wallet, if it didn't exist previously.