### PR TITLE
Port more EKG stuff

### DIFF
--- a/src/Pos/Block/Logic/Creation.hs
+++ b/src/Pos/Block/Logic/Creation.hs
@@ -244,7 +244,7 @@ createMainBlockFinish slotId pske prevHeader = do
         verifyBlocksPrefix (one (Right block)) >>=
         either onFailure (const onSuccess)
     clearMempools = do
-        clearTxpMemPool
+        clearTxpMemPool "createMainBlockFinish"
         sscResetLocal
         clearUSMemPool
         lift $ clearDlgMemPool

--- a/src/Pos/Explorer/Txp/Local.hs
+++ b/src/Pos/Explorer/Txp/Local.hs
@@ -97,7 +97,7 @@ eTxProcessTransaction itw@(txId, TxAux {taTx = UnsafeTx {..}}) = do
     -- with data to update. In case of `TxExtra` data is only added, but never updated,
     -- hence `mempty` here.
     let eet = ExplorerExtraTxp mempty hmHistories hmBalances
-    pRes <- modifyTxpLocalData $
+    pRes <- modifyTxpLocalData "eTxProcessTransaction" $
             processTxDo resolved toilEnv tipBefore itw curTime eet
     case pRes of
         Left er -> do
@@ -156,4 +156,4 @@ eTxNormalize = do
         runDBTxp $
         snd <$>
         runToilTLocalExtra mempty def mempty def (eNormalizeToil toNormalize)
-    setTxpLocalData (_tmUtxo, _tmMemPool, _tmUndos, utxoTip, _tmExtra)
+    setTxpLocalData "eTxNormalize" (_tmUtxo, _tmMemPool, _tmUndos, utxoTip, _tmExtra)

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -31,7 +31,6 @@ import           Control.Lens                    (each, to, _tail)
 import           Control.Monad.Fix               (MonadFix)
 import           Data.Default                    (def)
 import           Data.Tagged                     (Tagged (..), untag)
-import           Data.Text                       (pack)
 import qualified Data.Time                       as Time
 import qualified Ether
 import           Formatting                      (build, sformat, shown, (%))
@@ -215,10 +214,10 @@ runRealModeDo discoveryCtx transport np@NodeParams {..} sscnp listeners outSpecs
         --   fdef06b1ace22e9d91c5a81f7902eb5d4b6eb44f
         -- for flexible EKG setup.
         ekgStore <- liftIO $ Metrics.newStore
-        ekgMemPoolSize <- liftIO $ Metrics.createGauge (pack "MemPoolSize") ekgStore
-        ekgMemPoolWaitTime <- liftIO $ Metrics.createGauge (pack "MemPoolWaitTime") ekgStore
-        ekgMemPoolModifyTime <- liftIO $ Metrics.createGauge (pack "MemPoolModifyTime") ekgStore
-        ekgMemPoolQueueLength <- liftIO $ Metrics.createGauge (pack "MemPoolQueueLength") ekgStore
+        ekgMemPoolSize <- liftIO $ Metrics.createGauge "MemPoolSize" ekgStore
+        ekgMemPoolWaitTime <- liftIO $ Metrics.createGauge "MemPoolWaitTime" ekgStore
+        ekgMemPoolModifyTime <- liftIO $ Metrics.createGauge "MemPoolModifyTime" ekgStore
+        ekgMemPoolQueueLength <- liftIO $ Metrics.createGauge "MemPoolQueueLength" ekgStore
 
         -- An exponential moving average is used for the time gauges (wait
         -- and modify durations). The parameter alpha is chosen somewhat

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -31,6 +31,7 @@ import           Control.Lens                    (each, to, _tail)
 import           Control.Monad.Fix               (MonadFix)
 import           Data.Default                    (def)
 import           Data.Tagged                     (Tagged (..), untag)
+import           Data.Text                       (pack)
 import qualified Data.Time                       as Time
 import qualified Ether
 import           Formatting                      (build, sformat, shown, (%))
