### PR TITLE
[CSM-328] Wallet restore is not working

### DIFF
--- a/src/Pos/Wallet/Web/Account.hs
+++ b/src/Pos/Wallet/Web/Account.hs
@@ -5,7 +5,7 @@ module Pos.Wallet.Web.Account
        , getAddrIdx
        , getSKByAddr
        , getSKByAccAddr
-       , genSaveRootAddress
+       , genSaveRootKey
        , genUniqueAccountId
        , genUniqueAccountAddress
        , deriveAccountSK
@@ -69,18 +69,17 @@ getSKByAccAddr passphrase addrMeta@CWAddressMeta {..} = do
         then throwM . InternalError $ "Account is contradictory!"
         else return accKey
 
-genSaveRootAddress
+genSaveRootKey
     :: AccountMode m
     => PassPhrase
     -> BackupPhrase
-    -> m (CId Wal)
-genSaveRootAddress passphrase ph = encToCId <$> genSaveSK
+    -> m EncryptedSecretKey
+genSaveRootKey passphrase ph = do
+    sk <- either keyFromPhraseFailed (pure . fst) $
+        safeKeysFromPhrase passphrase ph
+    addSecretKey sk
+    return sk
   where
-    genSaveSK = do
-        sk <- either keyFromPhraseFailed (pure . fst)
-            $ safeKeysFromPhrase passphrase ph
-        addSecretKey sk
-        return sk
     keyFromPhraseFailed msg =
         throwM . RequestError $ "Key creation from phrase failed: " <> msg
 

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -223,10 +223,12 @@ removeCustomAddress t (addr, hh) = do
     return exists
 
 createAccount :: AccountId -> CAccountMeta -> Update ()
-createAccount accId cAccMeta = wsAccountInfos . at accId ?= AccountInfo cAccMeta mempty mempty
+createAccount accId cAccMeta =
+    wsAccountInfos . at accId %= Just . fromMaybe (AccountInfo cAccMeta mempty mempty)
 
 createWallet :: CId Wal -> CWalletMeta -> PassPhraseLU -> Update ()
-createWallet cWalId cWalMeta passLU = wsWalletInfos . at cWalId ?= WalletInfo cWalMeta passLU genesisHash
+createWallet cWalId cWalMeta passLU =
+    wsWalletInfos . at cWalId %= Just . fromMaybe (WalletInfo cWalMeta passLU genesisHash)
 
 addWAddress :: CWAddressMeta -> Update ()
 addWAddress addr@CWAddressMeta{..} = do

--- a/src/Pos/Wallet/Web/Tracking.hs
+++ b/src/Pos/Wallet/Web/Tracking.hs
@@ -37,14 +37,14 @@ import           Control.Monad.Trans        (MonadTrans)
 import           Data.List                  ((!!))
 import qualified Data.List.NonEmpty         as NE
 import qualified Ether
-import           Formatting                 (build, sformat, (%))
+import           Formatting                 (build, int, sformat, (%))
 import           Mockable                   (MonadMockable, SharedAtomicT)
 import           Serokell.Util              (listJson)
 import           System.Wlog                (WithLogger, logDebug, logInfo, logWarning)
 
 import           Pos.Block.Core             (Block, BlockHeader, getBlockHeader,
                                              mainBlockTxPayload)
-import           Pos.Block.Logic            (withBlkSemaphore_)
+import           Pos.Block.Logic            (withBlkSemaphore, withBlkSemaphore_)
 import           Pos.Block.Types            (Blund, undoTx)
 import           Pos.Constants              (genesisHash)
 import           Pos.Context                (BlkSemaphore)
@@ -74,8 +74,9 @@ import qualified Pos.Util.Modifier          as MM
 import           Pos.Util.Util              (maybeThrow)
 
 import           Pos.Wallet.SscType         (WalletSscType)
-import           Pos.Wallet.Web.ClientTypes (AccountId, Addr, CId, CWAddressMeta (..),
-                                             Wal, addressToCId, aiWId, encToCId,
+import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CAccountMeta (..), CId,
+                                             CWAddressMeta (..), Wal, addrMetaToAccount,
+                                             addressToCId, aiWId, encToCId,
                                              isTxLocalAddress)
 import           Pos.Wallet.Web.State       (AddressLookupMode (..),
                                              CustomAddressType (..), WalletWebDB,
@@ -144,17 +145,18 @@ instance (BlockLockMode WalletSscType m, MonadMockable m, MonadTxpMem ext m)
 selectAccountsFromUtxoLock
     :: forall ssc m . (WebWalletModeDB m, BlockLockMode ssc m)
     => [EncryptedSecretKey]
-    -> m ()
-selectAccountsFromUtxoLock encSKs = withBlkSemaphore_ $ \tip -> do
+    -> m [CWAddressMeta]
+selectAccountsFromUtxoLock encSKs = withBlkSemaphore $ \tip -> do
     let (hdPass, wAddr) = unzip $ map getEncInfo encSKs
     logDebug $ sformat ("Select accounts from Utxo: tip "%build%" for "%listJson) tip wAddr
     addresses <- discoverHDAddresses hdPass
-    let allAddreses = concatMap createWAddresss $ zip wAddr addresses
-    mapM_ WS.addWAddress allAddreses
-    tip <$  logDebug (sformat ("After selection from Utxo addresses was added: "%listJson) allAddreses)
+    let allAddresses = concatMap createWAddresses $ zip wAddr addresses
+    mapM_ addMetaInfo allAddresses
+    logDebug (sformat ("After selection from Utxo addresses was added: "%listJson) allAddresses)
+    return (allAddresses, tip)
   where
-    createWAddresss :: (CId Wal, [(Address, [Word32])]) -> [CWAddressMeta]
-    createWAddresss (wAddr, addresses) = do
+    createWAddresses :: (CId Wal, [(Address, [Word32])]) -> [CWAddressMeta]
+    createWAddresses (wAddr, addresses) = do
         let (ads, paths) = unzip addresses
         mapMaybe createWAddress $ zip3 (repeat wAddr) ads paths
 
@@ -162,6 +164,15 @@ selectAccountsFromUtxoLock encSKs = withBlkSemaphore_ $ \tip -> do
     createWAddress (wAddr, addr, derPath) = do
         guard $ length derPath == 2
         pure $ CWAddressMeta wAddr (derPath !! 0) (derPath !! 1) (addressToCId addr)
+
+    addMetaInfo :: CWAddressMeta -> m ()
+    addMetaInfo cwMeta = do
+        let accId = addrMetaToAccount cwMeta
+            accMeta = CAccountMeta
+                      { caName = sformat ("Account #"%int) $ aiIndex accId
+                      }
+        WS.createAccount accId accMeta
+        WS.addWAddress cwMeta
 
 -- Iterate over blocks (using forward links) and actualize our accounts.
 syncWalletsWithGStateLock

--- a/src/Pos/Wallet/Web/Tracking.hs
+++ b/src/Pos/Wallet/Web/Tracking.hs
@@ -139,7 +139,6 @@ instance (BlockLockMode WalletSscType m, MonadMockable m, MonadTxpMem ext m)
 -- Logic
 ----------------------------------------------------------------------------
 
--- THIS FUNCTION ISN'T USED!
 -- Select our accounts from Utxo and put to wallet-db.
 -- Used for importing of a secret key.
 selectAccountsFromUtxoLock


### PR DESCRIPTION
Wallet itself has been created deterministically from backup phrase, but underlying account and addresses were for some reason generated using random seed, which is completely wrong. This PR fixes it.