### PR TITLE
CSE-162 Explorer slow blocks, merge to master.

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -265,6 +265,7 @@ library
                         Pos.Explorer.Txp.Toil.Logic
                         Pos.Explorer.Txp.Toil.Types
                         Pos.Explorer.DB
+                        Pos.Explorer.BListener
 
   if flag(with-web)
     other-modules:      Pos.Aeson.Crypto

--- a/src/Pos/Block/Logic/Slog.hs
+++ b/src/Pos/Block/Logic/Slog.hs
@@ -30,7 +30,7 @@ import qualified Ether
 import           Formatting            (build, sformat, (%))
 import           Serokell.Util         (Color (Red), colorize)
 import           Serokell.Util.Verify  (formatAllErrors, verResToMonadError)
-import           System.Wlog           (WithLogger, logWarning)
+import           System.Wlog           (WithLogger)
 
 import           Pos.Binary.Core       ()
 import           Pos.Block.BListener   (MonadBListener (..))
@@ -156,17 +156,23 @@ slogApplyBlocks ::
     => OldestFirst NE (Blund ssc)
     -> m SomeBatchOp
 slogApplyBlocks blunds = do
-    -- Note: it's important to put blunds first
+    -- Note: it's important to put blunds first. The invariant is that
+    -- the sequence of blocks corresponding to the tip must exist in
+    -- BlockDB. If program is interrupted after we put blunds and
+    -- before we update GState, this invariant won't be violated. If
+    -- we update GState first, this invariant may be violated.
     mapM_ dbPutBlund blunds
-    -- If the program is interrupted at this point (after putting on block),
-    -- we will rollback all wallet sets at the next launch.
-    onApplyBlocks blunds `catch` logWarn
+    -- If the program is interrupted at this point (after putting on
+    -- block), we will have a garbage block in BlockDB, but it's not a
+    -- problem.
+    bListenerBatch <- onApplyBlocks blunds
+
     let putTip =
             SomeBatchOp $
             GS.PutTip $ headerHash $ NE.last $ getOldestFirst blunds
     sanityCheckDB
     putSlottingData =<< GS.getSlottingData
-    return $ SomeBatchOp [putTip, forwardLinksBatch, inMainBatch]
+    return $ SomeBatchOp [putTip, bListenerBatch, forwardLinksBatch, inMainBatch]
   where
     blocks = fmap fst blunds
     forwardLinks = map (view prevBlockL &&& view headerHashG) $ toList blocks
@@ -175,9 +181,6 @@ slogApplyBlocks blunds = do
     inMainBatch =
         SomeBatchOp . getOldestFirst $
         fmap (GS.SetInMainChain True . view headerHashG . fst) blunds
-    -- ↓ was written by @pva701
-    logWarn :: SomeException -> m ()
-    logWarn = logWarning . sformat ("onApplyBlocks raised exception: " %build)
 
 -- | This function does everything that should be done when rollback
 -- happens and that is not done in other components.
@@ -190,15 +193,14 @@ slogRollbackBlocks blunds = do
         when (isGenesis0 (blocks ^. _Wrapped . _neLast)) $
         assertionFailed $
         colorize Red "FATAL: we are TRYING TO ROLLBACK 0-TH GENESIS block"
-    -- If program is interrupted after call @onRollbackBlocks@,
-    -- we will load all wallet set not rolled yet at the next launch.
-    onRollbackBlocks blunds `catch` logWarn
+    bListenerBatch <- onRollbackBlocks blunds
+
     let putTip = SomeBatchOp $
                  GS.PutTip $
                  headerHash $
                  (NE.last $ getNewestFirst blunds) ^. prevBlockL
     sanityCheckDB
-    return $ SomeBatchOp [putTip, forwardLinksBatch, inMainBatch]
+    return $ SomeBatchOp [putTip, bListenerBatch, forwardLinksBatch, inMainBatch]
   where
     blocks = fmap fst blunds
     inMainBatch =
@@ -209,6 +211,3 @@ slogRollbackBlocks blunds = do
         fmap (GS.RemoveForwardLink . view prevBlockL) blocks
     isGenesis0 (Left genesisBlk) = genesisBlk ^. epochIndexL == 0
     isGenesis0 (Right _)         = False
-    -- ↓ was written by @pva701
-    logWarn :: SomeException -> m ()
-    logWarn = logWarning . sformat ("onRollbackBlocks raised exception: "%build)