@@ -50,6 +51,8 @@ import           Node                            (Node, NodeAction (..), NodeEnd
 import           Node.Util.Monitor               (setupMonitor, stopMonitor)
 import qualified STMContainers.Map               as SM
 import qualified System.Metrics                  as Metrics
+import qualified System.Metrics.Distribution     as Metrics.Distr
+import qualified System.Metrics.Gauge            as Metrics.Gauge
 import           System.Random                   (newStdGen)
 import qualified System.Remote.Monitoring        as Monitoring
 import qualified System.Remote.Monitoring.Statsd as Monitoring
@@ -102,7 +105,7 @@ import           Pos.Statistics                  (EkgParams (..), StatsdParams (
 import           Pos.Txp                         (mkTxpLocalData)
 import           Pos.Txp.DB                      (genesisFakeTotalStake,
                                                   runBalanceIterBootstrap)
-import           Pos.Txp.MemState                (TxpHolderTag)
+import           Pos.Txp.MemState                (TxpHolderTag, TxpMetrics(..))
 #ifdef WITH_EXPLORER
 import           Pos.Explorer                    (explorerTxpGlobalSettings)
 #else
@@ -201,6 +204,31 @@ runRealModeDo discoveryCtx transport np@NodeParams {..} sscnp listeners outSpecs
         ntpSlottingVar <- mkNtpSlottingVar
         dlgVar <- RWV.new def
 
+        -- EKG monitoring stuff.
+        --
+        -- Relevant even if monitoring is turned off (no port given). The
+        -- gauge and distribution can be sampled by the server dispatcher
+        -- and used to inform a policy for delaying the next receive event.
+        --
+        -- TODO implement this. Requires time-warp-nt commit
+        --   275c16b38a715264b0b12f32c2f22ab478db29e9
+        -- in addition to the non-master
+        --   fdef06b1ace22e9d91c5a81f7902eb5d4b6eb44f
+        -- for flexible EKG setup.
+        ekgStore <- liftIO $ Metrics.newStore
+        ekgMemPoolGauge <- liftIO $ Metrics.createGauge (pack "MemPoolSize") ekgStore
+        ekgMemPoolDistr <- liftIO $ Metrics.createDistribution (pack "MemPoolTime") ekgStore
+        let txpMetrics = TxpMetrics
+                { txpMetricsMemPoolSize =
+                      ( fromIntegral <$> Metrics.Gauge.read ekgMemPoolGauge
+                      , Metrics.Gauge.set ekgMemPoolGauge . fromIntegral
+                      )
+                , txpMetricsModifyTime =
+                      ( round . Metrics.Distr.mean <$> Metrics.Distr.read ekgMemPoolDistr
+                      , Metrics.Distr.add ekgMemPoolDistr . fromIntegral
+                      )
+                }
+
         -- TODO [CSL-775] need an effect-free way of running this into IO.
         let runIO :: forall t . RealMode ssc t -> IO t
             runIO (RealMode act) =
@@ -213,7 +241,7 @@ runRealModeDo discoveryCtx transport np@NodeParams {..} sscnp listeners outSpecs
                       , Tagged @SlottingVar slottingVar
                       , Tagged @(Bool, NtpSlottingVar) (npUseNTP, ntpSlottingVar)
                       , Tagged @SscMemTag bottomSscState
-                      , Tagged @TxpHolderTag txpVar
+                      , Tagged @TxpHolderTag (txpVar, txpMetrics)
                       , Tagged @DelegationVar dlgVar
                       , Tagged @PeerStateTag stateM_
                       ) .
@@ -243,7 +271,7 @@ runRealModeDo discoveryCtx transport np@NodeParams {..} sscnp listeners outSpecs
                , Tagged @SlottingVar slottingVar
                , Tagged @(Bool, NtpSlottingVar) (npUseNTP, ntpSlottingVar)
                , Tagged @SscMemTag sscState
-               , Tagged @TxpHolderTag txpVar
+               , Tagged @TxpHolderTag (txpVar, txpMetrics)
                , Tagged @DelegationVar dlgVar
                , Tagged @PeerStateTag stateM
                ) .
@@ -256,17 +284,15 @@ runRealModeDo discoveryCtx transport np@NodeParams {..} sscnp listeners outSpecs
            runGStateCoreRedirect .
            runBListenerStub .
             (\(RealMode m) -> m) .
-            runServer (simpleNodeEndPoint transport) (const noReceiveDelay) listeners outSpecs (startMonitoring runIO) stopMonitoring . ActionSpec $
+            runServer (simpleNodeEndPoint transport) (const noReceiveDelay) listeners outSpecs (startMonitoring ekgStore runIO) stopMonitoring . ActionSpec $
                \vI sa -> nodeStartMsg npBaseParams >> action vI sa
-
   where
     LoggingParams {..} = bpLoggingParams npBaseParams
 
-    startMonitoring (runIO :: forall t . RealMode ssc t -> IO t) node' =
+    startMonitoring ekgStore (runIO :: forall t . RealMode ssc t -> IO t) node' =
         case npEnableMetrics of
             False -> return Nothing
             True -> Just <$> do
-                ekgStore <- liftIO $ Metrics.newStore
                 ekgStore' <- setupMonitor runIO node' ekgStore
                 liftIO $ Metrics.registerGcMetrics ekgStore'
                 mEkgServer <- case npEkgParams of

--- a/src/Pos/Wallet/Web/Server/Full/Common.hs
+++ b/src/Pos/Wallet/Web/Server/Full/Common.hs
@@ -38,7 +38,7 @@ import           Pos.Slotting.Ntp              (runSlotsRedirect)
 import           Pos.Ssc.Extra                 (SscMemTag, SscState)
 import           Pos.Ssc.Extra.Class           (askSscMem)
 import           Pos.Txp                       (GenericTxpLocalData, TxpHolderTag,
-                                                askTxpMem)
+                                                askTxpMem, ignoreTxpMetrics)
 import           Pos.Wallet.Redirect           (runWalletRedirects)
 import           Pos.Util.TimeWarp             (runWithoutJsonLogT)
 import           Pos.Wallet.SscType            (WalletSscType)
