### PR TITLE
[TW-148] Use time-warp relay queueing

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/Listeners.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Listeners.hs
@@ -109,10 +109,10 @@ sscRelay gtTag contentsToKey toContents processData =
     InvReqData NoMempool $
         InvReqDataParams
           { contentsToKey = pure . tagWith contentsProxy . contentsToKey
-          , handleInv = sscIsDataUseful gtTag . unTagged
+          , handleInv = \_ -> sscIsDataUseful gtTag . unTagged
           , handleReq =
-              \(Tagged addr) -> toContents addr . view ldModifier <$> sscRunLocalQuery ask
-          , handleData = \dat -> do
+              \_ (Tagged addr) -> toContents addr . view ldModifier <$> sscRunLocalQuery ask
+          , handleData = \_ dat -> do
                 let addr = contentsToKey dat
                 -- [CSL-685] TODO: Add here malicious emulation for network
                 -- addresses when TW will support getting peer address

--- a/infra/Pos/Communication/Listener.hs
+++ b/infra/Pos/Communication/Listener.hs
@@ -39,7 +39,7 @@ listenerConv h = (lspec, mempty)
     spec = (rcvMsgName, ConvHandler sndMsgName)
     lspec =
       flip ListenerSpec spec $ \ourVerInfo ->
-          N.ListenerActionConversation $ \peerVerInfo' nNodeId conv -> do
+          N.Listener $ \peerVerInfo' nNodeId conv -> do
               checkingInSpecs ourVerInfo peerVerInfo' spec nNodeId $
                   h ourVerInfo nNodeId conv
 

--- a/infra/Pos/Communication/Protocol.hs
+++ b/infra/Pos/Communication/Protocol.hs
@@ -61,8 +61,8 @@ mapListener'
           -> N.ConversationActions snd rcv m
           -> N.ConversationActions snd rcv m)
     -> (forall t. m t -> m t) -> Listener m -> Listener m
-mapListener' _ caMapper mapper (N.ListenerActionConversation f) =
-    N.ListenerActionConversation $ \d nId -> mapper . f d nId . caMapper nId
+mapListener' _ caMapper mapper (N.Listener f) =
+    N.Listener $ \d nId -> mapper . f d nId . caMapper nId
 
 mapActionSpec
     :: (N.SendActions BiP PeerData m -> N.SendActions BiP PeerData m)
@@ -94,7 +94,7 @@ hoistMkListeners
     -> MkListeners n
 hoistMkListeners nat rnat (MkListeners act ins outs) = MkListeners act' ins outs
   where
-    act' v p = let ls = act v p in map (N.hoistListenerAction nat rnat) ls
+    act' v p = let ls = act v p in map (N.hoistListener nat rnat) ls
 
 convertSendActions
     :: ( WithLogger m

--- a/infra/Pos/Communication/Relay/Class.hs
+++ b/infra/Pos/Communication/Relay/Class.hs
@@ -6,19 +6,16 @@ module Pos.Communication.Relay.Class
        , InvReqDataParams (..)
        , DataParams (..)
        , MempoolParams (..)
-       , MonadRelayMem
-       , askRelayMem
        ) where
 
-import qualified Ether
 import           Node.Message.Class             (Message)
 import           Pos.Binary.Class               (Bi)
 import           Universum
 
 import           Pos.Communication.Limits.Types (MessageLimited)
-import           Pos.Communication.Relay.Types  (RelayContext)
 import           Pos.Communication.Types.Relay  (DataMsg, InvMsg, InvOrData, MempoolMsg,
                                                  ReqMsg (..))
+import           Pos.Communication.Types.Protocol (NodeId)
 
 -- | Data for general Inv/Req/Dat framework
 
