### PR TITLE
[DEVOPS-210] AppVeyor: Use OpenSSL 1.0.2L

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,9 @@ before_test:
 - IF EXIST %CACHE_DIR% dir %CACHE_DIR%
 - IF EXIST %CACHED_STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_ROOT% %STACK_ROOT%
 - IF EXIST %CACHED_STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_WORK% %STACK_WORK%
+# Install OpenSSL 1.0.2 (see https://github.com/appveyor/ci/issues/1665)
+- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2L.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
+- ps: cmd /c start /wait "$($env:USERPROFILE)\Win64OpenSSL.exe" /silent /verysilent /sp- /suppressmsgboxes /DIR=C:\OpenSSL-Win64-v102
 - ps: Install-Product node 6
 # Install stack
 - ps: Start-FileDownload http://www.stackage.org/stack/windows-x86_64 -FileName stack.zip
@@ -72,8 +75,8 @@ test_script:
       --local-bin-path %SYSTEMROOT%\system32
       --fast
       --work-dir %STACK_WORK%
-      --extra-include-dirs="C:\OpenSSL-Win64\include"
-      --extra-lib-dirs="C:\OpenSSL-Win64"
+      --extra-include-dirs="C:\OpenSSL-Win64-v102\include"
+      --extra-lib-dirs="C:\OpenSSL-Win64-v102"
       --extra-include-dirs="%WORK_DIR%\rocksdb\include"
       --extra-lib-dirs="%WORK_DIR%"
 #   TODO: CSL-1133. To be reenabled.
@@ -97,8 +100,8 @@ test_script:
       --flag cardano-sl-core:-asserts
       --flag cardano-sl-core:-dev-mode
       --flag cardano-sl-tools:for-installer
-      --extra-include-dirs="C:\OpenSSL-Win64\include"
-      --extra-lib-dirs="C:\OpenSSL-Win64"
+      --extra-include-dirs="C:\OpenSSL-Win64-v102\include"
+      --extra-lib-dirs="C:\OpenSSL-Win64-v102"
       --extra-include-dirs="%WORK_DIR%\rocksdb\include"
       --extra-lib-dirs="%WORK_DIR%"
   - stack exec --work-dir %STACK_WORK% -- cardano-wallet-hs2purs


### PR DESCRIPTION
Explicitly installs and uses OpenSSL 1.0.2l rather than using the version installed by AppVeyor. Prompted by AppVeyor recently upgrading to OpenSSL 1.1.0f which isn't backwards compatible.