### PR TITLE
[CSM-362] Sync progress changed datatype - fix api

### DIFF
--- a/src/Pos/Aeson/Types.hs
+++ b/src/Pos/Aeson/Types.hs
@@ -44,7 +44,6 @@ instance ToJSON TxOut where
         "address" .= sformat build txOutAddress ]
 
 deriving instance ToJSON SlotCount
-deriving instance ToJSON BlockCount
 
 -- NOTE: some of these types are used on frontend (PureScript).
 -- We are automatically deriving instances there and they are
@@ -52,6 +51,7 @@ deriving instance ToJSON BlockCount
 -- If datatype is used on frontend, please use this instead of
 -- any other way of deriving if possible.
 
+deriveToJSON defaultOptions ''BlockCount
 deriveToJSON defaultOptions ''ApplicationName
 deriveToJSON defaultOptions ''ChainDifficulty
 deriveToJSON defaultOptions ''SlotId


### PR DESCRIPTION
Fixes https://issues.serokell.io/issue/CSM-362 . This introduces breaking change for UI as it has to take into account another Object nesting:
 * before `getChainDifficulty: 2`
 * now `getChainDifficulty: { getBlockCount: 2 } `

```
> api.syncProgress().then(console.log)
Promise {
  <pending>,
  domain: 
   Domain {
     domain: null,
     _events: { error: [Function: debugDomainError] },
     _eventsCount: 1,
     _maxListeners: undefined,
     members: [] } }
> { _spPeers: 0,
  _spNetworkCD: { getChainDifficulty: { getBlockCount: 2 } },
  _spLocalCD: { getChainDifficulty: { getBlockCount: 2 } } }

```

cc @darko-mijic 