### PR TITLE
Attempt to fix Travis-on-nix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 - sudo /etc/init.d/memcached stop || true
 - sudo /etc/init.d/mysql stop || true
 - sudo /etc/init.d/postgresql stop || true
-- cat /etc/nix/nix.conf > ~/nix.conf
+- (cat /etc/nix/nix.conf || echo "") > ~/nix.conf
 - echo "binary-caches = https://cache.nixos.org https://hydra.iohk.io" >> ~/nix.conf
 - echo "binary-cache-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" >> ~/nix.conf
 - export NIX_CONF_DIR=~


### PR DESCRIPTION
A few hours ago we started seeing the following error in Travis
builds:

    cat: /etc/nix/nix.conf: No such file or directory

In some cases the file exists, but not always. This change bypasses
the issue.

The dependency on /etc/nix/nix.conf was introduced ~15 days ago for
Hydra.

cc @cleverca22 