@@ -99,7 +99,7 @@ convertHandler nc modernDBs tlw ssc ws delWrap psCtx
                    , Tagged @SlottingVar slotVar
                    , Tagged @(Bool, NtpSlottingVar) ntpSlotVar
                    , Tagged @SscMemTag ssc
-                   , Tagged @TxpHolderTag tlw
+                   , Tagged @TxpHolderTag (tlw, ignoreTxpMetrics)
                    , Tagged @DelegationVar delWrap
                    , Tagged @PeerStateTag peerStateCtx
                    ))

--- a/src/Pos/Web/Server.hs
+++ b/src/Pos/Web/Server.hs
@@ -41,8 +41,9 @@ import qualified Pos.Lrc.DB                           as LrcDB
 import           Pos.Ssc.Class                        (SscConstraint)
 import           Pos.Ssc.GodTossing                   (SscGodTossing, gtcParticipateSsc)
 import           Pos.Txp                              (TxOut (..), toaOut)
-import           Pos.Txp.MemState                     (GenericTxpLocalData, TxpHolderTag,
-                                                       askTxpMem, getLocalTxs)
+import           Pos.Txp.MemState                     (GenericTxpLocalData, TxpMetrics,
+                                                       TxpHolderTag, askTxpMem,
+                                                       getLocalTxs, ignoreTxpMetrics)
 import           Pos.Types                            (EpochIndex (..), SlotLeaders)
 import           Pos.WorkMode.Class                   (TxpExtra_TMP, WorkMode)
 
@@ -93,7 +94,7 @@ type WebHandler ssc =
     DBPureRedirect $
     Ether.ReadersT
         ( Tagged DB.NodeDBs DB.NodeDBs
-        , Tagged TxpHolderTag (GenericTxpLocalData TxpExtra_TMP)
+        , Tagged TxpHolderTag (GenericTxpLocalData TxpExtra_TMP, TxpMetrics)
         ) (
     Ether.ReadersT (NodeContext ssc) Production
     )
