### PR TITLE
[CSM-356] Enable sending to same set of addresses as senders addrs

### DIFF
--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -34,7 +34,6 @@ import qualified Data.DList                       as DL
 import qualified Data.HashMap.Strict              as HM
 import           Data.List                        (findIndex, notElem)
 import qualified Data.List.NonEmpty               as NE
-import qualified Data.Set                         as S
 import qualified Data.Text.Buildable
 import           Data.Time.Clock.POSIX            (getPOSIXTime)
 import           Data.Time.Units                  (Microsecond, Second)
@@ -562,10 +561,8 @@ sendMoney
     -> m CTx
 sendMoney sendActions passphrase moneySource dstDistr = do
     allAddrs <- getMoneySourceAddresses moneySource
-    let dstAccAddrsSet = S.fromList $ map fst $ toList dstDistr
-        notDstAccounts = filter (\a -> not $ cwamId a `S.member` dstAccAddrsSet) allAddrs
-        coins = foldr1 unsafeAddCoin $ snd <$> dstDistr
-    distr@(remaining, spendings) <- selectSrcAccounts coins notDstAccounts
+    let coins = foldr1 unsafeAddCoin $ snd <$> dstDistr
+    distr@(remaining, spendings) <- selectSrcAccounts coins allAddrs
     logDebug $ buildDistribution distr
     mRemTx <- mkRemainingTx remaining
     txOuts <- forM dstDistr $ \(cAddr, coin) -> do


### PR DESCRIPTION
If A is set of addresses we send from, and B set of addresses we
send to - this change enables that intersection of A and B can be
non empty. ie we are enabling A ∩ B = non-epty set .

Before it was forbidden to send from the same address that is in set B (see the diff)

Fixes: https://issues.serokell.io/issue/CSM-356

**Note** that I am not sure is there any case enabling this has cons. Some thoughts are here https://issues.serokell.io/issue/CSM-356#comment=96-5374 . In short, sending from address A to address A doesn't make sense (nor sending from account A to any address within the same account) and will only spend users *fee* in future. But I guess we don't care about that. UI might warn the user about such usecases as it clearly doesn't make sense and its most likely a mistake by user.

Tested and it works!