### PR TITLE
[CSL-1285] Fix 'prepareLrcRichmen'

### DIFF
--- a/src/Pos/Lrc/DB/Richmen.hs
+++ b/src/Pos/Lrc/DB/Richmen.hs
@@ -25,11 +25,13 @@ module Pos.Lrc.DB.Richmen
 
 import           Universum
 
+import qualified Data.HashMap.Strict         as HM
 import qualified Ether
 
 import           Pos.Binary.Core             ()
 import           Pos.Constants               (genesisHeavyDelThd)
-import           Pos.Context.Functions       (GenesisUtxo (..), genesisUtxoM)
+import           Pos.Context                 (GenesisStakes, genesisStakesM)
+import           Pos.Core                    (EpochIndex, applyCoinPortion)
 import           Pos.DB.Class                (MonadDB, MonadDBRead)
 import           Pos.Genesis                 (genesisDelegation)
 import           Pos.Lrc.Class               (RichmenComponent (..),
@@ -39,8 +41,7 @@ import           Pos.Lrc.DB.RichmenBase      (getRichmen, getRichmenP, putRichme
 import           Pos.Lrc.Logic               (RichmenType (..), findRichmenPure)
 import           Pos.Lrc.Types               (FullRichmenData, Richmen, toRichmen)
 import           Pos.Ssc.RichmenComponent    (RCSsc, getRichmenSsc)
-import           Pos.Txp.Core                (TxOutDistribution, txOutStake)
-import           Pos.Types                   (EpochIndex, applyCoinPortion)
+import           Pos.Txp.Core                (TxOutDistribution)
 import           Pos.Update.RichmenComponent (RCUs, getRichmenUS)
 
 ----------------------------------------------------------------------------
@@ -48,10 +49,10 @@ import           Pos.Update.RichmenComponent (RCUs, getRichmenUS)
 ----------------------------------------------------------------------------
 
 prepareLrcRichmen
-    :: (Ether.MonadReader' GenesisUtxo m, MonadDB m)
+    :: (Ether.MonadReader' GenesisStakes m, MonadDB m)
     => m ()
 prepareLrcRichmen = do
-    genesisDistribution <- concatMap txOutStake . toList <$> genesisUtxoM
+    genesisDistribution <- HM.toList <$> genesisStakesM
     mapM_ (prepareLrcRichmenDo genesisDistribution) components
   where
     prepareLrcRichmenDo distr (SomeRichmenComponent proxy) =


### PR DESCRIPTION
It was using 'GenesisUtxo' to determine richmen. I have no idea how it could
work. I fixed it to use `GenesisStakes' instead.