### PR TITLE
[CSM-363, CSM-364] Fix bugs in JSON import/export 

### DIFF
--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -1271,8 +1271,10 @@ restoreWalletFromBackup WalletBackup {..} = do
                     seedGen = DeterminedSeed aIdx
                 accId <- genUniqueAccountId seedGen wId
                 createAccount accId meta
+            void $ createWalletSafe wId wMeta
             void $ syncWalletOnImport wbSecretKey
-            Just <$> createWalletSafe wId wMeta
+            -- Get wallet again to return correct balance and stuff
+            Just <$> getWallet wId
 
 restoreStateFromBackup :: WalletWebMode m => StateBackup -> m [CWallet]
 restoreStateFromBackup (FullStateBackup walletBackups) =

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -1250,25 +1250,33 @@ testResetAll = deleteAllKeys >> testReset
 -- JSON backup methods
 ----------------------------------------------------------------------------
 
-restoreWalletFromBackup :: WalletWebMode m => WalletBackup -> m CWallet
+restoreWalletFromBackup :: WalletWebMode m => WalletBackup -> m (Maybe CWallet)
 restoreWalletFromBackup WalletBackup {..} = do
     let wId = encToCId wbSecretKey
-        (WalletMetaBackup wMeta) = wbMeta
-        accList = HM.toList wbAccounts
-                  & each . _2 %~ \(AccountMetaBackup am) -> am
+    wExists <- isJust <$> getWalletMeta wId
 
-    addSecretKey wbSecretKey
-    for_ accList $ \(idx, meta) -> do
-        let aIdx = fromInteger $ fromIntegral idx
-            seedGen = DeterminedSeed aIdx
-        accId <- genUniqueAccountId seedGen wId
-        createAccount accId meta
-    void $ syncWalletOnImport wbSecretKey
-    createWalletSafe wId wMeta
+    if wExists
+        then do
+            logWarning $
+                sformat ("Wallet with id "%build%" already exists") wId
+            pure Nothing
+        else do
+            let (WalletMetaBackup wMeta) = wbMeta
+                accList = HM.toList wbAccounts
+                          & each . _2 %~ \(AccountMetaBackup am) -> am
+
+            addSecretKey wbSecretKey
+            for_ accList $ \(idx, meta) -> do
+                let aIdx = fromInteger $ fromIntegral idx
+                    seedGen = DeterminedSeed aIdx
+                accId <- genUniqueAccountId seedGen wId
+                createAccount accId meta
+            void $ syncWalletOnImport wbSecretKey
+            Just <$> createWalletSafe wId wMeta
 
 restoreStateFromBackup :: WalletWebMode m => StateBackup -> m [CWallet]
 restoreStateFromBackup (FullStateBackup walletBackups) =
-    forM walletBackups restoreWalletFromBackup
+    catMaybes <$> forM walletBackups restoreWalletFromBackup
 
 importStateJSON :: WalletWebMode m => Text -> m [CWallet]
 importStateJSON (toString -> fp) = do

--- a/src/Pos/Wallet/Web/Tracking.hs
+++ b/src/Pos/Wallet/Web/Tracking.hs
@@ -39,12 +39,12 @@ import           Universum
 import           Control.Lens               (to)
 import           Control.Monad.Trans        (MonadTrans)
 import           Data.DList                 (DList)
-import           Ether.Internal             (HasLens (..))
 import qualified Data.DList                 as DL
 import           Data.List                  ((!!))
 import qualified Data.List.NonEmpty         as NE
-import qualified Data.Text.Buildable
 import qualified Data.Map                   as M
+import qualified Data.Text.Buildable
+import           Ether.Internal             (HasLens (..))
 import           Formatting                 (bprint, build, sformat, (%))
 import           Mockable                   (SharedAtomicT)
 import           Serokell.Util              (listJson)
@@ -56,7 +56,7 @@ import           Pos.Block.Logic            (withBlkSemaphore_)
 import           Pos.Block.Types            (Blund, undoTx)
 import           Pos.Client.Txp.History     (TxHistoryEntry (..), runGenesisToil)
 import           Pos.Constants              (genesisHash)
