### PR TITLE
CSL-1315 Support explicit boot stakeholders in keygen

### DIFF
--- a/core/Pos/Core/Arbitrary.hs
+++ b/core/Pos/Core/Arbitrary.hs
@@ -339,7 +339,6 @@ instance Arbitrary Fee.TxFeePolicy where
 -- Arbitrary types from 'Pos.Core.Genesis'
 ----------------------------------------------------------------------------
 
--- Unsafe? How is it used?
 instance Arbitrary G.GenesisCoreData where
     arbitrary = do
         -- This number'll be the length of every address list in the first argument of
@@ -375,9 +374,9 @@ instance Arbitrary G.GenesisCoreData where
                 , G.CustomStakes <$> vector innerLen
                 ]
         stakeDistrs <- vectorOf outerLen distributionGen
-        hashSetOfHolders <- arbitrary :: Gen (HashSet Types.StakeholderId)
+        hashmapOfHolders <- arbitrary :: Gen (HashMap Types.StakeholderId Word16)
         return $ leftToPanic "arbitrary@GenesisCoreData: " $
-            G.mkGenesisCoreData (zip listOfAddrList stakeDistrs) hashSetOfHolders
+            G.mkGenesisCoreData (zip listOfAddrList stakeDistrs) hashmapOfHolders
 
 instance Arbitrary G.StakeDistribution where
     arbitrary = oneof

--- a/core/Pos/Core/Genesis.hs
+++ b/core/Pos/Core/Genesis.hs
@@ -32,7 +32,7 @@ import           Universum
 
 import           Control.Lens            (ix)
 import           Data.Hashable           (hash)
-import qualified Data.HashSet            as HS
+import qualified Data.HashMap.Strict     as HM
 import qualified Data.Text               as T
 import           Formatting              (int, sformat, (%))
 
@@ -95,7 +95,7 @@ genesisProdAddrDistribution :: [AddrDistribution]
 genesisProdAddrDistribution = gcdAddrDistribution compileGenCoreData
 
 -- | Bootstrap era stakeholders for production mode.
-genesisProdBootStakeholders :: HashSet StakeholderId
+genesisProdBootStakeholders :: HashMap StakeholderId Word16
 genesisProdBootStakeholders =
     gcdBootstrapStakeholders compileGenCoreData
 
@@ -116,12 +116,14 @@ generateHdwGenesisSecretKey =
     encodeUtf8 .
     T.take 32 . sformat ("My 32-byte hdw seed #" %int % "                  ")
 
+-- TODO CSL-1351 It doesn't consider boot stakeholders weight
 -- | Returns a distribution sharing coins to given boot
 -- stakeholders. If number of addresses @n@ is more than coins @c@, we
 -- give 1 coin to every addr in the prefix of length @n@. Otherwise we
 -- give quotient to every boot addr and assign remainder randomly
 -- based on passed coin hash among addresses.
-genesisSplitBoot :: HashSet StakeholderId -> Coin -> [(StakeholderId, Coin)]
+genesisSplitBoot ::
+       HashMap StakeholderId Word16 -> Coin -> [(StakeholderId, Coin)]
 genesisSplitBoot bootHolders0 c
     | cval <= 0 =
       error $ "sendMoney#splitBoot: cval <= 0: " <> show cval
@@ -144,4 +146,4 @@ genesisSplitBoot bootHolders0 c
     addrsNum :: Int
     addrsNum = length bootHolders
     bootHolders :: [StakeholderId]
-    bootHolders = HS.toList bootHolders0
+    bootHolders = toList $ HM.keys bootHolders0

--- a/core/Pos/Core/Genesis/Types.hs
+++ b/core/Pos/Core/Genesis/Types.hs
@@ -71,8 +71,8 @@ data GenesisCoreData = UnsafeGenesisCoreData
     { gcdAddrDistribution      :: !([AddrDistribution])
       -- ^ Address distribution. Determines utxo without boot
       -- stakeholders distribution (addresses and coins).
-    , gcdBootstrapStakeholders :: !(HashSet StakeholderId)
-      -- ^ Bootstrap era stakeholders.
+    , gcdBootstrapStakeholders :: !(HashMap StakeholderId Word16)
+      -- ^ Bootstrap era stakeholders, values are weights.
     } deriving (Show, Eq, Generic)
 
 
@@ -80,7 +80,7 @@ data GenesisCoreData = UnsafeGenesisCoreData
 -- goes wrong.
 mkGenesisCoreData ::
        [AddrDistribution]