@@ -110,7 +111,7 @@ convertHandler nc nodeDBs wrap handler =
             flip Ether.runReadersT nc .
             flip Ether.runReadersT
               ( Tagged @DB.NodeDBs nodeDBs
-              , Tagged @TxpHolderTag wrap
+              , Tagged @TxpHolderTag (wrap, ignoreTxpMetrics)
               ) .
             runDBPureRedirect $
             handler)

--- a/src/Pos/WorkMode.hs
+++ b/src/Pos/WorkMode.hs
@@ -50,7 +50,8 @@ import           Pos.Slotting.MemState.Holder   (SlotsDataRedirect)
 import           Pos.Slotting.Ntp               (NtpSlottingVar, SlotsRedirect)
 import           Pos.Ssc.Class.Helpers          (SscHelpersClass)
 import           Pos.Ssc.Extra                  (SscMemTag, SscState)
-import           Pos.Txp.MemState               (GenericTxpLocalData, TxpHolderTag)
+import           Pos.Txp.MemState               (GenericTxpLocalData, TxpHolderTag,
+                                                 TxpMetrics)
 import           Pos.Types                      (HeaderHash)
 import           Pos.Util.Util                  (PowerLift (..))
 import           Pos.Util.TimeWarp              (JsonLogT, CanJsonLog (..))
@@ -75,7 +76,7 @@ type RealMode' ssc =
         , Tagged SlottingVar SlottingVar
         , Tagged (Bool, NtpSlottingVar) (Bool, NtpSlottingVar)
         , Tagged SscMemTag (SscState ssc)
-        , Tagged TxpHolderTag (GenericTxpLocalData TxpExtra_TMP)
+        , Tagged TxpHolderTag (GenericTxpLocalData TxpExtra_TMP, TxpMetrics)
         , Tagged DelegationVar DelegationVar
         , Tagged PeerStateTag (PeerStateCtx Production)
         ) (

--- a/txp/Pos/Txp/Logic/Local.hs
+++ b/txp/Pos/Txp/Logic/Local.hs
@@ -60,7 +60,7 @@ txProcessTransaction itw@(txId, txAux) = do
                    catMaybes $
                    toList $
                    NE.zipWith (liftM2 (,) . Just) _txInputs resolvedOuts
-    pRes <- modifyTxpLocalData $
+    pRes <- modifyTxpLocalData "txProcessTransaction" $
             processTxDo resolved toilEnv tipDB itw
     case pRes of
         Left er -> do
@@ -101,4 +101,4 @@ txNormalize = do
     localTxs <- getLocalTxs
     ToilModifier {..} <-
         runDBTxp $ execToilTLocal mempty def mempty $ normalizeToil localTxs
-    setTxpLocalData (_tmUtxo, _tmMemPool, _tmUndos, utxoTip, _tmExtra)
+    setTxpLocalData "txNormalize" (_tmUtxo, _tmMemPool, _tmUndos, utxoTip, _tmExtra)

--- a/txp/Pos/Txp/MemState/Class.hs
+++ b/txp/Pos/Txp/MemState/Class.hs
@@ -28,19 +28,29 @@ import           Data.Default           (Default (def))
 import qualified Data.HashMap.Strict    as HM
 import qualified Ether
 import           System.IO.Unsafe       (unsafePerformIO)
+import           System.Wlog            (WithLogger, logDebug)
+import           Formatting             (sformat, (%), shown)
 
 import           Pos.Txp.Core.Types     (TxAux, TxId, TxOutAux)
 import           Pos.Txp.MemState.Types (GenericTxpLocalData (..),
-                                         GenericTxpLocalDataPure)
-import           Pos.Txp.Toil.Types     (MemPool (_mpLocalTxs), UtxoModifier)
+                                         GenericTxpLocalDataPure,
+                                         TxpMetrics (..))
+import           Pos.Txp.Toil.Types     (MemPool (..), UtxoModifier)
+import           Pos.Util.TimeWarp      (currentTime)
 
 data TxpHolderTag
 
 -- | Reduced equivalent of @MonadReader (GenericTxpLocalData mw) m@.
