### PR TITLE
[CSM-324] Call `txMempoolToModifier` once per api request

### DIFF
--- a/src/Pos/Wallet/Web/Account.hs
+++ b/src/Pos/Wallet/Web/Account.hs
@@ -13,6 +13,8 @@ module Pos.Wallet.Web.Account
        , AccountMode
        , GenSeed (..)
        , AddrGenSeed
+
+       , MonadKeySearch (..)
        ) where
 
 import           Data.List                  (elemIndex)
@@ -169,3 +171,17 @@ deriveAccountAddress passphrase accId@AccountId{..} cwamAccountIndex = do
         cwamWalletIndex = aiIndex
         cwamId          = addressToCId addr
     return CWAddressMeta{..}
+
+-- | Allows to find a key related ti given @id@ item.
+class MonadKeySearch id m where
+    findKey :: id -> m EncryptedSecretKey
+
+instance AccountMode ctx m => MonadKeySearch (CId Wal) m where
+    findKey = getSKByAddr
+
+instance AccountMode ctx m => MonadKeySearch AccountId m where
+    findKey = findKey . aiWId
+
+instance AccountMode ctx m => MonadKeySearch CWAddressMeta m where
+    findKey = findKey . cwamWId
+

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -146,18 +146,19 @@ import           Pos.Wallet.Web.Server.Sockets    (ConnectionsVar, closeWSConnec
 import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing), CustomAddressType (ChangeAddr, UsedAddr),
                                                    addOnlyNewTxMeta, addUpdate,
                                                    addWAddress, closeState, createAccount,
-                                                   createWallet, getAccountMeta,
-                                                   getAccountWAddresses, getHistoryCache,
-                                                   getNextUpdate, getProfile, getTxMeta,
-                                                   getAccountIds, getWalletAddresses,
-                                                   getWalletMeta, getWalletPassLU,
-                                                   isCustomAddress, openState,
-                                                   removeAccount, removeHistoryCache,
-                                                   removeNextUpdate, removeTxMetas,
-                                                   removeWallet, setAccountMeta,
-                                                   setProfile, setWalletMeta,
-                                                   setWalletPassLU, setWalletTxMeta,
-                                                   testReset, updateHistoryCache)
+                                                   createWallet, getAccountIds,
+                                                   getAccountMeta, getAccountWAddresses,
+                                                   getHistoryCache, getNextUpdate,
+                                                   getProfile, getTxMeta,
+                                                   getWalletAddresses, getWalletMeta,
+                                                   getWalletPassLU, isCustomAddress,
+                                                   openState, removeAccount,
+                                                   removeHistoryCache, removeNextUpdate,
+                                                   removeTxMetas, removeWallet,
+                                                   setAccountMeta, setProfile,
+                                                   setWalletMeta, setWalletPassLU,
+                                                   setWalletTxMeta, testReset,
+                                                   updateHistoryCache)
 import           Pos.Wallet.Web.State.Storage     (WalletStorage)
 import           Pos.Wallet.Web.Tracking          (CAccModifier (..), sortedInsertions,
                                                    syncWalletOnImport,
@@ -518,7 +519,7 @@ getAccounts
 getAccounts mCAddr = do
     whenJust mCAddr $ \cAddr -> getWalletMeta cAddr `whenNothingM_` noWSet cAddr
     accIds <- maybe getAccountIds getWalletAccountIds mCAddr
-    let groupedAccIds = HM.fromListWith mappend $
+    let groupedAccIds = fmap reverse $ HM.fromListWith mappend $
                         accIds <&> \acc -> (aiWId acc, [acc])
     concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) ->
          fixCachedAccModifierFor wid $ forM walAccIds . getAccount

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -149,7 +149,7 @@ import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Exis
                                                    createWallet, getAccountMeta,
                                                    getAccountWAddresses, getHistoryCache,
                                                    getNextUpdate, getProfile, getTxMeta,
-                                                   getWAddressIds, getWalletAddresses,
+                                                   getAccountIds, getWalletAddresses,
                                                    getWalletMeta, getWalletPassLU,
                                                    isCustomAddress, openState,
                                                    removeAccount, removeHistoryCache,
@@ -517,7 +517,7 @@ getAccounts
     => Maybe (CId Wal) -> m [CAccount]
 getAccounts mCAddr = do
     whenJust mCAddr $ \cAddr -> getWalletMeta cAddr `whenNothingM_` noWSet cAddr
-    accIds <- maybe getWAddressIds getWalletAccountIds mCAddr
+    accIds <- maybe getAccountIds getWalletAccountIds mCAddr
     let groupedAccIds = HM.fromListWith mappend $
                         accIds <&> \acc -> (aiWId acc, [acc])
     concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) ->

