### PR TITLE
Feature/csl 1263 add benchmarking config

### DIFF
--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -23,6 +23,12 @@ flag dev-mode
 
   description: Switch between Development and Production mode
 
+flag dev-custom-config
+  default:     False
+  manual:      True
+
+  description: Enable this to allow setting CONFIG manually, as in --ghc-options=-DCONFIG=benchmark
+
 flag embed-config
   default:     False
   manual:      True
@@ -207,6 +213,8 @@ library
   if flag(asserts)
     cpp-options: -DASSERTS_ON
   if flag(dev-mode)
-    cpp-options: -DDEV_MODE -DCONFIG=dev
+    cpp-options: -DDEV_MODE
+    if !flag(dev-custom-config)
+      cpp-options: -DCONFIG=dev
   if flag(embed-config) || !flag(dev-mode)
     cpp-options: -DEMBED_CONFIG

--- a/core/constants.yaml
+++ b/core/constants.yaml
@@ -58,7 +58,7 @@ dev: &dev
   # messages: normal messages and confirmation messages. Both of them are
   # limited in size by this value multiplied by some constant. You are
   # advised to look at code if you need exact values, because it may change
-  # and most likely nobody will update this comment. 
+  # and most likely nobody will update this comment.
   #
   # The size is number of elements, not bytes.
   dlgCacheParam: 500
@@ -166,6 +166,15 @@ travis: &travis
   <<: *qanet_tns
 
   k: 3  # it's needed for tests
+
+benchmark: &benchmark
+  <<: *testnet
+
+  genesisN: 50000
+  k: 6
+
+  protocolmagic: 50988000
+  genesisBinSuffix: qa # qa is set here arbitrarily, it won't be actually used
 
 ##############################################################################
 ##                                                                          ##

--- a/lwallet/Main.hs
+++ b/lwallet/Main.hs
@@ -17,6 +17,7 @@ import           Data.ByteString.Base58     (bitcoinAlphabet, encodeBase58)
 import qualified Data.HashMap.Strict        as HM
 import           Data.List                  ((!!))
 import qualified Data.List.NonEmpty         as NE
+import qualified Data.Map                   as M
 import qualified Data.Set                   as S (fromList, toList)
 import           Data.String.QQ             (s)
 import qualified Data.Text                  as T
@@ -171,6 +172,7 @@ runCmd sendActions (SendToAllGenesis duration conc delay_ cooldown sendMode tpsS
         liftIO $ T.hPutStrLn h "time,txCount,txType"
         txQueue <- atomically $ newTQueue
         -- prepare a queue with all transactions
+        logInfo $ sformat ("Found "%shown%" keys in the genesis block.") (length skeys)
         forM_ (zip skeys [0..]) $ \(key, n) -> do
             let txOut = TxOut {
                     txOutAddress = makePubKeyAddress (toPublic key),
@@ -208,8 +210,9 @@ runCmd sendActions (SendToAllGenesis duration conc delay_ cooldown sendMode tpsS
                             submitTxRaw sendActions neighbours tx
                             addTxSubmit tpsMVar >> logInfo (sformat ("Submitted transaction: "%txaF%" to "%shown) tx neighbours)
                     delay $ ms delay_
+                    logInfo "Continuing to send transactions."
                     sendTxs
-                Nothing -> return ()
+                Nothing -> logInfo "No more transactions in the queue."
         let sendTxsConcurrently = void $ forConcurrently [1..conc] (const sendTxs)
         let sendTxsConcurrentlyFor n = race (delay (sec n)) sendTxsConcurrently
         either absurd identity <$> race
@@ -430,6 +433,10 @@ main = do
 
     loggerBracket logParams $ runProduction $
       bracketTransport TCP.Unaddressable $ \transport -> do
+        logInfo $ if isDevelopment
+            then "Development Mode"
+            else "Production Mode"
+        logInfo $ sformat ("Map.size npCustomUtxo: "%shown) (M.size npCustomUtxo)
         let transport' :: Transport LightWalletMode
             transport' = hoistTransport
                 (powerLift :: forall t . Production t -> LightWalletMode t)


### PR DESCRIPTION
This pull request is another step towards running the benchmarks on the current master. It does the following things:

- add a section in `core/constants.yaml` for the benchmarks
- allows choosing this configuration in `dev-mode`
- adds some logging to the transaction generator.