-type MonadTxpMem ext = Ether.MonadReader TxpHolderTag (GenericTxpLocalData ext)
+type MonadTxpMem ext m =
+    ( Ether.MonadReader TxpHolderTag (GenericTxpLocalData ext, TxpMetrics) m
+    , WithLogger m
+    )
 
 askTxpMem :: MonadTxpMem ext m => m (GenericTxpLocalData ext)
-askTxpMem = Ether.ask @TxpHolderTag
+askTxpMem = fst <$> Ether.ask @TxpHolderTag
+
+askTxpMemAndMetrics :: MonadTxpMem ext m => m (GenericTxpLocalData ext, TxpMetrics)
+askTxpMemAndMetrics = Ether.ask @TxpHolderTag
 
 getTxpLocalData
     :: (MonadIO m, MonadTxpMem e m)
@@ -84,19 +94,27 @@ modifyTxpLocalData
     :: (MonadIO m, MonadBaseControl IO m, MonadTxpMem ext m)
     => (GenericTxpLocalDataPure ext -> (a, GenericTxpLocalDataPure ext)) -> m a
 modifyTxpLocalData f =
-    askTxpMem >>= \TxpLocalData{..} -> withLock . atomically $ do
-        curUM  <- STM.readTVar txpUtxoModifier
-        curMP  <- STM.readTVar txpMemPool
-        curUndos <- STM.readTVar txpUndos
-        curTip <- STM.readTVar txpTip
-        curExtra <- STM.readTVar txpExtra
-        let (res, (newUM, newMP, newUndos, newTip, newExtra))
-              = f (curUM, curMP, curUndos, curTip, curExtra)
-        STM.writeTVar txpUtxoModifier newUM
-        STM.writeTVar txpMemPool newMP
-        STM.writeTVar txpUndos newUndos
-        STM.writeTVar txpTip newTip
-        STM.writeTVar txpExtra newExtra
+    askTxpMemAndMetrics >>= \(TxpLocalData{..}, TxpMetrics{..}) -> withLock $ do
+        beginTime <- currentTime
+        !(res, !newSize) <- atomically $ do
+            curUM  <- STM.readTVar txpUtxoModifier
+            curMP  <- STM.readTVar txpMemPool
+            curUndos <- STM.readTVar txpUndos
+            curTip <- STM.readTVar txpTip
+            curExtra <- STM.readTVar txpExtra
+            let (res, (newUM, newMP, newUndos, newTip, newExtra))
+                  = f (curUM, curMP, curUndos, curTip, curExtra)
+            STM.writeTVar txpUtxoModifier newUM
+            STM.writeTVar txpMemPool newMP
+            STM.writeTVar txpUndos newUndos
+            STM.writeTVar txpTip newTip
+            STM.writeTVar txpExtra newExtra
+            pure (res, _mpSize newMP)
+        endTime <- currentTime
+        let duration = endTime - beginTime
+        logDebug $ sformat ("modifyTxpLocalData took " % shown) duration
+        liftIO $ snd txpMetricsMemPoolSize newSize
+        liftIO $ snd txpMetricsModifyTime duration
         pure res
  where
    withLock = L.bracket_ (takeMVar txpLocalDataLock) (putMVar txpLocalDataLock ())

