### PR TITLE
[CSL-1312] Fix tx mempool (0.5-rc)

### DIFF
--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- | Framework for Inv\/Req\/Data message handling
 
@@ -29,13 +29,13 @@ module Pos.Communication.Relay.Logic
 
 import           Control.Concurrent.STM             (isFullTBQueue, readTBQueue,
                                                      writeTBQueue)
-import           Data.Aeson.TH                      (deriveJSON, defaultOptions)
+import           Data.Aeson.TH                      (defaultOptions, deriveJSON)
 import           Data.Proxy                         (asProxyTypeOf)
 import           Data.Tagged                        (Tagged, tagWith)
 import           Data.Typeable                      (typeRep)
 import           Formatting                         (build, sformat, shown, stext, (%))
 import           Mockable                           (Mockable, MonadMockable, Throw,
-                                                     handleAll, throw, throw, currentTime)
+                                                     currentTime, handleAll, throw, throw)
 import           Node.Message                       (Message)
 import           Paths_cardano_sl_infra             (version)
 import           System.Wlog                        (WithLogger, logDebug, logError,
@@ -65,8 +65,8 @@ import           Pos.Communication.Relay.Types      (PropagationMsg (..),
                                                      RelayContext (..))
 import           Pos.Communication.Relay.Util       (expectData, expectInv)
 import           Pos.Communication.Types.Relay      (DataMsg (..), InvMsg (..), InvOrData,
-                                                     MempoolMsg (..), ReqMsg (..),
-                                                     RelayLogEvent (..))
+                                                     MempoolMsg (..), RelayLogEvent (..),
+                                                     ReqMsg (..))
 import           Pos.DB.Class                       (MonadGState)
 import           Pos.Discovery.Broadcast            (converseToNeighbors)
 import           Pos.Discovery.Class                (MonadDiscovery)
@@ -128,21 +128,18 @@ handleMempoolL
     -> [(ListenerSpec m, OutSpecs)]
 handleMempoolL NoMempool = []
 handleMempoolL (KeyMempool tagP handleMempool) = pure $ listenerConv $ \__ourVerInfo ->
-  SizedCAHandler $ \__nodeId conv ->
-      let handlingLoop = do
-              mbMsg <- fmap (withLimitedLength' $ convToSProxy conv) <$> recv conv
-              whenJust mbMsg $ \msg@MempoolMsg -> do
-                  let _ = msg `asProxyTypeOf` mmP
-                  res <- handleMempool
-                  case nonEmpty res of
-                      Nothing ->
-                          logDebug $ sformat
-                              ("We don't have mempool data "%shown) (typeRep tagP)
-                      Just xs -> do
-                          logDebug $ sformat ("We have mempool data "%shown) (typeRep tagP)
-                          mapM_ (send conv . InvMsg) xs
-                  handlingLoop
-       in handlingLoop
+  SizedCAHandler $ \__nodeId conv -> do
+      mbMsg <- fmap (withLimitedLength' $ convToSProxy conv) <$> recv conv
+      whenJust mbMsg $ \msg@MempoolMsg -> do
+          let _ = msg `asProxyTypeOf` mmP
+          res <- handleMempool
+          case nonEmpty res of
+              Nothing ->
+                  logDebug $ sformat
+                      ("We don't have mempool data "%shown) (typeRep tagP)
+              Just xs -> do
+                  logDebug $ sformat ("We have mempool data "%shown) (typeRep tagP)
+                  mapM_ (send conv . InvMsg) xs
   where
     mmP = (const Proxy :: Proxy tag -> Proxy (MempoolMsg tag)) tagP
 


### PR DESCRIPTION
Bug was really stupid: code was written as copypaste of invReq listener, however it makes no sense for mempool. We didn't return anything (and ogic was that we simply close connection), but instead of closing we just waited for next `MempoolMsg`