### PR TITLE
[DEVOPS-204] Require MacOS builds again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
       # don't use sierra (xcode 8.1+) because of too restrictive linker path (DEVOPS-168)
 
   allow_failures:
-    - os: osx
     - env: MODE=nix
     # https://github.com/input-output-hk/stack2nix/issues/15
     # stack2nix will randomly omit sections of the generated file


### PR DESCRIPTION
The builds should not be timeouting anymore.

There are still going to be some transient **errors due to SSL**, those are fixed by restarting the build. The proper fix will be done as DEVOPS-203 is implement, which is expected to be this week.

cc @input-output-hk/serokell 