### PR TITLE
[CSL-1408] Rework LRC types

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/GState.hs
+++ b/godtossing/Pos/Ssc/GodTossing/GState.hs
@@ -25,7 +25,7 @@ import           Pos.Binary.GodTossing          ()
 import           Pos.Core                       (BlockVersionData, EpochIndex (..),
                                                  SlotId (..), epochIndexL, epochOrSlotG)
 import           Pos.DB                         (MonadDBRead, SomeBatchOp (..))
-import           Pos.Lrc.Types                  (RichmenStake)
+import           Pos.Lrc.Types                  (RichmenStakes)
 import           Pos.Ssc.Class.Storage          (SscGStateClass (..), SscVerifier)
 import           Pos.Ssc.Class.Types            (SscBlock, getSscBlock)
 import           Pos.Ssc.Extra                  (MonadSscMem, sscRunGlobalQuery)
@@ -34,7 +34,7 @@ import qualified Pos.Ssc.GodTossing.DB          as DB
 import           Pos.Ssc.GodTossing.Functions   (getStableCertsPure)
 import           Pos.Ssc.GodTossing.Genesis     (genesisCertificates)
 import           Pos.Ssc.GodTossing.Seed        (calculateSeed)
-import           Pos.Ssc.GodTossing.Toss        (MultiRichmenStake, PureToss,
+import           Pos.Ssc.GodTossing.Toss        (MultiRichmenStakes, PureToss,
                                                  TossVerFailure (..), applyGenesisBlock,
                                                  rollbackGT, runPureTossWithLogger,
                                                  supplyPureTossEnv,
@@ -110,7 +110,7 @@ rollbackBlocks blocks = tossToUpdate $ rollbackGT oldestEOS payloads
                    blocks
 
 verifyAndApply
-    :: RichmenStake
+    :: RichmenStakes
     -> BlockVersionData
     -> OldestFirst NE (SscBlock SscGodTossing)
     -> SscVerifier SscGodTossing ()
@@ -122,7 +122,7 @@ verifyAndApply richmenStake bvd blocks =
 
 verifyAndApplyMultiRichmen
     :: Bool
-    -> (MultiRichmenStake, BlockVersionData)
+    -> (MultiRichmenStakes, BlockVersionData)
     -> OldestFirst NE (SscBlock SscGodTossing)
     -> SscVerifier SscGodTossing ()
 verifyAndApplyMultiRichmen onlyCerts env =

--- a/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
+++ b/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
@@ -34,7 +34,7 @@ import           Pos.Core                           (BlockVersionData (..), Epoc
 import           Pos.Core.Constants                 (memPoolLimitRatio)
 import           Pos.DB                             (MonadDBRead,
                                                      MonadGState (gsAdoptedBVData))
-import           Pos.Lrc.Types                      (RichmenStake)
+import           Pos.Lrc.Types                      (RichmenStakes)
 import           Pos.Slotting                       (MonadSlots (getCurrentSlot))
 import           Pos.Ssc.Class.LocalData            (LocalQuery, LocalUpdate,
                                                      SscLocalDataClass (..))
@@ -95,7 +95,7 @@ getLocalPayload SlotId {..} = do
         | isExpected = view tmCertificates
         | otherwise = pure mempty
 
-normalize :: (EpochIndex, RichmenStake)
+normalize :: (EpochIndex, RichmenStakes)
           -> BlockVersionData
           -> GtGlobalState
           -> LocalUpdate SscGodTossing ()
@@ -227,7 +227,7 @@ sscProcessData tag payload =
 
 sscProcessDataDo
     :: (MonadState GtLocalData m, WithLogger m)
-    => (EpochIndex, RichmenStake)
+    => (EpochIndex, RichmenStakes)
     -> BlockVersionData
     -> GtGlobalState
     -> GtPayload

--- a/godtossing/Pos/Ssc/GodTossing/Seed.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Seed.hs
@@ -15,7 +15,7 @@ import           Pos.Core                     (SharedSeed, StakeholderId, addres
                                                mkCoin, sumCoins, unsafeIntegerToCoin)
 import           Pos.Crypto                   (Secret, Share, unsafeRecoverSecret,
                                                verifySecretProof)
-import           Pos.Lrc.Types                (RichmenStake)
+import           Pos.Lrc.Types                (RichmenStakes)
 import           Pos.Ssc.GodTossing.Core      (Commitment (..),
                                                CommitmentsMap (getCommitmentsMap),
                                                OpeningsMap, SharesMap, getOpening,
@@ -33,7 +33,7 @@ calculateSeed
     :: CommitmentsMap        -- ^ All participating nodes
     -> OpeningsMap           -- ^ Openings sent by those nodes
     -> SharesMap             -- ^ Decrypted shares
-    -> RichmenStake          -- ^ How much stake nodes have
+    -> RichmenStakes          -- ^ How much stake nodes have
     -> Either SeedError SharedSeed
 calculateSeed commitments' openings lShares richmen = do
     let commitments = getCommitmentsMap commitments' -- just unwrapping

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Base.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Base.hs
@@ -45,7 +45,7 @@ import           Pos.Core                        (CoinPortion, EpochIndex, Stake
                                                   coinPortionDenominator, getCoinPortion,
                                                   unsafeGetCoin)
 import           Pos.Crypto                      (Share, verifyShare)
-import           Pos.Lrc.Types                   (RichmenSet, RichmenStake)
+import           Pos.Lrc.Types                   (RichmenSet, RichmenStakes)
 import           Pos.Ssc.GodTossing.Core         (Commitment (..),
                                                   CommitmentsMap (getCommitmentsMap),
                                                   GtPayload (..), InnerSharesMap,
@@ -134,7 +134,7 @@ computeParticipants (HS.toMap -> richmen) = flip HM.intersection richmen
 
 computeSharesDistrPure
     :: MonadError TossVerFailure m
-    => RichmenStake
+    => RichmenStakes
     -> CoinPortion             -- ^ MPC threshold, e.g. 'genesisMpcThd'
     -> m SharesDistribution
 computeSharesDistrPure richmen threshold = do
@@ -301,7 +301,7 @@ checkCommitmentShares distr participants  (_, Commitment{..}, _) =
 -- | Like 'computeSharesDistrPure', but uses MPC threshold from the database.
 computeSharesDistr
     :: (MonadToss m, MonadTossEnv m, MonadError TossVerFailure m)
-    => RichmenStake -> m SharesDistribution
+    => RichmenStakes -> m SharesDistribution
 computeSharesDistr richmen =
     computeSharesDistrPure richmen =<< (bvdMpcThd <$> getAdoptedBVData)
 

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Class.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Class.hs
@@ -15,7 +15,7 @@ import           Universum
 
 import           Pos.Core                (BlockVersionData, EpochIndex, EpochOrSlot,
                                           StakeholderId)
-import           Pos.Lrc.Types           (RichmenStake)
+import           Pos.Lrc.Types           (RichmenStakes)
 import           Pos.Ssc.GodTossing.Core (CommitmentsMap, InnerSharesMap, Opening,
                                           OpeningsMap, SharesMap, SignedCommitment,
                                           VssCertificate, VssCertificatesMap)
@@ -74,13 +74,13 @@ instance MonadTossRead m => MonadTossRead (ExceptT s m)
 
 class Monad m => MonadTossEnv m where
     -- | Retrieve richmen for given epoch if they are known.
-    getRichmen :: EpochIndex -> m (Maybe RichmenStake)
+    getRichmen :: EpochIndex -> m (Maybe RichmenStakes)
 
     -- | Retrieve current adopted block data
     getAdoptedBVData :: m BlockVersionData
 
     default getRichmen :: (MonadTrans t, MonadTossEnv m', t m' ~ m) =>
-        EpochIndex -> m (Maybe RichmenStake)
+        EpochIndex -> m (Maybe RichmenStakes)
     getRichmen = lift . getRichmen
 
     default getAdoptedBVData :: (MonadTrans t, MonadTossEnv m', t m' ~ m) =>

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
@@ -3,7 +3,7 @@
 module Pos.Ssc.GodTossing.Toss.Pure
        ( PureToss (..)
        , PureTossWithEnv (..)
-       , MultiRichmenStake
+       , MultiRichmenStakes
        , MultiRichmenSet
        , runPureToss
        , runPureTossWithLogger
@@ -20,7 +20,7 @@ import           Universum
 
 import           Pos.Core                       (BlockVersionData, EpochIndex,
                                                  crucialSlot)
-import           Pos.Lrc.Types                  (RichmenSet, RichmenStake)
+import           Pos.Lrc.Types                  (RichmenSet, RichmenStakes)
 import           Pos.Ssc.GodTossing.Core        (deleteSignedCommitment,
                                                  insertSignedCommitment)
 import           Pos.Ssc.GodTossing.Genesis     (genesisCertificates)
@@ -30,7 +30,7 @@ import           Pos.Ssc.GodTossing.Types       (GtGlobalState, gsCommitments, g
                                                  gsShares, gsVssCertificates)
 import qualified Pos.Ssc.GodTossing.VssCertData as VCD
 
-type MultiRichmenStake = HashMap EpochIndex RichmenStake
+type MultiRichmenStakes = HashMap EpochIndex RichmenStakes
 type MultiRichmenSet   = HashMap EpochIndex RichmenSet
 
 newtype PureToss a = PureToss
@@ -40,7 +40,7 @@ newtype PureToss a = PureToss
 
 newtype PureTossWithEnv a = PureTossWithEnv
     { getPureTossWithEnv ::
-          ReaderT (MultiRichmenStake, BlockVersionData) PureToss a
+          ReaderT (MultiRichmenStakes, BlockVersionData) PureToss a
     } deriving (Functor, Applicative, Monad, CanLog, HasLoggerName,
                 MonadTossRead, MonadToss)
 
@@ -113,7 +113,7 @@ execPureTossWithLogger
 execPureTossWithLogger g = fmap snd . runPureTossWithLogger g
 
 supplyPureTossEnv
-    :: (MultiRichmenStake, BlockVersionData)
+    :: (MultiRichmenStakes, BlockVersionData)
     -> PureTossWithEnv a
     -> PureToss a
 supplyPureTossEnv env = flip runReaderT env . getPureTossWithEnv

--- a/godtossing/Pos/Ssc/GodTossing/Workers.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Workers.hs
@@ -49,7 +49,7 @@ import           Pos.Crypto                            (SecretKey, VssKeyPair,
 import           Pos.Crypto.SecretSharing              (toVssPublicKey)
 import           Pos.DB                                (gsAdoptedBVData)
 import           Pos.Lrc.Context                       (lrcActionOnEpochReason)
-import           Pos.Lrc.Types                         (RichmenStake)
+import           Pos.Lrc.Types                         (RichmenStakes)
 import           Pos.Recovery.Info                     (recoveryCommGuard)
 import           Pos.Slotting                          (getCurrentSlot,
                                                         getSlotStartEmpatically)
@@ -325,7 +325,7 @@ generateAndSetNewSecret sk SlotId {..} = do
     warnNoPs =
         logWarning "generateAndSetNewSecret: can't generate, no participants"
     reportDeserFail = logError "Wrong participants list: can't deserialize"
-    generateAndSetNewSecretDo :: RichmenStake
+    generateAndSetNewSecretDo :: RichmenStakes
                               -> NonEmpty (StakeholderId, AsBinary VssPublicKey)
                               -> m (Maybe SignedCommitment)
     generateAndSetNewSecretDo richmen ps = do

--- a/lrc/Pos/Lrc/Arbitrary.hs
+++ b/lrc/Pos/Lrc/Arbitrary.hs
@@ -4,8 +4,8 @@
 
 module Pos.Lrc.Arbitrary
        ( GenesisMpcThd
-       , InvalidRichmenStake (..)
-       , ValidRichmenStake (..)
+       , InvalidRichmenStakes (..)
+       , ValidRichmenStakes (..)
        ) where
 
 import           Universum
@@ -15,50 +15,50 @@ import           Data.Reflection                   (Reifies (..))
 import           Test.QuickCheck                   (Arbitrary (..), Gen, choose)
 import           Test.QuickCheck.Arbitrary.Generic (genericShrink)
 
-import           Pos.Core.Constants                (genesisMpcThd)
 import           Pos.Core                          (Coin, CoinPortion, StakeholderId,
                                                     mkCoin, unsafeGetCoin)
-import           Pos.Core.Coin                     (coinPortionToDouble)
-import           Pos.Lrc.Types                     (RichmenStake)
 import           Pos.Core.Arbitrary                ()
+import           Pos.Core.Coin                     (coinPortionToDouble)
+import           Pos.Core.Constants                (genesisMpcThd)
+import           Pos.Lrc.Types                     (RichmenStakes)
 
--- | Wrapper over 'RichmenStake'. Its 'Arbitrary' instance enforces that the stake
+-- | Wrapper over 'RichmenStakes'. Its 'Arbitrary' instance enforces that the stake
 -- distribution inside must be valid with respect to the threshold 'thd', i.e. all of the
 -- coins are non-zero and every stakeholder has sufficient coins
 -- (above 'coinPortionToDouble thd' %) to participate.
 -- Using reflection, the 'thd' phantom type is used to get the threshold desired in each
 -- case.
-newtype ValidRichmenStake thd = Valid
-    { getValid :: RichmenStake
+newtype ValidRichmenStakes thd = Valid
+    { getValid :: RichmenStakes
     } deriving (Generic, Show, Eq)
 
-instance (Reifies thd CoinPortion) => Arbitrary (ValidRichmenStake thd) where
-    arbitrary = Valid <$> genRichmenStake (reflect (Proxy @thd))
+instance (Reifies thd CoinPortion) => Arbitrary (ValidRichmenStakes thd) where
+    arbitrary = Valid <$> genRichmenStakes (reflect (Proxy @thd))
     shrink = genericShrink
 
--- | Wrapper over 'RichmenStake'. Its 'Arbitrary' instance enforces that the stake
+-- | Wrapper over 'RichmenStakes'. Its 'Arbitrary' instance enforces that the stake
 -- distribution inside must be invalid, i.e. one of the stakeholders does not have
 -- sufficient coins to participate.
-newtype InvalidRichmenStake thd = Invalid
-    { getInvalid :: RichmenStake
+newtype InvalidRichmenStakes thd = Invalid
+    { getInvalid :: RichmenStakes
     } deriving (Generic, Show, Eq)
 
-instance (Reifies thd CoinPortion) => Arbitrary (InvalidRichmenStake thd) where
+instance (Reifies thd CoinPortion) => Arbitrary (InvalidRichmenStakes thd) where
     arbitrary = Invalid <$> do
-        validRichmenStake <- genRichmenStake (reflect (Proxy @thd))
+        validRichmenStakes <- genRichmenStakes (reflect (Proxy @thd))
         poorMan <- arbitrary
-        return $ HM.insert poorMan (mkCoin 0) validRichmenStake
+        return $ HM.insert poorMan (mkCoin 0) validRichmenStakes
     shrink = genericShrink
 
-genRichmenStake
-    :: CoinPortion -> Gen RichmenStake
-genRichmenStake thd = do
-    -- Total number of coins in the 'RichmenStake' hashmap that will be returned. May not
+genRichmenStakes
+    :: CoinPortion -> Gen RichmenStakes
+genRichmenStakes thd = do
+    -- Total number of coins in the 'RichmenStakes' hashmap that will be returned. May not
     -- be exactly accurate because of a possible early return in 'fun' (see comment).
     totalCoins <- mkCoin <$> choose (1, unsafeGetCoin maxBound)
     let -- Minimum percentage of stake required to be a richmen.
         threshold = coinPortionToDouble thd
-        -- Given the total number of coins in a 'RichmenStake' hashmap, 'threshold'
+        -- Given the total number of coins in a 'RichmenStakes' hashmap, 'threshold'
         -- dictates that there is a minimum percentage of stake each holder must have so
         -- that 'computeSharesDistr' can be successful. 'minStake' is that minimum value,
         -- but expressed as a 'Word64'.
@@ -66,7 +66,7 @@ genRichmenStake thd = do
         minStake = ceiling $ threshold * (fromIntegral $ unsafeGetCoin totalCoins)
         -- Stops when presently available stake is below mpc threshold, in which case it
         -- is discarded and the stakeholder list is returned as is.
-        fun :: Word64 -> [(StakeholderId, Coin)] -> Gen RichmenStake
+        fun :: Word64 -> [(StakeholderId, Coin)] -> Gen RichmenStakes
         fun coinAccum participants
             | coinAccum < minStake = return $ HM.fromList participants
             | otherwise = do

--- a/lrc/Pos/Lrc/Consumer.hs
+++ b/lrc/Pos/Lrc/Consumer.hs
@@ -16,7 +16,7 @@ import           Pos.Core               (BlockVersionData, Coin, CoinPortion, Ep
 import           Pos.DB.Class           (MonadDB, MonadGState, gsAdoptedBVData)
 import           Pos.Lrc.Class          (RichmenComponent (..))
 import           Pos.Lrc.DB.RichmenBase (getRichmen, putRichmen)
-import           Pos.Lrc.Types          (RichmenStake)
+import           Pos.Lrc.Types          (RichmenStakes)
 
 -- | Datatype for LRC computation client.
 -- If you want to compute richmen, you should add such client to LRC framework
@@ -27,7 +27,7 @@ data LrcConsumer m = LrcConsumer
     -- the system as an argument.
     , lcIfNeedCompute     :: EpochIndex -> m Bool
     -- ^ Function which defines necessity of richmen computation
-    , lcComputedCallback  :: EpochIndex -> Coin -> RichmenStake -> m ()
+    , lcComputedCallback  :: EpochIndex -> Coin -> RichmenStakes -> m ()
     -- ^ Callback which will be called when richmen computed
     , lcConsiderDelegated :: Bool
     -- ^ Whether delegated stake should be considered
@@ -40,7 +40,7 @@ lrcConsumerFromComponent
        RichmenComponent c
     => (Coin -> m Coin)
     -> (EpochIndex -> m Bool)
-    -> (EpochIndex -> Coin -> RichmenStake -> m ())
+    -> (EpochIndex -> Coin -> RichmenStakes -> m ())
     -> LrcConsumer m
 lrcConsumerFromComponent thd ifNeedCompute callback =
     LrcConsumer

--- a/lrc/Pos/Lrc/Types.hs
+++ b/lrc/Pos/Lrc/Types.hs
@@ -1,33 +1,22 @@
 -- | Types used in LRC.
 
 module Pos.Lrc.Types
-       ( Richmen
-       , RichmenSet
-       , RichmenStake
-       , toRichmen
+       ( RichmenSet
+       , RichmenStakes
        , FullRichmenData
        ) where
 
-import qualified Data.HashMap.Strict as HM
 import           Universum
 
-import           Pos.Core.Types      (Coin, StakeholderId)
+import           Pos.Core.Types (Coin, StakeholderId)
 
--- | Addresses which have enough stake for participation in SSC.
-type Richmen = NonEmpty StakeholderId
-
--- | Hashset of richmen.
+-- | Hashset of richmen (i. e. stakeholders whose stake is greater
+-- than some threshold).
 type RichmenSet = HashSet StakeholderId
 
--- | Richmen with Stake
-type RichmenStake = HashMap StakeholderId Coin
-
-toRichmen :: RichmenStake -> Richmen
-toRichmen =
-    fromMaybe onNoRichmen . nonEmpty . HM.keys
-  where
-    onNoRichmen = error "There are no richmen!"
+-- | Richmen and their stakes.
+type RichmenStakes = HashMap StakeholderId Coin
 
 -- | Full richmen data consists of total stake at some point and stake
 -- distribution among richmen.
-type FullRichmenData = (Coin, RichmenStake)
+type FullRichmenData = (Coin, RichmenStakes)

--- a/src/Pos/Delegation/Logic/Mempool.hs
+++ b/src/Pos/Delegation/Logic/Mempool.hs
@@ -159,7 +159,6 @@ processProxySKHeavy psk = do
     curTime <- microsecondsToUTC <$> currentTime
     headEpoch <- view epochIndexL <$> DB.getTipHeader @ssc
     richmen <-
-        toList <$>
         lrcActionOnEpochReason
         headEpoch
         "Delegation.Logic#processProxySKHeavy: there are no richmen for current epoch"
@@ -170,7 +169,7 @@ processProxySKHeavy psk = do
         iPk = pskIssuerPk psk
         -- We don't check stake for revoking certs. You can revoke
         -- even if you don't have money anymore.
-        enoughStake = isRevokePsk psk || addressHash iPk `elem` richmen
+        enoughStake = isRevokePsk psk || addressHash iPk `HS.member` richmen
         omegaCorrect = headEpoch == pskOmega psk
     runDelegationStateAction $ do
         memPoolSize <- use dwPoolSize

--- a/src/Pos/Delegation/Logic/VAR.hs
+++ b/src/Pos/Delegation/Logic/VAR.hs
@@ -351,7 +351,6 @@ dlgVerifyBlocks blocks = do
         throwM $ DBMalformed "Multiple stakeholders have issued & published psks this epoch"
     let initState = DlgVerState _dvCurEpoch
     (richmen :: HashSet StakeholderId) <-
-        HS.fromList . toList <$>
         lrcActionOnEpochReason
         headEpoch
         "Delegation.Logic#delegationVerifyBlocks: there are no richmen for current epoch"

--- a/src/Pos/Lrc/DB/Richmen.hs
+++ b/src/Pos/Lrc/DB/Richmen.hs
@@ -39,10 +39,11 @@ import           Pos.Lrc.Class               (RichmenComponent (..),
                                               someRichmenComponent)
 import           Pos.Lrc.DB.RichmenBase      (getRichmen, getRichmenP, putRichmenP)
 import           Pos.Lrc.Logic               (RichmenType (..), findRichmenPure)
-import           Pos.Lrc.Types               (FullRichmenData, Richmen, toRichmen)
+import           Pos.Lrc.Types               (FullRichmenData, RichmenSet)
 import           Pos.Ssc.RichmenComponent    (RCSsc, getRichmenSsc)
 import           Pos.Txp.Core                (TxOutDistribution)
 import           Pos.Update.RichmenComponent (RCUs, getRichmenUS)
+import           Pos.Util.Util               (getKeys)
 
 ----------------------------------------------------------------------------
 -- Initialization
@@ -88,11 +89,11 @@ components = [ someRichmenComponent @RCSsc
 data RCDlg
 
 instance RichmenComponent RCDlg where
-    type RichmenData RCDlg = Richmen
-    rcToData = toRichmen . snd
+    type RichmenData RCDlg = RichmenSet
+    rcToData = getKeys . snd
     rcTag Proxy = "dlg"
     rcInitialThreshold Proxy = genesisHeavyDelThd
     rcConsiderDelegated Proxy = False
 
-getRichmenDlg :: MonadDBRead m => EpochIndex -> m (Maybe Richmen)
+getRichmenDlg :: MonadDBRead m => EpochIndex -> m (Maybe RichmenSet)
 getRichmenDlg epoch = getRichmen @RCDlg epoch

--- a/ssc/Pos/Ssc/Class/LocalData.hs
+++ b/ssc/Pos/Ssc/Class/LocalData.hs
@@ -14,7 +14,7 @@ import           Universum
 
 import           Pos.Core            (BlockVersionData, EpochIndex, SlotId)
 import           Pos.DB.Class        (MonadDBRead)
-import           Pos.Lrc.Types       (RichmenStake)
+import           Pos.Lrc.Types       (RichmenStakes)
 import           Pos.Slotting.Class  (MonadSlots)
 import           Pos.Ssc.Class.Types (Ssc (..))
 
@@ -34,7 +34,7 @@ class Ssc ssc => SscLocalDataClass ssc where
     sscGetLocalPayloadQ :: SlotId -> LocalQuery ssc (SscPayload ssc)
     -- | Make 'SscLocalData' valid for given epoch, richmen and global state.
     -- of best known chain).
-    sscNormalizeU :: (EpochIndex, RichmenStake)
+    sscNormalizeU :: (EpochIndex, RichmenStakes)
                   -> BlockVersionData
                   -> SscGlobalState ssc
                   -> LocalUpdate ssc ()

--- a/ssc/Pos/Ssc/Class/Storage.hs
+++ b/ssc/Pos/Ssc/Class/Storage.hs
@@ -17,7 +17,7 @@ import           Universum
 
 import           Pos.Core             (BlockVersionData, EpochIndex, SharedSeed)
 import           Pos.DB               (MonadDBRead, SomeBatchOp)
-import           Pos.Lrc.Types        (RichmenStake)
+import           Pos.Lrc.Types        (RichmenStakes)
 import           Pos.Ssc.Class.Types  (Ssc (..), SscBlock)
 import           Pos.Util.Chrono      (NE, NewestFirst, OldestFirst)
 
@@ -52,12 +52,12 @@ class Ssc ssc => SscGStateClass ssc where
     -- current GState and apply them on success.
     -- Blocks must be from the same epoch.
     sscVerifyAndApplyBlocks
-        :: RichmenStake
+        :: RichmenStakes
         -> BlockVersionData
         -> OldestFirst NE (SscBlock ssc)
         -> SscVerifier ssc ()
     -- | Calculate 'SharedSeed' for given epoch using 'SscGlobalState'.
     sscCalculateSeedQ
         :: EpochIndex
-        -> RichmenStake
+        -> RichmenStakes
         -> SscGlobalQuery ssc (Either (SscSeedError ssc) SharedSeed)

--- a/ssc/Pos/Ssc/Extra/Logic.hs
+++ b/ssc/Pos/Ssc/Extra/Logic.hs
@@ -44,7 +44,7 @@ import           Pos.DB                   (MonadBlockDBGeneric, MonadDBRead, Mon
 import           Pos.DB.GState.Common     (getTipHeaderGeneric)
 import           Pos.Exception            (assertionFailed)
 import           Pos.Lrc.Context          (LrcContext, lrcActionOnEpochReason)
-import           Pos.Lrc.Types            (RichmenStake)
+import           Pos.Lrc.Types            (RichmenStakes)
 import           Pos.Slotting.Class       (MonadSlots)
 import           Pos.Ssc.Class.Helpers    (SscHelpersClass)
 import           Pos.Ssc.Class.LocalData  (SscLocalDataClass (..))
@@ -312,7 +312,7 @@ sscVerifyBlocks blocks = do
 
 getRichmenFromLrc
     :: (MonadIO m, MonadDBRead m, MonadReader ctx m, HasLens LrcContext ctx LrcContext)
-    => Text -> EpochIndex -> m RichmenStake
+    => Text -> EpochIndex -> m RichmenStakes
 getRichmenFromLrc fname epoch =
     lrcActionOnEpochReason
         epoch

--- a/ssc/Pos/Ssc/RichmenComponent.hs
+++ b/ssc/Pos/Ssc/RichmenComponent.hs
@@ -11,16 +11,16 @@ import           Pos.Core               (EpochIndex, genesisMpcThd)
 import           Pos.DB.Class           (MonadDBRead)
 import           Pos.Lrc.Class          (RichmenComponent (..))
 import           Pos.Lrc.DB.RichmenBase (getRichmen)
-import           Pos.Lrc.Types          (RichmenStake)
+import           Pos.Lrc.Types          (RichmenStakes)
 
 data RCSsc
 
 instance RichmenComponent RCSsc where
-    type RichmenData RCSsc = RichmenStake
+    type RichmenData RCSsc = RichmenStakes
     rcToData = snd
     rcTag Proxy = "ssc"
     rcInitialThreshold Proxy = genesisMpcThd
     rcConsiderDelegated Proxy = True
 
-getRichmenSsc :: (MonadDBRead m) => EpochIndex -> m (Maybe RichmenStake)
+getRichmenSsc :: (MonadDBRead m) => EpochIndex -> m (Maybe RichmenStakes)
 getRichmenSsc = getRichmen @RCSsc


### PR DESCRIPTION
1. Old 'Richmen' type was bad. It assumed that there is always at least
one richman, but I don't think we can rely on it. Even if we could, it would
be better to throw error in 'MonadThrow' rather than use 'error'. Also
you almost always need to do lookup, so list is not good.
2. 'RichmenStake' was renamed to 'RichmenStakes' because it makes more sense.