### PR TITLE
[CSM-353] Remove history cache when deleting wallet

### DIFF
--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -145,7 +145,8 @@ import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Exis
                                                    getWAddressIds, getWalletAddresses,
                                                    getWalletMeta, getWalletPassLU,
                                                    isCustomAddress, openState,
-                                                   removeAccount, removeNextUpdate,
+                                                   removeAccount, removeHistoryCache,
+                                                   removeNextUpdate, removeTxMetas,
                                                    removeWallet, setAccountMeta,
                                                    setProfile, setWalletMeta,
                                                    setWalletPassLU, setWalletTxMeta,
@@ -836,6 +837,8 @@ deleteWallet wid = do
     accounts <- getAccounts (Just wid)
     mapM_ (\acc -> deleteAccount =<< decodeCAccountIdOrFail (caId acc)) accounts
     removeWallet wid
+    removeTxMetas wid
+    removeHistoryCache wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
 
 deleteAccount :: WalletWebMode m => AccountId -> m ()

--- a/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/src/Pos/Wallet/Web/State/Acidic.hs
@@ -47,6 +47,8 @@ module Pos.Wallet.Web.State.Acidic
        , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
        , RemoveWallet (..)
+       , RemoveTxMetas (..)
+       , RemoveHistoryCache (..)
        , RemoveAccount (..)
        , RemoveWAddress (..)
        , RemoveCustomAddress (..)
@@ -130,6 +132,8 @@ makeAcidic ''WalletStorage
     , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta
     , 'WS.removeWallet
+    , 'WS.removeTxMetas
+    , 'WS.removeHistoryCache
     , 'WS.removeAccount
     , 'WS.removeWAddress
     , 'WS.totallyRemoveWAddress

--- a/src/Pos/Wallet/Web/State/State.hs
+++ b/src/Pos/Wallet/Web/State/State.hs
@@ -51,6 +51,8 @@ module Pos.Wallet.Web.State.State
        , setWalletTxHistory
        , addOnlyNewTxMeta
        , removeWallet
+       , removeTxMetas
+       , removeHistoryCache
        , removeAccount
        , removeWAddress
        , removeCustomAddress
@@ -209,6 +211,12 @@ addOnlyNewTxMeta cWalId cTxId = updateDisk . A.AddOnlyNewTxMeta cWalId cTxId
 
 removeWallet :: WebWalletModeDB m => CId Wal -> m ()
 removeWallet = updateDisk . A.RemoveWallet
+
+removeTxMetas :: WebWalletModeDB m => CId Wal -> m ()
+removeTxMetas = updateDisk . A.RemoveTxMetas
+
+removeHistoryCache :: WebWalletModeDB m => CId Wal -> m ()
+removeHistoryCache = updateDisk . A.RemoveHistoryCache
 
 removeAccount :: WebWalletModeDB m => AccountId -> m ()
 removeAccount = updateDisk . A.RemoveAccount

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -44,6 +44,8 @@ module Pos.Wallet.Web.State.Storage
        , addOnlyNewTxMeta
        , setWalletTxMeta
        , removeWallet
+       , removeTxMetas
+       , removeHistoryCache
        , removeAccount
        , removeWAddress
        , totallyRemoveWAddress
@@ -312,6 +314,12 @@ setWalletTxMeta cWalId cTxId cTxMeta =
 
 removeWallet :: CId Wal -> Update ()
 removeWallet cWalId = wsWalletInfos . at cWalId .= Nothing
+
+removeTxMetas :: CId Wal -> Update ()
+removeTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
+
+removeHistoryCache :: CId Wal -> Update ()
+removeHistoryCache cWalId = wsHistoryCache . at cWalId .= Nothing
 
 removeAccount :: AccountId -> Update ()
 removeAccount accId = wsAccountInfos . at accId .= Nothing


### PR DESCRIPTION
When wallet is deleted, wallet history metadata and cache are not. This causes bugs when wallet is deleted and restored/imported again. This PR fixes it.