-    -> HashSet StakeholderId
+    -> HashMap StakeholderId Word16
     -> Either String GenesisCoreData
 mkGenesisCoreData distribution bootStakeholders = do
     -- Every set of addresses should match the stakeholders count

--- a/src/Pos/Genesis.hs
+++ b/src/Pos/Genesis.hs
@@ -115,7 +115,7 @@ stakeDistribution (CustomStakes coins) = map (,[]) coins
 -- and address distribution. In case boot stakeholders are supplied,
 -- all the balance is distributed among them. Otherwise, txDistr is
 -- set to @[]@ or left as it is (in case of 'ExplicitStakes').
-genesisUtxo :: Maybe (HashSet StakeholderId) -> [AddrDistribution] -> Utxo
+genesisUtxo :: Maybe (HashMap StakeholderId Word16) -> [AddrDistribution] -> Utxo
 genesisUtxo bootStakeholders ad =
     M.fromList $ concatMap (uncurry toUtxo . second stakeDistribution) ad
   where

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -67,9 +67,10 @@ import           Pos.Client.Txp.Util              (createMTx)
 import           Pos.Communication                (OutSpecs, SendActions, sendTxOuts,
                                                    submitMTx, submitRedemptionTx)
 import           Pos.Constants                    (curSoftwareVersion, isDevelopment)