--- a/src/Pos/Explorer/BListener.hs
+++ b/src/Pos/Explorer/BListener.hs
@@ -1,0 +1,367 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+-- | Blockchain listener for Explorer.
+-- Callbacks on application and rollback.
+
+module Pos.Explorer.BListener
+       ( runExplorerBListener 
+       -- * Instances
+       -- ** MonadBListener (ExplorerBListener m)
+       ) where
+
+import           Universum
+
+import           Control.Lens                 (at, non)
+import           Control.Monad.Trans.Identity (IdentityT (..))
+import           Data.Coerce                  (coerce)
+import           Data.List                    ((\\))
+import qualified Data.List.NonEmpty           as NE
+import qualified Data.Map                     as M
+import qualified Ether
+import           System.Wlog                  (WithLogger)
+
+import           Mockable                     (MonadMockable)
+import           Pos.Block.BListener          (MonadBListener (..))
+import           Pos.Block.Core               (Block)
+import           Pos.Block.Types              (Blund)
+import           Pos.Core                     (HeaderHash, difficultyL,
+                                               epochIndexL, getChainDifficulty,
+                                               headerHash)
+import           Pos.DB.BatchOp               (SomeBatchOp (..))
+import           Pos.DB.Class                 (MonadDBRead)
+import           Pos.Explorer.DB              (Page, Epoch)
+import qualified Pos.Explorer.DB              as DB
+import           Pos.Ssc.Class.Helpers        (SscHelpersClass)
+import           Pos.Util.Chrono              (NE, NewestFirst (..),
+                                               OldestFirst (..))
+
+----------------------------------------------------------------------------
+-- Declarations
+----------------------------------------------------------------------------
+
+
+data ExplorerBListenerTag
+
+type ExplorerBListener = Ether.TaggedTrans ExplorerBListenerTag IdentityT
+
+-- Kind of... Empty and devoid of meaning...
+runExplorerBListener :: ExplorerBListener m a -> m a
+runExplorerBListener = coerce
+
+-- Type alias, remove duplication
+type MonadBListenerT m ssc = 
+    ( SscHelpersClass ssc
+    , WithLogger m
+    , MonadCatch m
+    , MonadDBRead m
+    )
+
+-- Explorer implementation for usual node. Combines the operations.
+instance ( MonadDBRead m
+         , MonadMockable m
+         , MonadCatch m
+         , WithLogger m
+         )
+         => MonadBListener (ExplorerBListener m) where
+    onApplyBlocks     blunds = onApplyCallGeneral blunds
+    onRollbackBlocks  blunds = onRollbackCallGeneral blunds
+
+
+----------------------------------------------------------------------------
+-- General calls
+----------------------------------------------------------------------------
+
+
+onApplyCallGeneral
+    :: forall ssc m . 
+    MonadBListenerT m ssc
+    => OldestFirst NE (Blund ssc) -> m SomeBatchOp
+onApplyCallGeneral    blunds = do
+    epochBlocks <- onApplyEpochBlocksExplorer blunds
+    pageBlocks  <- onApplyPageBlocksExplorer blunds
+    pure $ SomeBatchOp [epochBlocks, pageBlocks]
+
+
+onRollbackCallGeneral
+    :: forall ssc m .
+    MonadBListenerT m ssc
+    => NewestFirst NE (Blund ssc) -> m SomeBatchOp
+onRollbackCallGeneral blunds = do
+    epochBlocks <- onRollbackEpochBlocksExplorer blunds
+    pageBlocks  <- onRollbackPageBlocksExplorer blunds
+    pure $ SomeBatchOp [epochBlocks, pageBlocks]
+
+
+----------------------------------------------------------------------------
+-- Function calls
+----------------------------------------------------------------------------
+
+
+-- For @EpochBlocks@
+onApplyEpochBlocksExplorer
+    :: forall ssc m.
+    MonadBListenerT m ssc
+    => OldestFirst NE (Blund ssc) 
+    -> m SomeBatchOp
+onApplyEpochBlocksExplorer blunds = onApplyKeyBlocksGeneral blunds epochBlocksMap 
+
+
+-- For @PageBlocks@
+onApplyPageBlocksExplorer
+    :: forall ssc m .
+    MonadBListenerT m ssc
+    => OldestFirst NE (Blund ssc) 
+    -> m SomeBatchOp
+onApplyPageBlocksExplorer blunds = onApplyKeyBlocksGeneral blunds pageBlocksMap 
+
+
+----------------------------------------------------------------------------
+-- Rollback
+----------------------------------------------------------------------------
+
+
+-- For @EpochBlocks@
+onRollbackEpochBlocksExplorer
+    :: forall ssc m .
+    MonadBListenerT m ssc
+    => NewestFirst NE (Blund ssc) -> m SomeBatchOp
+onRollbackEpochBlocksExplorer blunds = onRollbackGeneralBlocks blunds epochBlocksMap
+
+
+-- For @PageBlocks@
+onRollbackPageBlocksExplorer
+    :: forall ssc m .
+    MonadBListenerT m ssc
+    => NewestFirst NE (Blund ssc) -> m SomeBatchOp
+onRollbackPageBlocksExplorer blunds = onRollbackGeneralBlocks blunds pageBlocksMap
+
+
+----------------------------------------------------------------------------
+-- Common
+----------------------------------------------------------------------------
+
+
+-- Return a map from @Epoch@ to @HeaderHash@es for all non-empty blocks.
+epochBlocksMap 
+    :: forall ssc. (SscHelpersClass ssc)
+    => NE (Block ssc) 
+    -> M.Map Epoch [HeaderHash]
+epochBlocksMap neBlocks = blocksEpochs
+  where
+
+    blocksEpochs :: M.Map Epoch [HeaderHash]
+    blocksEpochs = M.fromListWith (++) [ (k, [v]) | (k, v) <- blockEpochBlocks]
+
+    blockEpochBlocks :: [(Epoch, HeaderHash)]
+    blockEpochBlocks = blockEpochs `zip` blocksHHs
+      where 
+        blocksHHs :: [HeaderHash]
+        blocksHHs = headerHash <$> blocks 
+
+        blockEpochs :: [Epoch]
+        blockEpochs = getBlockEpoch <$> blocks
+
+    getBlockEpoch :: (Block ssc) -> Epoch
+    getBlockEpoch block = block ^. epochIndexL
+
+    blocks :: [Block ssc]
+    blocks = NE.toList neBlocks
+
+
+-- Return a map from @Page@ to @HeaderHash@es for all non-empty blocks.
+pageBlocksMap 
+    :: forall ssc. (SscHelpersClass ssc) 
+    => NE (Block ssc) 
+    -> M.Map Page [HeaderHash]
+pageBlocksMap neBlocks = blocksPages
+  where
+
+    blocksPages :: M.Map Page [HeaderHash]
+    blocksPages = M.fromListWith (++) [ (k, [v]) | (k, v) <- blockIndexBlock]
+
+    blockIndexBlock :: [(Page, HeaderHash)]
+    blockIndexBlock = blockPages `zip` blocksHHs
+      where 
+        blocksHHs :: [HeaderHash]
+        blocksHHs = headerHash <$> blocks 
+
+        blockPages :: [Page]
+        blockPages = getCurrentPage <$> blockIndexes
+
+        getCurrentPage :: Int -> Page
+        getCurrentPage blockIndex = (blockIndex `div` pageSize) + 1
+
+        pageSize :: Int
+        pageSize = 10
+
+    blockIndexes :: [Int]
+    blockIndexes = getBlockIndex <$> blocks
+
+    getBlockIndex :: (Block ssc) -> Int
+    getBlockIndex block = fromIntegral $ getChainDifficulty $ block ^. difficultyL
+
+    blocks :: [Block ssc]
+    blocks = NE.toList neBlocks
+
+
+-- So the parameters can be type checked.
+newtype PrevKBlocks  k = PrevKBlocks { getPrevKBlocks :: M.Map k [HeaderHash] }
+newtype NewKBlocks   k = NewKBlocks { getNewKBlocks :: M.Map k [HeaderHash] }
+
+
+-- The result is the map that contains diffed blocks from the keys.
+rollbackedBlocks
+    :: forall a
+     . (Ord a)
+    => [a]
+    -> PrevKBlocks a
+    -> NewKBlocks a
+    -> M.Map a [HeaderHash]
+rollbackedBlocks keys' oldMap' newMap' = M.unions rolledbackKeyMaps
+  where
+    rolledbackKeyMaps = [ rollbackedKey key oldMap' newMap' | key <- keys' ]
+
+    -- From a single key, retrieve blocks and return their difference
+    rollbackedKey
+        :: a
+        -> PrevKBlocks a
+        -> NewKBlocks a
+        -> M.Map a [HeaderHash]
+    rollbackedKey key oldMap newMap = elementsExist
+      where
+        newBlocks' :: [HeaderHash]
+        newBlocks' = getNewKBlocks newMap ^. at key . non []
+
+        existingBlocks :: [HeaderHash]
+        existingBlocks = getPrevKBlocks oldMap ^. at key . non []
+
+        elementsExist :: M.Map a [HeaderHash]
+        elementsExist = M.singleton key finalBlocks
+          where
+            -- Rollback the new blocks, remove them from the collection
+            finalBlocks :: [HeaderHash]
+            finalBlocks = existingBlocks \\ newBlocks'
+
+
+-- The repetitions can be extracted
+class (Ord k) => KeyBlocksOperation k where
+    putKeyBlocksF :: (k -> [HeaderHash] -> DB.ExplorerOp)
+    getKeyBlocksF :: (MonadDBRead m) => (k -> m (Maybe [HeaderHash]))
+
+instance KeyBlocksOperation Epoch where
+    putKeyBlocksF = DB.PutEpochBlocks
+    getKeyBlocksF = DB.getEpochBlocks
+
+instance KeyBlocksOperation Page where
+    putKeyBlocksF = DB.PutPageBlocks
+    getKeyBlocksF = DB.getPageBlocks
+
+
+-- For each (k, [v]) pair, create a database operation.
+putKeysBlocks
+    :: forall k
+     . (KeyBlocksOperation k)
+    => M.Map k [HeaderHash]
+    -> [DB.ExplorerOp]
+putKeysBlocks keysBlocks = putKeyBlocks <$> M.toList keysBlocks
+  where
+    putKeyBlocks 
+        :: (k, [HeaderHash])
+        -> DB.ExplorerOp
+    putKeyBlocks keyBlocks = putKeyBlocksF key uniqueBlocks
+      where
+        key           = keyBlocks ^. _1
+        blocks        = keyBlocks ^. _2
+        uniqueBlocks  = ordNub blocks
+
+
+-- Get exisiting key blocks paired with the key.
+getExistingBlocks
+    :: forall k m. (MonadDBRead m, KeyBlocksOperation k) 
+    => [k]
+    -> m (M.Map k [HeaderHash])
+getExistingBlocks keys = do
+    keyBlocks <- sequence [ getExistingKeyBlocks key | key <- keys ]
+    pure $ M.unions keyBlocks
+  where
+    -- Get exisiting key blocks paired with the key. If there are no
+    -- saved blocks on the key return an empty list.
+    getExistingKeyBlocks 
+        :: (MonadDBRead m)
+        => k 
+        -> m (M.Map k [HeaderHash])
+    getExistingKeyBlocks key = do
+        keyBlocks        <- getKeyBlocksF key
+        let mKeyBlocks = fromMaybe [] keyBlocks
+        pure $ M.singleton key mKeyBlocks
+
+
+-- A general @Key@ @Block@ database application for the apply call.
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+onApplyKeyBlocksGeneral
+    :: forall k ssc m.
+    (MonadBListenerT m ssc, KeyBlocksOperation k)
+    => OldestFirst NE (Blund ssc) 
+    -> (NE (Block ssc) -> M.Map k [HeaderHash])
+    -> m SomeBatchOp
+onApplyKeyBlocksGeneral blunds newBlocksMapF = do
+
+    -- Get existing @HeaderHash@es from the keys so we can merge them.
+    existingBlocks <- getExistingBlocks keys
+
+    -- Merge the new and the old
+    let mergedBlocksMap = M.unionWith (<>) existingBlocks newBlocks
+
+    -- Create database operation
+    let mergedBlocks = putKeysBlocks mergedBlocksMap
+
+    -- In the end make sure we place this under @SomeBatchOp@ in order to
+    -- preserve atomicity.
+    pure $ SomeBatchOp mergedBlocks
+  where
+
+    keys :: [k]
+    keys = M.keys newBlocks
+
+    newBlocks :: M.Map k [HeaderHash]
+    newBlocks = newBlocksMapF blocksNE
+
+    blocksNE :: NE (Block ssc)  
+    blocksNE = fst <$> getOldestFirst blunds
+
+
+-- A general @Key@ @Block@ database application for the rollback call.
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+onRollbackGeneralBlocks
+    :: forall k ssc m.
+    (MonadBListenerT m ssc, KeyBlocksOperation k)
+    => NewestFirst NE (Blund ssc) 
+    -> (NE (Block ssc) -> M.Map k [HeaderHash])
+    -> m SomeBatchOp
+onRollbackGeneralBlocks blunds newBlocksMapF = do
+    
+    -- Get existing @HeaderHash@es from the keys so we can merge them.
+    existingBlocks <- getExistingBlocks keys
+    let prevKeyBlocks = PrevKBlocks existingBlocks
+    let newKeyBlocks  = NewKBlocks  newBlocks
+
+    -- Diffrence between the new and the old
+    let mergedBlocksMap = rollbackedBlocks keys prevKeyBlocks newKeyBlocks
+
+    -- Create database operation
+    let mergedBlocks = putKeysBlocks mergedBlocksMap
+
+    -- In the end make sure we place this under @SomeBatchOp@ in order to
+    -- preserve atomicity.
+    pure $ SomeBatchOp mergedBlocks
+  where
+
+    keys :: [k]
+    keys = M.keys newBlocks
+
+    newBlocks :: M.Map k [HeaderHash]
+    newBlocks = newBlocksMapF blocksNE
+
+    blocksNE :: NE (Block ssc)  
+    blocksNE = fst <$> getNewestFirst blunds

--- a/src/Pos/Explorer/DB.hs
+++ b/src/Pos/Explorer/DB.hs
@@ -2,9 +2,13 @@
 
 module Pos.Explorer.DB
        ( ExplorerOp (..)
+       , Page
+       , Epoch
        , getTxExtra
        , getAddrHistory
        , getAddrBalance
+       , getPageBlocks
+       , getEpochBlocks
        , prepareExplorerDB
        ) where
 
@@ -15,10 +19,10 @@ import qualified Data.Map.Strict       as M
 import qualified Database.RocksDB      as Rocks
 import qualified Ether
 
-import           Pos.Binary.Class      (encode)
+import           Pos.Binary.Class      (UnsignedVarInt (..), encode)
 import           Pos.Context.Functions (GenesisUtxo, genesisUtxoM)
 import           Pos.Core              (unsafeAddCoin)
-import           Pos.Core.Types        (Address, Coin)
+import           Pos.Core.Types        (Address, Coin, HeaderHash, EpochIndex)
 import           Pos.DB                (DBTag (GStateDB), MonadDB, MonadDBRead (dbGet),
                                         RocksBatchOp (..))
 import           Pos.DB.GState.Common  (gsGetBi, gsPutBi, writeBatchGState)
@@ -26,6 +30,18 @@ import           Pos.Explorer.Core     (AddrHistory, TxExtra (..))
 import           Pos.Txp.Core          (TxId, TxOutAux (..), _TxOut)
 import           Pos.Txp.Toil          (Utxo)
 import           Pos.Util.Chrono       (NewestFirst (..))
+
+----------------------------------------------------------------------------
+-- Types
+----------------------------------------------------------------------------
+
+-- Left like type aliases in order to remain flexible.
+type Page = Int
+type Epoch = EpochIndex
+
+-- type PageBlocks = [Block SscGodTossing]
+-- ^ this is much simpler but we are trading time for space 
+-- (since space is an issue, it seems)
 
 ----------------------------------------------------------------------------
 -- Getters
@@ -40,6 +56,12 @@ getAddrHistory = fmap (NewestFirst . concat . maybeToList) .
 
 getAddrBalance :: MonadDBRead m => Address -> m (Maybe Coin)
 getAddrBalance = gsGetBi . addrBalancePrefix
+
+getPageBlocks :: MonadDBRead m => Page -> m (Maybe [HeaderHash])
+getPageBlocks = gsGetBi . blockPagePrefix
+
+getEpochBlocks :: MonadDBRead m => Epoch -> m (Maybe [HeaderHash])
+getEpochBlocks = gsGetBi . blockEpochPrefix
 
 ----------------------------------------------------------------------------
 -- Initialization
@@ -77,17 +99,32 @@ putGenesisBalances genesisUtxo =
 data ExplorerOp
     = AddTxExtra !TxId !TxExtra
     | DelTxExtra !TxId
+
+    | PutPageBlocks !Page ![HeaderHash]
+
+    | PutEpochBlocks !Epoch ![HeaderHash]
+
     | UpdateAddrHistory !Address !AddrHistory
+
     | PutAddrBalance !Address !Coin
     | DelAddrBalance !Address
 
 instance RocksBatchOp ExplorerOp where
+  
     toBatchOp (AddTxExtra id extra) =
         [Rocks.Put (txExtraPrefix id) (encode extra)]
     toBatchOp (DelTxExtra id) =
         [Rocks.Del $ txExtraPrefix id]
+    
+    toBatchOp (PutPageBlocks page pageBlocks) =
+        [Rocks.Put (blockPagePrefix page) (encode pageBlocks)]
+
+    toBatchOp (PutEpochBlocks epoch pageBlocks) =
+        [Rocks.Put (blockEpochPrefix epoch) (encode pageBlocks)]
+
     toBatchOp (UpdateAddrHistory addr txs) =
         [Rocks.Put (addrHistoryPrefix addr) (encode txs)]
+
     toBatchOp (PutAddrBalance addr coin) =
         [Rocks.Put (addrBalancePrefix addr) (encode coin)]
     toBatchOp (DelAddrBalance addr) =
@@ -105,3 +142,11 @@ addrHistoryPrefix addr = "e/ah/" <> encode addr
 
 addrBalancePrefix :: Address -> ByteString
 addrBalancePrefix addr = "e/ab/" <> encode addr
+
+blockPagePrefix :: Page -> ByteString
+blockPagePrefix page = "e/page/" <> encodedPage
+  where
+    encodedPage = encode $ UnsignedVarInt page
+
+blockEpochPrefix :: Epoch -> ByteString
+blockEpochPrefix epoch = "e/epoch/" <> encode epoch

--- a/src/Pos/Wallet/Web/BListener.hs
+++ b/src/Pos/Wallet/Web/BListener.hs
@@ -22,7 +22,8 @@ import           Pos.Block.BListener        (MonadBListener (..))
 import           Pos.Block.Core             (mainBlockTxPayload)
 import           Pos.Block.Types            (Blund, undoTx)
 import           Pos.Core                   (HeaderHash, headerHash, prevBlockL)
-import           Pos.DB.Class               (MonadDBRead, MonadRealDB)
+import           Pos.DB.Class               (MonadRealDB, MonadDBRead)
+import           Pos.DB.BatchOp             (SomeBatchOp)
 import           Pos.Ssc.Class.Helpers      (SscHelpersClass)
 import           Pos.Txp.Core               (TxAux, TxUndo, flattenTxPayload)
 import           Pos.Txp.Toil               (evalToilTEmpty, runDBToil)
@@ -46,11 +47,15 @@ onApplyTracking
     , MonadRealDB m
     , MonadDBRead m
     )
