### PR TITLE
[TW-148] remove MonadDiscovery; use Kademlia to update OutboundQ

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -64,9 +64,6 @@ library
                         Pos.Generator.Block
                         Pos.Generator.BlockEvent
 
-                        -- Known peers
-                        Pos.KnownPeers
-
                         -- Genesis data
                         Pos.Genesis
 

--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -39,6 +39,7 @@ module Pos.Communication.Types.Protocol
        , MsgType (..)
        , Origin (..)
        , Msg
+       , MsgSubscribe (..)
        ) where
 
 import           Data.Aeson                 (ToJSON (..), FromJSON (..), Value)
@@ -290,3 +291,11 @@ instance Monad m => Monoid (MkListeners m) where
     a `mappend` b = MkListeners act (inSpecs a `mappend` inSpecs b) (outSpecs a `mappend` outSpecs b)
       where
         act vI pD = (++) (mkListeners a vI pD) (mkListeners b vI pD)
+
+-- | 'Subscribe' message
+--
+-- This can be used by behind-NAT nodes to subscribe to the 'OutboundQueue'
+-- of a relay node. The node will remain subscribed for the duration of the
+-- conversation.
+data MsgSubscribe = MsgSubscribe
+    deriving (Generic, Show, Eq)

--- a/infra/Pos/Communication/Util.hs
+++ b/infra/Pos/Communication/Util.hs
@@ -79,11 +79,8 @@ wrapListener
      , WithLogger m
      )
   => LoggerName -> Listener m -> Listener m
-wrapListener lname =
-    addWaitLogging .
-    modifyLogger lname
+wrapListener lname = modifyLogger lname
   where
-    addWaitLogging = mapListener' convWithWaitLogL identity
     modifyLogger _name = mapListener $ modifyLoggerName (<> lname)
 
 wrapActionSpec
@@ -91,11 +88,8 @@ wrapActionSpec
      , Mockable Bracket m
      )
   => LoggerName -> ActionSpec m a -> ActionSpec m a
-wrapActionSpec lname =
-    addWaitLogging .
-    modifyLogger lname
+wrapActionSpec lname = modifyLogger lname
   where
-    addWaitLogging = mapActionSpec sendActionsWithWaitLog identity
     modifyLogger _name = mapActionSpec identity $ modifyLoggerName
                                     (<> lname)
 

--- a/infra/Pos/DHT/Model/Types.hs
+++ b/infra/Pos/DHT/Model/Types.hs
@@ -13,8 +13,6 @@ module Pos.DHT.Model.Types
        -- * Parsers
        , dhtKeyParser
        , dhtNodeParser
-
-       , dhtNodeToNodeId
        ) where
 
 import qualified Control.Monad               as Monad (fail)
@@ -33,9 +31,8 @@ import qualified Text.Parsec.Char            as P
 import qualified Text.Parsec.String          as P
 import           Universum
 
-import           Pos.Communication.Protocol  (NodeId)
 import           Pos.Crypto.Random           (runSecureRandom)
-import           Pos.Util.TimeWarp           (NetworkAddress, addrParser, addressToNodeId)
+import           Pos.Util.TimeWarp           (NetworkAddress, addrParser)
 
 -- | Data type for DHT exceptions.
 data DHTException = NodeDown | AllPeersUnavailable
@@ -109,14 +106,3 @@ dhtKeyParser = P.base64Url >>= toDHTKey
 -- | Parser for 'DHTNode'.
 dhtNodeParser :: P.Parser DHTNode
 dhtNodeParser = DHTNode <$> addrParser <*> (P.char '/' *> dhtKeyParser)
-
--- | FIXME this is flimsy. It assumes that the node has a TCP server running
---   at the same host/port of its Kademlia instance, and that its 0'th EndPoint
---   is the desired target.
---
---   TBD would storing the opaque NodeId (a ByteString) as a value in the DHT,
---   keyed on the Kademlia ID of its host, work well?
-dhtNodeToNodeId :: DHTNode -> (DHTKey, NodeId)
-dhtNodeToNodeId dhtNode =
-    let twNodeId = addressToNodeId . dhtAddr $ dhtNode
-    in  (dhtNodeId dhtNode, twNodeId)

--- a/infra/Pos/DHT/Real/Param.hs
+++ b/infra/Pos/DHT/Real/Param.hs
@@ -1,17 +1,53 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Pos.DHT.Real.Param
-       ( KademliaParams(..)
+       ( KademliaParams (..)
+       , fromYamlConfig
+       , MalformedDHTKey (..)
        ) where
 
-import           Pos.DHT.Model.Types (DHTKey)
-import           Pos.Util.TimeWarp   (NetworkAddress)
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Base64.URL as B64 (decode)
+import           Pos.DHT.Model.Types   (DHTKey, bytesToDHTKey)
+import qualified Pos.Network.Yaml      as Y
+import           Pos.Util.TimeWarp     (NetworkAddress)
 import           Universum
 
 -- | Parameters for the Kademlia DHT subsystem.
 data KademliaParams = KademliaParams
-    { kpNetworkAddress  :: !NetworkAddress
-    , kpPeers           :: ![NetworkAddress] -- ^ Peers passed from CLI
+    { kpNetworkAddress  :: !(NetworkAddress)
+    , kpPeers           :: ![NetworkAddress]       -- ^ Peers passed from CLI
     , kpKey             :: !(Maybe DHTKey)
     , kpExplicitInitial :: !Bool
-    , kpDump            :: !FilePath         -- ^ Path to kademlia dump file
-    , kpExternalAddress :: !NetworkAddress   -- ^ External address of node
+    , kpDumpFile        :: !(Maybe FilePath)       -- ^ Path to kademlia dump file
+    , kpExternalAddress :: !(Maybe NetworkAddress) -- ^ External address of node
     } deriving (Show)
+
+-- | Get a KademliaParams from its yaml counterpart. Could fail because the
+-- DHTKey must be a base64-url encoded valid DHTKey.
+fromYamlConfig :: Y.KademliaParams -> Either String KademliaParams
+fromYamlConfig yamlParams = do
+    parsedKey <- case Y.kpId yamlParams of
+        Nothing  -> pure Nothing
+        Just key -> Just <$> kademliaIdToDHTKey key
+    return $ KademliaParams
+        { kpKey             = parsedKey
+        , kpNetworkAddress  = kademliaAddressToNetworkAddress (Y.kpBind yamlParams)
+        , kpExternalAddress = kademliaAddressToNetworkAddress <$> Y.kpAddress yamlParams
+        , kpPeers           = kademliaAddressToNetworkAddress <$> Y.kpPeers yamlParams
+        , kpDumpFile        = Y.kpDumpFile yamlParams
+        , kpExplicitInitial = Y.kpExplicitInitial yamlParams
+        }
+
+kademliaAddressToNetworkAddress :: Y.KademliaAddress -> NetworkAddress
+kademliaAddressToNetworkAddress yamlAddr = (B8.pack $ Y.kaHost yamlAddr, Y.kaPort yamlAddr)
+
+kademliaIdToDHTKey :: Y.KademliaId -> Either String DHTKey
+kademliaIdToDHTKey (Y.KademliaId txt) = do
+    bytes <- B64.decode (B8.pack txt)
+    bytesToDHTKey bytes
+
+data MalformedDHTKey = MalformedDHTKey String
+    deriving (Show, Typeable)
+
+instance Exception MalformedDHTKey

--- a/infra/Pos/DHT/Real/Types.hs
+++ b/infra/Pos/DHT/Real/Types.hs
@@ -45,4 +45,7 @@ data KademliaDHTInstance = KademliaDHTInstance
     , kdiKnownPeersCache :: !(TVar [NetworkAddress])
     , kdiDumpPath        :: !(Maybe FilePath)
     , kdiPeerType        :: !NodeType
+    , kdiSubscribe       :: !Bool
+      -- ^ True if Kademlia peers should be used to populate the set of known
+      -- peers (via MonadKnownPeers instance).
     }

--- a/infra/Pos/DHT/Real/Types.hs
+++ b/infra/Pos/DHT/Real/Types.hs
@@ -15,6 +15,7 @@ import qualified Network.Kademlia       as K
 
 import           Pos.Binary.Class       (Bi (..), encode)
 import           Pos.DHT.Model.Types    (DHTData, DHTKey)
+import           Pos.Network.Types      (NodeType)
 import           Pos.Util.TimeWarp      (NetworkAddress)
 import           System.IO.Unsafe       (unsafePerformIO)
 
@@ -42,5 +43,6 @@ data KademliaDHTInstance = KademliaDHTInstance
     , kdiInitialPeers    :: ![NetworkAddress]
     , kdiExplicitInitial :: !Bool
     , kdiKnownPeersCache :: !(TVar [NetworkAddress])
-    , kdiDumpPath        :: !FilePath
+    , kdiDumpPath        :: !(Maybe FilePath)
+    , kdiPeerType        :: !NodeType
     }

