### PR TITLE
Remove `npm link` from daedalus-bridge build script

### DIFF
--- a/scripts/build/daedalus-bridge.sh
+++ b/scripts/build/daedalus-bridge.sh
@@ -18,4 +18,3 @@ echo "3. Building Bridge..."
 cd daedalus
 npm install
 npm run build:prod
-npm link


### PR DESCRIPTION
`npm link` generally requires root privileges to install things under `/usr/lib/`.

Installing in a system-wide location is not always desirable, and the documentation does not mention the need of `sudo`. Furthermore, the docs describe `npm link` as a separate step entirely. Hence I believe it is better to remove it from the build script.