### PR TITLE
[CSL-1298] Fix misused 'recoveryCommGuard'

### DIFF
--- a/infra/Pos/DHT/Workers.hs
+++ b/infra/Pos/DHT/Workers.hs
@@ -20,6 +20,7 @@ import           Pos.Core.Types             (slotIdF)
 import           Pos.DHT.Constants          (kademliaDumpInterval)
 import           Pos.DHT.Real.Types         (KademliaDHTInstance (..))
 import           Pos.Discovery.Class        (MonadDiscovery)
+import           Pos.Recovery.Info          (MonadRecoveryInfo, recoveryCommGuard)
 import           Pos.Reporting              (MonadReportingMem)
 import           Pos.Shutdown               (MonadShutdownMem)
 import           Pos.Slotting.Class         (MonadSlots)
@@ -32,6 +33,7 @@ type DhtWorkMode m =
     , Mockable Fork m
     , Mockable Delay m
     , MonadReportingMem m
+    , MonadRecoveryInfo m
     , MonadShutdownMem m
     , MonadDiscovery m
     )
@@ -46,9 +48,11 @@ dumpKademliaStateWorker
     => KademliaDHTInstance
     -> (WorkerSpec m, OutSpecs)
 dumpKademliaStateWorker kademliaInst = localOnNewSlotWorker True $ \slotId ->
-    when (flattenSlotId slotId `mod` kademliaDumpInterval == 0) $ do
+    when (isTimeToDump slotId) $ recoveryCommGuard $ do
         let dumpFile = kdiDumpPath kademliaInst
         logNotice $ sformat ("Dumping kademlia snapshot on slot: "%slotIdF) slotId
         let inst = kdiHandle kademliaInst
         snapshot <- liftIO $ takeSnapshot inst
         liftIO . BS.writeFile dumpFile $ encode snapshot
+  where
+    isTimeToDump slotId = flattenSlotId slotId `mod` kademliaDumpInterval == 0

--- a/infra/Pos/Recovery/Info.hs
+++ b/infra/Pos/Recovery/Info.hs
@@ -1,3 +1,6 @@
+-- | The main goal of this module is to encapsulate recovery mechanism
+-- and provide helpers related to it.
+
 module Pos.Recovery.Info
        ( MonadRecoveryInfo(..)
        , recoveryCommGuard
@@ -5,17 +8,15 @@ module Pos.Recovery.Info
 
 import           Universum
 
-import           Pos.Communication.Types.Protocol (ActionSpec (..), OutSpecs, WorkerSpec)
-
 class Monad m => MonadRecoveryInfo m where
     -- | Returns if 'RecoveryHeader' is 'Just' (which is equivalent to “we're
     -- doing recovery”).
     recoveryInProgress :: m Bool
 
--- | This function is a helper for workers. It doesn't run a worker if the
--- node is in recovery mode.
+-- | This is a helper function which runs given action only if we are
+-- not doing recovery at this moment.  It is useful for workers which
+-- shouldn't do anything while we are not synchronized.
 recoveryCommGuard
     :: MonadRecoveryInfo m
-    => (WorkerSpec m, OutSpecs) -> (WorkerSpec m, OutSpecs)
-recoveryCommGuard (ActionSpec worker, outs) =
-    (,outs) . ActionSpec $ \vI sA -> unlessM recoveryInProgress $ worker vI sA
+    => m () -> m ()
+recoveryCommGuard action = unlessM recoveryInProgress action

--- a/src/Pos/Block/Worker.hs
+++ b/src/Pos/Block/Worker.hs
@@ -65,7 +65,9 @@ blkWorkers =
 
 -- Action which should be done when new slot starts.
 blkOnNewSlot :: WorkMode ssc m => (WorkerSpec m, OutSpecs)
-blkOnNewSlot = recoveryCommGuard $ onNewSlotWorker True announceBlockOuts blkOnNewSlotImpl
+blkOnNewSlot =
+    onNewSlotWorker True announceBlockOuts $ \slotId sendActions ->
+        recoveryCommGuard $ blkOnNewSlotImpl slotId sendActions
 
 blkOnNewSlotImpl
     :: WorkMode ssc m

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -31,10 +31,10 @@ import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlo
 import           Pos.Constants              (slotSecurityParam)
 import           Pos.Context                (BlkSemaphore, recoveryCommGuard)
 import           Pos.Core                   (Coin, EpochIndex, EpochOrSlot (..),
-                                             EpochOrSlot (..), HeaderHash, HeaderHash,
-                                             SharedSeed, SlotId (..), StakeholderId,
-                                             crucialSlot, epochIndexL, getEpochOrSlot,
-                                             getEpochOrSlot, getSlotIndex)
+                                             EpochOrSlot (..), HeaderHash, SharedSeed,
+                                             SlotId (..), StakeholderId, crucialSlot,
+                                             epochIndexL, getEpochOrSlot, getEpochOrSlot,
+                                             getSlotIndex)
 import qualified Pos.DB.DB                  as DB
 import qualified Pos.DB.GState              as GS
 import           Pos.Lrc.Consumer           (LrcConsumer (..))
