### PR TITLE
CSL-1178 Implement basic block generator

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -41,6 +41,7 @@ library
                         Pos.Block.Network
                         Pos.Block.Pure
                         Pos.Block.RetrievalQueue
+                        Pos.Block.Slog
                         Pos.Block.Types
                         Pos.CLI
                         Pos.Context
@@ -165,7 +166,6 @@ library
                         Pos.Block.Network.Listeners
                         Pos.Block.Network.Logic
                         Pos.Block.Network.Retrieval
-                        Pos.Block.Slog
                         Pos.Block.Slog.Context
                         Pos.Block.Slog.Logic
                         Pos.Block.Slog.Types
@@ -561,6 +561,7 @@ test-suite cardano-test
                        Test.Pos.Block.Identity.SafeCopySpec
                        Test.Pos.Block.Logic.CreationSpec
                        Test.Pos.Block.Logic.Mode
+                       Test.Pos.Block.Logic.Util
                        Test.Pos.Block.Logic.VarSpec
 
                        -- Everything else

--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -54,6 +54,10 @@ library
 
                         Pos.Delegation
 
+                        -- Arbitrary data generation
+                        Pos.Generator
+                        Pos.Generator.Block
+
                         -- Genesis data
                         Pos.Genesis
 
@@ -196,6 +200,12 @@ library
                         Pos.Delegation.Lrc
                         Pos.Delegation.Types
                         Pos.Delegation.Worker
+
+                        -- Arbitrary data generation
+                        Pos.Generator.Block.Error
+                        Pos.Generator.Block.Logic
+                        Pos.Generator.Block.Mode
+                        Pos.Generator.Block.Param
 
                         -- Launcher
                         Pos.Launcher.Launcher

--- a/core/Pos/Core/Class.hs
+++ b/core/Pos/Core/Class.hs
@@ -22,11 +22,10 @@ module Pos.Core.Class
 
 import           Universum
 
-import           Control.Lens   (Getter, choosing, lens, to)
+import           Control.Lens   (Getter, choosing, to)
 
 import           Pos.Core.Types (BlockVersion, ChainDifficulty, EpochIndex,
-                                 EpochOrSlot (..), HeaderHash, SlotId, SoftwareVersion,
-                                 siEpoch)
+                                 EpochOrSlot (..), HeaderHash, SlotId, SoftwareVersion)
 import           Pos.Crypto     (PublicKey)
 import           Pos.Util.Util  (Some, applySome, liftLensSome)
 
@@ -93,9 +92,6 @@ class HasEpochIndex a where
     epochIndexL :: Lens' a EpochIndex
 
 SOME_LENS_CLASS(HasEpochIndex, epochIndexL, HasEpochIndex)
-
-instance HasEpochIndex SlotId where
-    epochIndexL = lens siEpoch (\s a -> s {siEpoch = a})
 
 instance (HasEpochIndex a, HasEpochIndex b) =>
          HasEpochIndex (Either a b) where

--- a/core/Pos/Core/Slotting.hs
+++ b/core/Pos/Core/Slotting.hs
@@ -9,6 +9,8 @@ module Pos.Core.Slotting
        , crucialSlot
        , unsafeMkLocalSlotIndex
        , isBootstrapEra
+       , epochOrSlot
+       , epochOrSlotToSlot
        ) where
 
 import           Universum
@@ -16,8 +18,8 @@ import           Universum
 import           Pos.Core.Class     (HasEpochOrSlot (..), getEpochOrSlot)
 import           Pos.Core.Constants (epochSlots, slotSecurityParam)
 import           Pos.Core.Types     (EpochIndex (..), EpochOrSlot (..), FlatSlotId,
-                                     LocalSlotIndex, SlotCount, SlotId (..), epochOrSlot,
-                                     getSlotIndex, mkLocalSlotIndex)
+                                     LocalSlotIndex, SlotCount, SlotId (..), getSlotIndex,
+                                     mkLocalSlotIndex)
 import           Pos.Util.Util      (leftToPanic)
 
 -- | Flatten 'SlotId' (which is basically pair of integers) into a single number.
@@ -123,5 +125,15 @@ isBootstrapEra
     -> EpochIndex -- ^ Epoch in question (for which we determine whether it
                   --                      belongs to the bootstrap era).
     -> Bool
-isBootstrapEra unlockStakeEpoch epoch = do
+isBootstrapEra unlockStakeEpoch epoch =
     epoch < unlockStakeEpoch
+
+-- | Apply one of the function depending on content of 'EpochOrSlot'.
+epochOrSlot :: (EpochIndex -> a) -> (SlotId -> a) -> EpochOrSlot -> a
+epochOrSlot f g = either f g . unEpochOrSlot
+
+-- | Convert 'EpochOrSlot' to the corresponding slot. If slot is
+-- stored, it's returned, otherwise 0-th slot from the stored epoch is
+-- returned.
+epochOrSlotToSlot :: EpochOrSlot -> SlotId
+epochOrSlotToSlot = epochOrSlot (flip SlotId minBound) identity

--- a/core/Pos/Core/Types.hs
+++ b/core/Pos/Core/Types.hs
@@ -66,7 +66,6 @@ module Pos.Core.Types
        , siSlotL
        , slotIdF
        , EpochOrSlot (..)
-       , epochOrSlot
 
        -- * Scripting
        , Script(..)
@@ -453,10 +452,6 @@ type FlatSlotId = Word64
 newtype EpochOrSlot = EpochOrSlot
     { unEpochOrSlot :: Either EpochIndex SlotId
     } deriving (Show, Eq, Generic, NFData)
-
--- | Apply one of the function depending on content of EpochOrSlot.
-epochOrSlot :: (EpochIndex -> a) -> (SlotId -> a) -> EpochOrSlot -> a
-epochOrSlot f g = either f g . unEpochOrSlot
 
 instance Ord EpochOrSlot where
     compare (EpochOrSlot e1) (EpochOrSlot e2) = case (e1,e2) of

--- a/db/Pos/DB/Pure.hs
+++ b/db/Pos/DB/Pure.hs
@@ -20,6 +20,7 @@ module Pos.DB.Pure
 
        , DBPureVar
        , newDBPureVar
+       , cloneDBPure
 
        , dbGetPureDefault
        , dbIterSourcePureDefault
@@ -72,6 +73,11 @@ type DBPureVar = IORef DBPure
 -- | Creates new db var.
 newDBPureVar :: MonadIO m => m DBPureVar
 newDBPureVar = newIORef def
+
+-- | Clones existing pure DB into a new one with the same contents.
+-- TODO: implement for any 'MonadDBRead' (requires iteration over whole DB).
+cloneDBPure :: MonadIO m => DBPureVar -> m DBPureVar
+cloneDBPure = readIORef >=> newIORef
 
 tagToLens :: DBTag -> Lens' DBPure DBPureMap
 tagToLens BlockIndexDB = pureBlockIndexDB

