### PR TITLE
[CSM-335] Extrapolate transaction timestamp

### DIFF
--- a/core/Pos/Core/Timestamp.hs
+++ b/core/Pos/Core/Timestamp.hs
@@ -4,6 +4,8 @@ module Pos.Core.Timestamp
        ( Timestamp (..)
        , timestampF
        , getCurrentTimestamp
+       , diffTimestamp
+       , addMicrosecondsToTimestamp
        ) where
 
 import           Universum
@@ -45,3 +47,9 @@ timestampF = build
 -- Get the current time as a timestamp
 getCurrentTimestamp :: IO Timestamp
 getCurrentTimestamp = Timestamp . round . (*1000000) <$> getPOSIXTime
+
+diffTimestamp :: Timestamp -> Timestamp -> Microsecond
+diffTimestamp t1 t2 = getTimestamp t1 - getTimestamp t2
+
+addMicrosecondsToTimestamp :: Microsecond -> Timestamp -> Timestamp
+addMicrosecondsToTimestamp m t = Timestamp { getTimestamp = (getTimestamp t) + m }

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -163,7 +163,7 @@ deriveAddrHistoryPartialWithTimestamp hist addrs chain maybeSd =
                    map mapper $ flattenTxPayload (blk ^. mainBlockTxPayload)
         let difficulty = blk ^. difficultyL
             txs' = map (thDifficulty .~ Just difficulty) txs
-        let maybeTimestamp = maybeSd >>= getSlotStartPure (blk ^. mainBlockSlot)
+        let maybeTimestamp = maybeSd >>= getSlotStartPure True (blk ^. mainBlockSlot)
             txs'' = map (thTimestamp .~ maybeTimestamp) txs'
         return $ DL.fromList txs'' <> hst
 


### PR DESCRIPTION
When it cannot be precisely determined from the blockchain. The extrapolation will be accurate as long as the slot duration doesn't change.