### PR TITLE
[CSL-1295] Request missing headers in a worker

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -40,6 +40,7 @@ library
                         Pos.Block.Logic
                         Pos.Block.Network
                         Pos.Block.Pure
+                        Pos.Block.RetrievalQueue
                         Pos.Block.Types
                         Pos.CLI
                         Pos.Context

--- a/src/Pos/Block/Network/Listeners.hs
+++ b/src/Pos/Block/Network/Listeners.hs
@@ -78,8 +78,8 @@ handleBlockHeaders
     :: forall ssc m.
        (SscWorkersClass ssc, WorkMode ssc m)
     => (ListenerSpec m, OutSpecs)
-handleBlockHeaders = listenerConv $ \__ourVerInfo nodeId conv -> do
+handleBlockHeaders = listenerConv @Void $ \__ourVerInfo nodeId conv -> do
     logDebug "handleBlockHeaders: got some unsolicited block header(s)"
     mHeaders <- recvLimited conv
     whenJust mHeaders $ \(MsgHeaders headers) ->
-        handleUnsolicitedHeaders (getNewestFirst headers) nodeId conv
+        handleUnsolicitedHeaders (getNewestFirst headers) nodeId

--- a/src/Pos/Block/Network/Listeners.hs
+++ b/src/Pos/Block/Network/Listeners.hs
@@ -16,7 +16,7 @@ import           Pos.Block.Logic            (getHeadersFromToIncl)
 import           Pos.Block.Network.Announce (handleHeadersCommunication)
 import           Pos.Block.Network.Logic    (handleUnsolicitedHeaders)
 import           Pos.Block.Network.Types    (MsgBlock (..), MsgGetBlocks (..),
-                                             MsgHeaders (..))
+                                             MsgGetHeaders, MsgHeaders (..))
 import           Pos.Communication.Limits   (recvLimited)
 import           Pos.Communication.Listener (listenerConv)
 import           Pos.Communication.Protocol (ConversationActions (..), ListenerSpec (..),
@@ -78,7 +78,10 @@ handleBlockHeaders
     :: forall ssc m.
        (SscWorkersClass ssc, WorkMode ssc m)
     => (ListenerSpec m, OutSpecs)
-handleBlockHeaders = listenerConv @Void $ \__ourVerInfo nodeId conv -> do
+handleBlockHeaders = listenerConv @MsgGetHeaders $ \__ourVerInfo nodeId conv -> do
+    -- The type of the messages we send is set to 'MsgGetHeaders' for
+    -- protocol compatibility reasons only. We could use 'Void' here because
+    -- we don't really send any messages.
     logDebug "handleBlockHeaders: got some unsolicited block header(s)"
     mHeaders <- recvLimited conv
     whenJust mHeaders $ \(MsgHeaders headers) ->

--- a/src/Pos/Block/Network/Logic.hs
+++ b/src/Pos/Block/Network/Logic.hs
@@ -150,10 +150,11 @@ requestTip nodeId conv = do
 mkHeadersRequest
     :: forall ssc m.
        WorkMode ssc m
-    => Maybe HeaderHash -> m (Maybe MsgGetHeaders)
-mkHeadersRequest upto = do
-    mbHeaders <- nonEmpty . toList <$> getHeadersOlderExp @ssc Nothing
-    pure $ (\h -> MsgGetHeaders (toList h) upto) <$> mbHeaders
+    => HeaderHash -> m (Maybe MsgGetHeaders)
+mkHeadersRequest upto = runMaybeT $ do
+    bHeaders <- MaybeT $ nonEmpty . toList <$> getHeadersOlderExp @ssc Nothing
+    guard (not $ upto `elem` bHeaders)
+    pure $ MsgGetHeaders (toList bHeaders) (Just upto)
 
 -- Second case of 'handleBlockheaders'
 handleUnsolicitedHeaders

--- a/src/Pos/Block/Network/Retrieval.hs
+++ b/src/Pos/Block/Network/Retrieval.hs
@@ -137,7 +137,7 @@ retrievalWorkerImpl sendActions =
     handleHeadersRecovery (nodeId, rHeader) = do
         logDebug "Block retrieval queue is empty and we're in recovery mode,\
                  \ so we will request more headers"
-        whenJustM (mkHeadersRequest (Just $ headerHash rHeader)) $ \mghNext ->
+        whenJustM (mkHeadersRequest (headerHash rHeader)) $ \mghNext ->
             handleAll (handleHeadersRecoveryE nodeId) $
             reportingFatal version $
             withConnectionTo sendActions nodeId $ \_ -> pure $ Conversation $
@@ -155,7 +155,7 @@ retrievalWorkerImpl sendActions =
         dropUpdateHeader
         dropRecoveryHeaderAndRepeat sendActions nodeId
     handleBlockRetrievalWithTip nodeId tip = do
-        mghM <- mkHeadersRequest (Just (headerHash tip))
+        mghM <- mkHeadersRequest (headerHash tip)
         whenJust mghM $ \mgh ->
             withConnectionTo sendActions nodeId $ \_ -> pure $ Conversation $
                 requestHeaders' (handleBlockRetrieval nodeId) mgh nodeId

--- a/src/Pos/Block/RetrievalQueue.hs
+++ b/src/Pos/Block/RetrievalQueue.hs
@@ -1,0 +1,24 @@
+module Pos.Block.RetrievalQueue
+       ( BlockRetrievalQueueTag
+       , BlockRetrievalQueue
+       , BlockRetrievalTask(..)
+       , MonadBlockRetrievalQueue
+       ) where
+
+import           Control.Concurrent.STM  (TBQueue)
+import qualified Ether
+
+import           Pos.Block.Core          (BlockHeader)
+import           Pos.Communication.Types (NodeId)
+import           Pos.Util.Chrono         (NE, NewestFirst)
+
+data BlockRetrievalTask ssc
+    = RetrieveBlocksByHeaders (NewestFirst NE (BlockHeader ssc))
+    | RetrieveHeadersByTip (BlockHeader ssc)
+
+data BlockRetrievalQueueTag
+
+type BlockRetrievalQueue ssc = TBQueue (NodeId, BlockRetrievalTask ssc)
+
+type MonadBlockRetrievalQueue ssc =
+    Ether.MonadReader BlockRetrievalQueueTag (BlockRetrievalQueue ssc)

--- a/src/Pos/Context/Context.hs
+++ b/src/Pos/Context/Context.hs
@@ -34,7 +34,6 @@ module Pos.Context.Context
 
 import           Universum
 
-import           Control.Concurrent.STM        (TBQueue)
 import qualified Control.Concurrent.STM        as STM
 import           Control.Lens                  (coerced, lens, makeLensesFor)
 import           Data.Time.Clock               (UTCTime)
@@ -43,6 +42,9 @@ import           Ether.Internal                (HasLens (..))
 import           System.Wlog                   (LoggerConfig)
 
 import           Pos.Block.Core                (BlockHeader)
+import           Pos.Block.RetrievalQueue      (BlockRetrievalQueue,
+                                                BlockRetrievalQueueTag,
+                                                MonadBlockRetrievalQueue)
 import           Pos.Communication.Relay       (RelayPropagationQueue)
 import           Pos.Communication.Relay.Types (RelayContext (..))
 import           Pos.Communication.Types       (NodeId)
@@ -64,7 +66,6 @@ import           Pos.Txp.Settings              (TxpGlobalSettings)
 import           Pos.Txp.Toil.Types            (Utxo)
 import           Pos.Update.Context            (UpdateContext)
 import           Pos.Update.Params             (UpdateParams)
-import           Pos.Util.Chrono               (NE, NewestFirst)
 import           Pos.Util.UserSecret           (UserSecret)
 
 ----------------------------------------------------------------------------
@@ -79,11 +80,6 @@ type MonadLastKnownHeader ssc = Ether.MonadReader LastKnownHeaderTag (LastKnownH
 data ProgressHeaderTag
 type ProgressHeader ssc = STM.TMVar (BlockHeader ssc)
 type MonadProgressHeader ssc = Ether.MonadReader ProgressHeaderTag (ProgressHeader ssc)
-
-data BlockRetrievalQueueTag
-type BlockRetrievalQueue ssc = TBQueue (NodeId, NewestFirst NE (BlockHeader ssc))
-type MonadBlockRetrievalQueue ssc =
-    Ether.MonadReader BlockRetrievalQueueTag (BlockRetrievalQueue ssc)
 
 data RecoveryHeaderTag
 type RecoveryHeader ssc = STM.TMVar (NodeId, BlockHeader ssc)


### PR DESCRIPTION
To be honest, I couldn't reproduce the issue in the exact way it was reported. In particular, I didn't get the "Header c3f52eb6 potentially represents good alternative chain, requesting more headers" message at all, and "Action Recv from NodeId 34.249.78.18:3000:0 in conversation took more than 4s" were not grouped.

Furthermore, I see errors like this in the log: "Error in conversation to NodeId 192.169.1.38:3001:0: NoParse".

Anyway, I don't know whether this is something wrong with the code or my testing setup. I've implemented the changes as discussed with @georgeee, but I'm hoping someone else could verify that they help (and don't break anything).