-import           Pos.Context                      (genesisStakeholdersM, GenesisUtxo)
-import           Pos.Core                         (Address (..), Coin, TxFeePolicy (..), addressF,
-                                                   bvdTxFeePolicy, calculateTxSizeLinear,
+import           Pos.Context                      (GenesisUtxo, genesisStakeholdersM)
+import           Pos.Core                         (Address (..), Coin, TxFeePolicy (..),
+                                                   addressF, bvdTxFeePolicy,
+                                                   calculateTxSizeLinear,
                                                    decodeTextAddress, getCurrentTimestamp,
                                                    getTimestamp, integerToCoin,
                                                    makeRedeemAddress, mkCoin, sumCoins,
@@ -103,7 +104,8 @@ import           Pos.Wallet.KeyStorage            (addSecretKey, deleteSecretKey
 import           Pos.Wallet.SscType               (WalletSscType)
 import           Pos.Wallet.WalletMode            (applyLastUpdate,
                                                    blockchainSlotDuration, connectedPeers,
-                                                   getBalance, getLocalHistory, localChainDifficulty,
+                                                   getBalance, getLocalHistory,
+                                                   localChainDifficulty,
                                                    networkChainDifficulty, waitForUpdate)
 import           Pos.Wallet.Web.Account           (AddrGenSeed, GenSeed (..),
                                                    genSaveRootKey,
@@ -140,8 +142,7 @@ import           Pos.Wallet.Web.Secret            (WalletUserSecret (..),
 import           Pos.Wallet.Web.Server.Sockets    (ConnectionsVar, closeWSConnections,
                                                    getWalletWebSockets, initWSConnections,
                                                    notifyAll, upgradeApplicationWS)
-import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing),
-                                                   CustomAddressType (ChangeAddr, UsedAddr),
+import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing), CustomAddressType (ChangeAddr, UsedAddr),
                                                    addOnlyNewTxMeta, addUpdate,
                                                    addWAddress, closeState, createAccount,
                                                    createWallet, getAccountMeta,
@@ -157,7 +158,7 @@ import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Exis
                                                    setWalletPassLU, setWalletTxMeta,
                                                    testReset, updateHistoryCache)
 import           Pos.Wallet.Web.State.Storage     (WalletStorage)
-import           Pos.Wallet.Web.Tracking          (sortedInsertions, CAccModifier (..),
+import           Pos.Wallet.Web.Tracking          (CAccModifier (..), sortedInsertions,
                                                    syncWalletOnImport,
                                                    syncWalletsWithGState,
                                                    txMempoolToModifier)
@@ -710,7 +711,8 @@ prepareTxInfoRaw moneySource dstDistr = do
                 -- we want to be able to distribute at least 1 coin to everybody
                 when (unsafeGetCoin c < fromIntegral (length genStakeholders)) $
                     cantSpendDust c
-                pure $ genesisSplitBoot genStakeholders c
+                -- TODO CSL-1351 boot stakeholders' weights are not used
+                pure $ genesisSplitBoot (HM.fromList $ map (,1) $ toList genStakeholders) c
 
     txOuts <- forM dstDistr $ \(cAddr, coin) -> do
         addr <- decodeCIdOrFail cAddr

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -343,6 +343,7 @@ executable cardano-keygen
                      , text
                      , lens
                      , optparse-applicative >= 0.12
+                     , parsec
                      , string-qq
                      , unordered-containers
                      , bytestring >= 0.10

--- a/tools/src/keygen/KeygenOptions.hs
+++ b/tools/src/keygen/KeygenOptions.hs
@@ -43,7 +43,7 @@ data GenesisGenOptions = GenesisGenOptions
     , ggoFakeAvvmStake    :: Maybe FakeAvvmOptions
     , ggoBootStakeholders :: [(StakeholderId, Word16)]
       -- ^ Explicit bootstrap era stakeholders, list of addresses with
-      -- weights (@[(A, 0.5), (B, 0.2), (C, 0.3)]@). Setting this
+      -- weights (@[(A, 5), (B, 2), (C, 3)]@). Setting this
       -- overrides default settings for boot stakeholders (e.g. rich
       -- in testnet stakes).
     } deriving (Show)

--- a/tools/src/keygen/KeygenOptions.hs
+++ b/tools/src/keygen/KeygenOptions.hs
@@ -16,8 +16,14 @@ import           Options.Applicative          (Parser, auto, execParser, footerD
                                                fullDesc, header, help, helper, info,
                                                infoOption, long, metavar, option,
                                                progDesc, short, strOption, value)
+import           Serokell.Util.OptParse       (fromParsec)
+import qualified Text.Parsec                  as P
+import qualified Text.Parsec.String           as P
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
-import           Universum                    hiding (show)
+import           Universum
+
+import           Pos.Core.Types               (Address (..), StakeholderId)
+import           Pos.Types                    (decodeTextAddress)
 
 import           Paths_cardano_sl             (version)
 
@@ -30,11 +36,16 @@ data KeygenOptions = KeygenOptions
     }
 
 data GenesisGenOptions = GenesisGenOptions
-    { ggoGenesisDir    :: FilePath
+    { ggoGenesisDir       :: FilePath
       -- ^ Output directory everything will be put into
-    , ggoTestStake     :: Maybe TestStakeOptions
-    , ggoAvvmStake     :: Maybe AvvmStakeOptions
-    , ggoFakeAvvmStake :: Maybe FakeAvvmOptions
+    , ggoTestStake        :: Maybe TestStakeOptions
+    , ggoAvvmStake        :: Maybe AvvmStakeOptions
+    , ggoFakeAvvmStake    :: Maybe FakeAvvmOptions
+    , ggoBootStakeholders :: [(StakeholderId, Double)]
+      -- ^ Explicit bootstrap era stakeholders, list of addresses with
+      -- weights (@[(A, 0.5), (B, 0.2), (C, 0.3)]@). Setting this
+      -- overrides default settings for boot stakeholders (e.g. rich
+      -- in testnet stakes).
     } deriving (Show)
 
 data TestStakeOptions = TestStakeOptions
@@ -80,6 +91,7 @@ genesisGenParser = do
     ggoTestStake <- optional testStakeParser
     ggoAvvmStake <- optional avvmStakeParser
     ggoFakeAvvmStake <- optional fakeAvvmParser
+    ggoBootStakeholders <- many bootStakeholderParser
     pure $ GenesisGenOptions{..}
 
 testStakeParser :: Parser TestStakeOptions
@@ -142,20 +154,51 @@ fakeAvvmParser = do
         help    "A stake assigned to each of fake AVVM stakeholders."
     return FakeAvvmOptions{..}
 
+bootStakeholderParser :: Parser (StakeholderId, Double)
+bootStakeholderParser =
+    option (fromParsec pairParser) $
+        long "bootstakeholder" <>
+        metavar "ADDRESS,DOUBLE" <>
+        help "Explicit boot stakeholder with his stake weight for the boot era."
+  where
+    pairParser :: P.Parser (StakeholderId, Double)
+    pairParser = do
+        st <- stakeholderId
+        void $ P.char ','
+        d <- double
+        pure (st,d)
+
+    lexeme :: P.Parser a -> P.Parser a
+    lexeme p = P.spaces *> p >>= \x -> P.spaces $> x
+
+    double :: P.Parser Double
+    double = lexeme $ do
+        val <- readMaybe <$> P.many1 (P.digit <|> P.char '.')
+        maybe (fail $ show val <> " is not a valid double") pure val
+
+    stakeholderId :: P.Parser StakeholderId
+    stakeholderId = lexeme $ do
+        str <- P.many1 P.alphaNum
+        case decodeTextAddress (toText str) of
+            Left err                  -> fail (toString err)
+            Right (PubKeyAddress{..}) -> pure addrKeyHash
+            Right p                   ->
+                fail $ "Expected public key address, but it's " <> pretty p
+
 getKeygenOptions :: IO KeygenOptions
 getKeygenOptions = execParser programInfo
   where
     programInfo = info (helper <*> versionOption <*> optionsParser) $
         fullDesc <> progDesc "Produce 'genesis-*' directory with generated keys."
                  <> header "Tool to generate keyfiles."
-                 <> footerDoc usageExample
+                 <> footerDoc (Just usageExample)
 
     versionOption = infoOption
         ("cardano-keygen-" <> showVersion version)
         (long "version" <> help "Show version.")
 
-usageExample :: Maybe Doc
-usageExample = Just [s|
+usageExample :: Doc
+usageExample = [s|
 Command example:
 
   stack exec -- cardano-keygen                          \
@@ -167,8 +210,10 @@ Command example:
     --utxo-file /tmp/avvm-files/utxo-dump-last-new.json \
     --randcerts                                         \
     --blacklisted /tmp/avvm-files/full_blacklist.js     \
-    --fake-avvm-entries 100
+    --fake-avvm-entries 100                             \
+    --bootstakeholder "1fKNcnJ44voGtWmekuKic1HJdbHEwd1YEwZNu6XaAwE8RSk,0.5" \
+    --bootstakeholder "1HJdbHEwd1YEwZNu6XaAwE8RSk1fKNcnJ44voGtWmekuKic,0.3" \
+    --bootstakeholder "8RSk1fKNcnJ41HJdbNu6XaAwE4voGtWmekuHEwd1YEwZKic,0.2"
 
-Subdirectory 'genesis-*/nodes' contains keys for uploading to nodes (in cluster).
-Subdirectory 'genesis-*/avvm' contains AVVM seeds.
-Subdirectory 'genesis-*/secrets' contains secret keys.|]
+Subdirectory 'genesis-*/keys-testnet' contains keys for uploading to nodes (in cluster).
+Subdirectory 'genesis-*/keys-fakeavvm' contains AVVM seeds. |]

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -175,11 +175,11 @@ genGenesisFiles GenesisGenOptions{..} = do
             [mAvvmAddrDistr, mFakeAvvmAddrDistr, view _1 <$> mTestnetData]
     when (null gcdAddrDistribution) $ error "gcdAddrDistribution is empty"
     -- boot stakeholders
-    let gcdBootstrapStakeholders =
-            mconcat $ catMaybes
-            [ view _2 <$> mTestnetData
-            -- , CSL-1315 real boot stakeholders for mainnet, as addresses list
-            ]
+    let gcdBootstrapStakeholders
+            | null ggoBootStakeholders =
+                mconcat $ catMaybes [ view _2 <$> mTestnetData ]
+            | otherwise =
+                HM.fromList ggoBootStakeholders
     when (null gcdBootstrapStakeholders) $
         error "gcdBootstrapStakeholders is empty. Current keygen implementation \
               \doesn't support explicit boot stakeholders, so if testnet is not \

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -8,7 +8,6 @@ import           Control.Lens         ((?~))
 import           Data.Aeson           (eitherDecode)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.HashMap.Strict  as HM
-import qualified Data.HashSet         as HS
 import qualified Data.Text            as T
 import           Formatting           (sformat, shown, (%))
 import           Serokell.Util.Text   (listJson)
@@ -59,7 +58,7 @@ getTestnetData ::
        (MonadIO m, MonadFail m, WithLogger m)
     => FilePath
     -> TestStakeOptions
-    -> m ([AddrDistribution], HashSet StakeholderId, GenesisGtData)
+    -> m ([AddrDistribution], HashMap StakeholderId Word16, GenesisGtData)
 getTestnetData dir tso@TestStakeOptions{..} = do
 
     let keysDir = dir </> "keys-testnet"
@@ -86,7 +85,7 @@ getTestnetData dir tso@TestStakeOptions{..} = do
     let distr = genTestnetDistribution tso
         richmenStakeholders = case distr of
             RichPoorStakes {..} ->
-                HS.fromList $ map (addressHash . fst) genesisListRich
+                HM.fromList $ map ((,1) . addressHash . fst) genesisListRich
             _ -> error "cardano-keygen: impossible type of generated testnet stake"
         genesisAddrs = map (makePubKeyAddress . fst) genesisList
                     <> map (view _3) poorsList


### PR DESCRIPTION
Now you can pass a list of addresses that will be stakeholders instead of just taking testnet/rich. 
I also did some changes related to future stakes weight integration, see CSL-1351.