### PR TITLE
[TW-154] bump network-transport revision

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -55,7 +55,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/network-transport
-    commit: f2321a103f53f51d36c99383132e3ffa3ef1c401
+    commit: 0b8f5a7bec389a4ffa653792cfd203c742a0857b
   extra-dep: true
 - location:
     git: https://github.com/input-output-hk/cardano-crypto


### PR DESCRIPTION
This one has a fix to prependLength which checks for overflow. It's in
mainline master but we use a fork.