--- a/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/src/Pos/Wallet/Web/State/Acidic.hs
@@ -12,7 +12,7 @@ module Pos.Wallet.Web.State.Acidic
        , update
 
        , GetProfile (..)
-       , GetWAddressIds (..)
+       , GetAccountIds (..)
        , GetAccountMetas (..)
        , GetAccountMeta (..)
        , GetWalletMetas (..)
@@ -97,7 +97,7 @@ makeAcidic ''WalletStorage
     [
       'WS.testReset
     , 'WS.getProfile
-    , 'WS.getWAddressIds
+    , 'WS.getAccountIds
     , 'WS.getAccountMetas
     , 'WS.getAccountMeta
     , 'WS.getWalletMetas

--- a/src/Pos/Wallet/Web/State/State.hs
+++ b/src/Pos/Wallet/Web/State/State.hs
@@ -14,7 +14,7 @@ module Pos.Wallet.Web.State.State
 
        -- * Getters
        , getProfile
-       , getWAddressIds
+       , getAccountIds
        , getAccountMetas
        , getAccountMeta
        , getAccountWAddresses
@@ -100,8 +100,8 @@ updateDisk
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
 
-getWAddressIds :: WebWalletModeDB ctx m => m [AccountId]
-getWAddressIds = queryDisk A.GetWAddressIds
+getAccountIds :: WebWalletModeDB ctx m => m [AccountId]
+getAccountIds = queryDisk A.GetAccountIds
 
 getAccountMetas :: WebWalletModeDB ctx m => m [CAccountMeta]
 getAccountMetas = queryDisk A.GetAccountMetas

--- a/src/Pos/Wallet/Web/State/Storage.hs
+++ b/src/Pos/Wallet/Web/State/Storage.hs
@@ -10,7 +10,7 @@ module Pos.Wallet.Web.State.Storage
        , Update
        , getProfile
        , setProfile
-       , getWAddressIds
+       , getAccountIds
        , getAccountMetas
        , getAccountMeta
        , getWalletMetas
@@ -65,9 +65,9 @@ import           Data.SafeCopy              (base, deriveSafeCopySimple)
 import           Data.Time.Clock.POSIX      (POSIXTime)
 
 import           Pos.Client.Txp.History     (TxHistoryEntry)
-import           Pos.Txp                    (Utxo)
 import           Pos.Constants              (genesisHash)
 import           Pos.Core.Types             (Timestamp)
+import           Pos.Txp                    (Utxo)
 import           Pos.Types                  (HeaderHash)
 import           Pos.Util.BackupPhrase      (BackupPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId, Addr, CAccountMeta, CCoin, CHash,
@@ -165,8 +165,8 @@ getProfile = view wsProfile
 setProfile :: CProfile -> Update ()
 setProfile cProfile = wsProfile .= cProfile
 
-getWAddressIds :: Query [AccountId]
-getWAddressIds = HM.keys <$> view wsAccountInfos
+getAccountIds :: Query [AccountId]
+getAccountIds = HM.keys <$> view wsAccountInfos
 
 getAccountMetas :: Query [CAccountMeta]
 getAccountMetas = map (view aiMeta) . toList <$> view wsAccountInfos

--- a/src/Pos/Wallet/Web/Tracking.hs
+++ b/src/Pos/Wallet/Web/Tracking.hs
@@ -540,7 +540,7 @@ getWalletAddrMetasDB
     :: (WebWalletModeDB ctx m, MonadThrow m)
     => AddressLookupMode -> CId Wal -> m [CWAddressMeta]
 getWalletAddrMetasDB lookupMode cWalId = do
-    walletAccountIds <- filter ((== cWalId) . aiWId) <$> WS.getWAddressIds
+    walletAccountIds <- filter ((== cWalId) . aiWId) <$> WS.getAccountIds
     concatMapM (getAccountAddrsOrThrowDB lookupMode) walletAccountIds
   where
     getAccountAddrsOrThrowDB

--- a/src/Pos/Wallet/Web/Util.hs
+++ b/src/Pos/Wallet/Web/Util.hs
@@ -15,12 +15,10 @@ import           Formatting                 (build, sformat, stext, (%))
 import           Pos.Client.Txp.Util        (TxError (..))
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, Wal)
 import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletError)
-import           Pos.Wallet.Web.State       (WebWalletModeDB, getWAddressIds)
-
--- TODO: move more here from Methods.hs
+import           Pos.Wallet.Web.State       (WebWalletModeDB, getAccountIds)
 
 getWalletAccountIds :: WebWalletModeDB ctx m => CId Wal -> m [AccountId]
-getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getWAddressIds
+getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getAccountIds
 
 rewrapTxError
     :: forall m a. MonadCatch m


### PR DESCRIPTION
This allows not to recalculate mempool accounts modifier (which is somewhat expensive) many times for given request, but rather fixate it once and pass implicitly around