### PR TITLE
[CSL-1288] Fix 'instance Monoid StakeDistribution'

### DIFF
--- a/core/Pos/Core/Genesis/Types.hs
+++ b/core/Pos/Core/Genesis/Types.hs
@@ -38,7 +38,10 @@ data StakeDistribution
 
 instance Monoid StakeDistribution where
     mempty = FlatStakes 0 (mkCoin 0)
-    mappend = CombinedStakes
+    mappend a b
+        | a == mempty = b
+        | b == mempty = a
+        | otherwise = CombinedStakes a b
 
 instance Default StakeDistribution where
     def = FlatStakes genesisKeysN


### PR DESCRIPTION
Old version was invalid. One of 'Monoid' rules is that
`mempty <> a == a`.