### PR TITLE
[CSL-1258] Fix block header communication

### DIFF
--- a/src/Pos/Block/Network/Announce.hs
+++ b/src/Pos/Block/Network/Announce.hs
@@ -99,8 +99,8 @@ handleHeadersCommunication conv = do
             Left _  -> fromMaybe tipHeader <$> DB.blkGetHeader (tip ^. prevBlockL)
             Right _ -> pure tipHeader
     handleSuccess h = do
-        onSuccess
         send conv (MsgHeaders h)
+        onSuccess
         handleHeadersCommunication conv
     onSuccess =
         logDebug "handleGetHeaders: responded successfully"


### PR DESCRIPTION
This fixes were needed to make cluster with `slot: 15s, k: 5000, recoveryMessageHeaders: 10000` to work.

Issue was that cluster node first responded with it's tip `T`, wallet requested block range from 0th epoch genesis to `T`, node (due to bug) responded in turn not with only `T`, but with also `T'` -- new tip, which appeared in meanwhile. Wallet received chain with `T'` and was rejecting it because it requested chain up to `T`, not `T'` and also is not in recovery mode.