### PR TITLE
[CSL-1326] Fix 'verifyNextBVMod'

### DIFF
--- a/update/Pos/Update/Poll/Logic/Base.hs
+++ b/update/Pos/Update/Poll/Logic/Base.hs
@@ -240,7 +240,7 @@ verifyNextBVMod upId
   BlockVersionModifier { bvmScriptVersion = newSV
                        , bvmMaxBlockSize = newMBS
                        }
-    | newSV /= oldSV + 1 =
+    | newSV /= oldSV + 1 && newSV /= oldSV =
         throwError
             PollWrongScriptVersion
             { pwsvAdopted = oldSV


### PR DESCRIPTION
There we check that proposed script version is greater than the adopted one by
one.
That was our initial understanding, but recently George Agapov told us that
it's also legal to have the same script version as the adopted one.