@@ -59,21 +56,15 @@ data MempoolParams m where
 data InvReqDataParams key contents m = InvReqDataParams
     { contentsToKey :: contents -> m key
       -- ^ Get key for given contents.
-    , handleInv     :: key -> m Bool
+    , handleInv     :: Maybe NodeId -> key -> m Bool
       -- ^ Handle inv msg and return whether it's useful or not
-    , handleReq     :: key -> m (Maybe contents)
+    , handleReq     :: Maybe NodeId -> key -> m (Maybe contents)
       -- ^ Handle req msg and return (Just data) in case requested data can be provided
-    , handleData    :: contents -> m Bool
+    , handleData    :: Maybe NodeId -> contents -> m Bool
       -- ^ Handle data msg and return True if message is to be propagated
     }
 
 data DataParams contents m = DataParams
-    { handleDataOnly :: contents -> m Bool
+    { handleDataOnly :: Maybe NodeId -> contents -> m Bool
       -- ^ Handle data msg and return True if message is to be propagated
     }
-
-
-type MonadRelayMem = Ether.MonadReader' RelayContext
-
-askRelayMem :: MonadRelayMem m => m RelayContext
-askRelayMem = Ether.ask'

--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -298,15 +298,6 @@ addToRelayQueue
 addToRelayQueue relayContext pm provenance = do
     let enqueue = _rlyEnqueue relayContext
     enqueue pm provenance
-    {-
-    isFull <- atomically $ isFullTBQueue queue
-    if isFull then do
-        logWarning $ "Propagation queue is full, no propagation"
-        jsonLog RelayQueueFull
-    else do
-        ts <- currentTime
-        atomically $ writeTBQueue queue (ts, pm)
-    -}
 
 relayPropagateOut :: Message Void => [Relay m] -> OutSpecs
 relayPropagateOut = mconcat . map propagateOutImpl
@@ -374,24 +365,6 @@ relayWorkersImpl relayContext allOutSpecs =
             (msg, provenance, peer, time) <- dequeue
             sendIt msg provenance peer time
 
-
-        {-
-        enqueue <- _rlyDequeue <$> askRelayMem
-        forever $ atomically (readTBQueue queue) >>= \(ts, message) -> do
-            ts' <- currentTime
-            jsonLog $ EnqueueDequeueTime $ fromIntegral $ ts' - ts
-            case message of
-                InvReqDataPM _ key contents -> do
-                    logDebug $ sformat
-                        ("Propagation data with key: "%build) key
-                    converseToNeighbors sendActions $ \__node ->
-                        pure $ Conversation $ irdHandler key contents
-                DataOnlyPM _ contents -> do
-                    logDebug $ sformat
-                        ("Propagation data: "%build) contents
-                    converseToNeighbors sendActions $ \__node ->
-                        pure $ Conversation $ doHandler contents
-        -}
 
     doHandler
         :: contents1

--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -183,7 +183,7 @@ data ListenerSpec m = ListenerSpec
 
 -- | The MessageName that the listener responds to.
 listenerMessageName :: forall m . Listener m -> MessageName
-listenerMessageName (N.ListenerActionConversation (_ :: PeerData -> N.NodeId -> N.ConversationActions snd rcv m -> m ())) =
+listenerMessageName (N.Listener (_ :: PeerData -> N.NodeId -> N.ConversationActions snd rcv m -> m ())) =
     messageName (Proxy @rcv)
 
 newtype InSpecs = InSpecs HandlerSpecs

--- a/src/Pos/Communication/Server.hs
+++ b/src/Pos/Communication/Server.hs
@@ -17,7 +17,7 @@ import           System.Wlog                 (LoggerName)
 import           Pos.Binary.Communication    ()
 import           Pos.Block.Network.Listeners (blockListeners)
 import           Pos.Communication.Protocol  (MkListeners (..))
-import           Pos.Communication.Relay     (relayListeners)
+import           Pos.Communication.Relay     (relayListeners, RelayContext)
 import           Pos.Communication.Util      (wrapListener)
 import           Pos.Delegation.Listeners    (delegationRelays)
 import           Pos.Ssc.Class               (SscListenersClass (..), SscWorkersClass)
@@ -28,13 +28,13 @@ import           Pos.WorkMode.Class          (WorkMode)
 -- | All listeners running on one node.
 allListeners
     :: (SscListenersClass ssc, SscWorkersClass ssc, WorkMode ssc m)
-    => MkListeners m
-allListeners = mconcat
+    => RelayContext m -> MkListeners m
+allListeners relayContext = mconcat
         [ modifier "block"       $ blockListeners
-        , modifier "ssc"         $ relayListeners (untag sscRelays)
-        , modifier "tx"          $ relayListeners txRelays
-        , modifier "delegation"  $ relayListeners delegationRelays
-        , modifier "update"      $ relayListeners usRelays
+        , modifier "ssc"         $ relayListeners relayContext (untag sscRelays)
+        , modifier "tx"          $ relayListeners relayContext txRelays
+        , modifier "delegation"  $ relayListeners relayContext (delegationRelays relayContext)
+        , modifier "update"      $ relayListeners relayContext usRelays
         ]
   where
     modifier lname mkL = mkL { mkListeners = mkListeners' }

--- a/src/Pos/Context/Context.hs
+++ b/src/Pos/Context/Context.hs
@@ -43,8 +43,6 @@ import           Ether.Internal                (HasLens (..))
 import           System.Wlog                   (LoggerConfig)
 
 import           Pos.Block.Core                (BlockHeader)
-import           Pos.Communication.Relay       (RelayPropagationQueue)
-import           Pos.Communication.Relay.Types (RelayContext (..))
 import           Pos.Communication.Types       (NodeId)
 import           Pos.Core                      (GenesisStakes (..), HeaderHash,
                                                 PrimaryKeyTag)
@@ -131,9 +129,6 @@ modeContext [d|
         , ncProgressHeader      :: !(ProgressHeaderTag ::: ProgressHeader ssc)
         -- Header of the last block that was downloaded in retrieving
         -- queue. Is needed to show smooth prorgess on the frontend.
-        , ncInvPropagationQueue :: !(RelayPropagationQueue ::: RelayPropagationQueue)
-        -- Queue is used in Relay framework,
-        -- it stores inv messages for earlier received data.
         , ncLoggerConfig        :: !(LoggerConfig ::: LoggerConfig)
         -- Logger config, as taken/read from CLI.
         , ncNodeParams          :: !(NodeParams ::: NodeParams)
@@ -158,7 +153,6 @@ makeLensesFor
     , ("npSecurityParams", "npSecurityParamsL")
     , ("npSecretKey", "npSecretKeyL")
     , ("npReportServers", "npReportServersL")
-    , ("npPropagation", "npPropagationL")
     , ("npCustomUtxo", "npCustomUtxoL")
     , ("npGenesisStakes", "npGenesisStakesL") ]
     ''NodeParams
@@ -192,6 +186,7 @@ instance HasLens ReportingContext (NodeContext ssc) ReportingContext where
             set (lensOf @NodeParams . npReportServersL) (rc ^. rcReportServers) .
             set (lensOf @LoggerConfig) (rc ^. rcLoggingConfig)
 
+{-
 instance HasLens RelayContext (NodeContext ssc) RelayContext where
     lensOf = lens getter (flip setter)
       where
@@ -202,3 +197,4 @@ instance HasLens RelayContext (NodeContext ssc) RelayContext where
         setter rc =
             set (lensOf @NodeParams . npPropagationL) (_rlyIsPropagation rc) .
             set (lensOf @RelayPropagationQueue) (_rlyPropagationQueue rc)
+-}

--- a/src/Pos/Context/Context.hs
+++ b/src/Pos/Context/Context.hs
@@ -185,16 +185,3 @@ instance HasLens ReportingContext (NodeContext ssc) ReportingContext where
         setter rc =
             set (lensOf @NodeParams . npReportServersL) (rc ^. rcReportServers) .
             set (lensOf @LoggerConfig) (rc ^. rcLoggingConfig)
-
-{-
-instance HasLens RelayContext (NodeContext ssc) RelayContext where
-    lensOf = lens getter (flip setter)
-      where
-        getter nc =
-            RelayContext
-                (nc ^. lensOf @NodeParams . npPropagationL)
-                (nc ^. lensOf @RelayPropagationQueue)
-        setter rc =
-            set (lensOf @NodeParams . npPropagationL) (_rlyIsPropagation rc) .
-            set (lensOf @RelayPropagationQueue) (_rlyPropagationQueue rc)
--}

--- a/src/Pos/Launcher/Launcher.hs
+++ b/src/Pos/Launcher/Launcher.hs
@@ -10,6 +10,7 @@ module Pos.Launcher.Launcher
 import           Mockable                   (Production)
 
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec)
+import           Pos.Communication.Relay    (hoistRelayContext)
 import           Pos.Launcher.Param         (NodeParams (..))
 import           Pos.Launcher.Resource      (NodeResources (..), bracketNodeResources,
                                              hoistNodeResources)
@@ -38,4 +39,4 @@ runNodeReal np sscnp plugins = bracketNodeResources np sscnp action
     action nr@NodeResources {..} =
         runRealMode
             (hoistNodeResources powerLift nr)
-            (runNode @ssc nrContext plugins)
+            (runNode @ssc (hoistRelayContext powerLift nrRelayContext) nrContext plugins)

--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -36,7 +36,7 @@ import           Network.QDisc.Fair          (fairQDisc)
 import           Network.Transport.Abstract  (Transport, closeTransport, hoistTransport)
 import           Network.Transport.Concrete  (concrete)
 import qualified Network.Transport.TCP       as TCP
-import           Network.Broadcast.Relay     (simpleRelayer)
+import           Network.Broadcast.Relay.Simple (simpleRelayer)
 import qualified STMContainers.Map           as SM
 import           System.IO                   (Handle, hClose)
 import           System.Wlog                 (CanLog, LoggerConfig (..), WithLogger,

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -32,6 +32,7 @@ import           Pos.Binary                 ()
 import           Pos.Communication          (ActionSpec (..), BiP (..), InSpecs (..),
                                              MkListeners (..), OutSpecs (..),
                                              VerInfo (..), allListeners, hoistMkListeners)
+import           Pos.Communication.Relay    (hoistRelayContext)
 import qualified Pos.Constants              as Const
 import           Pos.Context                (NodeContext (..))
 import           Pos.DHT.Real               (foreverRejoinNetwork)
@@ -42,6 +43,7 @@ import           Pos.Launcher.Resource      (NodeResources (..), hoistNodeResour
 import           Pos.Security               (SecurityWorkersClass)
 import           Pos.Ssc.Class              (SscConstraint)
 import           Pos.Util.JsonLog           (JsonLogConfig (..), jsonLogConfigFromHandle)
+import           Pos.Util.Util              (powerLift)
 import           Pos.WorkMode               (RealMode, RealModeContext (..), WorkMode,
                                              unRealMode)
 
@@ -72,7 +74,8 @@ runRealBasedMode unwrap wrap nr@NodeResources {..} (ActionSpec action, outSpecs)
     ActionSpec $ \vI sendActions ->
         unwrap . action vI $ hoistSendActions wrap unwrap sendActions
   where
-    listeners = hoistMkListeners unwrap wrap allListeners
+    listeners = hoistMkListeners unwrap wrap
+        (allListeners (hoistRelayContext powerLift nrRelayContext))
 
 -- | RealMode runner.
 runRealModeDo
@@ -125,6 +128,7 @@ runRealModeDo NodeResources {..} listeners outSpecs action =
             nrPeerState
             jlConf
             lpRunnerTag
+            nrRelayContext
             nrContext
 
 runServer

--- a/src/Pos/Txp/Network/Listeners.hs
+++ b/src/Pos/Txp/Network/Listeners.hs
@@ -39,9 +39,9 @@ txInvReqDataParams :: WorkMode ssc m
 txInvReqDataParams =
     InvReqDataParams
        { contentsToKey = txContentsToKey
-       , handleInv = txHandleInv
-       , handleReq = txHandleReq
-       , handleData = txHandleData
+       , handleInv = \_ -> txHandleInv
+       , handleReq = \_ -> txHandleReq
+       , handleData = \_ -> txHandleData
        }
   where
     txContentsToKey = pure . Tagged . hash . taTx . getTxMsgContents

--- a/src/Pos/Update/Network/Listeners.hs
+++ b/src/Pos/Update/Network/Listeners.hs
@@ -40,9 +40,9 @@ proposalRelay =
         NoMempool $
         InvReqDataParams
            { contentsToKey = \(up, _) -> pure . tag  $ hash up
-           , handleInv = isProposalNeeded . unTagged
-           , handleReq = getLocalProposalNVotes . unTagged
-           , handleData = \(proposal, votes) -> do
+           , handleInv = \_ -> isProposalNeeded . unTagged
+           , handleReq = \_ -> getLocalProposalNVotes . unTagged
+           , handleData = \_ (proposal, votes) -> do
                  res <- processProposal proposal
                  logProp proposal res
                  let processed = isRight res
@@ -76,9 +76,9 @@ voteRelay =
         InvReqDataParams
            { contentsToKey = \UpdateVote{..} ->
                  pure $ tag (uvProposalId, uvKey, uvDecision)
-           , handleInv = \(Tagged (id, pk, dec)) -> isVoteNeeded id pk dec
-           , handleReq = \(Tagged (id, pk, dec)) -> getLocalVote id pk dec
-           , handleData = \uv -> do
+           , handleInv = \_ (Tagged (id, pk, dec)) -> isVoteNeeded id pk dec
+           , handleReq = \_ (Tagged (id, pk, dec)) -> getLocalVote id pk dec
+           , handleData = \_ uv -> do
                  res <- processVote uv
                  logProcess res
                  pure $ isRight res

--- a/src/Pos/WorkMode.hs
+++ b/src/Pos/WorkMode.hs
@@ -27,6 +27,7 @@ import           Pos.Block.Types             (Undo)
 import           Pos.Communication.PeerState (PeerStateCtx, PeerStateTag,
                                               WithPeerState (..), clearPeerStateDefault,
                                               getAllStatesDefault, getPeerStateDefault)
+import           Pos.Communication.Relay     (RelayContext)
 import           Pos.Context                 (NodeContext)
 import           Pos.Core                    (IsHeader)
 import           Pos.DB                      (MonadGState (..), NodeDBs)
@@ -72,6 +73,7 @@ modeContext [d|
         !(PeerStateTag  ::: PeerStateCtx Production)
         !(JsonLogConfig ::: JsonLogConfig)
         !(LoggerName    ::: LoggerName)
+        !(RelayContext  ::: RelayContext Production)
         !(NodeContext ssc)
     |]
 

--- a/src/Pos/WorkMode/Class.hs
+++ b/src/Pos/WorkMode/Class.hs
@@ -17,12 +17,11 @@ import           Universum
 import           Control.Monad.Catch         (MonadMask)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Ether
-import           Mockable                    (MonadMockable)
+import           Mockable                    (MonadMockable, Production)
 import           System.Wlog                 (WithLogger)
 
 import           Pos.Block.BListener         (MonadBListener)
 import           Pos.Communication.PeerState (WithPeerState)
-import           Pos.Communication.Relay     (MonadRelayMem)
 import           Pos.Context                 (BlkSemaphore, GenesisStakes,
                                               MonadBlockRetrievalQueue,
                                               MonadLastKnownHeader, MonadProgressHeader,
@@ -50,6 +49,7 @@ import           Pos.Txp.MemState            (MonadTxpMem)
 import           Pos.Update.Context          (UpdateContext)
 import           Pos.Update.Params           (UpdateParams)
 import           Pos.Util.TimeWarp           (CanJsonLog)
+import           Pos.Util.Util               (PowerLift)
 
 -- Something extremely unpleasant.
 -- TODO: get rid of it after CSL-777 is done.
@@ -70,7 +70,6 @@ type WorkMode ssc m
       , MonadGState m
       , MonadRealDB m
       , MonadTxpMem TxpExtra_TMP m
-      , MonadRelayMem m
       , MonadDelegation m
       , MonadSscMem ssc m
       , MonadReportingMem m
@@ -97,6 +96,7 @@ type WorkMode ssc m
       , MonadShutdownMem m
       , MonadBListener m
       , MonadDiscovery m
+      , PowerLift Production m
       )
 
 -- | More relaxed version of 'WorkMode'.

--- a/src/Pos/Worker.hs
+++ b/src/Pos/Worker.hs
@@ -6,7 +6,6 @@
 
 module Pos.Worker
        ( allWorkers
-       , allWorkersCount
        ) where
 
 import           Universum
@@ -15,20 +14,20 @@ import           Data.Tagged          (untag)
 
 import           Pos.Block.Worker     (blkWorkers)
 import           Pos.Communication    (OutSpecs, WorkerSpec, localWorker, relayWorkers,
-                                       wrapActionSpec)
+                                       wrapActionSpec, RelayContext)
 import           Pos.Context          (NodeContext (..), recoveryCommGuard)
 import           Pos.Delegation       (delegationRelays, dlgWorkers)
 import           Pos.Discovery        (discoveryWorkers)
 import           Pos.Lrc.Worker       (lrcOnNewSlotWorker)
 import           Pos.Security.Workers (SecurityWorkersClass, securityWorkers)
 import           Pos.Slotting         (logNewSlotWorker, slottingWorkers)
-import           Pos.Ssc.Class        (SscConstraint, SscListenersClass (sscRelays),
+import           Pos.Ssc.Class        (SscListenersClass (sscRelays),
                                        SscWorkersClass (sscWorkers))
 import           Pos.Txp              (txRelays)
 import           Pos.Txp.Worker       (txpWorkers)
 import           Pos.Update           (usRelays, usWorkers)
 import           Pos.Util             (mconcatPair)
-import           Pos.WorkMode         (RealMode, WorkMode)
+import           Pos.WorkMode         (WorkMode)
 
 -- | All, but in reality not all, workers used by full node.
 allWorkers
@@ -37,8 +36,8 @@ allWorkers
        , SecurityWorkersClass ssc
        , WorkMode ssc m
        )
-    => NodeContext ssc  -> ([WorkerSpec m], OutSpecs)
-allWorkers NodeContext {..} = mconcatPair
+    => RelayContext m -> NodeContext ssc  -> ([WorkerSpec m], OutSpecs)
+allWorkers relayContext NodeContext {..} = mconcatPair
     [
       -- Only workers of "onNewSlot" type
       -- I have no idea what this ↑ comment means (@gromak).
@@ -52,25 +51,14 @@ allWorkers NodeContext {..} = mconcatPair
 
       -- Have custom loggers
     , wrap' "block"      $ blkWorkers
-    , wrap' "txp"        $ txpWorkers
+    , wrap' "txp"        $ txpWorkers relayContext
     , wrap' "delegation" $ dlgWorkers
     , wrap' "slotting"   $ (properSlottingWorkers, mempty)
-    , wrap' "relay"      $ relayWorkers $ mconcat
-        [delegationRelays, untag sscRelays, txRelays, usRelays]
+    , wrap' "relay"      $ relayWorkers relayContext $ mconcat
+        [delegationRelays relayContext, untag sscRelays, txRelays, usRelays]
     ]
   where
     properSlottingWorkers =
        fst (recoveryCommGuard (localWorker logNewSlotWorker)) :
        map (fst . localWorker) (slottingWorkers ncSlottingContext)
     wrap' lname = first (map $ wrapActionSpec $ "worker" <> lname)
-
--- FIXME this shouldn't be needed.
--- FIXME 'RealMode' is hardcoded, maybe it's bad, this mechanism seems
--- to be fundamentally broken.
-allWorkersCount
-    :: forall ssc.
-       ( SscConstraint ssc
-       , SecurityWorkersClass ssc
-       )
-    => NodeContext ssc -> Int
-allWorkersCount = length . fst . (allWorkers @ssc @(RealMode ssc))

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -19,7 +19,8 @@ import           System.Wlog         (logError, logInfo)
 
 import           Pos.Binary          ()
 import qualified Pos.CLI             as CLI
-import           Pos.Communication   (ActionSpec (..), OutSpecs, WorkerSpec, worker)
+import           Pos.Communication   (ActionSpec (..), OutSpecs, WorkerSpec, worker,
+                                      hoistRelayContext)
 import           Pos.Constants       (isDevelopment)
 import           Pos.Context         (MonadNodeContext)
 import           Pos.Core.Types      (Timestamp (..))
@@ -86,7 +87,7 @@ actionWithWallet sscParams nodeParams args@Args {..} =
                     db
                     conn
                     (hoistNodeResources powerLift nr)
-                    (runNode @SscGodTossing nrContext plugins)
+                    (runNode @SscGodTossing (hoistRelayContext powerLift nrRelayContext) nrContext plugins)
   where
     convPlugins = (, mempty) . map (\act -> ActionSpec $ \__vI __sA -> act)
     plugins :: ([WorkerSpec WalletWebMode], OutSpecs)

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 8bfba580e628791a03b0bec4d913890dde16811d # master
+    commit: 4cf7ab5d4c9718dc67f6f7f2172deee4c0f605b7
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 4cf7ab5d4c9718dc67f6f7f2172deee4c0f605b7
+    commit: 5dd5171239be62a9ae8c502686506e51a89a98a0
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 5dd5171239be62a9ae8c502686506e51a89a98a0
+    commit: dfefb3ccbcd746909b10048e9f49641e1885a4ec
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/update/Pos/Update/Mode.hs
+++ b/update/Pos/Update/Mode.hs
@@ -10,7 +10,6 @@ import           Mockable                    (MonadMockable)
 import           System.Wlog                 (WithLogger)
 
 import           Pos.Communication.PeerState (WithPeerState)
-import           Pos.Communication.Relay     (MonadRelayMem)
 import           Pos.DB.Class                (MonadDB, MonadGState)
 import           Pos.Lrc.Context             (LrcContext)
 import           Pos.Update.Context          (UpdateContext)
@@ -24,7 +23,6 @@ type UpdateMode m
       , MonadMask m
       , MonadGState m
       , MonadDB m
-      , MonadRelayMem m
       , Ether.MonadReader' UpdateContext m
       , Ether.MonadReader' LrcContext m
       , Ether.MonadReader' UpdateParams m


### PR DESCRIPTION
Instead of slicing out all of the relay code to time-warp, which proved so incredibly difficult to do, the relay mechanism was trimmed down to just a kind of `QDisc`: you can enqueue and dequeue messages. The listeners and workers all remain in cardano-sl, but they require a `RelayContext`. I couldn't figure out how to put the `RelayContext` into the `NodeResources` and still obtain an ether `HasLens` on it (it kept demanding a `HasLens` over `NodeContext`).

Related time-warp https://github.com/serokell/time-warp-nt/pull/76