### PR TITLE
[DEVOPS-217] AppVeyor: build and package cardano-node.exe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,6 +111,8 @@ test_script:
   - ps: Install-Product node 7
   - ..\scripts\ci\appveyor-retry call npm install
   - npm run build:prod
+  - dir "%WORK_DIR%\daedalus\"
+  - ps: foreach ($x in @("cardano-addr-convert.exe", "cardano-genupdate.exe", "cardano-launcher.exe", "cardano-node.exe", "cardano-wallet-hs2purs.exe")) { if (-NOT (Test-Path "$($env:WORK_DIR)\daedalus\$x")) { throw "ERROR... Missing $x" }}
 
 after_test:
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,25 @@ test_script:
 #   - stack hpc report cardano-sl cardano-sl-txp cardano-sl-core cardano-sl-db cardano-sl-update cardano-sl-godtossing cardano-sl-infra cardano-sl-lrc cardano-sl-ssc
 # Retry transient failures due to https://github.com/haskell/cabal/issues/4005
   # We intentionally don't build lwallet here, because this build is for installer.
+  - scripts\ci\appveyor-retry call stack install cardano-sl
+      -j 2
+      --no-terminal
+      --local-bin-path daedalus
+      --fast
+      --test
+      --no-haddock-deps
+      --bench
+      --no-run-benchmarks
+      --work-dir %STACK_WORK%
+      --ghc-options="-DCONFIG=%DCONFIG%"
+      --flag cardano-sl:with-web
+      --flag cardano-sl:with-wallet
+      --flag cardano-sl-core:-asserts
+      --flag cardano-sl-core:-dev-mode
+      --extra-include-dirs="C:\OpenSSL-Win64-v102\include"
+      --extra-lib-dirs="C:\OpenSSL-Win64-v102"
+      --extra-include-dirs="%WORK_DIR%\rocksdb\include"
+      --extra-lib-dirs="%WORK_DIR%"
   - scripts\ci\appveyor-retry call stack install cardano-sl-tools
       -j 2
       --no-terminal


### PR DESCRIPTION
Following work on CSL-781 the AppVeyor artifact zip no longer included `cardano-node.exe`. This change builds it and confirms that it and the other exe files will be archived in the `CardanoSL.zip` artifact.