--- a/infra/Pos/DHT/Workers.hs
+++ b/infra/Pos/DHT/Workers.hs
@@ -1,30 +1,38 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Pos.DHT.Workers
        ( DhtWorkMode
        , dhtWorkers
        ) where
 
+import           Control.Concurrent.STM     (retry)
 import           Universum
 
 import qualified Data.ByteString.Lazy       as BSL
+import qualified Data.Set                   as S
 import qualified Data.Store                 as Store
-import           Formatting                 (sformat, (%))
+import           Formatting                 (sformat, shown, (%))
 import           Mockable                   (Delay, Fork, Mockable)
+import           Network.Broadcast.OutboundQueue.Types (simplePeers)
 import           Network.Kademlia           (takeSnapshot)
 import           System.Wlog                (WithLogger, logNotice)
 
 import           Pos.Binary.Infra.DHTModel  ()
-import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
+import           Pos.Communication.Protocol (NodeId, OutSpecs, WorkerSpec, Worker,
+                                             localOnNewSlotWorker, ActionSpec (..))
 import           Pos.Core.Slotting          (flattenSlotId)
 import           Pos.Core.Types             (slotIdF)
 import           Pos.DHT.Constants          (kademliaDumpInterval)
 import           Pos.DHT.Real.Types         (KademliaDHTInstance (..))
-import           Pos.Discovery.Class        (MonadDiscovery)
+import           Pos.DHT.Real.Real          (kademliaGetKnownPeers)
+import           Pos.KnownPeers             (MonadKnownPeers (..))
+import           Pos.Network.Types          (NodeType)
 import           Pos.Recovery.Info          (MonadRecoveryInfo, recoveryCommGuard)
 import           Pos.Reporting              (HasReportingContext)
 import           Pos.Shutdown               (HasShutdownContext)
 import           Pos.Slotting.Class         (MonadSlots)
+import           Pos.Util.TimeWarp          (addressToNodeId)
 
 type DhtWorkMode ctx m =
     ( WithLogger m
@@ -33,18 +41,21 @@ type DhtWorkMode ctx m =
     , MonadMask m
     , Mockable Fork m
     , Mockable Delay m
+    , MonadKnownPeers m
     , MonadRecoveryInfo m
     , MonadReader ctx m
     , HasReportingContext ctx
     , HasShutdownContext ctx
-    , MonadDiscovery m
     )
 
 dhtWorkers
     :: ( DhtWorkMode ctx m
        )
     => KademliaDHTInstance -> ([WorkerSpec m], OutSpecs)
-dhtWorkers kademliaInst = first pure (dumpKademliaStateWorker kademliaInst)
+dhtWorkers kademliaInst = mconcat
+    [ first pure (dumpKademliaStateWorker kademliaInst)
+    , ([kademliaSubscriptionWorker kademliaInst], mempty)
+    ]
 
 dumpKademliaStateWorker
     :: ( DhtWorkMode ctx m
@@ -57,6 +68,39 @@ dumpKademliaStateWorker kademliaInst = localOnNewSlotWorker True $ \slotId ->
         logNotice $ sformat ("Dumping kademlia snapshot on slot: "%slotIdF) slotId
         let inst = kdiHandle kademliaInst
         snapshot <- liftIO $ takeSnapshot inst
-        liftIO . BSL.writeFile dumpFile . BSL.fromStrict $ Store.encode snapshot
+        case dumpFile of
+            Just fp -> liftIO . BSL.writeFile fp . BSL.fromStrict $ Store.encode snapshot
+            Nothing -> return ()
   where
     isTimeToDump slotId = flattenSlotId slotId `mod` kademliaDumpInterval == 0
+
+kademliaSubscriptionWorker
+    :: forall ctx m .
+       ( DhtWorkMode ctx m
+       )
+    => KademliaDHTInstance
+    -> WorkerSpec m
+kademliaSubscriptionWorker kademliaInst = ActionSpec $ \_ _ -> do
+    logNotice "Kademlia subscription worker started"
+    blockAndUpdate S.empty
+  where
+    peerType :: NodeType
+    peerType = kdiPeerType kademliaInst
+    blockAndUpdate :: Set NodeId -> m x
+    blockAndUpdate lastSet = do
+        (additions, removals) <- atomically $ do
+            peersList <- kademliaGetKnownPeers kademliaInst
+            let peersSet = S.fromList (addressToNodeId <$> peersList)
+                additions = peersSet S.\\ lastSet
+                removals = lastSet S.\\ peersSet
+            when (S.null additions && S.null removals) retry
+            return (additions, removals)
+        logNotice $
+            sformat ("Kademlia peer changes: adding '{"%shown%"}' removing '{"%shown%"}'")
+                additions
+                removals
+        let peersToAdd = simplePeers ((,) peerType <$> S.toList additions)
+        forM_ (S.toList removals) removeKnownPeer
+        addKnownPeers peersToAdd
+        let newSet = (lastSet S.\\ removals) `S.union` additions
+        blockAndUpdate newSet

--- a/infra/Pos/DHT/Workers.hs
+++ b/infra/Pos/DHT/Workers.hs
@@ -6,21 +6,29 @@ module Pos.DHT.Workers
        , dhtWorkers
        ) where
 
-import           Control.Concurrent.STM     (retry)
+import qualified Control.Concurrent.STM       as STM
+import qualified Control.Concurrent.STM.TVar  as STM
+import qualified Control.Concurrent.STM.TMVar as STM
+import           Control.Monad                (foldM)
 import           Universum
 
 import qualified Data.ByteString.Lazy       as BSL
 import qualified Data.Set                   as S
 import qualified Data.Store                 as Store
 import           Formatting                 (sformat, shown, (%))
-import           Mockable                   (Delay, Fork, Mockable)
-import           Network.Broadcast.OutboundQueue.Types (simplePeers)
+import           Mockable                   (Delay, Async, Fork, Mockable, withAsync,
+                                             Catch, try)
+import           Network.Broadcast.OutboundQueue.Types (peersFromList, Peers)
 import           Network.Kademlia           (takeSnapshot)
 import           System.Wlog                (WithLogger, logNotice)
 
+import           Pos.Binary.Class           (Bi)
 import           Pos.Binary.Infra.DHTModel  ()
 import           Pos.Communication.Protocol (NodeId, OutSpecs, WorkerSpec, Worker,
-                                             localOnNewSlotWorker, ActionSpec (..))
+                                             localOnNewSlotWorker, ActionSpec (..),
+                                             MsgSubscribe (..), SendActions (..),
+                                             Conversation (..), ConversationActions (..),
+                                             Message, convH, toOutSpecs)
 import           Pos.Core.Slotting          (flattenSlotId)
 import           Pos.Core.Types             (slotIdF)
 import           Pos.DHT.Constants          (kademliaDumpInterval)
@@ -39,23 +47,35 @@ type DhtWorkMode ctx m =
     , MonadSlots m
     , MonadIO m
     , MonadMask m
+    , Mockable Async m
     , Mockable Fork m
     , Mockable Delay m
+    , Mockable Catch m
     , MonadKnownPeers m
     , MonadRecoveryInfo m
     , MonadReader ctx m
     , HasReportingContext ctx
     , HasShutdownContext ctx