-import           Pos.Context                (BlkSemaphore, genesisUtxoM, GenesisUtxo (..))
+import           Pos.Context                (BlkSemaphore, GenesisUtxo (..), genesisUtxoM)
 import           Pos.Core                   (AddrPkAttrs (..), Address (..),
                                              ChainDifficulty, HasDifficulty (..),
                                              HeaderHash, Timestamp, headerHash,
@@ -73,27 +73,27 @@ import qualified Pos.DB.GState              as GS
 import           Pos.DB.GState.BlockExtra   (foldlUpWhileM, resolveForwardLink)
 import           Pos.DB.Rocks               (MonadRealDB)
 import           Pos.Slotting               (getSlotStartPure)
-import           Pos.Txp.Core               (Tx (..), TxAux (..), TxId, TxOutAux (..), TxIn (..) ,
-                                             TxUndo, flattenTxPayload, toaOut, topsortTxs, getTxDistribution,
+import           Pos.Txp.Core               (Tx (..), TxAux (..), TxId, TxIn (..),
+                                             TxOutAux (..), TxUndo, flattenTxPayload,
+                                             getTxDistribution, toaOut, topsortTxs,
                                              txOutAddress)
 import           Pos.Txp.MemState.Class     (MonadTxpMem, getLocalTxs)
 import           Pos.Txp.Toil               (MonadUtxo (..), MonadUtxoRead (..), ToilT,
-                                             UtxoModifier, applyTxToUtxo, evalToilTEmpty, runDBToil)
+                                             UtxoModifier, applyTxToUtxo, evalToilTEmpty,
+                                             runDBToil)
 import           Pos.Util.Chrono            (getNewestFirst)
-import qualified Pos.Util.Modifier          as MM
 import           Pos.Util.Modifier          (MapModifier)
+import qualified Pos.Util.Modifier          as MM
 import           Pos.Util.Util              (maybeThrow)
 
-import           Pos.Wallet.Web.Error.Types (WalletError (..))
 import           Pos.Ssc.Class              (SscHelpersClass)
 import           Pos.Wallet.SscType         (WalletSscType)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
-                                             CWAddressMeta (..), Wal,
-                                             addressToCId, aiWId, encToCId,
-                                             isTxLocalAddress)
+                                             CWAddressMeta (..), Wal, addressToCId, aiWId,
+                                             encToCId, isTxLocalAddress)
+import           Pos.Wallet.Web.Error.Types (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode (..),
-                                             CustomAddressType (..),
-                                             WebWalletModeDB)
+                                             CustomAddressType (..), WebWalletModeDB)
 import qualified Pos.Wallet.Web.State       as WS
 
 -- VoidModifier describes a difference between two states.
@@ -268,14 +268,17 @@ syncWalletWithGStateUnsafe encSK = do
                               %" by last synced hh: "%build) wAddr wTip
                 Just wHeader -> do
                     genesisUtxo <- genesisUtxoM
-                    mapModifier@CAccModifier{..} <- computeAccModifier wHeader
                     when (wTip == genesisHash) $ do
                         let encInfo = getEncInfo encSK
-                        let ownGenesisUtxo =
-                                M.fromList $
-                                map fst $
-                                selectOwnAccounts encInfo (txOutAddress . toaOut . snd) (M.toList genesisUtxo)
+                            ownGenesisData =
+                                selectOwnAccounts encInfo (txOutAddress . toaOut . snd) $
+                                M.toList genesisUtxo
+                            ownGenesisUtxo = M.fromList $ map fst ownGenesisData
+                            ownGenesisAddrs = map snd ownGenesisData
+                        mapM_ WS.addWAddress ownGenesisAddrs
                         WS.getWalletUtxo >>= WS.setWalletUtxo . (ownGenesisUtxo <>)
+
+                    mapModifier@CAccModifier{..} <- computeAccModifier wHeader
                     applyModifierToWallet wAddr (headerHash tipHeader) mapModifier
                     logDebug $ sformat ("Wallet "%build%" has been synced with tip "
                                         %shortHashF%", "%build)


### PR DESCRIPTION
There were two problems:
1) Couldn't import wallets, if some of them were already present - fixed by checking every wallet for existense
2) Wallet was imported with 0 ADA - fixed by starting a wallet sync after metadata initialization, not before (which was incorrect)