@@ -60,9 +60,10 @@ lrcOnNewSlotWorker
     :: forall ssc m.
        (WorkMode ssc m, SscWorkersClass ssc)
     => (WorkerSpec m, OutSpecs)
-lrcOnNewSlotWorker = recoveryCommGuard $ localOnNewSlotWorker True $ \SlotId {..} ->
-    when (getSlotIndex siSlot < slotSecurityParam) $
-        lrcSingleShot @ssc siEpoch `catch` onLrcError
+lrcOnNewSlotWorker = localOnNewSlotWorker True $ \SlotId {..} ->
+    recoveryCommGuard $
+        when (getSlotIndex siSlot < slotSecurityParam) $
+            lrcSingleShot @ssc siEpoch `catch` onLrcError
   where
     -- Here we log it as a warning and report an error, even though it
     -- can happen there we don't know recent blocks. That's because if

--- a/src/Pos/Update/Worker.hs
+++ b/src/Pos/Update/Worker.hs
@@ -20,7 +20,8 @@ import           Pos.WorkMode.Class         (WorkMode)
 usWorkers :: WorkMode ssc m => ([WorkerSpec m], OutSpecs)
 usWorkers =
     first pure $
-    recoveryCommGuard $ localOnNewSlotWorker True $ \s ->
+    localOnNewSlotWorker True $ \s ->
+        recoveryCommGuard $
         processNewSlot s >> void (fork checkForUpdate)
 
 checkForUpdate :: WorkMode ssc m => m ()

--- a/src/Pos/Worker.hs
+++ b/src/Pos/Worker.hs
@@ -60,7 +60,7 @@ allWorkers = mconcatPair
     ]
   where
     properSlottingWorkers =
-       fst (recoveryCommGuard (localWorker logNewSlotWorker)) :
+       fst (localWorker (recoveryCommGuard logNewSlotWorker)) :
        map (fst . localWorker) slottingWorkers
     wrap' lname = first (map $ wrapActionSpec $ "worker" <> lname)
 

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -32,7 +32,7 @@ import qualified Pos.CLI                    as CLI
 import           Pos.Communication          (ActionSpec (..), NodeId, OutSpecs,
                                              WorkerSpec, worker, wrapActionSpec)
 import           Pos.Constants              (isDevelopment)
-import           Pos.Context                (MonadNodeContext, recoveryCommGuard)
+import           Pos.Context                (MonadNodeContext)
 import           Pos.Core.Types             (Timestamp (..))
 import           Pos.DHT.Real               (KademliaDHTInstance (..),
                                              foreverRejoinNetwork)
@@ -88,8 +88,10 @@ action peerHolder args@Args {..} transport = do
 
     let vssSK = fromJust $ npUserSecret currentParams ^. usVss
     let gtParams = gtSscParams args vssSK
+    -- TODO: this code is impossible to maintain, hence we have 'identity' here.
+    -- Fortunately it's refactored in master.
     let wDhtWorkers :: WorkMode ssc m => KademliaDHTInstance -> ([WorkerSpec m], OutSpecs)
-        wDhtWorkers = (\(ws, outs) -> (map (fst . recoveryCommGuard . (, outs)) ws, outs)) . -- TODO simplify
+        wDhtWorkers = (\(ws, outs) -> (map (fst . identity . (, outs)) ws, outs)) . -- TODO simplify
                       first (map $ wrapActionSpec $ "worker" <> "dht") . dhtWorkers
 
 #ifdef WITH_WEB


### PR DESCRIPTION
Previously 'recoveryCommGuard' was totally misused in «on new slot workers».
Specifically, it was checking whether we are doing recovery only once: before
the worker is actually launched. But we want to do it for each tick of the
worker.