-    => OldestFirst NE (Blund ssc) -> m ()
+    => OldestFirst NE (Blund ssc) -> m SomeBatchOp
 onApplyTracking blunds = do
     let txs = concatMap (gbTxs . fst) $ getOldestFirst blunds
     let newTip = headerHash $ NE.last $ getOldestFirst blunds
     mapM_ (syncWalletSet newTip txs) =<< WS.getWalletAddresses
+    
+    -- It's silly, but when the wallet is migrated to RocksDB, we can write
+    -- something a bit more reasonable.
+    pure mempty
   where
     syncWalletSet :: HeaderHash -> [TxAux] -> CId Wal -> m ()
     syncWalletSet newTip txs wAddr = do
@@ -71,11 +76,15 @@ onRollbackTracking
     , AccountMode m
     , WithLogger m
     )
-    => NewestFirst NE (Blund ssc) -> m ()
+    => NewestFirst NE (Blund ssc) -> m SomeBatchOp
 onRollbackTracking blunds = do
     let txs = concatMap (reverse . blundTxUn) $ getNewestFirst blunds
     let newTip = (NE.last $ getNewestFirst blunds) ^. prevBlockL
     mapM_ (syncWalletSet newTip txs) =<< WS.getWalletAddresses
+
+    -- It's silly, but when the wallet is migrated to RocksDB, we can write
+    -- something a bit more reasonable.
+    pure mempty
   where
     syncWalletSet :: HeaderHash -> [(TxAux, TxUndo)] -> CId Wal -> m ()
     syncWalletSet newTip txs wAddr = do


### PR DESCRIPTION
Merge to master, resolve conflicts.
I'm guessing switching from `encodeString` to `encode` has some benefits (lazy behavior, so memory usage?) but don't really know what they are.