### PR TITLE
[DEVOPS-22-165]  Switch to Nix for `cardano-sl` build used for genesis generation

### DIFF
--- a/scripts/generate/genesis.sh
+++ b/scripts/generate/genesis.sh
@@ -27,7 +27,7 @@ fi
 F=100 # fake avvm keys
 
 function abc {
-  cmd="stack exec cardano-keygen -- -f $DIR/../secrets/secret-{}.key -m $M -n $N --richmen-share 0.94 --testnet-stake 19072918462000000 --utxo-file $utxo_file --randcerts --blacklisted $blacklist --fake-avvm-seed-pattern avvm/fake-{}.seed --fake-avvm-entries $F"
+  cmd="$(nix-build -A cardano-sl-static $IOHKOPS_DIR/default.nix)/bin/cardano-keygen -f $DIR/../secrets/secret-{}.key -m $M -n $N --richmen-share 0.94 --testnet-stake 19072918462000000 --utxo-file $utxo_file --randcerts --blacklisted $blacklist --fake-avvm-seed-pattern avvm/fake-{}.seed --fake-avvm-entries $F"
   echo "Running command: $cmd"
   $cmd
   rm $DIR/../secrets/*.lock

--- a/scripts/generate/genesis.sh
+++ b/scripts/generate/genesis.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -xe
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 IOHKOPS_DIR="$DIR/../.."
 name=${1:-genesis-qanet-`date +%F`}

--- a/scripts/generate/genesis.sh
+++ b/scripts/generate/genesis.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
-name=genesis-qanet-`date +%F`
+IOHKOPS_DIR="$DIR/../.."
+name=${1:-genesis-qanet-`date +%F`}
 
 if [[ -d "$DIR/../$name" ]]; then
   echo "$name exists" >&2


### PR DESCRIPTION
We are slowly switching all deployment-related operations to operate from an environment established by `nix-shell` entered in `iohk-nixops`.

This is a part of this unification process, and it makes the genesis generation script use Nix to provide the `cardano-sl` build.

This makes the `pkgs/generate.sh` invocation a prerequisite for genesis itself -- but this already is a prerequisite for deployment anyway.  Purely dev-based scenarios will change, though.