### PR TITLE
[CSL-1281] Use constants from database, not genesis constants

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/Toss/Class.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Class.hs
@@ -4,6 +4,7 @@
 
 module Pos.Ssc.GodTossing.Toss.Class
        ( MonadTossRead (..)
+       , MonadTossEnv (..)
        , MonadToss (..)
        ) where
 
@@ -12,7 +13,8 @@ import           Control.Monad.Trans            (MonadTrans)
 import           System.Wlog                    (WithLogger)
 import           Universum
 
-import           Pos.Core                       (EpochIndex, EpochOrSlot, StakeholderId)
+import           Pos.Core                       (BlockVersionData, EpochIndex,
+                                                 EpochOrSlot, StakeholderId)
 import           Pos.Lrc.Types                  (RichmenStake)
 import           Pos.Ssc.GodTossing.Core        (CommitmentsMap, InnerSharesMap, Opening,
                                                  OpeningsMap, SharesMap, SignedCommitment,
@@ -45,9 +47,6 @@ class (Monad m, WithLogger m) =>
     -- | Retrieve all stable 'VssCertificate's for given epoch.
     getStableCertificates :: EpochIndex -> m VssCertificatesMap
 
-    -- | Retrieve richmen for given epoch if they are known.
-    getRichmen :: EpochIndex -> m (Maybe RichmenStake)
-
     -- | Default implementations for 'MonadTrans'.
     default getCommitments :: (MonadTrans t, MonadTossRead m', t m' ~ m) =>
         m CommitmentsMap
@@ -73,13 +72,32 @@ class (Monad m, WithLogger m) =>
         EpochIndex -> m VssCertificatesMap
     getStableCertificates = lift . getStableCertificates
 
-    default getRichmen :: (MonadTrans t, MonadTossRead m', t m' ~ m) =>
-        EpochIndex -> m (Maybe RichmenStake)
-    getRichmen = lift . getRichmen
-
 instance MonadTossRead m => MonadTossRead (ReaderT s m)
 instance MonadTossRead m => MonadTossRead (StateT s m)
 instance MonadTossRead m => MonadTossRead (ExceptT s m)
+
+----------------------------------------------------------------------------
+-- Environment
+----------------------------------------------------------------------------
+
+class Monad m => MonadTossEnv m where
+    -- | Retrieve richmen for given epoch if they are known.
+    getRichmen :: EpochIndex -> m (Maybe RichmenStake)
+
+    -- | Retrieve current adopted block data
+    getAdoptedBVData :: m BlockVersionData
+
+    default getRichmen :: (MonadTrans t, MonadTossEnv m', t m' ~ m) =>
+        EpochIndex -> m (Maybe RichmenStake)
+    getRichmen = lift . getRichmen
+
+    default getAdoptedBVData :: (MonadTrans t, MonadTossEnv m', t m' ~ m) =>
+        m BlockVersionData
+    getAdoptedBVData = lift getAdoptedBVData
+
+instance MonadTossEnv m => MonadTossEnv (ReaderT s m)
+instance MonadTossEnv m => MonadTossEnv (StateT s m)
+instance MonadTossEnv m => MonadTossEnv (ExceptT s m)
 
 ----------------------------------------------------------------------------
 -- Writeable

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
@@ -2,38 +2,47 @@
 
 module Pos.Ssc.GodTossing.Toss.Pure
        ( PureToss (..)
+       , PureTossWithEnv (..)
        , MultiRichmenStake
        , MultiRichmenSet
        , runPureToss
        , runPureTossWithLogger
        , evalPureTossWithLogger
        , execPureTossWithLogger
+       , supplyPureTossEnv
        ) where
 
-import           Control.Lens                   (at, (%=), (.=))
-import           Control.Monad.RWS.Strict       (RWS, runRWS)
-import qualified Data.HashMap.Strict            as HM
+import           Control.Lens                   (at, sequenceAOf, (%=), (.=))
 import           System.Wlog                    (CanLog, HasLoggerName (..), LogEvent,
                                                  NamedPureLogger (..), WithLogger,
                                                  launchNamedPureLog, runNamedPureLog)
 import           Universum
 
-import           Pos.Core                       (EpochIndex, crucialSlot)
+import           Pos.Core                       (BlockVersionData, EpochIndex,
+                                                 crucialSlot)
 import           Pos.Lrc.Types                  (RichmenSet, RichmenStake)
 import           Pos.Ssc.GodTossing.Core        (deleteSignedCommitment,
                                                  insertSignedCommitment)
 import           Pos.Ssc.GodTossing.Genesis     (genesisCertificates)
-import           Pos.Ssc.GodTossing.Toss.Class  (MonadToss (..), MonadTossRead (..))
+import           Pos.Ssc.GodTossing.Toss.Class  (MonadToss (..), MonadTossEnv (..),
+                                                 MonadTossRead (..))
 import           Pos.Ssc.GodTossing.Types       (GtGlobalState, gsCommitments, gsOpenings,
                                                  gsShares, gsVssCertificates)
 import qualified Pos.Ssc.GodTossing.VssCertData as VCD
 
 type MultiRichmenStake = HashMap EpochIndex RichmenStake
-type MultiRichmenSet = HashMap EpochIndex RichmenSet
+type MultiRichmenSet   = HashMap EpochIndex RichmenSet
 
 newtype PureToss a = PureToss
-    { getPureToss :: NamedPureLogger (RWS MultiRichmenStake () GtGlobalState) a
+    { getPureToss ::
+          NamedPureLogger (State GtGlobalState) a
     } deriving (Functor, Applicative, Monad, CanLog, HasLoggerName)
+
+newtype PureTossWithEnv a = PureTossWithEnv
+    { getPureTossWithEnv ::
+          ReaderT (MultiRichmenStake, BlockVersionData) PureToss a
+    } deriving (Functor, Applicative, Monad, CanLog, HasLoggerName,
+                MonadTossRead, MonadToss)
 
 instance MonadTossRead PureToss where
     getCommitments = PureToss $ use gsCommitments
@@ -47,7 +56,10 @@ instance MonadTossRead PureToss where
             PureToss $
             VCD.certs . VCD.setLastKnownSlot (crucialSlot epoch) <$>
             use gsVssCertificates
-    getRichmen epoch = PureToss $ asks (HM.lookup epoch)
+
+instance MonadTossEnv PureTossWithEnv where
+    getRichmen epoch = PureTossWithEnv $ view (_1 . at epoch)
+    getAdoptedBVData = PureTossWithEnv $ view _2
 
 instance MonadToss PureToss where
     putCommitment signedComm =
@@ -67,35 +79,42 @@ instance MonadToss PureToss where
     setEpochOrSlot eos = PureToss $ gsVssCertificates %= VCD.setLastKnownEoS eos
 
 runPureToss
-    :: MultiRichmenStake
-    -> GtGlobalState
+    :: GtGlobalState
     -> PureToss a
     -> (a, GtGlobalState, [LogEvent])
-runPureToss richmenData gs =
-    convertRes . (\a -> runRWS a richmenData gs) . runNamedPureLog . getPureToss
+runPureToss gs =
+    reorder . (`runState` gs) . runNamedPureLog . getPureToss
   where
-    convertRes :: ((a, [LogEvent]), GtGlobalState, ())
-               -> (a, GtGlobalState, [LogEvent])
-    convertRes ((res, logEvents), newGs, ()) = (res, newGs, logEvents)
+    reorder :: ((a, [LogEvent]), GtGlobalState)
+            -> (a, GtGlobalState, [LogEvent])
+    reorder ((res, logEvents), newGs) = (res, newGs, logEvents)
 
 runPureTossWithLogger
     :: WithLogger m
-    => MultiRichmenStake
-    -> GtGlobalState
+    => GtGlobalState
     -> PureToss a
     -> m (a, GtGlobalState)
-runPureTossWithLogger richmenData gs action = do
-    let traverse' (fa, b, c) = (, b, c) <$> fa
-    let unwrapLower a = return $ traverse' $ runRWS a richmenData gs
-    (res, newGS, ()) <- launchNamedPureLog unwrapLower $ getPureToss action
+runPureTossWithLogger gs action = do
+    let unwrapLower a = return $ sequenceAOf _1 $ runState a gs
+    (res, newGS) <- launchNamedPureLog unwrapLower $ getPureToss action
     return (res, newGS)
 
 evalPureTossWithLogger
     :: WithLogger m
-    => MultiRichmenStake -> GtGlobalState -> PureToss a -> m a
-evalPureTossWithLogger r g = fmap fst . runPureTossWithLogger r g
+    => GtGlobalState
+    -> PureToss a
+    -> m a
+evalPureTossWithLogger g = fmap fst . runPureTossWithLogger g
 
 execPureTossWithLogger
     :: WithLogger m
-    => MultiRichmenStake -> GtGlobalState -> PureToss a -> m GtGlobalState
-execPureTossWithLogger r g = fmap snd . runPureTossWithLogger r g
+    => GtGlobalState
+    -> PureToss a
+    -> m GtGlobalState
+execPureTossWithLogger g = fmap snd . runPureTossWithLogger g
+
+supplyPureTossEnv
+    :: (MultiRichmenStake, BlockVersionData)
+    -> PureTossWithEnv a
+    -> PureToss a
+supplyPureTossEnv env = flip runReaderT env . getPureTossWithEnv

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Trans.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Trans.hs
@@ -18,7 +18,8 @@ import           Universum
 
 import           Pos.Ssc.GodTossing.Core        (deleteSignedCommitment, getCertId,
                                                  insertSignedCommitment)
-import           Pos.Ssc.GodTossing.Toss.Class  (MonadToss (..), MonadTossRead (..))
+import           Pos.Ssc.GodTossing.Toss.Class  (MonadToss (..), MonadTossEnv (..),
+                                                 MonadTossRead (..))
 import           Pos.Ssc.GodTossing.Toss.Types  (TossModifier (..), tmCertificates,
                                                  tmCommitments, tmOpenings, tmShares)
 import           Pos.Ssc.GodTossing.VssCertData (VssCertData (certs))
@@ -60,7 +61,11 @@ instance MonadTossRead m =>
     getVssCertificates = certs <$> getVssCertData
     getVssCertData = ether getVssCertData
     getStableCertificates = ether . getStableCertificates
+
+instance MonadTossEnv m =>
+         MonadTossEnv (TossT m) where
     getRichmen = ether . getRichmen
+    getAdoptedBVData = ether getAdoptedBVData
 
 instance MonadToss m =>
          MonadToss (TossT m) where

--- a/godtossing/cardano-sl-godtossing.cabal
+++ b/godtossing/cardano-sl-godtossing.cabal
@@ -61,7 +61,8 @@ library
     Pos.Binary.GodTossing.Toss
     Pos.Binary.GodTossing.Relay
 
-  build-depends:       aeson
+  build-depends:       QuickCheck
+                     , aeson
                      , base
                      , bytestring
                      , cardano-sl-core
@@ -78,10 +79,10 @@ library
                      , generic-arbitrary
                      , lens
                      , log-warper
+                     , mmorph
                      , mono-traversable
                      , mtl
                      , node-sketch
-                     , QuickCheck
                      , rocksdb-haskell >= 1.0.0
                      , serokell-util
                      , stm

--- a/ssc/Pos/Ssc/Class/LocalData.hs
+++ b/ssc/Pos/Ssc/Class/LocalData.hs
@@ -12,7 +12,7 @@ module Pos.Ssc.Class.LocalData
 import           System.Wlog         (WithLogger)
 import           Universum
 
-import           Pos.Core            (EpochIndex, SlotId)
+import           Pos.Core            (BlockVersionData, EpochIndex, SlotId)
 import           Pos.DB.Class        (MonadDBRead)
 import           Pos.Lrc.Types       (RichmenStake)
 import           Pos.Slotting.Class  (MonadSlots)
@@ -34,8 +34,8 @@ class Ssc ssc => SscLocalDataClass ssc where
     sscGetLocalPayloadQ :: SlotId -> LocalQuery ssc (SscPayload ssc)
     -- | Make 'SscLocalData' valid for given epoch, richmen and global state.
     -- of best known chain).
-    sscNormalizeU :: EpochIndex
-                  -> RichmenStake
+    sscNormalizeU :: (EpochIndex, RichmenStake)
+                  -> BlockVersionData
                   -> SscGlobalState ssc
                   -> LocalUpdate ssc ()
     -- | Create new (empty) local data. We are using this function instead of

--- a/ssc/Pos/Ssc/Class/Storage.hs
+++ b/ssc/Pos/Ssc/Class/Storage.hs
@@ -15,7 +15,7 @@ import           Data.Tagged          (Tagged)
 import           System.Wlog          (WithLogger)
 import           Universum
 
-import           Pos.Core             (EpochIndex, SharedSeed)
+import           Pos.Core             (BlockVersionData, EpochIndex, SharedSeed)
 import           Pos.DB               (MonadDBRead, SomeBatchOp)
 import           Pos.Lrc.Types        (RichmenStake)
 import           Pos.Ssc.Class.Types  (Ssc (..), SscBlock)
@@ -53,6 +53,7 @@ class Ssc ssc => SscGStateClass ssc where
     -- Blocks must be from the same epoch.
     sscVerifyAndApplyBlocks
         :: RichmenStake
+        -> BlockVersionData
         -> OldestFirst NE (SscBlock ssc)
         -> SscVerifier ssc ()
     -- | Calculate 'SharedSeed' for given epoch using 'SscGlobalState'.

--- a/ssc/Pos/Ssc/NistBeacon.hs
+++ b/ssc/Pos/Ssc/NistBeacon.hs
@@ -30,7 +30,8 @@ data SscNistBeacon
 deriving instance Show SscNistBeacon
 deriving instance Eq SscNistBeacon
 
--- FIXME Why is it here at all?
+-- FIXME this is needed because 'Ssc' puts the Buildable constraint on
+-- things. However, this instance should really be in Pos.Util.Util instead.
 instance Buildable () where
     build _ = "()"
 
@@ -68,7 +69,7 @@ instance SscGStateClass SscNistBeacon where
     sscLoadGlobalState = pass
     sscGlobalStateToBatch _ = Tagged []
     sscRollbackU _ = pass
-    sscVerifyAndApplyBlocks _ _ = pass
+    sscVerifyAndApplyBlocks _ _ _ = pass
     sscCalculateSeedQ i _ = do
         let h :: ByteString
             h = ByteArray.convert $ Hash.hashlazy @SHA256 (encodeLazy i)

--- a/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
+++ b/test/Test/Pos/Ssc/GodTossing/ComputeSharesSpec.hs
@@ -13,6 +13,7 @@ import           Universum
 import           Pos.Constants         (genesisMpcThd)
 import           Pos.Core              (mkCoin)
 import           Pos.Core.Coin         (coinPortionToDouble, sumCoins)
+import           Pos.Lrc               (RichmenStake)
 import           Pos.Lrc.Arbitrary     (GenesisMpcThd, InvalidRichmenStake (..),
                                         ValidRichmenStake (..))
 import qualified Pos.Ssc.GodTossing    as T
@@ -37,14 +38,17 @@ spec = describe "computeSharesDistr" $ do
     validRichmenStakeWorksDesc = "Given a valid distribution of stake, calculating the\
     \ distribution of shares successfully works."
 
+computeShares' :: RichmenStake -> Either T.TossVerFailure T.SharesDistribution
+computeShares' stake = runExcept $ T.computeSharesDistrPure stake genesisMpcThd
+
 emptyRichmenStake :: Expectation
 emptyRichmenStake =
-    let emptyRes = runExcept $ T.computeSharesDistr mempty
+    let emptyRes = computeShares' mempty
     in isLeft emptyRes `shouldBe` True
 
 allRichmenGetShares :: ValidRichmenStake GenesisMpcThd -> Bool
 allRichmenGetShares (getValid -> richmen) =
-    let outputStakeholder = runExcept $ T.computeSharesDistr richmen
+    let outputStakeholder = computeShares' richmen
     in case outputStakeholder of
         Left _ -> False
         Right result ->
@@ -52,7 +56,7 @@ allRichmenGetShares (getValid -> richmen) =
 
 validRichmenStakeWorks :: ValidRichmenStake GenesisMpcThd -> Bool
 validRichmenStakeWorks (getValid -> richmen) =
-    let outputStakeholder = runExcept $ T.computeSharesDistr richmen
+    let outputStakeholder = computeShares' richmen
         totalCoins = sumCoins $ HM.elems richmen
         mpcThreshold = coinPortionToDouble genesisMpcThd
         minStake = mkCoin . ceiling $ (fromIntegral totalCoins) * mpcThreshold
@@ -63,8 +67,8 @@ validRichmenStakeWorks (getValid -> richmen) =
 totalStakeIsZero :: ValidRichmenStake GenesisMpcThd -> Bool
 totalStakeIsZero (getValid -> richmen) =
     let zeroStake = richmen $> (mkCoin 0)
-    in isLeft $ runExcept $ T.computeSharesDistr zeroStake
+    in isLeft $ computeShares' zeroStake
 
 invalidStakeErrors :: InvalidRichmenStake GenesisMpcThd -> Bool
 invalidStakeErrors (getInvalid -> richmen) =
-    isLeft $ runExcept $ T.computeSharesDistr richmen
+    isLeft $ computeShares' richmen


### PR DESCRIPTION
There were three places overall where genesis constants were used wrongly.

The first commit deals with two places in `update`. The first commit is small and easy.

The second commit deals with `computeSharesDistr`. The second commit is fat and introduces a new monad class and a new newtype. I don't like `computeSharesDistr`.

---

Questions:

1. Is it okay that `generateAndSetNewSecret` uses block version data for current slot and not the slot it was passed?

2. I used `MonadGState` instead of `MonadDBRead` in some places because I wasn't sure about adding an `cardano-sl-update` dependency for `cardano-sl-ssc`. I can change that if needed.

3. I use `getAdoptedBVData` from `MonadPollRead` in the first commit, but `gsAdoptedBVData` from `MonadGState` in the second commit. Since I don't understand the difference well enough (despite @pva701's explanation), I'm not sure that it's correct.