--- a/txp/Pos/Txp/MemState/Metrics.hs
+++ b/txp/Pos/Txp/MemState/Metrics.hs
@@ -1,0 +1,68 @@
+module Pos.Txp.MemState.Metrics
+    ( ignoreTxpMetrics
+    , recordTxpMetrics
+    ) where
+
+import           Formatting                      (sformat, shown, (%))
+import qualified System.Metrics                  as Metrics
+import qualified System.Metrics.Gauge            as Metrics.Gauge
+import           System.Wlog                     (logDebug)
+import           Universum
+
+import           Pos.Txp.MemState.Types          (TxpMetrics(..))
+
+-- | A TxpMetrics that never does any writes. Use it if you don't care about
+-- metrics.
+ignoreTxpMetrics :: TxpMetrics
+ignoreTxpMetrics = TxpMetrics
+    { txpMetricsWait = (const (pure ()))
+    , txpMetricsAcquire = (const (pure ()))
+    , txpMetricsRelease = (const (const (pure ())))
+    }
+
+-- | Record MemPool metrics.
+recordTxpMetrics :: Metrics.Store -> IO TxpMetrics
+recordTxpMetrics ekgStore = do
+    ekgMemPoolSize        <- Metrics.createGauge "MemPoolSize" ekgStore
+    ekgMemPoolWaitTime    <- Metrics.createGauge "MemPoolWaitTime" ekgStore
+    ekgMemPoolModifyTime  <- Metrics.createGauge "MemPoolModifyTime" ekgStore
+    ekgMemPoolQueueLength <- Metrics.createGauge "MemPoolQueueLength" ekgStore
+
+    -- An exponential moving average is used for the time gauges (wait
+    -- and modify durations). The parameter alpha is chosen somewhat
+    -- arbitrarily.
+    -- FIXME take alpha from configuration/CLI, or use a better
+    -- estimator.
+    let alpha :: Double
+        alpha = 0.75
+
+    -- This TxpMetrics specifies what to do when waiting on the
+    -- mempool lock, when the mempool lock has been granted, and
+    -- when that lock has been released. It updates EKG metrics
+    -- and also logs each data point at debug level.
+    pure TxpMetrics
+        { txpMetricsWait = \reason -> do
+              liftIO $ Metrics.Gauge.inc ekgMemPoolQueueLength
+              qlen <- liftIO $ Metrics.Gauge.read ekgMemPoolQueueLength
+              logDebug $ sformat ("MemPool metrics wait: "%shown%" queue length is "%shown) reason qlen
+
+        , txpMetricsAcquire = \timeWaited -> do
+              liftIO $ Metrics.Gauge.dec ekgMemPoolQueueLength
+              timeWaited' <- liftIO $ Metrics.Gauge.read ekgMemPoolWaitTime
+              -- Assume a 0-value estimate means we haven't taken
+              -- any samples yet.
+              let new_ = if timeWaited' == 0
+                        then fromIntegral timeWaited
+                        else round $ alpha * fromIntegral timeWaited + (1 - alpha) * fromIntegral timeWaited'
+              liftIO $ Metrics.Gauge.set ekgMemPoolWaitTime new_
+              logDebug $ sformat ("MemPool metrics acquire: wait time was "%shown) timeWaited
+
+        , txpMetricsRelease = \timeElapsed memPoolSize -> do
+              liftIO $ Metrics.Gauge.set ekgMemPoolSize (fromIntegral memPoolSize)
+              timeElapsed' <- liftIO $ Metrics.Gauge.read ekgMemPoolModifyTime
+              let new_ = if timeElapsed' == 0
+                        then fromIntegral timeElapsed
+                        else round $ alpha * fromIntegral timeElapsed + (1 - alpha) * fromIntegral timeElapsed'
+              liftIO $ Metrics.Gauge.set ekgMemPoolModifyTime new_
+              logDebug $ sformat ("MemPool metrics release: modify time was "%shown%" size is "%shown) timeElapsed memPoolSize
+        }

--- a/txp/Pos/Txp/MemState/Types.hs
+++ b/txp/Pos/Txp/MemState/Types.hs
@@ -16,6 +16,7 @@ module Pos.Txp.MemState.Types
 import           Data.Aeson.TH      (deriveJSON, defaultOptions)
 import           Universum
 import           Data.Time.Units        (Microsecond)
+import           System.Wlog            (LoggerNameBox)
 
 import           Pos.Core.Types     (HeaderHash)
 import           Pos.Communication.Types.Protocol (PeerId)
