### PR TITLE
[CSM-359] Fix not working sending tx + CSM-322 Check whether we can use purescript-bridge from LTS 

### DIFF
--- a/core/Pos/Util/Util.hs
+++ b/core/Pos/Util/Util.hs
@@ -16,6 +16,7 @@ module Pos.Util.Util
 
        , maybeThrow
        , eitherToFail
+       , eitherToThrow
        , getKeys
        , sortWithMDesc
        , leftToPanic
@@ -273,6 +274,12 @@ maybeThrow e = maybe (throwM e) pure
 -- | Fail or return result depending on what is stored in 'Either'.
 eitherToFail :: (MonadFail m, ToString s) => Either s a -> m a
 eitherToFail = either (fail . toString) pure
+
+-- | Throw exception or return result depending on what is stored in 'Either'
+eitherToThrow
+    :: (MonadThrow m, Exception e)
+    => (s -> e) -> Either s a -> m a
+eitherToThrow f = either (throwM . f) pure
 
 -- | Create HashSet from HashMap's keys
 getKeys :: HashMap k v -> HashSet k

--- a/db/Pos/DB/Class.hs
+++ b/db/Pos/DB/Class.hs
@@ -69,7 +69,7 @@ import           Serokell.Data.Memory.Units   (Byte)
 
 import           Pos.Binary.Class             (Bi)
 import           Pos.Core                     (BlockVersionData (..), EpochIndex,
-                                               HeaderHash, isBootstrapEra)
+                                               HeaderHash, isBootstrapEra, isDevelopment)
 
 ----------------------------------------------------------------------------
 -- Pure
@@ -185,9 +185,11 @@ gsUnlockStakeEpoch = bvdUnlockStakeEpoch <$> gsAdoptedBVData
 
 -- | Checks if provided epoch is in the bootstrap era.
 gsIsBootstrapEra :: MonadGState m => EpochIndex -> m Bool
-gsIsBootstrapEra epoch = do
-    unlockStakeEpoch <- gsUnlockStakeEpoch
-    return $ isBootstrapEra unlockStakeEpoch epoch
+gsIsBootstrapEra epoch =
+    if isDevelopment then pure False
+    else do
+        unlockStakeEpoch <- gsUnlockStakeEpoch
+        return $ isBootstrapEra unlockStakeEpoch epoch
 
 ----------------------------------------------------------------------------
 -- Block DB abstraction

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -68,7 +68,7 @@ import           Pos.Txp                      (MonadTxpMem, MonadUtxo, MonadUtxo
                                                evalToilTEmpty, flattenTxPayload,
                                                getLocalTxs, runDBToil, topsortTxs,
                                                txOutAddress, utxoGet)
-import           Pos.Util                     (maybeThrow)
+import           Pos.Util                     (eitherToThrow, maybeThrow)
 import           Pos.WorkMode.Class           (TxpExtra_TMP)
 
 -- Remove this once there's no #ifdef-ed Pos.Txp import
@@ -262,8 +262,10 @@ getLocalHistoryDefault addrs = runDBToil . evalToilTEmpty $ do
     return $ DL.fromList txs
 
 saveTxDefault :: TxHistoryEnv ctx m => (TxId, TxAux) -> m ()
+saveTxDefault txw = do
 #ifdef WITH_EXPLORER
-saveTxDefault txw = () <$ runExceptT (eTxProcessTransaction txw)
+    res <- runExceptT (eTxProcessTransaction txw)
 #else
-saveTxDefault txw = () <$ runExceptT (txProcessTransaction txw)
+    res <- runExceptT (txProcessTransaction txw)
 #endif
+    eitherToThrow identity res

--- a/src/Pos/Wallet/Web/Error/Util.hs
+++ b/src/Pos/Wallet/Web/Error/Util.hs
@@ -22,12 +22,12 @@ import           Pos.Wallet.Web.Error.Types (WalletError (..), _RequestError)
 rewrapToWalletError
     :: forall e m a.
        (MonadCatch m, Exception e)
-    => (e -> Bool) -> (e -> Text) -> m a -> m a
-rewrapToWalletError whetherCatch toMsg = flip catches
+    => (e -> Bool) -> (e -> WalletError) -> m a -> m a
+rewrapToWalletError whetherCatch toWE = flip catches
      [ Handler $ throwM @_ @WalletError
      , Handler $ \e ->
            if whetherCatch e
-           then throwM . RequestError $ toMsg e
+           then throwM $ toWE e
            else throwM e
      ]
 

--- a/src/Pos/Wallet/Web/Util.hs
+++ b/src/Pos/Wallet/Web/Util.hs
@@ -1,15 +1,32 @@
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Different utils for wallets
 
 module Pos.Wallet.Web.Util
     ( getWalletAccountIds
+    , rewrapTxError
     ) where
 
 import           Universum
 
+import           Formatting                 (build, sformat, stext, (%))
+
+import           Pos.Client.Txp.Util        (TxError (..))
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, Wal)
+import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletError)
 import           Pos.Wallet.Web.State       (WebWalletModeDB, getWAddressIds)
 
 -- TODO: move more here from Methods.hs
 
 getWalletAccountIds :: WebWalletModeDB ctx m => CId Wal -> m [AccountId]
 getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getWAddressIds
+
+rewrapTxError
+    :: forall m a. MonadCatch m
+    => Text -> m a -> m a
+rewrapTxError prefix =
+    rewrapToWalletError (const True) (InternalError . sbuild) .
+    rewrapToWalletError (\TxError{} -> True) (RequestError . sbuild)
+  where
+    sbuild = sformat (stext%": "%build) prefix

--- a/stack.yaml
+++ b/stack.yaml
@@ -84,7 +84,7 @@ extra-deps:
 - base58-bytestring-0.1.0
 - log-warper-1.1.2
 - concurrent-extra-0.7.0.10       # not yet in lts-8
-- purescript-bridge-0.8.0.1
+# - purescript-bridge-0.8.0.1
 - cryptonite-0.23
 - cryptonite-openssl-0.6
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8

--- a/txp/Pos/Txp/Toil/Failure.hs
+++ b/txp/Pos/Txp/Toil/Failure.hs
@@ -42,6 +42,8 @@ data ToilVerFailure
     | ToilBootDifferentStake !TxOutDistribution
     deriving (Show, Eq)
 
+instance Exception ToilVerFailure
+
 instance Buildable ToilVerFailure where
     build ToilKnown =
         "transaction already is in the mem pool"


### PR DESCRIPTION
Sending transactions weren't working due to changes in txp processing related to bootstrap era logic. This is solved by explicitly stating that there's no bootstrap era in dev mode. Also error handling in `Pos.Communication.Tx` and related is rewritten to simplify things and avoid ignoring txp verification errors on API level.

In addition, in this PR LTS version of purescript-bridge is used (CSM-322). Didn't make another PR because it's minor change and it's unnecessary to run CI separately for that.