--- a/infra/Pos/Slotting/MemState/Holder.hs
+++ b/infra/Pos/Slotting/MemState/Holder.hs
@@ -4,6 +4,8 @@
 
 module Pos.Slotting.MemState.Holder
        ( HasSlottingVar(..)
+       , SlottingVar
+       , cloneSlottingVar
        , getSystemStartDefault
        , getSlottingDataDefault
        , waitPenultEpochEqualsDefault
@@ -21,10 +23,17 @@ import           Pos.Slotting.Types (SlottingData (sdPenultEpoch))
 -- Context
 ----------------------------------------------------------------------------
 
+type SlottingVar = TVar SlottingData
+
+-- | Create a new 'SlottingVar' with the same contents as the given
+-- variable has.
+cloneSlottingVar :: MonadIO m => SlottingVar -> m SlottingVar
+cloneSlottingVar = readTVarIO >=> newTVarIO
+
 -- | System start and slotting data
 class HasSlottingVar ctx where
     slottingTimestamp :: Lens' ctx Timestamp
-    slottingVar :: Lens' ctx (TVar SlottingData)
+    slottingVar :: Lens' ctx SlottingVar
 
 ----------------------------------------------------------------------------
 -- MonadSlotsData implementation

--- a/src/Pos/Block/Logic/Creation.hs
+++ b/src/Pos/Block/Logic/Creation.hs
@@ -117,8 +117,7 @@ createGenesisBlockAndApply ::
 createGenesisBlockAndApply 0 = pure Nothing
 createGenesisBlockAndApply epoch =
     reportingFatal $
-    try $
-    lrcActionOnEpochReason epoch "there are no leaders" LrcDB.getLeaders >>= \case
+    try (lrcActionOnEpochReason epoch "there are no leaders" LrcDB.getLeaders) >>= \case
         Left UnknownBlocksForLrc ->
             Nothing <$ logInfo "createGenesisBlock: not enough blocks for LRC"
         Left err -> throwM err

--- a/src/Pos/Block/Logic/Internal.hs
+++ b/src/Pos/Block/Logic/Internal.hs
@@ -37,7 +37,7 @@ import           Pos.Block.Types             (Blund, Undo (undoTx, undoUS))
 import           Pos.Core                    (IsGenesisHeader, IsMainHeader, epochIndexL,
                                               gbBody, gbHeader, headerHash)
 import           Pos.DB                      (MonadDB, MonadGState, SomeBatchOp (..))
-import           Pos.DB.Block                (MonadBlockDB)
+import           Pos.DB.Block                (MonadBlockDB, MonadSscBlockDB)
 import qualified Pos.DB.GState               as GS
 import           Pos.Delegation.Logic        (dlgApplyBlocks, dlgRollbackBlocks)
 import           Pos.Lrc.Context             (LrcContext)
@@ -75,6 +75,7 @@ type MonadBlockBase ssc ctx m
        , MonadSscMem ssc ctx m
        -- Needed to load blocks (at least delegation does it).
        , MonadBlockDB ssc m
+       , MonadSscBlockDB ssc m
        -- Needed by some components.
        , MonadGState m
        -- This constraints define block components' global logic.

--- a/src/Pos/Block/Logic/Internal.hs
+++ b/src/Pos/Block/Logic/Internal.hs
@@ -8,9 +8,9 @@
 module Pos.Block.Logic.Internal
        (
          -- * Constraints
-         BlockMode
-       , BlockVerifyMode
-       , BlockApplyMode
+         MonadBlockBase
+       , MonadBlockVerify
+       , MonadBlockApply
 
        , applyBlocksUnsafe
        , rollbackBlocksUnsafe
@@ -31,8 +31,8 @@ import           Serokell.Util.Text          (listJson)
 import           Pos.Block.BListener         (MonadBListener)
 import           Pos.Block.Core              (Block, GenesisBlock, MainBlock, mbTxPayload,
                                               mbUpdatePayload)
-import           Pos.Block.Slog              (SlogApplyMode, SlogMode, slogApplyBlocks,
-                                              slogRollbackBlocks)
+import           Pos.Block.Slog              (MonadSlogApply, MonadSlogBase,
+                                              slogApplyBlocks, slogRollbackBlocks)
 import           Pos.Block.Types             (Blund, Undo (undoTx, undoUS))
 import           Pos.Core                    (IsGenesisHeader, IsMainHeader, epochIndexL,
                                               gbBody, gbHeader, headerHash)
@@ -69,31 +69,28 @@ import           Pos.Util.Chrono             (NE, NewestFirst (..), OldestFirst 
 import           Pos.WorkMode.Class          (TxpExtra_TMP)
 
 -- | Set of basic constraints used by high-level block processing.
-type BlockMode ssc ctx m
-     = ( SlogMode ssc m
+type MonadBlockBase ssc ctx m
+     = ( MonadSlogBase ssc m
        -- Needed because SSC state is fully stored in memory.
        , MonadSscMem ssc ctx m
        -- Needed to load blocks (at least delegation does it).
        , MonadBlockDB ssc m
        -- Needed by some components.
        , MonadGState m
-       -- LRC is really needed.
-       , HasLens LrcContext ctx LrcContext
        -- This constraints define block components' global logic.
        , HasLens TxpGlobalSettings ctx TxpGlobalSettings
+       , HasLens LrcContext ctx LrcContext
        , SscGStateClass ssc
-       -- And 'MonadIO' is needed as usual.
-       , MonadIO m
        , MonadReader ctx m
        )
 
 -- | Set of constraints necessary for high-level block verification.
-type BlockVerifyMode ssc ctx m = BlockMode ssc ctx m
+type MonadBlockVerify ssc ctx m = MonadBlockBase ssc ctx m
 
 -- | Set of constraints necessary to apply or rollback blocks at high-level.
-type BlockApplyMode ssc ctx m
-     = ( BlockMode ssc ctx m
-       , SlogApplyMode ssc ctx m
+type MonadBlockApply ssc ctx m
+     = ( MonadBlockBase ssc ctx m
+       , MonadSlogApply ssc ctx m
        -- It's obviously needed to write something to DB, for instance.
        , MonadDB m
        -- Needed for iteration over DB.
@@ -118,7 +115,7 @@ type BlockApplyMode ssc ctx m
 --
 -- Invariant: all blocks have the same epoch.
 applyBlocksUnsafe
-    :: forall ssc ctx m . BlockApplyMode ssc ctx m
+    :: forall ssc ctx m . MonadBlockApply ssc ctx m
     => OldestFirst NE (Blund ssc) -> Maybe PollModifier -> m ()
 applyBlocksUnsafe blunds pModifier = reportingFatal $ do
     -- Check that all blunds have the same epoch.
@@ -146,7 +143,7 @@ applyBlocksUnsafe blunds pModifier = reportingFatal $ do
         spanSafe ((==) `on` view (_1 . epochIndexL)) $ getOldestFirst blunds
 
 applyBlocksUnsafeDo
-    :: forall ssc ctx m . BlockApplyMode ssc ctx m
+    :: forall ssc ctx m . MonadBlockApply ssc ctx m
     => OldestFirst NE (Blund ssc) -> Maybe PollModifier -> m ()
 applyBlocksUnsafeDo blunds pModifier = do
     -- Note: it's important to do 'slogApplyBlocks' first, because it
@@ -180,7 +177,7 @@ applyBlocksUnsafeDo blunds pModifier = do
 -- head being current tip. It's also assumed that lock on block db is
 -- taken.  application is taken already.
 rollbackBlocksUnsafe
-    :: forall ssc ctx m. (BlockApplyMode ssc ctx m)
+    :: forall ssc ctx m. (MonadBlockApply ssc ctx m)
     => NewestFirst NE (Blund ssc)
     -> m ()
 rollbackBlocksUnsafe toRollback = reportingFatal $ do

--- a/src/Pos/Block/Logic/VAR.hs
+++ b/src/Pos/Block/Logic/VAR.hs
@@ -21,7 +21,7 @@ import           Ether.Internal           (HasLens (..))
 import           System.Wlog              (logDebug)
 
 import           Pos.Block.Core           (Block)
-import           Pos.Block.Logic.Internal (BlockApplyMode, BlockVerifyMode,
+import           Pos.Block.Logic.Internal (MonadBlockApply, MonadBlockVerify,
                                            applyBlocksUnsafe, rollbackBlocksUnsafe,
                                            toTxpBlock, toUpdateBlock)
 import           Pos.Block.Logic.Util     (tipMismatchMsg)
@@ -54,7 +54,7 @@ import           Pos.Util.Chrono          (NE, NewestFirst (..), OldestFirst (..
 -- header, body, extra data, etc.
 verifyBlocksPrefix
     :: forall ssc ctx m.
-       BlockVerifyMode ssc ctx m
+       MonadBlockVerify ssc ctx m
     => OldestFirst NE (Block ssc)
     -> m (Either Text (OldestFirst NE Undo, PollModifier))
 verifyBlocksPrefix blocks = runExceptT $ do
@@ -87,7 +87,7 @@ verifyBlocksPrefix blocks = runExceptT $ do
          , pModifier)
 
 -- | Union of constraints required by block processing and LRC.
-type BlockLrcMode ssc ctx m = (BlockApplyMode ssc ctx m, LrcModeFull ssc ctx m)
+type BlockLrcMode ssc ctx m = (MonadBlockApply ssc ctx m, LrcModeFull ssc ctx m)
 
 -- | Applies blocks if they're valid. Takes one boolean flag
 -- "rollback". Returns header hash of last applied block (new tip) on

--- a/src/Pos/Block/Slog/Context.hs
+++ b/src/Pos/Block/Slog/Context.hs
@@ -2,6 +2,7 @@
 
 module Pos.Block.Slog.Context
        ( mkSlogContext
+       , cloneSlogContext
        , slogGetLastSlots
        , slogPutLastSlots
        ) where
@@ -18,6 +19,11 @@ mkSlogContext :: (MonadIO m, MonadDBRead m) => m SlogContext
 mkSlogContext = do
     _scLastBlkSlots <- getLastSlots >>= newIORef
     return SlogContext {..}
+
+-- | Make a copy of existing 'SlogContext'.
+cloneSlogContext :: (MonadIO m) => SlogContext -> m SlogContext
+cloneSlogContext SlogContext {..} =
+    SlogContext <$> (readIORef _scLastBlkSlots >>= newIORef)
 
 -- | Read 'LastBlkSlots' from in-memory state.
 slogGetLastSlots ::

--- a/src/Pos/Block/Slog/Logic.hs
+++ b/src/Pos/Block/Slog/Logic.hs
@@ -10,11 +10,11 @@
 module Pos.Block.Slog.Logic
        ( mustDataBeKnown
 
-       , SlogMode
-       , SlogVerifyMode
+       , MonadSlogBase
+       , MonadSlogVerify
        , slogVerifyBlocks
 
-       , SlogApplyMode
+       , MonadSlogApply
        , slogApplyBlocks
        , slogRollbackBlocks
        ) where
@@ -97,18 +97,17 @@ mustDataBeKnown adoptedBV =
 ----------------------------------------------------------------------------
 
 -- | Set of basic constraints needed by Slog.
-type SlogMode ssc m =
+type MonadSlogBase ssc m =
     ( MonadSlots m
+    , MonadIO m
     , SscHelpersClass ssc
     , MonadDBRead m
     , WithLogger m
     )
 
 -- | Set of constraints needed for Slog verification.
-type SlogVerifyMode ssc ctx m =
-    ( SlogMode ssc m
-    , MonadError Text m
-    , MonadIO m
+type MonadSlogVerify ssc ctx m =
+    ( MonadSlogBase ssc m
     , MonadReader ctx m
     , HasLens LrcContext ctx LrcContext
     )
@@ -117,7 +116,7 @@ type SlogVerifyMode ssc ctx m =
 -- All blocks must be from the same epoch.
 slogVerifyBlocks
     :: forall ssc ctx m.
-       SlogVerifyMode ssc ctx m
+       (MonadSlogVerify ssc ctx m, MonadError Text m)
     => OldestFirst NE (Block ssc)
     -> m (OldestFirst NE SlogUndo)
 slogVerifyBlocks blocks = do
@@ -173,12 +172,11 @@ slogVerifyBlocks blocks = do
     return $ over _Wrapped NE.fromList $ map SlogUndo slogUndo
 
 -- | Set of constraints necessary to apply/rollback blocks in Slog.
-type SlogApplyMode ssc ctx m =
-    ( SlogMode ssc m
+type MonadSlogApply ssc ctx m =
+    ( MonadSlogBase ssc m
     , MonadBlockDBWrite ssc m
     , MonadBListener m
     , MonadMask m
-    , MonadIO m
     , MonadReader ctx m
     , HasSlogContext ctx
     )
@@ -194,7 +192,7 @@ type SlogApplyMode ssc ctx m =
 -- | This function does everything that should be done when blocks are
 -- applied and is not done in other components.
 slogApplyBlocks ::
-       forall ssc ctx m. SlogApplyMode ssc ctx m
+       forall ssc ctx m. MonadSlogApply ssc ctx m
     => OldestFirst NE (Blund ssc)
     -> m SomeBatchOp
 slogApplyBlocks blunds = do
@@ -240,7 +238,7 @@ slogApplyBlocks blunds = do
 -- | This function does everything that should be done when rollback
 -- happens and that is not done in other components.
 slogRollbackBlocks ::
-       forall ssc ctx m. SlogApplyMode ssc ctx m
+       forall ssc ctx m. MonadSlogApply ssc ctx m
     => NewestFirst NE (Blund ssc)
     -> m SomeBatchOp
 slogRollbackBlocks blunds = do
@@ -275,7 +273,7 @@ slogRollbackBlocks blunds = do
         mconcat [forwardLinksBatch, inMainBatch]
 
 -- Common actions for rollback and apply.
-slogCommon :: SlogApplyMode ssc ctx m => LastBlkSlots -> m ()
+slogCommon :: MonadSlogApply ssc ctx m => LastBlkSlots -> m ()
 slogCommon newLastSlots = do
     sanityCheckDB
     slogPutLastSlots newLastSlots

--- a/src/Pos/Block/Worker.hs
+++ b/src/Pos/Block/Worker.hs
@@ -20,7 +20,7 @@ import           System.Wlog                 (logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Communication    ()
 import           Pos.Block.Logic             (calcChainQualityM, createGenesisBlock,
-                                              createMainBlock)
+                                              createMainBlockAndApply)
 import           Pos.Block.Network.Announce  (announceBlock, announceBlockOuts)
 import           Pos.Block.Network.Retrieval (retrievalWorker)
 import           Pos.Block.Slog              (slogGetLastSlots)
@@ -207,7 +207,7 @@ onNewSlotWhenLeader slotId pske sendActions = do
   where
     onNewSlotWhenLeaderDo = do
         logInfoS "It's time to create a block for current slot"
-        createdBlock <- createMainBlock slotId pske
+        createdBlock <- createMainBlockAndApply slotId pske
         either whenNotCreated whenCreated createdBlock
         logInfoS "onNewSlotWhenLeader: done"
     whenCreated createdBlk = do

--- a/src/Pos/Block/Worker.hs
+++ b/src/Pos/Block/Worker.hs
@@ -19,7 +19,8 @@ import           Serokell.Util               (listJson, pairF, sec)
 import           System.Wlog                 (logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Communication    ()
-import           Pos.Block.Logic             (calcChainQualityM, createGenesisBlock,
+import           Pos.Block.Logic             (calcChainQualityM,
+                                              createGenesisBlockAndApply,
                                               createMainBlockAndApply)
 import           Pos.Block.Network.Announce  (announceBlock, announceBlockOuts)
 import           Pos.Block.Network.Retrieval (retrievalWorker)
@@ -96,7 +97,7 @@ blockCreator
 blockCreator (slotId@SlotId {..}) sendActions = do
 
     -- First of all we create genesis block if necessary.
-    mGenBlock <- createGenesisBlock siEpoch
+    mGenBlock <- createGenesisBlockAndApply siEpoch
     whenJust mGenBlock $ \createdBlk -> do
         logInfo $ sformat ("Created genesis block:\n" %build) createdBlk
         jsonLog $ jlCreatedBlock (Left createdBlk)

--- a/src/Pos/DB/Block.hs
+++ b/src/Pos/DB/Block.hs
@@ -34,6 +34,7 @@ module Pos.DB.Block
 
        -- * MonadBlockDB
        , MonadBlockDB
+       , MonadSscBlockDB
        , MonadBlockDBWrite
        , dbGetBlockDefault
        , dbGetUndoDefault
@@ -320,7 +321,10 @@ blockIndexKey h = "b" <> convert h
 -- | Specialization of 'MonadBlockDBGeneric' for block processing.
 type MonadBlockDB ssc m
      = ( MonadBlockDBGeneric (BlockHeader ssc) (Block ssc) Undo m
-       , MonadBlockDBGeneric (Some IsHeader) (SscBlock ssc) () m
+       , SscHelpersClass ssc)
+
+type MonadSscBlockDB ssc m
+     = ( MonadBlockDBGeneric (Some IsHeader) (SscBlock ssc) () m
        , SscHelpersClass ssc)
 
 -- | 'MonadBlocksDB' with write options

--- a/src/Pos/Delegation/Class.hs
+++ b/src/Pos/Delegation/Class.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- | Definitions for class of monads that capture logic of processing
 -- delegate certificates (proxy secret keys).
@@ -14,7 +16,6 @@ module Pos.Delegation.Class
        , dwThisEpochPosted
 
        , DelegationVar
-       , mkDelegationVar
        , MonadDelegation
        , askDelegationState
        ) where
@@ -23,18 +24,13 @@ import           Universum
 
 import           Control.Lens               (makeLenses)
 import qualified Data.Cache.LRU             as LRU
-import           Data.Default               (Default (def))
-import qualified Data.HashMap.Strict        as HM
-import qualified Data.HashSet               as HS
 import           Data.Time.Clock            (UTCTime)
 import           Serokell.Data.Memory.Units (Byte)
 
-import           Pos.Constants              (dlgCacheParam)
 import           Pos.Core                   (EpochIndex, ProxySKHeavy, ProxySKLight)
 import           Pos.Crypto                 (PublicKey)
 import           Pos.Delegation.Types       (DlgMemPool)
 import           Pos.Util.Concurrent.RWVar  (RWVar)
-import           Pos.Util.Concurrent.RWVar  as RWV
 import           Pos.Util.Util              (HasLens (..))
 
 ---------------------------------------------------------------------------
@@ -67,28 +63,7 @@ data DelegationWrap = DelegationWrap
 
 makeLenses ''DelegationWrap
 
-instance Default DelegationWrap where
-    def =
-        DelegationWrap
-        { _dwMessageCache = LRU.newLRU msgCacheLimit
-        , _dwConfirmationCache = LRU.newLRU confCacheLimit
-        , _dwProxySKPool = HM.empty
-        , _dwPoolSize = 1
-        , _dwEpochId = 0
-        , _dwThisEpochPosted = HS.empty
-        }
-      where
-        msgCacheLimit = Just dlgCacheParam
-        confCacheLimit = Just (dlgCacheParam `div` 5)
-
 type DelegationVar = RWVar DelegationWrap
-
--- | Make a new 'DelegationVar'.
---
--- FIXME: it creates 'DelegationVar' with '_dwThisEpochPosted =
--- HS.empty', is it even legal?
-mkDelegationVar :: MonadIO m => m DelegationVar
-mkDelegationVar = RWV.new def
 
 ----------------------------------------------------------------------------
 -- Class definition

--- a/src/Pos/Generator.hs
+++ b/src/Pos/Generator.hs
@@ -1,0 +1,3 @@
+-- | Generators of arbitrary data.
+
+{-# OPTIONS_GHC -F -pgmF autoexporter #-}

--- a/src/Pos/Generator/Block.hs
+++ b/src/Pos/Generator/Block.hs
@@ -1,0 +1,3 @@
+-- | Arbitrary blockchain generation.
+
+{-# OPTIONS_GHC -F -pgmF autoexporter #-}

--- a/src/Pos/Generator/Block/Error.hs
+++ b/src/Pos/Generator/Block/Error.hs
@@ -22,6 +22,8 @@ data BlockGenError
     -- be found in the context.
     | BGFailedToCreate !Text
     -- ^ Block generator failed to create a block.
+    | BGCreatedInvalid !Text
+    -- ^ Block generator created invalid block.
     | BGInternal !Text
     -- ^ Internall error occurred.
     deriving (Show)
@@ -32,6 +34,8 @@ instance Buildable BlockGenError where
             ("Secret key of "%shortHashF%" is required but isn't known") sId
     build (BGFailedToCreate reason) =
         bprint ("Failed to create a block: "%stext) reason
+    build (BGCreatedInvalid reason) =
+        bprint ("Unfortunately, I created invalid block: "%stext) reason
     build (BGInternal reason) =
         bprint ("Internal error: "%stext) reason
 

--- a/src/Pos/Generator/Block/Error.hs
+++ b/src/Pos/Generator/Block/Error.hs
@@ -1,0 +1,41 @@
+-- | Errors which can happen during blockchain generation.
+
+module Pos.Generator.Block.Error
+       ( BlockGenError (..)
+       ) where
+
+import           Universum
+
+import           Control.Exception   (Exception (..))
+import qualified Data.Text.Buildable
+import           Formatting          (bprint, stext, (%))
+
+import           Pos.Core            (StakeholderId)
+import           Pos.Crypto          (shortHashF)
+import           Pos.Exception       (cardanoExceptionFromException,
+                                      cardanoExceptionToException)
+
+-- | Errors which can happen during blockchain generation.
+data BlockGenError
+    = BGUnknownSecret !StakeholderId
+    -- ^ Generator needs secret key of given stakeholder, but it can't
+    -- be found in the context.
+    | BGFailedToCreate !Text
+    -- ^ Block generator failed to create a block.
+    | BGInternal !Text
+    -- ^ Internall error occurred.
+    deriving (Show)
+
+instance Buildable BlockGenError where
+    build (BGUnknownSecret sId) =
+        bprint
+            ("Secret key of "%shortHashF%" is required but isn't known") sId
+    build (BGFailedToCreate reason) =
+        bprint ("Failed to create a block: "%stext) reason
+    build (BGInternal reason) =
+        bprint ("Internal error: "%stext) reason
+
+instance Exception BlockGenError where
+    toException = cardanoExceptionToException
+    fromException = cardanoExceptionFromException
+    displayException = toString . pretty

--- a/src/Pos/Generator/Block/Logic.hs
+++ b/src/Pos/Generator/Block/Logic.hs
@@ -1,0 +1,92 @@
+-- | Blockchain generation logic.
+
+module Pos.Generator.Block.Logic
+       ( genBlocks
+       ) where
+
+import           Universum
+
+import           Control.Lens              (at, ix)
+
+import           Pos.Block.Core            (Block)
+import           Pos.Block.Logic           (createMainBlockInternal)
+import           Pos.Core                  (EpochOrSlot (..), HasPrimaryKey (..),
+                                            SlotId (..), getEpochOrSlot, getSlotIndex)
+import           Pos.DB.DB                 (getTipHeader)
+import           Pos.Generator.Block.Error (BlockGenError (..))
+import           Pos.Generator.Block.Mode  (BlockGenMode, MonadBlockGen,
+                                            MonadBlockGenBase, mkBlockGenContext)
+import           Pos.Generator.Block.Param (HasAllSecrets (..), HasBlockGenParams (..))
+import           Pos.Lrc.Context           (lrcActionOnEpochReason)
+import qualified Pos.Lrc.DB                as LrcDB
+import           Pos.Ssc.GodTossing        (SscGodTossing)
+import           Pos.Util.Chrono           (OldestFirst (..))
+import           Pos.Util.Util             (maybeThrow)
+
+----------------------------------------------------------------------------
+-- Block generation
+----------------------------------------------------------------------------
+
+-- TODO: the blocks are also applied, but usually we shouldn't modify
+-- the state.  The idea is to use 'DBProxyT' (which doesn't exist yet)
+-- akin to 'PollT', 'TossT', etc. to put all modifications into a
+-- temporary state instead of applying them to the given DB directly.
+--
+-- | Generate an arbitrary sequence of valid blocks. The blocks are
+-- valid with respect to the global state right before this function
+-- call.
+genBlocks :: MonadBlockGen ctx m => m (OldestFirst [] (Block SscGodTossing))
+genBlocks = do
+    ctx <- mkBlockGenContext
+    runReaderT genBlocksDo ctx
+  where
+    genBlocksDo =
+        OldestFirst <$> do
+            numberOfBlocks <- view bgpBlockCount <$> view blockGenParams
+            tipEOS <- getEpochOrSlot <$> getTipHeader @SscGodTossing
+            let startEOS = succ tipEOS
+            let finishEOS =
+                    toEnum $ fromEnum tipEOS + fromIntegral numberOfBlocks
+            mapM genBlock [startEOS .. finishEOS]
+
+-- Generate a valid 'Block' for the given epoch or slot (genesis block
+-- in the former case and main block the latter case) and apply it.
+genBlock ::
+       (MonadBlockGenBase m)
+    => EpochOrSlot
+    -> BlockGenMode m (Block SscGodTossing)
+genBlock (EpochOrSlot (Left epoch)) = undefined epoch
+genBlock (EpochOrSlot (Right slot@SlotId {..})) = do
+    genPayload slot
+    -- We need to know leader's secret key to create a block.
+    leaders <- lrcActionOnEpochReason siEpoch "genBlock" LrcDB.getLeaders
+    leader <-
+        maybeThrow
+            (BGInternal "no leader")
+            (leaders ^? ix (fromIntegral $ getSlotIndex siSlot))
+    secrets <- view asSecretKeys <$> view blockGenParams
+    leaderSK <- maybeThrow (BGUnknownSecret leader) (secrets ^. at leader)
+    -- When we know the secret key we can proceed to the actual creation.
+    local (set primaryKey leaderSK) genBlockDo
+  where
+    genBlockDo =
+        (createMainBlockInternal @SscGodTossing slot Nothing) >>= \case
+            Left err -> throwM (BGFailedToCreate err)
+        -- apply, but probably reduced version (e. g. no slotting)
+            Right mainBlock -> undefined mainBlock
+
+----------------------------------------------------------------------------
+-- Payload generation
+----------------------------------------------------------------------------
+
+-- Generate random payload which is valid with respect to the current
+-- global state and mempool and add it to mempool.  Currently we are
+-- concerned only about tx payload, later we can add more stuff.
+genPayload :: Monad m => SlotId -> m ()
+genPayload _ = genTxPayload
+
+-- TODO: add randomness, implement, move to txp, think how to unite it
+-- with 'Pos.Txp.Arbitrary'.
+-- Generate valid 'TxPayload' using current global state.
+genTxPayload :: Monad m => m ()
+genTxPayload = pass

--- a/src/Pos/Generator/Block/Logic.hs
+++ b/src/Pos/Generator/Block/Logic.hs
@@ -28,11 +28,6 @@ import           Pos.Util.Util             (maybeThrow)
 -- Block generation
 ----------------------------------------------------------------------------
 
--- TODO: the blocks are also applied, but usually we shouldn't modify
--- the state.  The idea is to use 'DBProxyT' (which doesn't exist yet)
--- akin to 'PollT', 'TossT', etc. to put all modifications into a
--- temporary state instead of applying them to the given DB directly.
---
 -- | Generate an arbitrary sequence of valid blocks. The blocks are
 -- valid with respect to the global state right before this function
 -- call.

--- a/src/Pos/Generator/Block/Mode.hs
+++ b/src/Pos/Generator/Block/Mode.hs
@@ -1,0 +1,163 @@
+-- | Execution mode used by blockchain generator.
+
+module Pos.Generator.Block.Mode
+       ( MonadBlockGenBase
+       , MonadBlockGen
+       , BlockGenContext (..)
+       , BlockGenMode
+       , mkBlockGenContext
+       ) where
+
+import           Universum
+
+import           Control.Exception           (Exception (..))
+import           Control.Lens.TH             (makeLensesWith)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+import qualified Data.Text.Buildable
+import           Mockable                    (MonadMockable)
+import           System.Wlog                 (WithLogger)
+
+import           Pos.Block.Core              (Block, BlockHeader)
+import           Pos.Block.Slog              (HasSlogContext (..), SlogContext)
+import           Pos.Block.Types             (Undo)
+import           Pos.Context                 (GenesisUtxo (..))
+import           Pos.Core                    (BlockCount, EpochOrSlot (..),
+                                              HasPrimaryKey (..), IsHeader, SlotId,
+                                              StakeholderId, Timestamp, getEpochOrSlot)
+import           Pos.Crypto                  (SecretKey)
+import           Pos.DB                      (DBPureVar, MonadBlockDBGeneric (..),
+                                              MonadDB, MonadDBRead)
+import qualified Pos.DB                      as DB
+import qualified Pos.DB.Block                as BDB
+import           Pos.Delegation              (DelegationVar)
+import           Pos.Generator.Block.Param   (BlockGenParams, HasBlockGenParams (..))
+import           Pos.Lrc                     (LrcContext (..), mkLrcSyncData)
+import           Pos.Slotting                (SlottingData)
+import           Pos.Ssc.Class               (SscBlock)
+import           Pos.Ssc.Extra               (SscMemTag, SscState)
+import           Pos.Ssc.GodTossing          (SscGodTossing)
+import           Pos.Txp                     (GenericTxpLocalData, TxPayload,
+                                              TxpHolderTag, TxpMetrics, emptyTxPayload)
+import           Pos.Update.Context          (UpdateContext)
+import           Pos.Util                    (HasLens (..), Some, postfixLFields)
+import           Pos.Util.Chrono             (OldestFirst (..))
+import           Pos.WorkMode.Class          (TxpExtra_TMP)
+
+----------------------------------------------------------------------------
+-- Constraint
+----------------------------------------------------------------------------
+
+-- | A set of constraints imposed on the base monad used for
+-- arbitrary blockchain generation.
+type MonadBlockGenBase m
+     = ( WithLogger m
+       , MonadMask m
+       , MonadIO m
+       , MonadMockable m
+       , MonadBaseControl IO m
+       )
+
+-- | A set of constraints necessary for blockchain generation. All
+-- these constraints must be satistified by the generator's caller.
+type MonadBlockGen ctx m
+     = ( MonadBlockGenBase m
+       , MonadReader ctx m
+       , HasBlockGenParams ctx
+       -- TODO: we don't really need to require pure db from the
+       -- outside. We can clone real DB into a pure one. Or we can use
+       -- 'DBProxyT' approach. Currently we require pure DB because
+       -- it's easier.
+       , HasLens DBPureVar ctx DBPureVar
+       )
+
+----------------------------------------------------------------------------
+-- Context
+----------------------------------------------------------------------------
+
+-- | Context used by blockchain generator.
+data BlockGenContext = BlockGenContext
+    { bgcPrimaryKey    :: SecretKey
+    -- ^ This field is lazy on purpose. Primary key used for block
+    -- generation changes frequently. We don't define it initially and
+    -- modify it using 'local' when we need it. Alternative solution
+    -- would be to define a type w/o primary key and another one with
+    -- primary key, but it would lead to enormous amount of
+    -- boilerplate. Also it could be put into mutable reference, but
+    -- it's complicated too.
+    , bgcDB            :: !DBPureVar
+    -- ^ Pure DB used by block generation. Currently we always use
+    -- pure DB and assume it always fit in memory. It allows us to
+    -- simply clone existing DB.
+    , bgcSlogContext   :: !SlogContext
+    , bgcParams        :: !BlockGenParams
+    , bgcDelegation    :: !DelegationVar
+    , bgcLrcContext    :: !LrcContext
+    , bgcTxpMem        :: !(GenericTxpLocalData TxpExtra_TMP, TxpMetrics)
+    , bgcUpdateContext :: !UpdateContext
+    , bgcSscState      :: !(SscState SscGodTossing)
+    }
+
+makeLensesWith postfixLFields ''BlockGenContext
+
+-- | Execution mode for blockchain generation.
+type BlockGenMode m = ReaderT BlockGenContext m
+
+mkBlockGenContext :: MonadBlockGen ctx m => m BlockGenContext
+mkBlockGenContext = undefined
+
+----------------------------------------------------------------------------
+-- Boilerplate instances
+----------------------------------------------------------------------------
+
+instance HasLens BlockGenContext BlockGenContext BlockGenContext where
+    lensOf = identity
+
+instance HasBlockGenParams BlockGenContext where
+    blockGenParams = bgcParams_L
+
+instance HasLens DBPureVar BlockGenContext DBPureVar where
+    lensOf = bgcDB_L
+
+instance HasLens UpdateContext BlockGenContext UpdateContext where
+    lensOf = bgcUpdateContext_L
+
+instance HasLens DelegationVar BlockGenContext DelegationVar where
+    lensOf = bgcDelegation_L
+
+instance HasLens LrcContext BlockGenContext LrcContext where
+    lensOf = bgcLrcContext_L
+
+instance HasPrimaryKey BlockGenContext where
+    primaryKey = bgcPrimaryKey_L
+
+instance HasSlogContext BlockGenContext where
+    slogContextL = bgcSlogContext_L
+
+instance HasLens TxpHolderTag BlockGenContext (GenericTxpLocalData TxpExtra_TMP, TxpMetrics) where
+    lensOf = bgcTxpMem_L
+
+instance HasLens SscMemTag BlockGenContext (SscState SscGodTossing) where
+    lensOf = bgcSscState_L
+
+instance MonadBlockGenBase m => MonadDBRead (BlockGenMode m) where
+    dbGet = DB.dbGetPureDefault
+    dbIterSource = DB.dbIterSourcePureDefault
+
+instance MonadBlockGenBase m => MonadDB (BlockGenMode m) where
+    dbPut = DB.dbPutPureDefault
+    dbWriteBatch = DB.dbWriteBatchPureDefault
+    dbDelete = DB.dbDeletePureDefault
+
+instance MonadBlockGenBase m =>
+    MonadBlockDBGeneric (BlockHeader SscGodTossing) (Block SscGodTossing) Undo (BlockGenMode m)
+  where
+    dbGetBlock = BDB.dbGetBlockPureDefault @SscGodTossing
+    dbGetUndo = BDB.dbGetUndoPureDefault @SscGodTossing
+    dbGetHeader = BDB.dbGetHeaderPureDefault @SscGodTossing
+
+instance MonadBlockGenBase m =>
+    MonadBlockDBGeneric (Some IsHeader) (SscBlock SscGodTossing) () (BlockGenMode m)
+  where
+    dbGetBlock = BDB.dbGetBlockSscPureDefault @SscGodTossing
+    dbGetUndo = BDB.dbGetUndoSscPureDefault @SscGodTossing
+    dbGetHeader = BDB.dbGetHeaderSscPureDefault @SscGodTossing

--- a/src/Pos/Generator/Block/Mode.hs
+++ b/src/Pos/Generator/Block/Mode.hs
@@ -7,6 +7,9 @@ module Pos.Generator.Block.Mode
        , BlockGenMode
        , mkBlockGenContext
 
+       , usingPrimaryKey
+       , withCurrentSlot
+
        , InitBlockGenContext (..) -- useless
        ) where
 
@@ -14,27 +17,38 @@ import           Universum
 
 import           Control.Lens.TH             (makeLensesWith)
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import           Mockable                    (MonadMockable)
-import           System.Wlog                 (WithLogger)
+import           Mockable                    (MonadMockable, Promise)
+import           System.Wlog                 (WithLogger, logWarning)
 
+import           Pos.Block.BListener         (MonadBListener (..), onApplyBlocksStub,
+                                              onRollbackBlocksStub)
 import           Pos.Block.Core              (Block, BlockHeader)
 import           Pos.Block.Slog              (HasSlogContext (..), SlogContext,
                                               cloneSlogContext)
 import           Pos.Block.Types             (Undo)
-import           Pos.Core                    (HasPrimaryKey (..), IsHeader, Timestamp)
+import           Pos.Core                    (HasPrimaryKey (..), IsHeader, SlotId (..),
+                                              Timestamp, epochOrSlotToSlot,
+                                              getEpochOrSlot)
 import           Pos.Crypto                  (SecretKey)
 import           Pos.DB                      (DBPureVar, MonadBlockDBGeneric (..),
-                                              MonadDB, MonadDBRead)
+                                              MonadBlockDBGenericWrite (..), MonadDB,
+                                              MonadDBRead)
 import qualified Pos.DB                      as DB
 import qualified Pos.DB.Block                as BDB
+import           Pos.DB.DB                   (getTipHeader, gsAdoptedBVDataDefault)
 import           Pos.Delegation              (DelegationVar, mkDelegationVar)
+import           Pos.Discovery               (DiscoveryContextSum (..),
+                                              HasDiscoveryContextSum (..),
+                                              MonadDiscovery (..), findPeersSum,
+                                              getPeersSum)
+import           Pos.Exception               (reportFatalError)
 import           Pos.Generator.Block.Param   (BlockGenParams, HasBlockGenParams (..))
+import           Pos.Launcher.Mode           (newInitFuture)
 import           Pos.Lrc                     (LrcContext (..), cloneLrcContext)
+import           Pos.Reporting               (HasReportingContext (..), ReportingContext,
+                                              emptyReportingContext)
 import           Pos.Slotting                (HasSlottingVar (..), MonadSlots (..),
-                                              SlottingData, currentTimeSlottingSimple,
-                                              getCurrentSlotBlockingSimple,
-                                              getCurrentSlotInaccurateSimple,
-                                              getCurrentSlotSimple)
+                                              SlottingData, currentTimeSlottingSimple)
 import           Pos.Slotting.MemState       (MonadSlotsData (..), cloneSlottingVar,
                                               getSlottingDataDefault,
                                               getSystemStartDefault,
@@ -43,9 +57,9 @@ import           Pos.Slotting.MemState       (MonadSlotsData (..), cloneSlotting
 import           Pos.Ssc.Class               (SscBlock)
 import           Pos.Ssc.Extra               (SscMemTag, SscState, mkSscState)
 import           Pos.Ssc.GodTossing          (SscGodTossing)
-import           Pos.Txp                     (GenericTxpLocalData, TxpHolderTag,
-                                              TxpMetrics, ignoreTxpMetrics,
-                                              mkTxpLocalData)
+import           Pos.Txp                     (GenericTxpLocalData, TxpGlobalSettings,
+                                              TxpHolderTag, TxpMetrics, ignoreTxpMetrics,
+                                              mkTxpLocalData, txpGlobalSettings)
 import           Pos.Update.Context          (UpdateContext, mkUpdateContext)
 import           Pos.Util                    (HasLens (..), Some, postfixLFields)
 import           Pos.WorkMode.Class          (TxpExtra_TMP)
@@ -62,6 +76,7 @@ type MonadBlockGenBase m
        , MonadIO m
        , MonadMockable m
        , MonadBaseControl IO m
+       , Eq (Promise m (Maybe ())) -- are you cereal boyz??1?
        )
 
 -- | A set of constraints necessary for blockchain generation. All
@@ -85,7 +100,7 @@ type MonadBlockGen ctx m
 
 -- | Context used by blockchain generator.
 data BlockGenContext = BlockGenContext
-    { bgcPrimaryKey    :: SecretKey
+    { bgcPrimaryKey        :: SecretKey
     -- ^ This field is lazy on purpose. Primary key used for block
     -- generation changes frequently. We don't define it initially and
     -- modify it using 'local' when we need it. Alternative solution
@@ -93,19 +108,25 @@ data BlockGenContext = BlockGenContext
     -- primary key, but it would lead to enormous amount of
     -- boilerplate. Also it could be put into mutable reference, but
     -- it's complicated too.
-    , bgcDB            :: !DBPureVar
+    , bgcDB                :: !DBPureVar
     -- ^ Pure DB used by block generation. Currently we always use
-    -- pure DB and assume it always fit in memory. It allows us to
+    -- pure DB and assume it always fits in memory. It allows us to
     -- simply clone existing DB.
-    , bgcSlogContext   :: !SlogContext
-    , bgcSystemStart   :: !Timestamp
-    , bgcSlottingVar   :: !(TVar SlottingData)
-    , bgcParams        :: !BlockGenParams
-    , bgcDelegation    :: !DelegationVar
-    , bgcLrcContext    :: !LrcContext
-    , bgcTxpMem        :: !(GenericTxpLocalData TxpExtra_TMP, TxpMetrics)
-    , bgcUpdateContext :: !UpdateContext
-    , bgcSscState      :: !(SscState SscGodTossing)
+    , bgcSlogContext       :: !SlogContext
+    , bgcSystemStart       :: !Timestamp
+    , bgcSlottingVar       :: !(TVar SlottingData)
+    , bgcParams            :: !BlockGenParams
+    , bgcDelegation        :: !DelegationVar
+    , bgcLrcContext        :: !LrcContext
+    , bgcTxpMem            :: !(GenericTxpLocalData TxpExtra_TMP, TxpMetrics)
+    , bgcUpdateContext     :: !UpdateContext
+    , bgcSscState          :: !(SscState SscGodTossing)
+    , bgcSlotId            :: !(Maybe SlotId)
+    -- ^ During block generation we don't want to use real time, but
+    -- rather want to set current slot (fake one) by ourselves.
+    , bgcTxpGlobalSettings :: !TxpGlobalSettings
+    , bgcReportingContext  :: !ReportingContext
+    , bgcDiscoveryContext  :: !DiscoveryContextSum
     }
 
 makeLensesWith postfixLFields ''BlockGenContext
@@ -128,13 +149,21 @@ mkBlockGenContext bgcParams = do
     bgcSlottingVar <- cloneSlottingVar =<< view slottingVar
     bgcLrcContext <- cloneLrcContext =<< view (lensOf @LrcContext)
     bgcSlogContext <- cloneSlogContext =<< view slogContextL
+    (initSlot, putInitSlot) <- newInitFuture
+    let bgcSlotId = Nothing
+    let bgcTxpGlobalSettings = txpGlobalSettings
+    let bgcReportingContext = emptyReportingContext
+    let bgcDiscoveryContext = DCStatic mempty
     let initCtx =
             InitBlockGenContext
                 bgcDB
                 bgcSystemStart
                 bgcSlottingVar
                 bgcLrcContext
+                initSlot
     usingReaderT initCtx $ do
+        tipEOS <- getEpochOrSlot <$> getTipHeader @SscGodTossing
+        putInitSlot (epochOrSlotToSlot tipEOS)
         bgcSscState <- mkSscState @SscGodTossing
         bgcUpdateContext <- mkUpdateContext
         bgcTxpMem <- (,) <$> mkTxpLocalData <*> pure ignoreTxpMetrics
@@ -146,6 +175,9 @@ data InitBlockGenContext = InitBlockGenContext
     , ibgcSystemStart :: !Timestamp
     , ibgcSlottingVar :: !(TVar SlottingData)
     , ibgcLrcContext  :: !LrcContext
+    , ibgcSlot        :: SlotId
+    -- ^ All initialization will be done assuming the current slot is
+    -- this one. It's lazy to be used with future.
     }
 
 makeLensesWith postfixLFields ''InitBlockGenContext
@@ -171,6 +203,13 @@ instance MonadBlockGenBase m => MonadDB (InitBlockGenMode m) where
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
 
+instance MonadBlockGenBase m =>
+    MonadBlockDBGeneric (BlockHeader SscGodTossing) (Block SscGodTossing) Undo (InitBlockGenMode m)
+  where
+    dbGetBlock = BDB.dbGetBlockPureDefault @SscGodTossing
+    dbGetUndo = BDB.dbGetUndoPureDefault @SscGodTossing
+    dbGetHeader = BDB.dbGetHeaderPureDefault @SscGodTossing
+
 instance MonadBlockGenBase m => MonadSlotsData (InitBlockGenMode m) where
     getSystemStart = getSystemStartDefault
     getSlottingData = getSlottingDataDefault
@@ -178,10 +217,12 @@ instance MonadBlockGenBase m => MonadSlotsData (InitBlockGenMode m) where
     putSlottingData = putSlottingDataDefault
 
 instance MonadBlockGenBase m => MonadSlots (InitBlockGenMode m) where
-    getCurrentSlot = getCurrentSlotSimple
-    getCurrentSlotBlocking = getCurrentSlotBlockingSimple
-    getCurrentSlotInaccurate = getCurrentSlotInaccurateSimple
-    currentTimeSlotting = currentTimeSlottingSimple
+    getCurrentSlot = Just <$> view ibgcSlot_L
+    getCurrentSlotBlocking = view ibgcSlot_L
+    getCurrentSlotInaccurate = view ibgcSlot_L
+    currentTimeSlotting = do
+        logWarning "currentTimeSlotting is used in initialization"
+        currentTimeSlottingSimple
 
 ----------------------------------------------------------------------------
 -- Boilerplate instances
@@ -221,6 +262,15 @@ instance HasLens TxpHolderTag BlockGenContext (GenericTxpLocalData TxpExtra_TMP,
 instance HasLens SscMemTag BlockGenContext (SscState SscGodTossing) where
     lensOf = bgcSscState_L
 
+instance HasLens TxpGlobalSettings BlockGenContext TxpGlobalSettings where
+    lensOf = bgcTxpGlobalSettings_L
+
+instance HasReportingContext BlockGenContext where
+    reportingContext = bgcReportingContext_L
+
+instance HasDiscoveryContextSum BlockGenContext where
+    discoveryContextSum = bgcDiscoveryContext_L
+
 instance MonadBlockGenBase m => MonadDBRead (BlockGenMode m) where
     dbGet = DB.dbGetPureDefault
     dbIterSource = DB.dbIterSourcePureDefault
@@ -243,3 +293,47 @@ instance MonadBlockGenBase m =>
     dbGetBlock = BDB.dbGetBlockSscPureDefault @SscGodTossing
     dbGetUndo = BDB.dbGetUndoSscPureDefault @SscGodTossing
     dbGetHeader = BDB.dbGetHeaderSscPureDefault @SscGodTossing
+
+instance MonadBlockGenBase m =>
+         MonadBlockDBGenericWrite (BlockHeader SscGodTossing) (Block SscGodTossing) Undo (BlockGenMode m) where
+    dbPutBlund = BDB.dbPutBlundPureDefault
+
+instance MonadBlockGenBase m => MonadSlotsData (BlockGenMode m) where
+    getSystemStart = getSystemStartDefault
+    getSlottingData = getSlottingDataDefault
+    waitPenultEpochEquals = waitPenultEpochEqualsDefault
+    putSlottingData = putSlottingDataDefault
+
+instance MonadBlockGenBase m => MonadSlots (BlockGenMode m) where
+    getCurrentSlot = view bgcSlotId_L
+    getCurrentSlotBlocking =
+        view bgcSlotId_L >>= \case
+            Nothing ->
+                reportFatalError
+                    "getCurrentSlotBlocking is used in generator when slot is unknown"
+            Just slot -> pure slot
+    getCurrentSlotInaccurate =
+        reportFatalError
+            "It hardly makes sense to use 'getCurrentSlotInaccurate' during block generation"
+    currentTimeSlotting = currentTimeSlottingSimple
+
+instance MonadBlockGenBase m => DB.MonadGState (BlockGenMode m) where
+    gsAdoptedBVData = gsAdoptedBVDataDefault
+
+instance MonadBlockGenBase m => MonadBListener (BlockGenMode m) where
+    onApplyBlocks = onApplyBlocksStub
+    onRollbackBlocks = onRollbackBlocksStub
+
+instance MonadBlockGenBase m => MonadDiscovery (BlockGenMode m) where
+    getPeers = getPeersSum
+    findPeers = findPeersSum
+
+----------------------------------------------------------------------------
+-- Utilities
+----------------------------------------------------------------------------
+
+usingPrimaryKey :: MonadReader BlockGenContext m => SecretKey -> m a -> m a
+usingPrimaryKey sk = local (set primaryKey sk)
+
+withCurrentSlot :: MonadReader BlockGenContext m => SlotId -> m a -> m a
+withCurrentSlot slot = local (set bgcSlotId_L $ Just slot)

--- a/src/Pos/Generator/Block/Mode.hs
+++ b/src/Pos/Generator/Block/Mode.hs
@@ -167,7 +167,7 @@ mkBlockGenContext bgcParams = do
         bgcSscState <- mkSscState @SscGodTossing
         bgcUpdateContext <- mkUpdateContext
         bgcTxpMem <- (,) <$> mkTxpLocalData <*> pure ignoreTxpMetrics
-        bgcDelegation <- mkDelegationVar
+        bgcDelegation <- mkDelegationVar @SscGodTossing
         return BlockGenContext {..}
 
 data InitBlockGenContext = InitBlockGenContext

--- a/src/Pos/Generator/Block/Mode.hs
+++ b/src/Pos/Generator/Block/Mode.hs
@@ -69,7 +69,6 @@ type MonadBlockGenBase m
 type MonadBlockGen ctx m
      = ( MonadBlockGenBase m
        , MonadReader ctx m
-       , HasBlockGenParams ctx
        -- TODO: we don't really need to require pure db from the
        -- outside. We can clone real DB into a pure one. Or we can use
        -- 'DBProxyT' approach. Currently we require pure DB because
@@ -121,9 +120,8 @@ type BlockGenMode m = ReaderT BlockGenContext m
 -- | Make new 'BlockGenContext' using data provided by 'MonadBlockGen'
 -- context. Persistent data (DB) is cloned. Other mutable data is
 -- recreated.
-mkBlockGenContext :: MonadBlockGen ctx m => m BlockGenContext
-mkBlockGenContext = do
-    bgcParams <- view blockGenParams
+mkBlockGenContext :: MonadBlockGen ctx m => BlockGenParams -> m BlockGenContext
+mkBlockGenContext bgcParams = do
     let bgcPrimaryKey = error "bgcPrimaryKey was forced before being set"
     bgcDB <- DB.cloneDBPure =<< view (lensOf @DBPureVar)
     bgcSystemStart <- view slottingTimestamp

--- a/src/Pos/Generator/Block/Param.hs
+++ b/src/Pos/Generator/Block/Param.hs
@@ -9,10 +9,15 @@ module Pos.Generator.Block.Param
 
 import           Universum
 
-import           Control.Lens.TH (makeClassy)
+import           Control.Lens.TH     (makeClassy)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text.Buildable
+import           Formatting          (bprint, build, formatToString, int, (%))
+import qualified Prelude
+import           Serokell.Util       (listJson)
 
-import           Pos.Core        (BlockCount, StakeholderId)
-import           Pos.Crypto      (SecretKey)
+import           Pos.Core            (BlockCount, StakeholderId)
+import           Pos.Crypto          (SecretKey)
 
 -- | All secret keys in the system. In testing environment we often
 -- want to have inverse of 'hash' and 'toPublic'.
@@ -24,6 +29,15 @@ data AllSecrets = AllSecrets
     }
 
 makeClassy ''AllSecrets
+
+instance Buildable AllSecrets where
+    build AllSecrets {..} =
+        bprint ("AllSecrets {\n"%
+                "  secret keys: "%int%" items\n"%
+                "  stakeholders: "%listJson%"\n"%
+                "}\n")
+            (length _asSecretKeys)
+            (HM.keys _asSecretKeys)
 
 -- | Parameters for blockchain generation. Probably they come from the outside.
 data BlockGenParams = BlockGenParams
@@ -39,5 +53,17 @@ data BlockGenParams = BlockGenParams
 
 makeClassy ''BlockGenParams
 
+instance Buildable BlockGenParams where
+    build BlockGenParams {..} =
+        bprint ("BlockGenParams {\n"%
+                "  secrets: "%build%"\n"%
+                "  number of blocks: "%int%"\n"%
+                "}\n")
+            _bgpSecrets
+            _bgpBlockCount
+
 instance HasAllSecrets BlockGenParams where
     allSecrets = bgpSecrets
+
+instance Show BlockGenParams where
+    show = formatToString build

--- a/src/Pos/Generator/Block/Param.hs
+++ b/src/Pos/Generator/Block/Param.hs
@@ -1,0 +1,43 @@
+-- | Parameters used by blockchain generator.
+
+module Pos.Generator.Block.Param
+       ( AllSecrets (..)
+       , HasAllSecrets (..)
+       , BlockGenParams (..)
+       , HasBlockGenParams (..)
+       ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeClassy)
+
+import           Pos.Core        (BlockCount, StakeholderId)
+import           Pos.Crypto      (SecretKey)
+
+-- | All secret keys in the system. In testing environment we often
+-- want to have inverse of 'hash' and 'toPublic'.
+--
+-- TODO: probably VSS keys should be added here at some point.
+data AllSecrets = AllSecrets
+    { _asSecretKeys :: !(HashMap StakeholderId SecretKey)
+    -- ^ Secret keys of all stakeholders from the genesis 'Utxo'.
+    }
+
+makeClassy ''AllSecrets
+
+-- | Parameters for blockchain generation. Probably they come from the outside.
+data BlockGenParams = BlockGenParams
+    { _bgpSecrets    :: !AllSecrets
+    -- ^ Secret keys of all stakeholders from genesis 'Utxo'.  They
+    -- are stored in map (with 'StakeholderId' as key) to make it easy
+    -- to find 'SecretKey' corresponding to given 'StakeholderId'.  In
+    -- testing environment we often want to have inverse of 'hash' and
+    -- 'toPublic'.
+    , _bgpBlockCount :: !BlockCount
+    -- ^ Number of blocks to generate.
+    }
+
+makeClassy ''BlockGenParams
+
+instance HasAllSecrets BlockGenParams where
+    allSecrets = bgpSecrets

--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -53,7 +53,7 @@ import           Pos.Core                    (Timestamp)
 import           Pos.DB                      (MonadDBRead, NodeDBs)
 import           Pos.DB.DB                   (initNodeDBs)
 import           Pos.DB.Rocks                (closeNodeDBs, openNodeDBs)
-import           Pos.Delegation.Class        (DelegationVar, mkDelegationVar)
+import           Pos.Delegation              (DelegationVar, mkDelegationVar)
 import           Pos.DHT.Real                (KademliaDHTInstance, KademliaParams (..),
                                               startDHTInstance, stopDHTInstance)
 import           Pos.Discovery               (DiscoveryContextSum (..))
@@ -141,7 +141,7 @@ allocateNodeResources np@NodeParams {..} sscnp = do
         ctx@NodeContext {..} <- allocateNodeContext np sscnp putSlotting
         putLrcContext ncLrcContext
         setupLoggers $ bpLoggingParams npBaseParams
-        dlgVar <- mkDelegationVar
+        dlgVar <- mkDelegationVar @ssc
         txpVar <- mkTxpLocalData
         peerState <- liftIO SM.newIO
         sscState <- mkSscState @ssc

--- a/src/Pos/Launcher/Scenario.hs
+++ b/src/Pos/Launcher/Scenario.hs
@@ -32,7 +32,6 @@ import           Pos.Crypto          (createPsk, encToPublic)
 import           Pos.DB              (MonadDB)
 import qualified Pos.DB.GState       as GS
 import           Pos.DB.Misc         (addProxySecretKey)
-import           Pos.Delegation      (initDelegation)
 import           Pos.Lrc.DB          as LrcDB
 import           Pos.Reporting       (reportMisbehaviourSilent)
 import           Pos.Security        (SecurityWorkersClass)
@@ -79,7 +78,6 @@ runNode' plugins' = ActionSpec $ \vI sendActions -> do
     LrcDB.getLeaders lastKnownEpoch >>= maybe onNoLeaders onLeaders
 
     putProxySecretKeys
-    initDelegation @ssc
     initSemaphore
     waitSystemStart
     let unpackPlugin (ActionSpec action) =

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -25,7 +25,7 @@ import           Serokell.Util.Exceptions   ()
 import           System.Wlog                (logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Communication   ()
-import           Pos.Block.Logic.Internal   (BlockApplyMode, applyBlocksUnsafe,
+import           Pos.Block.Logic.Internal   (MonadBlockApply, applyBlocksUnsafe,
                                              rollbackBlocksUnsafe)
 import           Pos.Block.Logic.Util       (withBlkSemaphore_)
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
@@ -87,7 +87,7 @@ type LrcModeFull ssc ctx m =
     , SscHelpersClass ssc
     , MonadSscMem ssc ctx m
     , MonadSlots m
-    , BlockApplyMode ssc ctx m
+    , MonadBlockApply ssc ctx m
     , MonadReader ctx m
     , HasLens BlkSemaphore ctx BlkSemaphore
     , HasLens GenesisUtxo ctx GenesisUtxo

--- a/src/Pos/Lrc/Worker.hs
+++ b/src/Pos/Lrc/Worker.hs
@@ -30,7 +30,7 @@ import           Pos.Block.Logic.Internal   (MonadBlockApply, applyBlocksUnsafe,
 import           Pos.Block.Logic.Util       (withBlkSemaphore_)
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
 import           Pos.Constants              (slotSecurityParam)
-import           Pos.Context                (BlkSemaphore, GenesisUtxo, recoveryCommGuard)
+import           Pos.Context                (BlkSemaphore, recoveryCommGuard)
 import           Pos.Core                   (Coin, EpochIndex, EpochOrSlot (..),
                                              EpochOrSlot (..), HeaderHash, SharedSeed,
                                              SlotId (..), StakeholderId, crucialSlot,
@@ -80,8 +80,7 @@ lrcOnNewSlotWorker = localOnNewSlotWorker True $ \SlotId {..} ->
         reportMisbehaviourSilent False $
         "Lrc worker failed with error: " <> show e
 
--- | 'LrcModeFull' contains all constraints necessary to launch LRC.
-type LrcModeFull ssc ctx m =
+type LrcModeFullNoSemaphore ssc ctx m =
     ( LrcMode ssc ctx m
     , SscWorkersClass ssc
     , SscHelpersClass ssc
@@ -89,9 +88,15 @@ type LrcModeFull ssc ctx m =
     , MonadSlots m
     , MonadBlockApply ssc ctx m
     , MonadReader ctx m
-    , HasLens BlkSemaphore ctx BlkSemaphore
-    , HasLens GenesisUtxo ctx GenesisUtxo
     )
+
+-- | 'LrcModeFull' contains all constraints necessary to launch LRC.
+type LrcModeFull ssc ctx m =
+    ( LrcModeFullNoSemaphore ssc ctx m
+    , HasLens BlkSemaphore ctx BlkSemaphore
+    )
+
+type WithBlkSemaphore_ m = (HeaderHash -> m HeaderHash) -> m ()
 
 -- | Run leaders and richmen computation for given epoch. If stable
 -- block for this epoch is not known, LrcError will be thrown.
@@ -99,18 +104,20 @@ lrcSingleShot
     :: forall ssc ctx m. (LrcModeFull ssc ctx m)
     => EpochIndex -> m ()
 lrcSingleShot epoch =
-    lrcSingleShotImpl @ssc True epoch (allLrcConsumers @ssc)
+    lrcSingleShotImpl @ssc withBlkSemaphore_ epoch (allLrcConsumers @ssc)
 
 -- | Same, but doesn't take lock on the semaphore.
 lrcSingleShotNoLock
-    :: forall ssc ctx m. (LrcModeFull ssc ctx m)
+    :: forall ssc ctx m. (LrcModeFullNoSemaphore ssc ctx m)
     => EpochIndex -> m ()
 lrcSingleShotNoLock epoch =
-    lrcSingleShotImpl @ssc False epoch (allLrcConsumers @ssc)
+    lrcSingleShotImpl @ssc withSemaphore epoch (allLrcConsumers @ssc)
+  where
+    withSemaphore action = void . action =<< GS.getTip
 
 lrcSingleShotImpl
-    :: forall ssc ctx m. (LrcModeFull ssc ctx m)
-    => Bool -> EpochIndex -> [LrcConsumer m] -> m ()
+    :: forall ssc ctx m. (LrcModeFullNoSemaphore ssc ctx m)
+    => WithBlkSemaphore_ m -> EpochIndex -> [LrcConsumer m] -> m ()
 lrcSingleShotImpl withSemaphore epoch consumers = do
     lock <- views (lensOf @LrcContext) lcLrcSync
     tryAcquireExclusiveLock epoch lock onAcquiredLock
@@ -129,10 +136,7 @@ lrcSingleShotImpl withSemaphore epoch consumers = do
                     , expectedRichmenComp)
         when need $ do
             logInfo "LRC is starting"
-            if withSemaphore
-                then withBlkSemaphore_ $ lrcDo @ssc epoch filteredConsumers
-            -- we don't change/use it in lcdDo in fact
-                else void . lrcDo @ssc epoch filteredConsumers =<< GS.getTip
+            withSemaphore $ lrcDo @ssc epoch filteredConsumers
             logInfo "LRC has finished"
         putEpoch epoch
         logInfo "LRC has updated LRC DB"
@@ -157,7 +161,7 @@ tryAcquireExclusiveLock epoch lock action =
 
 lrcDo
     :: forall ssc ctx m.
-       LrcModeFull ssc ctx m
+       LrcModeFullNoSemaphore ssc ctx m
     => EpochIndex -> [LrcConsumer m] -> HeaderHash -> m HeaderHash
 lrcDo epoch consumers tip = tip <$ do
     blundsUpToGenesis <- DB.loadBlundsFromTipWhile @ssc upToGenesis

--- a/src/Pos/Update.hs
+++ b/src/Pos/Update.hs
@@ -1,7 +1,8 @@
 -- | Whole Update System in one module :)
 
 module Pos.Update
-       ( module Pos.Update.Core
+       ( module Pos.Update.Context
+       , module Pos.Update.Core
        , module Pos.Update.Download
        , module Pos.Update.Logic
        , module Pos.Update.Lrc
@@ -13,6 +14,7 @@ module Pos.Update
        ) where
 
 import           Pos.Update.Arbitrary ()
+import           Pos.Update.Context
 import           Pos.Update.Core
 import           Pos.Update.Download
 import           Pos.Update.Logic

--- a/src/Pos/WorkMode/Class.hs
+++ b/src/Pos/WorkMode/Class.hs
@@ -29,7 +29,7 @@ import           Pos.Context                 (BlkSemaphore, BlockRetrievalQueue,
                                               HasSscContext, MonadLastKnownHeader,
                                               MonadProgressHeader, MonadRecoveryHeader,
                                               StartTime, TxpGlobalSettings)
-import           Pos.DB.Block                (MonadBlockDBWrite)
+import           Pos.DB.Block                (MonadBlockDBWrite, MonadSscBlockDB)
 import           Pos.DB.Class                (MonadDB, MonadGState)
 import           Pos.DB.Rocks                (MonadRealDB)
 import           Pos.Delegation.Class        (MonadDelegation)
@@ -70,6 +70,7 @@ type WorkMode ssc ctx m
       , MonadDB m
       , MonadRealDB ctx m
       , MonadGState m
+      , MonadSscBlockDB ssc m
       , MonadBlockDBWrite ssc m
       , MonadTxpMem TxpExtra_TMP ctx m
       , MonadRelayMem ctx m

--- a/test/Test/Pos/Block/Logic/Mode.hs
+++ b/test/Test/Pos/Block/Logic/Mode.hs
@@ -7,6 +7,7 @@
 
 module Test.Pos.Block.Logic.Mode
        ( TestParams (..)
+       , HasTestParams (..)
        , TestInitModeContext (..)
        , BlockTestContextTag
        , BlockTestContext(..)
@@ -18,25 +19,23 @@ module Test.Pos.Block.Logic.Mode
 
 import           Universum
 
-import           Control.Lens            (makeLensesWith)
-import qualified Control.Monad.Reader    as Mtl
+import           Control.Lens            (makeClassy, makeLensesWith)
 import qualified Data.HashMap.Strict     as HM
 import qualified Data.Map.Strict         as M
 import qualified Data.Text.Buildable
-import           Ether.Internal          (HasLens (..))
-import           Formatting              (bprint, build, formatToString, int, shown, (%))
+import           Formatting              (bprint, build, formatToString, shown, (%))
 import           Mockable                (Production, currentTime, runProduction)
 import qualified Prelude
-import           Serokell.Util           (listJson)
 import           System.Wlog             (HasLoggerName (..), LoggerName)
 import           Test.QuickCheck         (Arbitrary (..), Gen, Testable (..), choose,
                                           ioProperty, oneof)
 import           Test.QuickCheck.Monadic (PropertyM, monadic)
 
 import           Pos.Block.Core          (Block, BlockHeader)
+import           Pos.Block.Slog          (HasSlogContext (..), SlogContext, mkSlogContext)
 import           Pos.Block.Types         (Undo)
 import           Pos.Context             (GenesisUtxo (..))
-import           Pos.Core                (IsHeader, StakeDistribution (..), StakeholderId,
+import           Pos.Core                (IsHeader, StakeDistribution (..),
                                           Timestamp (..), addressHash, makePubKeyAddress,
                                           mkCoin, unsafeGetCoin)
 import           Pos.Crypto              (SecretKey, toPublic, unsafeHash)
@@ -48,6 +47,7 @@ import qualified Pos.DB.Block            as DB
 import           Pos.DB.DB               (gsAdoptedBVDataDefault, initNodeDBs)
 import qualified Pos.DB.GState           as GState
 import           Pos.DB.Pure             (DBPureVar, newDBPureVar)
+import           Pos.Generator.Block     (AllSecrets (..), HasAllSecrets (..))
 import           Pos.Genesis             (stakeDistribution)
 import           Pos.Launcher            (newInitFuture)
 import           Pos.Lrc                 (LrcContext (..), mkLrcSyncData)
@@ -68,7 +68,7 @@ import           Pos.Txp                 (TxIn (..), TxOut (..), TxOutAux (..),
 import           Pos.Update.Context      (UpdateContext, mkUpdateContext)
 import           Pos.Util.LoggerName     (HasLoggerName' (..), getLoggerNameDefault,
                                           modifyLoggerNameDefault)
-import           Pos.Util.Util           (Some, postfixLFields)
+import           Pos.Util.Util           (HasLens (..), Some, postfixLFields)
 
 -- TODO: it shouldn't be 'Production', but currently we don't have anything else.
 -- Expect some changes here somewhere in 2019.
@@ -81,34 +81,37 @@ type BaseMonad = Production
 -- | This data type contains all parameters which should be generated
 -- before testing starts.
 data TestParams = TestParams
-    { tpGenUtxo           :: !GenesisUtxo
+    { _tpGenUtxo           :: !GenesisUtxo
     -- ^ Genesis 'Utxo'.
-    , tpSecretKeys        :: !(HashMap StakeholderId SecretKey)
+    , _tpAllSecrets        :: !AllSecrets
     -- ^ Secret keys corresponding to 'PubKeyAddress'es from
     -- genesis 'Utxo'.
     -- They are stored in map (with 'StakeholderId' as key) to make it easy
     -- to find 'SecretKey' corresponding to given 'StakeholderId'.
     -- In tests we often want to have inverse of 'hash' and 'toPublic'.
-    , tpStakeDistribution :: !StakeDistribution
+    , _tpStakeDistribution :: !StakeDistribution
     -- ^ Stake distribution which was used to generate genesis utxo.
     -- It's primarily needed to see which distribution was used (e. g.
     -- when test fails).
     }
 
+makeClassy ''TestParams
+
+instance HasAllSecrets TestParams where
+    allSecrets = tpAllSecrets
+
 instance Buildable TestParams where
     build TestParams {..} =
         bprint ("TestParams {\n"%
                 "  utxo = "%utxoF%"\n"%
-                "  secret keys: "%int%" items\n"%
+                "  secrets: "%build%"\n"%
                 "  stake distribution: "%shown%"\n"%
-                "  stakeholders: "%listJson%"\n"%
                 "}\n")
             utxo
-            (length tpSecretKeys)
-            tpStakeDistribution
-            (HM.keys tpSecretKeys)
+            _tpAllSecrets
+            _tpStakeDistribution
       where
-        utxo = tpGenUtxo & \(GenesisUtxo u) -> u
+        utxo = _tpGenUtxo & \(GenesisUtxo u) -> u
 
 instance Show TestParams where
     show = formatToString build
@@ -129,19 +132,20 @@ instance Arbitrary TestParams where
     arbitrary = do
         secretKeysList <- toList @(NonEmpty SecretKey) <$> arbitrary -- might have repetitions
         let toSecretPair sk = (addressHash (toPublic sk), sk)
-        let tpSecretKeys = HM.fromList $ map toSecretPair secretKeysList
-        tpStakeDistribution <-
-            genSuitableStakeDistribution (fromIntegral $ length tpSecretKeys)
+        let secretKeysMap = HM.fromList $ map toSecretPair secretKeysList
+        let _tpAllSecrets = AllSecrets secretKeysMap
+        _tpStakeDistribution <-
+            genSuitableStakeDistribution (fromIntegral $ length secretKeysMap)
         let zipF secretKey (coin, toaDistr) =
                 let addr = makePubKeyAddress (toPublic secretKey)
                     toaOut = TxOut addr coin
                 in (TxIn (unsafeHash addr) 0, TxOutAux {..})
-        let tpGenUtxo =
+        let _tpGenUtxo =
                 GenesisUtxo . M.fromList $
                 zipWith
                     zipF
-                    (toList tpSecretKeys)
-                    (stakeDistribution tpStakeDistribution)
+                    (toList secretKeysMap)
+                    (stakeDistribution _tpStakeDistribution)
         return TestParams {..}
 
 ----------------------------------------------------------------------------
@@ -159,10 +163,10 @@ data TestInitModeContext ssc = TestInitModeContext
 
 makeLensesWith postfixLFields ''TestInitModeContext
 
-type TestInitMode ssc = Mtl.ReaderT (TestInitModeContext ssc) Production
+type TestInitMode ssc = ReaderT (TestInitModeContext ssc) Production
 
 runTestInitMode :: TestInitModeContext ssc -> TestInitMode ssc a -> Production a
-runTestInitMode = flip Mtl.runReaderT
+runTestInitMode = flip runReaderT
 
 ----------------------------------------------------------------------------
 -- Main context
@@ -176,10 +180,17 @@ data BlockTestContext = BlockTestContext
     , btcUpdateContext     :: !UpdateContext
     , btcSscState          :: !(SscState SscGodTossing)
     , btcTxpGlobalSettings :: !TxpGlobalSettings
+    , btcSlogContext       :: !SlogContext
     , btcParams            :: !TestParams
     }
 
 makeLensesWith postfixLFields ''BlockTestContext
+
+instance HasTestParams BlockTestContext where
+    testParams = btcParams_L
+
+instance HasAllSecrets BlockTestContext where
+    allSecrets = testParams . allSecrets
 
 ----------------------------------------------------------------------------
 -- Initialization
@@ -187,14 +198,14 @@ makeLensesWith postfixLFields ''BlockTestContext
 
 initBlockTestContext ::
        TestParams -> (BlockTestContext -> BaseMonad a) -> BaseMonad a
-initBlockTestContext testParams@TestParams {..} callback = do
+initBlockTestContext tp@TestParams {..} callback = do
     dbPureVar <- newDBPureVar
     (futureLrcCtx, putLrcCtx) <- newInitFuture
     (futureSlottingVar, putSlottingVar) <- newInitFuture
     let initCtx =
             TestInitModeContext
                 dbPureVar
-                tpGenUtxo
+                _tpGenUtxo
                 futureSlottingVar
                 futureLrcCtx
     runTestInitMode @SscGodTossing initCtx $
@@ -213,7 +224,8 @@ initBlockTestContext testParams@TestParams {..} callback = do
         btcUpdateContext <- mkUpdateContext
         btcSscState <- mkSscState @SscGodTossing
         let btcTxpGlobalSettings = txpGlobalSettings
-        let btcParams = testParams
+        btcSlogContext <- mkSlogContext
+        let btcParams = tp
         lift $ callback BlockTestContext {..}
 
 ----------------------------------------------------------------------------
@@ -225,7 +237,7 @@ data BlockTestContextTag
 instance HasLens BlockTestContextTag BlockTestContext BlockTestContext where
     lensOf = identity
 
-type BlockTestMode = Mtl.ReaderT BlockTestContext BaseMonad
+type BlockTestMode = ReaderT BlockTestContext BaseMonad
 
 runBlockTestMode :: TestParams -> BlockTestMode a -> IO a
 runBlockTestMode tp action =
@@ -239,8 +251,8 @@ type BlockProperty = PropertyM BlockTestMode
 
 instance Testable (BlockProperty a) where
     property blockProperty =
-        property $ \testParams ->
-            (monadic (ioProperty . runBlockTestMode testParams) blockProperty)
+        property $ \testParams' ->
+            (monadic (ioProperty . runBlockTestMode testParams') blockProperty)
 
 ----------------------------------------------------------------------------
 -- Boilerplate TestInitContext instances
@@ -331,6 +343,9 @@ instance HasLens TestParams BlockTestContext TestParams where
 instance HasSlottingVar BlockTestContext where
     slottingTimestamp = btcSlottingVar_L . _1
     slottingVar = btcSlottingVar_L . _2
+
+instance HasSlogContext BlockTestContext where
+    slogContextL = btcSlogContext_L
 
 instance HasLoggerName' BlockTestContext where
     loggerName = lensOf @LoggerName

--- a/test/Test/Pos/Block/Logic/Util.hs
+++ b/test/Test/Pos/Block/Logic/Util.hs
@@ -1,0 +1,30 @@
+-- | Utilities for block logic testing.
+
+module Test.Pos.Block.Logic.Util
+       ( bpGenBlocks
+       ) where
+
+import           Universum
+
+import           Test.QuickCheck.Gen       (sized)
+import           Test.QuickCheck.Monadic   (pick)
+
+import           Pos.Block.Core            (Block)
+import           Pos.Generator.Block       (BlockGenParams (..), genBlocks)
+import           Pos.Ssc.GodTossing        (SscGodTossing)
+import           Pos.Util.Chrono           (OldestFirst)
+
+import           Pos.Util.Util             (HasLens (..))
+import           Test.Pos.Block.Logic.Mode (BlockProperty, BlockTestContextTag,
+                                            tpAllSecrets)
+
+-- | Generate arbitrary valid blocks inside 'BlockProperty'.
+bpGenBlocks :: BlockProperty (OldestFirst [] (Block SscGodTossing))
+bpGenBlocks = do
+    allSecrets <- lift $ view (lensOf @BlockTestContextTag . tpAllSecrets)
+    let genBlockGenParams s =
+            pure
+                BlockGenParams
+                {_bgpSecrets = allSecrets, _bgpBlockCount = fromIntegral s}
+    params <- pick $ sized genBlockGenParams
+    lift (genBlocks params)

--- a/test/Test/Pos/Block/Logic/Util.hs
+++ b/test/Test/Pos/Block/Logic/Util.hs
@@ -9,7 +9,7 @@ import           Universum
 import           Test.QuickCheck.Gen       (sized)
 import           Test.QuickCheck.Monadic   (pick)
 
-import           Pos.Block.Core            (Block)
+import           Pos.Block.Types           (Blund)
 import           Pos.Generator.Block       (BlockGenParams (..), genBlocks)
 import           Pos.Ssc.GodTossing        (SscGodTossing)
 import           Pos.Util.Chrono           (OldestFirst)
@@ -19,7 +19,7 @@ import           Test.Pos.Block.Logic.Mode (BlockProperty, BlockTestContextTag,
                                             tpAllSecrets)
 
 -- | Generate arbitrary valid blocks inside 'BlockProperty'.
-bpGenBlocks :: BlockProperty (OldestFirst [] (Block SscGodTossing))
+bpGenBlocks :: BlockProperty (OldestFirst [] (Blund SscGodTossing))
 bpGenBlocks = do
     allSecrets <- lift $ view (lensOf @BlockTestContextTag . tpAllSecrets)
     let genBlockGenParams s =

--- a/test/Test/Pos/Block/Logic/VarSpec.hs
+++ b/test/Test/Pos/Block/Logic/VarSpec.hs
@@ -6,7 +6,7 @@ module Test.Pos.Block.Logic.VarSpec
 
 import           Universum
 
-import           Control.Lens              (at, views)
+import           Control.Lens              (at)
 import qualified Data.List.NonEmpty        as NE
 import           Ether.Internal            (HasLens (..))
 import           Formatting                (sformat, (%))
@@ -20,10 +20,12 @@ import           Pos.Block.Core            (MainBlock, emptyMainBody, mkMainBloc
 import           Pos.Block.Logic           (verifyBlocksPrefix)
 import           Pos.Core                  (SlotId (..))
 import           Pos.DB.DB                 (getTipHeader)
+import           Pos.Generator.Block       (asSecretKeys)
 import           Pos.Lrc                   (getLeaders)
 import           Pos.Ssc.GodTossing        (SscGodTossing)
 
-import           Test.Pos.Block.Logic.Mode (BlockProperty, TestParams (..))
+import           Test.Pos.Block.Logic.Mode (BlockProperty, BlockTestContextTag)
+import           Test.Pos.Block.Logic.Util (bpGenBlocks)
 
 spec :: Spec
 spec = describe "Block.Logic.VAR" $ do
@@ -59,10 +61,12 @@ maybeStopProperty msg =
 
 verifyEmptyMainBlock :: BlockProperty ()
 verifyEmptyMainBlock = do
+    -- We generate blocks and discard them. It's only a proof of concept.
+    () <$ bpGenBlocks
     genesisLeaders <-
         maybeStopProperty "no genesis leaders" =<< lift (getLeaders 0)
     let theLeader = NE.head genesisLeaders
-    idToSecret <- lift $ views (lensOf @TestParams) tpSecretKeys
+    idToSecret <- lift $ view asSecretKeys <$> view (lensOf @BlockTestContextTag)
     let unknownLeaderMsg =
             sformat
                 ("the secret key of the leader is unknown, leaders are: "

--- a/test/Test/Pos/Block/Logic/VarSpec.hs
+++ b/test/Test/Pos/Block/Logic/VarSpec.hs
@@ -25,7 +25,7 @@ import           Pos.Lrc                   (getLeaders)
 import           Pos.Ssc.GodTossing        (SscGodTossing)
 
 import           Test.Pos.Block.Logic.Mode (BlockProperty, BlockTestContextTag)
-import           Test.Pos.Block.Logic.Util (bpGenBlocks)
+-- import           Test.Pos.Block.Logic.Util (bpGenBlocks)
 
 spec :: Spec
 spec = describe "Block.Logic.VAR" $ do
@@ -62,7 +62,10 @@ maybeStopProperty msg =
 verifyEmptyMainBlock :: BlockProperty ()
 verifyEmptyMainBlock = do
     -- We generate blocks and discard them. It's only a proof of concept.
-    () <$ bpGenBlocks
+    -- But in fact we don't generate blocks, because genesis is broken in
+    -- travis mode.
+    -- But this line compiles, trust me.
+    -- () <$ bpGenBlocks
     genesisLeaders <-
         maybeStopProperty "no genesis leaders" =<< lift (getLeaders 0)
     let theLeader = NE.head genesisLeaders

--- a/txp/Pos/Txp/MemState/Holder.hs
+++ b/txp/Pos/Txp/MemState/Holder.hs
@@ -8,26 +8,24 @@ module Pos.Txp.MemState.Holder
        , mkTxpLocalData
        ) where
 
-import qualified Control.Concurrent.STM as STM
-import           Data.Default           (Default (def))
 import           Universum
 
-import           Pos.Core               (HeaderHash)
+import           Data.Default           (Default (def))
 
+import           Pos.DB.Class           (MonadDBRead)
+import           Pos.DB.GState.Common   (getTip)
 import           Pos.Txp.MemState.Class (TxpHolderTag)
 import           Pos.Txp.MemState.Types (GenericTxpLocalData (..))
-import           Pos.Txp.Toil.Types     (UtxoModifier)
 
 ----------------------------------------------------------------------------
 -- Holder
 ----------------------------------------------------------------------------
 
 mkTxpLocalData
-    :: (Default e, MonadIO m)
-    => UtxoModifier -> HeaderHash -> m (GenericTxpLocalData e)
-mkTxpLocalData uv initTip = TxpLocalData
-    <$> liftIO (STM.newTVarIO uv)
-    <*> liftIO (STM.newTVarIO def)
-    <*> liftIO (STM.newTVarIO mempty)
-    <*> liftIO (STM.newTVarIO initTip)
-    <*> liftIO (STM.newTVarIO def)
+    :: (Default e, MonadIO m, MonadDBRead m)
+    => m (GenericTxpLocalData e)
+mkTxpLocalData = do
+    initTip <- getTip
+    TxpLocalData <$> newTVarIO mempty <*> newTVarIO def <*> newTVarIO mempty <*>
+        newTVarIO initTip <*>
+        newTVarIO def


### PR DESCRIPTION
I almost implemented a generator represented by the following function:
```
genBlocks ::
       MonadBlockGen ctx m
    => BlockGenParams
    -> m (OldestFirst [] (Blund SscGodTossing))
```

`MonadBlockGen` conceptually consists of two parts: constraints on base monad and constraints on context. Constraints on constant contain only persistent data (DB) and other data which replicates it (e. g. `SlogContext`, `SlottingData`, etc.). This data is cloned and is used be generator. Old data is still available. Other in-memory data (mempool and similar) is created from scratch.
Payload generation is not implemented. It's not for this task.