@@ -76,20 +77,21 @@ $(deriveJSON defaultOptions ''MemPoolModifyReason)
 --   mockable system doesn't work well with ether.
 data TxpMetrics = TxpMetrics
     { -- | Called when a thread begins to wait to modify the mempool.
-      txpMetricsWait :: !(IO ())
+      --   Parameter is the reason for modifying the mempool.
+      txpMetricsWait :: !(String -> LoggerNameBox IO ())
       -- | Called when a thread is granted the lock on the mempool. Parameter
       --   indicates how long it waited.
-    , txpMetricsAcquire :: !(Microsecond -> IO ())
+    , txpMetricsAcquire :: !(Microsecond -> LoggerNameBox IO ())
       -- | Called when a thread is finished modifying the mempool and has
       --   released the lock. Parameters indicates time elapsed since acquiring
       --   the lock, and new mempool size.
-    , txpMetricsRelease :: !(Microsecond -> Byte -> IO ())
+    , txpMetricsRelease :: !(Microsecond -> Byte -> LoggerNameBox IO ())
     }
 
 -- | A TxpMetrics never does any writes. Use it if you don't care about metrics.
 ignoreTxpMetrics :: TxpMetrics
 ignoreTxpMetrics = TxpMetrics
-    { txpMetricsWait = (pure ())
+    { txpMetricsWait = (const (pure ()))
     , txpMetricsAcquire = (const (pure ()))
     , txpMetricsRelease = (const (const (pure ())))
     }

--- a/txp/Pos/Txp/MemState/Types.hs
+++ b/txp/Pos/Txp/MemState/Types.hs
@@ -10,7 +10,6 @@ module Pos.Txp.MemState.Types
        , TransactionProvenance (..)
        , MemPoolModifyReason (..)
        , TxpMetrics (..)
-       , ignoreTxpMetrics
        ) where
 
 import           Data.Aeson.TH      (deriveJSON, defaultOptions)
@@ -86,12 +85,4 @@ data TxpMetrics = TxpMetrics
       --   released the lock. Parameters indicates time elapsed since acquiring
       --   the lock, and new mempool size.
     , txpMetricsRelease :: !(Microsecond -> Byte -> LoggerNameBox IO ())
-    }
-
--- | A TxpMetrics never does any writes. Use it if you don't care about metrics.
-ignoreTxpMetrics :: TxpMetrics
-ignoreTxpMetrics = TxpMetrics
-    { txpMetricsWait = (const (pure ()))
-    , txpMetricsAcquire = (const (pure ()))
-    , txpMetricsRelease = (const (const (pure ())))
     }

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -44,6 +44,7 @@ library
     Pos.Txp.MemState
     Pos.Txp.MemState.Class
     Pos.Txp.MemState.Holder
+    Pos.Txp.MemState.Metrics
     Pos.Txp.MemState.Types
 
     Pos.Txp.Settings
@@ -66,6 +67,7 @@ library
                      , containers
                      , data-default
                      , derive
+                     , ekg-core
                      , ether
                      , formatting
                      , hashable

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -83,6 +83,7 @@ library
                      , template-haskell
                      , text
                      , text-format
+                     , time-units
                      , transformers
                      , universum
                      , unordered-containers


### PR DESCRIPTION
Ports the following:
- 3c5f59b4037ee71ce168279c94e50223ca30175c
- 25c83d7b09935fd5194ed37bf93cf0b4c721c81c
- 9cad0c00bebba638002e8cbe59ab29356b4d8195

For the record, subsequent related patches (I think):
- 7db4653736e759f5bcd0c5be357c7e67a6736553
- da6250fc87cc5d731a99050e4efe9069c4fd6579
- 72d219b2e3f7590a92e23b52494964946b5465e0
- b549bd139c35f6ebf2658e02047317322da84f22

But these deal with JSON logging and trying to incorporate these currently leads to circular dependency (as json logging is in cardano-sl, cardano-sl depends on cardano-sl-txp, but cardano-sl-txp also wants to log).