### PR TITLE
Fix launch script

### DIFF
--- a/scripts/launch/demo-with-wallet-api.sh
+++ b/scripts/launch/demo-with-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_TEST=1 "$base"/demo-without-wallet-api.sh
+WALLET_TEST=1 "$base"/demo.sh


### PR DESCRIPTION
Apparently, the file `demo-without-wallet-api.sh` was renamed to just `demo.sh`. This PR updates the `demo-with-wallet-api.sh` script with that change.