+    , Message Void
+    , Message MsgSubscribe
+    , Bi MsgSubscribe
     )
 
 dhtWorkers
     :: ( DhtWorkMode ctx m
        )
     => KademliaDHTInstance -> ([WorkerSpec m], OutSpecs)
-dhtWorkers kademliaInst = mconcat
+dhtWorkers kademliaInst@KademliaDHTInstance {..} = mconcat
     [ first pure (dumpKademliaStateWorker kademliaInst)
-    , ([kademliaSubscriptionWorker kademliaInst], mempty)
+    , if kdiSubscribe
+      then ([kademliaSubscriptionWorker kademliaInst], kademliaSubscriptionWorkerOutSpecs)
+      else ([], mempty)
     ]
+
+kademliaSubscriptionWorkerOutSpecs
+    :: ( Message MsgSubscribe, Message Void )
+    => OutSpecs
+kademliaSubscriptionWorkerOutSpecs = toOutSpecs [ convH (Proxy @MsgSubscribe) (Proxy @Void) ]
 
 dumpKademliaStateWorker
     :: ( DhtWorkMode ctx m
@@ -74,33 +94,146 @@ dumpKademliaStateWorker kademliaInst = localOnNewSlotWorker True $ \slotId ->
   where
     isTimeToDump slotId = flattenSlotId slotId `mod` kademliaDumpInterval == 0
 
+-- | This worker will update the known peers (via MonadKnownPeers) every time
+-- the Kademlia peers change.
 kademliaSubscriptionWorker
     :: forall ctx m .
        ( DhtWorkMode ctx m
        )
     => KademliaDHTInstance
     -> WorkerSpec m
-kademliaSubscriptionWorker kademliaInst = ActionSpec $ \_ _ -> do
+kademliaSubscriptionWorker kademliaInst = ActionSpec $ \_ sendActions -> do
     logNotice "Kademlia subscription worker started"
-    blockAndUpdate S.empty
+    -- A  TMVar NodeId  for each peer to which 
+    toSubscribe <- liftIO . atomically $ forM [1..nSubscriptions] (const STM.newEmptyTMVar)
+    -- A  TVar (Set NodeId)  for the set of peers to which we're currently
+    -- subscribed.
+    subscribed <- liftIO $ STM.newTVarIO S.empty
+    -- Spawn a thread for each of the subscriptions that we wish to make.
+    withAsyncs (fmap (subThread sendActions subscribed) toSubscribe) $ do
+        -- Repeatedly do an STM transaction which retries until the best set
+        -- of peers changes. Read the where clause comments and program text
+        -- for more details.
+        updateForever subscribed toSubscribe mempty
   where
+
+    -- Spawn a bunch of threads using withAsync and ignore their results.
+    -- They'll be cancelled when the continuation finishes.
+    withAsyncs :: [m x] -> m t -> m t
+    withAsyncs [] k = k
+    withAsyncs (it : rest) k = withAsync it $ const (withAsyncs rest k)
+
+    -- How many peers to subscribe to.
+    nSubscriptions :: Int
+    nSubscriptions = 3
+
+    -- The NodeType that we assume our peers to be.
     peerType :: NodeType
     peerType = kdiPeerType kademliaInst
-    blockAndUpdate :: Set NodeId -> m x
-    blockAndUpdate lastSet = do
-        (additions, removals) <- atomically $ do
-            peersList <- kademliaGetKnownPeers kademliaInst
-            let peersSet = S.fromList (addressToNodeId <$> peersList)
-                additions = peersSet S.\\ lastSet
-                removals = lastSet S.\\ peersSet
-            when (S.null additions && S.null removals) retry
-            return (additions, removals)
+
+    -- Subscribe to the node which appears in the TMVar, updating the TVar so
+    -- that it includes that node whenever a subscription is active.
+    subThread :: SendActions m -> STM.TVar (Set NodeId) -> STM.TMVar NodeId -> m ()
+    subThread sendActions subscribedVar peerVar = do
+        logNotice $ sformat ("This is a subscription thread")
+        action
+      where
+        action = do
+            -- Block until we get a NodeId to subscribe to.
+            peer <- liftIO . atomically $ STM.readTMVar peerVar
+            subscribeTo sendActions peer
+            liftIO . atomically $ do
+                -- Take the TMVar so that the updating thread can replace it
+                -- with another candidate, whenever it has one.
+                STM.takeTMVar peerVar
+                STM.modifyTVar subscribedVar (S.delete peer)
+            action
+
+    -- TODO import this and re-use in the behind-NAT subscription worker.
+    subscribeTo :: SendActions m -> NodeId -> m ()
+    subscribeTo sendActions peer = do
+        logNotice $ sformat ("Establishing subscription to "%shown) peer
+        Left (ex :: SomeException) <- try $ withConnectionTo sendActions peer $ \_ ->
+            pure $ Conversation $ \conv -> do
+                send conv MsgSubscribe
+                logNotice $ sformat ("Subscription to "%shown%" established") peer
+                _void :: Maybe Void <- recv conv 0 -- Other side will never send
+                return _void
+        logNotice $ sformat ("Subscription to "%shown%" terminated: "%shown) peer ex
+
+    -- Main updating action. It runs an STM transaction until the new Peers
+    -- term comes out. When this happens depends upon
+    --   1. The Kadmelia internal state TVar.
+    --   2. The state of active subscriptions, as reflected by the TMVars
+    --      in the 'peerVars' parameters.
+    -- See 'updateFromKademlia'. It guarantees that the 'Peers NodeId' term
+    -- it produces is not the same as the one it takes as its final parameter
+    -- (if they're equal, it will retry).
+    --
+    -- It is assumed that there is no concurrent user of the MonadKnownPeers
+    -- mutator functions (we'll overwrite them).
+    updateForever
+        :: STM.TVar (Set NodeId)
+        -> [STM.TMVar NodeId]
+        -> Peers NodeId
+        -> m ()
+    updateForever subscribedVar peerVars peers = do
+        -- Will block until at least one of the current best peers changes.
+        peers' <- liftIO . atomically $ updateFromKademlia subscribedVar peerVars peers
         logNotice $
-            sformat ("Kademlia peer changes: adding '{"%shown%"}' removing '{"%shown%"}'")
-                additions
-                removals
-        let peersToAdd = simplePeers ((,) peerType <$> S.toList additions)
-        forM_ (S.toList removals) removeKnownPeer
-        addKnownPeers peersToAdd
-        let newSet = (lastSet S.\\ removals) `S.union` additions
-        blockAndUpdate newSet
+            sformat ("Kademlia peer set changed to "%shown) peers'
+        updateKnownPeers (const peers')
+        updateForever subscribedVar peerVars peers'
+
+    -- Given a list of 'TMVar's corresponding to subscription threads, try to
+    -- put a list of 'NodeId's into them. Any full ones are passed up, and
+    -- the 'NodeId' is carried on to the next one. This is the second component
+    -- of the tuple. The first component is an accumulation of the 'NodeId's
+    -- that are actually in the 'TMVar's.
+    updatePeerVars
+        :: STM.TVar (Set NodeId)
+        -> [STM.TMVar NodeId]
+        -> ([NodeId], [NodeId])
+        -> STM ([NodeId], [NodeId])
+    updatePeerVars _ [] (mains, remaining) = return (reverse mains, remaining)
+    updatePeerVars subscribedVar (peerVar : peerVars) (mains, []) = do
+        -- There's nothing to put into this TMVar.
+        -- If it's full, tack its value onto the list of nodes present.
+        current <- STM.tryReadTMVar peerVar
+        let mains' = maybe identity (:) current mains
+        updatePeerVars subscribedVar peerVars (mains', [])
+    updatePeerVars subscribedVar (peerVar : peerVars) (mains, peer : peers) = do
+        current <- STM.tryReadTMVar peerVar
+        (mains', peers') <- case current of
+            -- It's empty. Put the new one in.
+            Nothing -> do
+                STM.putTMVar peerVar peer
+                STM.modifyTVar subscribedVar (S.insert peer)
+                return (peer : mains, peers)
+            -- It's not empty. Carry the new peer forward and remember the
+            -- current peer.
+            Just peer' -> return (peer' : mains, peer : peers)
+        updatePeerVars subscribedVar peerVars (mains', peers')
+
+    updateFromKademlia
+        :: STM.TVar (Set NodeId)
+        -> [STM.TMVar NodeId]
+        -> Peers NodeId
+        -> STM (Peers NodeId)
+    updateFromKademlia subscribedVar peerVars oldPeers = do
+        addrList <- kademliaGetKnownPeers kademliaInst
+        alreadySubscribed <- STM.readTVar subscribedVar
+        let peersList = fmap addressToNodeId addrList
+            uncontactedPeers = S.toList (S.fromList peersList S.\\ alreadySubscribed)
+        -- Try to put the peers which are not already in the 'peerVars' into
+        -- one of them. The result: a list of the ones which *are* in 'peerVars'
+        -- along with the ones from the original list 'uncontactedPeers' which
+        -- didn't make it in.
+        (mains, remaining) <- updatePeerVars subscribedVar peerVars ([], uncontactedPeers)
+        -- The ones which did make it into one of the 'peerVars' (or were
+        -- already there) become the mains, and any remainders become a
+        -- fallback.
+        let peersList' = zipWith (:) mains (fmap pure remaining ++ repeat [])
+            newPeers = peersFromList (fmap ((,) peerType) peersList')
+        when (newPeers == oldPeers) STM.retry
+        return newPeers

--- a/infra/Pos/KnownPeers.hs
+++ b/infra/Pos/KnownPeers.hs
@@ -1,11 +1,17 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Pos.KnownPeers (
     MonadKnownPeers(..)
   ) where
 
-import Pos.Communication.Protocol (NodeId)
+import Data.Monoid ((<>))
+import Formatting (Format)
+import Pos.Communication.Types.Protocol (NodeId)
 import Network.Broadcast.OutboundQueue (Peers)
 
 class MonadKnownPeers m where
   updateKnownPeers :: (Peers NodeId -> Peers NodeId) -> m ()
   addKnownPeers    :: Peers NodeId -> m ()
   removeKnownPeer  :: NodeId -> m ()
+  -- | Good for debugging purposes.
+  formatKnownPeers :: (forall a . Format r a -> a) -> m r

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -35,6 +35,8 @@ import           Pos.DHT.Real.Param (KademliaParams (..))
 data NetworkConfig = NetworkConfig
     { ncTopology :: !Topology
       -- ^ Network topology from the point of view of the current node
+    , ncKademlia :: !(Maybe KademliaParams)
+      -- ^ Kademlia instance description if applicable.
     , ncDefaultPort :: !Word16
       -- ^ Port number to use when translating IP addresses to NodeIds
     , ncSelfName :: !(Maybe NodeName)
@@ -45,6 +47,7 @@ data NetworkConfig = NetworkConfig
 defaultNetworkConfig :: Topology -> NetworkConfig
 defaultNetworkConfig ncTopology = NetworkConfig {
       ncDefaultPort = 3000
+    , ncKademlia    = Nothing
     , ncSelfName    = Nothing
     , ..
     }
@@ -64,13 +67,13 @@ data Topology =
     -- | We discover our peers through Kademlia
     --
     -- This is used for exchanges.
-  | TopologyP2P !KademliaParams
+  | TopologyP2P
 
     -- | We discover our peers through Kademlia, and every node in the network
     -- is a core node.
     --
     -- TODO: This is temporary.
-  | TopologyTransitional !KademliaParams
+  | TopologyTransitional
 
     -- | Light wallets simulate "real" edge nodes, but are configured with
     -- a static set of relays.
@@ -81,8 +84,8 @@ data Topology =
 topologyNodeType :: Topology -> NodeType
 topologyNodeType (TopologyStatic nodeType _) = nodeType
 topologyNodeType (TopologyBehindNAT _)       = NodeEdge
-topologyNodeType (TopologyP2P _)             = NodeEdge
-topologyNodeType (TopologyTransitional _)    = NodeCore
+topologyNodeType (TopologyP2P)               = NodeEdge
+topologyNodeType (TopologyTransitional)      = NodeCore
 topologyNodeType (TopologyLightWallet _)     = NodeEdge
 
 -- | Variation on resolveDnsDomains that returns node IDs
@@ -103,8 +106,8 @@ staticallyKnownPeers NetworkConfig{..} = go ncTopology
     go :: Topology -> Peers NodeId
     go (TopologyStatic _selfType peers) = peers
     go (TopologyBehindNAT _)            = mempty
-    go (TopologyP2P _)                  = mempty
-    go (TopologyTransitional _)         = mempty
+    go (TopologyP2P)                    = mempty
+    go (TopologyTransitional)           = mempty
     go (TopologyLightWallet peers)      = simplePeers $ map (NodeRelay, ) peers
 
 

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -2,6 +2,7 @@ module Pos.Network.Types
     ( NetworkConfig (..)
     , Topology(..)
     , topologyNodeType
+    , topologySubscriberNodeType
     , resolveDnsDomains
     , defaultNetworkConfig
     , staticallyKnownPeers
@@ -87,6 +88,14 @@ topologyNodeType (TopologyBehindNAT _)       = NodeEdge
 topologyNodeType (TopologyP2P)               = NodeEdge
 topologyNodeType (TopologyTransitional)      = NodeCore
 topologyNodeType (TopologyLightWallet _)     = NodeEdge
+
+-- | The NodeType to assign to subscribers. Give Nothing if subscribtion
+-- is not allowed for a node with this topology.
+topologySubscriberNodeType :: Topology -> Maybe NodeType
+topologySubscriberNodeType (TopologyStatic NodeRelay _) = Just NodeEdge
+topologySubscriberNodeType (TopologyTransitional)       = Just NodeCore
+topologySubscriberNodeType (TopologyP2P)                = Just NodeRelay
+topologySubscriberNodeType _                            = Nothing
 
 -- | Variation on resolveDnsDomains that returns node IDs
 resolveDnsDomains :: NetworkConfig

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -29,6 +29,7 @@ import           Pos.Network.Yaml (NodeName(..))
 import           Pos.Util.TimeWarp  (addressToNodeId)
 import qualified Pos.Network.DnsDomains as DnsDomains
 import qualified Data.ByteString.Char8  as BS.C8
+import           Pos.DHT.Real.Param (KademliaParams (..))
 
 -- | Information about the network in which a node participates.
 data NetworkConfig = NetworkConfig
@@ -63,17 +64,13 @@ data Topology =
     -- | We discover our peers through Kademlia
     --
     -- This is used for exchanges.
-    --
-    -- TODO: Not sure what parameters we need here; possibly the
-    -- 'NetworkParams' type from 'Pos.Launcher.Param'
-  | TopologyP2P
+  | TopologyP2P !KademliaParams
 
     -- | We discover our peers through Kademlia, and every node in the network
     -- is a core node.
     --
-    -- TODO: Not sure what parameters we need here; see 'TopologyP2P'.
     -- TODO: This is temporary.
-  | TopologyTransitional
+  | TopologyTransitional !KademliaParams
 
     -- | Light wallets simulate "real" edge nodes, but are configured with
     -- a static set of relays.
@@ -84,8 +81,8 @@ data Topology =
 topologyNodeType :: Topology -> NodeType
 topologyNodeType (TopologyStatic nodeType _) = nodeType
 topologyNodeType (TopologyBehindNAT _)       = NodeEdge
-topologyNodeType (TopologyP2P)               = NodeEdge
-topologyNodeType (TopologyTransitional)      = NodeCore
+topologyNodeType (TopologyP2P _)             = NodeEdge
+topologyNodeType (TopologyTransitional _)    = NodeCore
 topologyNodeType (TopologyLightWallet _)     = NodeEdge
 
 -- | Variation on resolveDnsDomains that returns node IDs
@@ -106,8 +103,8 @@ staticallyKnownPeers NetworkConfig{..} = go ncTopology
     go :: Topology -> Peers NodeId
     go (TopologyStatic _selfType peers) = peers
     go (TopologyBehindNAT _)            = mempty
-    go (TopologyP2P)                    = mempty
-    go (TopologyTransitional)           = mempty
+    go (TopologyP2P _)                  = mempty
+    go (TopologyTransitional _)         = mempty
     go (TopologyLightWallet peers)      = simplePeers $ map (NodeRelay, ) peers
 
 

--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -33,8 +33,8 @@ import           Universum
 import           Pos.Core               (FlatSlotId, SlotId (..), Timestamp (..),
                                          addTimeDiffToTimestamp, flattenSlotId,
                                          getSlotIndex, slotIdF, subTimeDiffSafe)
-import           Pos.Discovery.Class    (MonadDiscovery)
 import           Pos.Exception          (CardanoException)
+import           Pos.KnownPeers         (MonadKnownPeers)
 import           Pos.Recovery.Info      (MonadRecoveryInfo (recoveryInProgress))
 import           Pos.Reporting.MemState (HasReportingContext)
 import           Pos.Reporting.Methods  (reportMisbehaviourSilent, reportingFatal)
@@ -105,8 +105,8 @@ type OnNewSlot ctx m =
     , Mockable Delay m
     , HasReportingContext ctx
     , HasShutdownContext ctx
-    , MonadDiscovery m
     , MonadRecoveryInfo m
+    , MonadKnownPeers m
     )
 
 -- | Run given action as soon as new slot starts, passing SlotId to

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -39,10 +39,6 @@ library
                         Pos.Slotting.Error
                         Pos.Slotting.Util
 
-                        Pos.Discovery
-                        Pos.Discovery.Class
-                        Pos.Discovery.Holders
-
                         -- Pos.DHT
                         Pos.DHT
                         Pos.DHT.Constants
@@ -72,6 +68,9 @@ library
                         Pos.Communication.Relay.Types
                         Pos.Communication.Relay.Util
                         Pos.Communication.Util
+
+                        -- Known peers
+                        Pos.KnownPeers
 
                         -- Network topology
                         Pos.Network.DnsDomains

--- a/lwallet/Pos/Wallet/Light/Launcher/Runner.hs
+++ b/lwallet/Pos/Wallet/Light/Launcher/Runner.hs
@@ -7,8 +7,6 @@ import           Universum                       hiding (bracket)
 
 import           Control.Monad.Fix               (MonadFix)
 import qualified Control.Monad.Reader            as Mtl
-import qualified Data.Set                        as Set
-import           Formatting                      (sformat, shown, (%))
 import           Mockable                        (MonadMockable, Production, bracket,
                                                   fork, sleepForever)
 import           Network.Transport.Abstract      (Transport)
@@ -17,7 +15,6 @@ import           System.Wlog                     (WithLogger, logDebug, logInfo)
 
 import           Pos.Communication               (ActionSpec (..), MkListeners, NodeId,
                                                   OutSpecs, WorkerSpec)
-import           Pos.Discovery                   (findPeers)
 import           Pos.Launcher                    (BaseParams (..), LoggingParams (..),
                                                   runServer, OQ, initQueue)
 import           Pos.Network.Types               (NetworkConfig, defaultNetworkConfig,
@@ -67,8 +64,6 @@ runWallet
     -> (WorkerSpec m, OutSpecs)
 runWallet (plugins', pouts) = (,outs) . ActionSpec $ \vI sendActions -> do
     logInfo "Wallet is initialized!"
-    peers <- findPeers
-    logInfo $ sformat ("Known peers: "%shown) (toList peers)
     let unpackPlugin (ActionSpec action) = action vI sendActions
     mapM_ (fork . unpackPlugin) $ plugins' ++ workers'
     logDebug "Forked all plugins successfully"

--- a/run/kademlia0.yaml
+++ b/run/kademlia0.yaml
@@ -1,0 +1,8 @@
+peers:
+  - host: '127.0.0.1'
+    port: 3001
+  - host: '127.0.0.1'
+    port: 3002
+address:
+  host: '127.0.0.1'
+  port: 3000

--- a/run/kademlia1.yaml
+++ b/run/kademlia1.yaml
@@ -1,0 +1,8 @@
+peers:
+  - host: '127.0.0.1'
+    port: 3000
+  - host: '127.0.0.1'
+    port: 3002
+address:
+  host: '127.0.0.1'
+  port: 3001

--- a/run/kademlia2.yaml
+++ b/run/kademlia2.yaml
@@ -1,0 +1,8 @@
+peers:
+  - host: '127.0.0.1'
+    port: 3000
+  - host: '127.0.0.1'
+    port: 3001
+address:
+  host: '127.0.0.1'
+  port: 3002

--- a/run/topology0.yaml
+++ b/run/topology0.yaml
@@ -1,0 +1,1 @@
+p2p: transitional

--- a/run/topology1.yaml
+++ b/run/topology1.yaml
@@ -1,0 +1,1 @@
+p2p: transitional

--- a/run/topology2.yaml
+++ b/run/topology2.yaml
@@ -1,0 +1,1 @@
+p2p: transitional

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -74,42 +74,12 @@ function dht_key {
   $(find_binary cardano-dht-keygen) -n 000000000000$i2 | tr -d '\n'
 }
 
-function peer_config {
-  local j=$1
-  echo -n " --kademlia-peer 127.0.0.1:"`get_port $j`
-}
-
-function dht_config {
-  local i="$1"
-  shift
-  local j=0
-  if [[ "$1" == "all" ]]; then
-    n=$2
-    while [[ $j -lt $n ]]; do
-        peer_config $j
-        j=$((j+1))
-    done
-    echo -n " --explicit-initial --disable-propagation"
-  else
-    while [[ $# -gt 0 ]]; do
-      peer_config $1
-      shift
-    done
-  fi
-
-  if [[ "$i" != "rand" ]]; then
-    echo -n " --kademlia-id "`dht_key $i`
-  fi
-}
-
 function node_cmd {
   local i=$1
-  local dht_cmd=$2
-  local is_stat=$3
-  local stake_distr=$4
-  local wallet_args=$5
-  local kademlia_dump_path=$6
-  local system_start=$7
+  local is_stat=$2
+  local stake_distr=$3
+  local wallet_args=$4
+  local system_start=$5
   local st=''
   local reb=''
   local no_ntp=''
@@ -133,6 +103,7 @@ function node_cmd {
     no_ntp=" --no-ntp "
   fi
   if [[ $is_stat != "" ]]; then
+    # FIXME this is not a valid option. What was the original intention?
     stats=" --stats "
   fi
   if [[ "$REPORT_SERVER" != "" ]]; then
@@ -156,17 +127,18 @@ function node_cmd {
 
   echo -n " --address 127.0.0.1:"`get_port $i`
   echo -n " --listen 127.0.0.1:"`get_port $i`
-  echo -n " --kademlia-address 127.0.0.1:"`get_port $i`
   echo -n " $(logs node$i.log) $time_lord $stats"
   echo -n " $stake_distr $ssc_algo "
   echo -n " $web "
   echo -n " $report_server "
   echo -n " $wallet_args "
-  echo -n " --kademlia-dump-path  $(dump_path $kademlia_dump_path)"
   echo -n " --system-start $system_start"
   echo -n " --metrics +RTS -T -RTS"
   echo -n " --ekg-server $ekg_server"
   #echo -n " --statsd-server $statsd_server"
+  echo -n " --node-id node{$i}"
+  echo -n " --topology $run_dir/topology$i.yaml"
+  echo -n " --kademlia $run_dir/kademlia$i.yaml"
   echo ''
 }
 

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -82,19 +82,13 @@ while [[ $i -lt $panesCnt ]]; do
   fi
 
   stake_distr=" --flat-distr \"($n, 100000)\" "
-  kademlia_dump_path="kademlia$i.dump"
-  static_peers=''
-
-  if [[ $STATIC_PEERS != "" ]]; then
-      static_peers=' --static-peers'
-  fi
 
   if [[ "$CSL_PRODUCTION" != "" ]]; then
       stake_distr=""
   fi
 
   if [[ $i -lt $n ]]; then
-    tmux send-keys "$(node_cmd $i "$dht_conf" "$stats" "$stake_distr" "$wallet_args" "$kademlia_dump_path" "$system_start") $static_peers --no-ntp" C-m
+    tmux send-keys "$(node_cmd $i "$stats" "$stake_distr" "$wallet_args" "$system_start" ) --no-ntp" C-m
   else
     tmux send-keys "NODE_COUNT=$n $base/../bench/run-smart-generator.sh 0 -R 1 -N 2 -t $TPS -S 3 --init-money 100000 --recipients-share 0" C-m
   fi

--- a/src/Pos/Binary/Communication.hs
+++ b/src/Pos/Binary/Communication.hs
@@ -19,10 +19,9 @@ import           Pos.Binary.Class                 (Bi (..), Cons (..), Field (..
                                                    label, labelS, putBytesS, putField,
                                                    putS, putSmallWithLengthS, putWord8S)
 import           Pos.Block.Network.Types          (MsgBlock (..), MsgGetBlocks (..),
-                                                   MsgGetHeaders (..), MsgHeaders (..),
-                                                   MsgSubscribe(..))
+                                                   MsgGetHeaders (..), MsgHeaders (..))
 import           Pos.Communication.Types.Protocol (HandlerSpec (..), HandlerSpecs,
-                                                   VerInfo (..))
+                                                   VerInfo (..), MsgSubscribe (..))
 import           Pos.Core                         (BlockVersion, HeaderHash)
 import           Pos.Ssc.Class.Helpers            (SscHelpersClass)
 

--- a/src/Pos/Block/Logic/Internal.hs
+++ b/src/Pos/Block/Logic/Internal.hs
@@ -23,6 +23,7 @@ module Pos.Block.Logic.Internal
 import           Universum
 
 import           Control.Lens            (each, _Wrapped)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Ether.Internal          (HasLens (..))
 import           Formatting              (sformat, (%))
 import           Mockable                (CurrentTime, Mockable)
@@ -41,10 +42,10 @@ import           Pos.DB.Block            (MonadBlockDB, MonadSscBlockDB)
 import           Pos.Delegation.Class    (MonadDelegation)
 import           Pos.Delegation.Logic    (dlgApplyBlocks, dlgNormalizeOnRollback,
                                           dlgRollbackBlocks)
-import           Pos.Discovery.Class     (MonadDiscovery)
 import           Pos.Exception           (assertionFailed)
 import qualified Pos.GState              as GS
 import           Pos.Lrc.Context         (LrcContext)
+import           Pos.KnownPeers          (MonadKnownPeers)
 import           Pos.Reporting           (HasReportingContext, reportingFatal)
 import           Pos.Ssc.Class.Helpers   (SscHelpersClass)
 import           Pos.Ssc.Class.LocalData (SscLocalDataClass)
@@ -106,8 +107,9 @@ type MonadBlockApply ssc ctx m
        , Mockable CurrentTime m
        -- Needed for error reporting.
        , HasReportingContext ctx
-       , MonadDiscovery m
+       , MonadBaseControl IO m
        , MonadReader ctx m
+       , MonadKnownPeers m
        )
 
 -- | Applies a definitely valid prefix of blocks. This function is unsafe,

--- a/src/Pos/Block/Logic/Internal.hs
+++ b/src/Pos/Block/Logic/Internal.hs
@@ -23,7 +23,6 @@ module Pos.Block.Logic.Internal
 import           Universum
 
 import           Control.Lens            (each, _Wrapped)
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Ether.Internal          (HasLens (..))
 import           Formatting              (sformat, (%))
 import           Mockable                (CurrentTime, Mockable)
@@ -107,7 +106,6 @@ type MonadBlockApply ssc ctx m
        , Mockable CurrentTime m
        -- Needed for error reporting.
        , HasReportingContext ctx
-       , MonadBaseControl IO m
        , MonadReader ctx m
        , MonadKnownPeers m
        )

--- a/src/Pos/Block/Network/Listeners.hs
+++ b/src/Pos/Block/Network/Listeners.hs
@@ -20,12 +20,12 @@ import           Pos.Block.Logic            (getHeadersFromToIncl)
 import           Pos.Block.Network.Announce (handleHeadersCommunication)
 import           Pos.Block.Network.Logic    (handleUnsolicitedHeaders)
 import           Pos.Block.Network.Types    (MsgBlock (..), MsgGetBlocks (..),
-                                             MsgGetHeaders, MsgHeaders (..),
-                                             MsgSubscribe (..))
+                                             MsgGetHeaders, MsgHeaders (..))
 import           Pos.Communication.Limits   (recvLimited)
 import           Pos.Communication.Listener (listenerConv)
 import           Pos.Communication.Protocol (ConversationActions (..), ListenerSpec (..),
-                                             MkListeners, OutSpecs, constantListeners)
+                                             MkListeners, OutSpecs, constantListeners,
+                                             MsgSubscribe (..))
 import qualified Pos.DB.Block               as DB
 import           Pos.DB.Error               (DBError (DBMalformed))
 import           Pos.KnownPeers             (MonadKnownPeers(..))

--- a/src/Pos/Block/Network/Types.hs
+++ b/src/Pos/Block/Network/Types.hs
@@ -5,7 +5,6 @@ module Pos.Block.Network.Types
        , MsgGetBlocks (..)
        , MsgHeaders (..)
        , MsgBlock (..)
-       , MsgSubscribe (..)
        ) where
 
 import qualified Data.Text.Buildable
@@ -73,11 +72,3 @@ newtype MsgBlock ssc =
     deriving (Generic, Show)
 
 deriving instance (Ssc ssc, Eq (SscPayload ssc)) => Eq (MsgBlock ssc)
-
--- | 'Subscribe' message
---
--- This can be used by behind-NAT nodes to subscribe to the 'OutboundQueue'
--- of a relay node. The node will remain subscribed for the duration of the
--- conversation.
-data MsgSubscribe = MsgSubscribe
-    deriving (Generic, Show, Eq)

--- a/src/Pos/Communication/Limits.hs
+++ b/src/Pos/Communication/Limits.hs
@@ -24,9 +24,9 @@ import           GHC.Exts                           (IsList (..))
 import           Pos.Binary.Class                   (AsBinary (..))
 import           Pos.Block.Core                     (Block, BlockHeader)
 import           Pos.Block.Network.Types            (MsgBlock (..), MsgGetBlocks (..),
-                                                     MsgGetHeaders (..), MsgHeaders (..),
-                                                     MsgSubscribe (..))
+                                                     MsgGetHeaders (..), MsgHeaders (..))
 import           Pos.Communication.Types.Relay      (DataMsg (..))
+import           Pos.Communication.Types.Protocol   (MsgSubscribe (..))
 import qualified Pos.Constants                      as Const
 import           Pos.Core                           (BlockVersionData (..),
                                                      coinPortionToDouble)

--- a/src/Pos/Communication/Message.hs
+++ b/src/Pos/Communication/Message.hs
@@ -8,10 +8,11 @@ import           Node.Message.Class               (Message (..), MessageName (..
 
 import           Pos.Binary.Class                 (UnsignedVarInt (..), encode)
 import           Pos.Block.Network.Types          (MsgBlock, MsgGetBlocks, MsgGetHeaders,
-                                                   MsgHeaders, MsgSubscribe)
+                                                   MsgHeaders)
 import           Pos.Communication.MessagePart    (MessagePart (..))
 import           Pos.Communication.Types.Relay    (DataMsg, InvMsg, InvOrData, MempoolMsg,
                                                    ReqMsg)
+import           Pos.Communication.Types.Protocol (MsgSubscribe)
 import           Pos.Delegation.Types             (ProxySKLightConfirmation)
 import           Pos.Ssc.GodTossing.Types.Message (MCCommitment, MCOpening, MCShares,
                                                    MCVssCertificate)

--- a/src/Pos/Communication/Server.hs
+++ b/src/Pos/Communication/Server.hs
@@ -22,6 +22,7 @@ import           Pos.Communication.Protocol  (MkListeners (..), EnqueueMsg)
 import           Pos.Communication.Relay     (relayListeners)
 import           Pos.Communication.Util      (wrapListener)
 import           Pos.Delegation.Listeners    (delegationRelays)
+import           Pos.Network.Types           (Topology)
 import           Pos.Ssc.Class               (SscListenersClass (..), SscWorkersClass)
 import           Pos.Txp                     (txRelays)
 import           Pos.Update                  (usRelays)
@@ -30,11 +31,11 @@ import           Pos.WorkMode.Class          (WorkMode)
 -- | All listeners running on one node.
 allListeners
     :: (SscListenersClass ssc, SscWorkersClass ssc, WorkMode ssc ctx m)
-    => EnqueueMsg m -> MkListeners m
-allListeners enqueue = mconcat
+    => Topology -> EnqueueMsg m -> MkListeners m
+allListeners topology enqueue = mconcat
         -- TODO blockListeners should use 'enqueue' rather than its own
         -- block retrieval queue, no?
-        [ modifier "block"       $ blockListeners
+        [ modifier "block"       $ blockListeners topology
         , modifier "ssc"         $ relayListeners enqueue (untag sscRelays)
         , modifier "tx"          $ relayListeners enqueue txRelays
         , modifier "delegation"  $ relayListeners enqueue delegationRelays

--- a/src/Pos/Communication/Update.hs
+++ b/src/Pos/Communication/Update.hs
@@ -1,5 +1,7 @@
 -- | Functions for operating with messages of update system
 
+{-# LANGUAGE RankNTypes #-}
+
 module Pos.Communication.Update
        ( submitVote
        , submitUpdateProposal
@@ -9,8 +11,7 @@ import           Universum
 
 import           Pos.Binary                 ()
 import           Pos.Communication.Methods  (sendUpdateProposal, sendVote)
-import           Pos.Communication.Protocol (NodeId, SendActions,
-                                             immediateConcurrentConversations)
+import           Pos.Communication.Protocol (EnqueueMsg)
 import           Pos.Crypto                 (SafeSigner, SignTag (SignUSVote), hash,
                                              safeSign, safeToPublic)
 import           Pos.DB.Class               (MonadGState)
@@ -20,22 +21,20 @@ import           Pos.WorkMode.Class         (MinWorkMode)
 -- | Send UpdateVote to given addresses
 submitVote
     :: (MinWorkMode m, MonadGState m)
-    => SendActions m
-    -> [NodeId]
+    => EnqueueMsg m
     -> UpdateVote
     -> m ()
-submitVote sendActions na voteUpd = do
-    sendVote (immediateConcurrentConversations sendActions na) voteUpd
+submitVote enqueue voteUpd = do
+    sendVote enqueue voteUpd
 
 -- | Send UpdateProposal with one positive vote to given addresses
 submitUpdateProposal
     :: (MinWorkMode m, MonadGState m)
-    => SendActions m
+    => EnqueueMsg m
     -> SafeSigner
-    -> [NodeId]
     -> UpdateProposal
     -> m ()
-submitUpdateProposal sendActions ss na prop = do
+submitUpdateProposal enqueue ss prop = do
     let upid = hash prop
     let initUpdVote = UpdateVote
             { uvKey        = safeToPublic ss
@@ -43,4 +42,4 @@ submitUpdateProposal sendActions ss na prop = do
             , uvDecision   = True
             , uvSignature  = safeSign SignUSVote ss (upid, True)
             }
-    sendUpdateProposal (immediateConcurrentConversations sendActions na) upid prop [initUpdVote]
+    sendUpdateProposal enqueue upid prop [initUpdVote]

--- a/src/Pos/Context/Context.hs
+++ b/src/Pos/Context/Context.hs
@@ -45,8 +45,6 @@ import           Pos.Block.Slog.Types          (HasSlogContext (..), SlogContext
 import           Pos.Communication.Types       (NodeId)
 import           Pos.Core                      (GenesisStakeholders (..),
                                                 HasPrimaryKey (..), HeaderHash, Timestamp)
-import           Pos.Discovery                 (DiscoveryContextSum,
-                                                HasDiscoveryContextSum (..))
 import           Pos.Launcher.Param            (BaseParams (..), NodeParams (..))
 import           Pos.Lrc.Context               (LrcContext)
 import           Pos.Network.Types             (NetworkConfig (..))
@@ -100,8 +98,6 @@ data NodeContext ssc = NodeContext
     -- ^ Context needed for the update system
     , ncLrcContext          :: !LrcContext
     -- ^ Context needed for LRC
-    , ncDiscoveryContext    :: !DiscoveryContextSum
-    -- ^ Context needed for Discovery.
     , ncSlottingVar         :: !(Timestamp, TVar SlottingData)
     -- ^ Data necessary for 'MonadSlotsData'.
     , ncSlottingContext     :: !SlottingContextSum
@@ -156,9 +152,6 @@ instance HasNodeContext ssc (NodeContext ssc) where
 
 instance HasSscContext ssc (NodeContext ssc) where
     sscContext = ncSscContext_L
-
-instance HasDiscoveryContextSum (NodeContext ssc) where
-    discoveryContextSum = ncDiscoveryContext_L
 
 instance HasSlottingVar (NodeContext ssc) where
     slottingTimestamp = ncSlottingVar_L . _1

--- a/src/Pos/Delegation/Worker.hs
+++ b/src/Pos/Delegation/Worker.hs
@@ -16,7 +16,7 @@ import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localWorker)
 import           Pos.Delegation.Class       (MonadDelegation)
 import           Pos.Delegation.Logic       (invalidateProxyCaches,
                                              runDelegationStateAction)
-import           Pos.Discovery.Class        (MonadDiscovery)
+import           Pos.KnownPeers             (MonadKnownPeers)
 import           Pos.Reporting              (HasReportingContext)
 import           Pos.Reporting.Methods      (reportingFatal)
 import           Pos.Shutdown               (HasShutdownContext, runIfNotShutdown)
@@ -37,7 +37,7 @@ dlgInvalidateCaches
        , HasReportingContext ctx
        , HasShutdownContext ctx
        , MonadDelegation ctx m
-       , MonadDiscovery m
+       , MonadKnownPeers m
        , MonadReader ctx m
        , Mockable CurrentTime m
        )

--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -6,7 +6,7 @@
 module Pos.Launcher.Param
        ( LoggingParams (..)
        , BaseParams (..)
-       , NetworkParams (..)
+       , TransportParams (..)
        , NodeParams (..)
        ) where
 
@@ -17,10 +17,8 @@ import           Ether.Internal          (HasLens (..))
 import qualified Network.Transport.TCP   as TCP
 import           System.Wlog             (LoggerName)
 
-import           Pos.Communication.Types (NodeId)
 import           Pos.Core                (HasPrimaryKey (..), Timestamp)
 import           Pos.Crypto              (SecretKey)
-import           Pos.DHT.Real            (KademliaParams)
 import           Pos.Network.Types       (NetworkConfig)
 import           Pos.Reporting.MemState  (HasReportServers (..))
 import           Pos.Security.Params     (SecurityParams)
@@ -43,11 +41,8 @@ data BaseParams = BaseParams
     } deriving (Show)
 
 -- | Network parameters.
-data NetworkParams = NetworkParams
-    { npDiscovery :: !(Either (Set NodeId) KademliaParams)
-    -- ^ If this value is 'Left', then given peers will be used in static mode.
-    -- Otherwise kademlia with given params will be used.
-    , npTcpAddr   :: !TCP.TCPAddr
+data TransportParams = TransportParams
+    { tpTcpAddr   :: !TCP.TCPAddr
     -- ^ External TCP address of the node.
     -- It encapsulates bind address and address visible to other nodes.
     }
@@ -68,7 +63,7 @@ data NodeParams = NodeParams
     , npUpdateParams   :: !UpdateParams         -- ^ Params for update system
     , npSecurityParams :: !SecurityParams       -- ^ Params for "Pos.Security"
     , npUseNTP         :: !Bool                 -- TODO COMMENT
-    , npNetwork        :: !NetworkParams        -- ^ Network parameters
+    , npTransport      :: !TransportParams      -- ^ (TCP) transport parameters.
     , npEnableMetrics  :: !Bool                 -- ^ Gather runtime statistics.
     , npEkgParams      :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
     , npStatsdParams   :: !(Maybe StatsdParams) -- ^ statsd statistics backend.

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -111,7 +111,7 @@ runRealModeDo NodeResources {..} outSpecs action =
           runServer ncNetworkConfig
                     (simpleNodeEndPoint nrTransport)
                     (const noReceiveDelay)
-                    allListeners
+                    (allListeners ncTopology)
                     outSpecs
                     (startMonitoring oq)
                     stopMonitoring
@@ -119,6 +119,7 @@ runRealModeDo NodeResources {..} outSpecs action =
                     action
   where
     NodeContext {..} = nrContext
+    NetworkConfig {..} = ncNetworkConfig
     NodeParams {..} = ncNodeParams
     LoggingParams {..} = bpLoggingParams npBaseParams
     startMonitoring oq node' =

--- a/src/Pos/Subscription.hs
+++ b/src/Pos/Subscription.hs
@@ -14,11 +14,10 @@ import qualified Network.DNS             as DNS
 
 import           Mockable                (delay, try)
 import           Network.Broadcast.OutboundQueue.Types (NodeType(..), peersFromList)
-import           Pos.Communication       (OutSpecs, WorkerSpec)
+import           Pos.Communication       (OutSpecs, WorkerSpec, MsgSubscribe (..))
 import           Pos.KnownPeers          (MonadKnownPeers(..))
 import           Pos.Ssc.Class           (SscWorkersClass)
 import           Pos.WorkMode.Class      (WorkMode)
-import           Pos.Block.Network.Types (MsgSubscribe (..))
 import           Pos.Communication       (Conversation (..), ConversationActions (..),
                                           convH, toOutSpecs, worker,
                                           NodeId, withConnectionTo, SendActions)

--- a/src/Pos/Wallet/WalletMode.hs
+++ b/src/Pos/Wallet/WalletMode.hs
@@ -19,7 +19,6 @@ import           Pos.Client.Txp.Balances (MonadBalances (..))
 import           Pos.Client.Txp.History  (MonadTxHistory (..))
 import           Pos.Communication       (TxMode)
 import           Pos.Core                (ChainDifficulty)
-import           Pos.Discovery           (MonadDiscovery)
 import           Pos.Update              (ConfirmedProposalState (..))
 import           Pos.Util.TimeWarp       (CanJsonLog)
 import           Pos.Wallet.KeyStorage   (MonadKeys)
@@ -60,6 +59,5 @@ type MonadWallet ssc ctx m
       , MonadKeys ctx m
       , MonadBlockchainInfo m
       , MonadUpdates m
-      , MonadDiscovery m
       , CanJsonLog m
       )

--- a/src/Pos/WorkMode/Class.hs
+++ b/src/Pos/WorkMode/Class.hs
@@ -31,7 +31,6 @@ import           Pos.DB.Block                (MonadBlockDBWrite, MonadSscBlockDB
 import           Pos.DB.Class                (MonadDB, MonadGState)
 import           Pos.DB.Rocks                (MonadRealDB)
 import           Pos.Delegation.Class        (MonadDelegation)
-import           Pos.Discovery.Class         (MonadDiscovery)
 import           Pos.Lrc.Context             (LrcContext)
 #ifdef WITH_EXPLORER
 import           Pos.Explorer.Txp.Toil       (ExplorerExtra)
@@ -83,7 +82,6 @@ type WorkMode ssc ctx m
       , MonadProgressHeader ssc ctx m
       , MonadLastKnownHeader ssc ctx m
       , MonadBListener m
-      , MonadDiscovery m
       , MonadReader ctx m
       , MonadKnownPeers m
       , HasLens StartTime ctx StartTime

--- a/src/Pos/Worker.hs
+++ b/src/Pos/Worker.hs
@@ -18,7 +18,7 @@ import           Pos.Communication    (OutSpecs, WorkerSpec, localWorker,
                                        relayPropagateOut)
 import           Pos.Context          (NodeContext (..), recoveryCommGuard)
 import           Pos.Delegation       (delegationRelays, dlgWorkers)
-import           Pos.Discovery        (discoveryWorkers)
+import           Pos.DHT.Workers      (dhtWorkers)
 import           Pos.Launcher.Resource (NodeResources (..))
 import           Pos.Lrc.Worker       (lrcOnNewSlotWorker)
 import           Pos.Network.Types    (NetworkConfig(..), Topology(..))
@@ -47,9 +47,7 @@ allWorkers NodeResources {..} = mconcatPair
       -- Only workers of "onNewSlot" type
       -- I have no idea what this ↑ comment means (@gromak).
 
-      wrap' "dht"        $ discoveryWorkers ncDiscoveryContext
-
-    , wrap' "ssc"        $ sscWorkers
+      wrap' "ssc"        $ sscWorkers
     , wrap' "security"   $ untag securityWorkers
     , wrap' "lrc"        $ first one lrcOnNewSlotWorker
     , wrap' "us"         $ usWorkers
@@ -70,6 +68,7 @@ allWorkers NodeResources {..} = mconcatPair
       -- There's no cardano-sl worker for them; they're put out by the outbound
       -- queue system from time-warp (enqueueConversation on SendActions).
     , ([], relayPropagateOut (mconcat [delegationRelays, untag sscRelays, txRelays, usRelays] :: [Relay m]))
+    , maybe mempty dhtWorkers nrKademlia
     ]
   where
     NodeContext {..} = nrContext

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -159,7 +159,6 @@ action args@Args {..} = do
 #else
     putText "Wallet is disabled, because software is built w/o it"
 #endif
-    putText $ "Static peers is on: " <> show staticPeers
 
     let vssSK = fromJust $ npUserSecret currentParams ^. usVss
     let gtParams = gtSscParams args vssSK

--- a/src/node/NodeOptions.hs
+++ b/src/node/NodeOptions.hs
@@ -88,7 +88,6 @@ data Args = Args
     , updateLatestPath          :: !FilePath
     , updateWithPackage         :: !Bool
     , noNTP                     :: !Bool
-    , staticPeers               :: !Bool
     , enableMetrics             :: !Bool
     , ekgParams                 :: !(Maybe EkgParams)
     , statsdParams              :: !(Maybe StatsdParams)
@@ -215,9 +214,6 @@ argsParser = do
     noNTP <- switch $
         long "no-ntp" <>
         help "Whether to use real NTP servers to synchronise time or rely on local time"
-    staticPeers <- switch $
-        long "static-peers" <>
-        help "Don't use Kademlia, use only static peers"
 
     enableMetrics <- switch $
         long "metrics" <>

--- a/ssc/Pos/Ssc/Mode.hs
+++ b/ssc/Pos/Ssc/Mode.hs
@@ -13,7 +13,7 @@ import           System.Wlog         (WithLogger)
 
 import           Pos.Core            (HasPrimaryKey)
 import           Pos.DB.Class        (MonadDB, MonadGState)
-import           Pos.Discovery       (MonadDiscovery)
+import           Pos.KnownPeers      (MonadKnownPeers)
 import           Pos.Lrc.Context     (LrcContext)
 import           Pos.Recovery.Info   (MonadRecoveryInfo)
 import           Pos.Reporting       (HasReportingContext)
@@ -34,10 +34,10 @@ type SscMode ssc ctx m
       , MonadSlots m
       , MonadGState m
       , MonadDB m
+      , MonadKnownPeers m
       , MonadSscMem ssc ctx m
       , MonadRecoveryInfo m
       , HasShutdownContext ctx
-      , MonadDiscovery m
       , MonadReader ctx m
       , HasSscContext ssc ctx
       , HasReportingContext ctx

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,7 +29,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/kademlia.git
-    commit: bbdca50c263c6dae251e67eb36a7d4e1ba7c1cb6
+    commit: 027941b1fa0cfc042c5b9f39b5b285b3de0258c6
   extra-dep: true
 - location:
     git: https://github.com/input-output-hk/plutus-prototype


### PR DESCRIPTION
It's not needed anymore. Only the OutboundQ will need to deal with peer
discovery.

You can hit a known set of peers by using `immediateConcurrentConversations` on
a `SendActions`, as the light wallet does, but typically you won't specify any targets
at all and just use `enqueueMsg`.

Notice the merge target: pull request #1116 