### PR TITLE
[DEVOPS-100] Automate redemption certificate generation

### DIFF
--- a/scripts/generate/certificates.sh
+++ b/scripts/generate/certificates.sh
@@ -1,34 +1,53 @@
-#!/bin/bash
+#!/usr/bin/env nix-shell
+#! nix-shell -j 4 -i bash -p nodejs-7_x stack
 
-set -e
+# NOTE: this file must be kept idempotent
+
+
+set -ex
 
 genesis=$1
 
 if [[ ! -d "$genesis" ]]; then
-  echo "No genesis"
+  echo "No such folder $genesis"
   exit 1
 fi
 
-genesis_=`cd $genesis && pwd`
+pushd "$genesis"
+  if [[ ! -d postvend-app ]]; then
+    git clone git@github.com:input-output-hk/postvend-app.git
+  fi
 
-postvend_app_dir=`pwd`/../postvend-app
+  pushd postvend-app
+    if [[ ! -f "build-done" ]]; then
+      for i in certificate-generation-script new-certificate-generator paper-vend-generator; do
+        pushd $i
+          npm install
+        popd
+      done
+      mkdir -p bin
+      stack build --nix --local-bin-path bin --copy-bins
+      echo "done" > build-done
+    fi
 
-{ for i in $genesis/avvm/*.seed; do cat $i; echo ''; done; } > $postvend_app_dir/seeds.txt
+    # cleanup
+    rm -Rf paper-certs-* redeem-certs-* seeds.txt
 
-DIR=`pwd`
+    for i in ../avvm/*.seed; do
+      cat "$i" >> seeds.txt
+      echo '' >> seeds.txt
+    done
+  
+    ./bin/postvend-cli -- gen-test-certs --seeds-file seeds.txt
+  
+    mkdir ../certs
+  
+    mv paper-certs-mnem-* ../certs/paper-certs-mnem
+    mv paper-certs-* ../certs/paper-certs
+    mv redeem-certs-* ../certs/redeem-certs
+  popd
+popd
 
-cd $postvend_app_dir
+tar -czf "$genesis-certs-secrets.tgz" "$genesis/certs" "$genesis/secrets"
 
-rm -Rf paper-certs-* redeem-certs-*
-
-stack exec postvend-cli -- gen-test-certs --seeds-file seeds.txt
-
-mkdir $genesis_/certs
-
-mv paper-certs-mnem-* $genesis_/certs/paper-certs-mnem
-mv paper-certs-* $genesis_/certs/paper-certs
-mv redeem-certs-* $genesis_/certs/redeem-certs
-
-cd $DIR
-
-tar -czf `basename $genesis`-certs-secrets.tgz $genesis/certs $genesis/secrets
+echo "Done"


### PR DESCRIPTION
- launchable by Nix to provide correct dependencies
- automate postvend-app building (should probably be moved to the post-vend-app so we would just call `make`)
- other smaller changes for readability
- shellcheck only complains about unknown shebang