### PR TITLE
[CSM-391] Throw error on sending money to redeem address

### DIFF
--- a/core/Pos/Core/Types.hs
+++ b/core/Pos/Core/Types.hs
@@ -7,6 +7,7 @@ module Pos.Core.Types
        (
        -- * Address
          Address (..)
+       , _RedeemAddress
        , AddrPkAttrs (..)
        , AddressHash
        , StakeholderId
@@ -81,7 +82,7 @@ module Pos.Core.Types
 
 import           Universum
 
-import           Control.Lens               (makeLensesFor)
+import           Control.Lens               (makeLensesFor, makePrisms)
 import           Control.Monad.Except       (MonadError (throwError))
 import           Crypto.Hash                (Blake2b_224)
 import           Data.Char                  (isAscii)
@@ -520,3 +521,5 @@ newtype SlotCount = SlotCount {getSlotCount :: Word64}
 flip makeLensesFor ''SlotId [
     ("siEpoch", "siEpochL"),
     ("siSlot" , "siSlotL") ]
+
+makePrisms ''Address

--- a/src/Pos/Client/Txp/Balances.hs
+++ b/src/Pos/Client/Txp/Balances.hs
@@ -10,11 +10,14 @@ module Pos.Client.Txp.Balances
 
 import           Universum
 
+import           Control.Lens         (has)
 import           Control.Monad.Trans  (MonadTrans)
 import qualified Data.HashSet         as HS
+import           Data.List            (partition)
 import qualified Data.Map             as M
 
 import           Pos.Core             (AddressIgnoringAttributes (AddressIA))
+import           Pos.Core.Types       (_RedeemAddress)
 import           Pos.DB               (MonadDBRead, MonadGState, MonadRealDB)
 import           Pos.Txp              (MonadTxpMem, TxOutAux (..), Utxo, addrBelongsToSet,
                                        getUtxoModifier, txOutValue)
@@ -53,10 +56,7 @@ type BalancesEnv ext ctx m =
 
 getOwnUtxosDefault :: BalancesEnv ext ctx m => [Address] -> m Utxo
 getOwnUtxosDefault addrs = do
-    let isRedeem (RedeemAddress _) = True
-        isRedeem _                 = False
-        redeemAddrs = filter isRedeem addrs
-        commonAddrs = filter (not . isRedeem) addrs
+    let (redeemAddrs, commonAddrs) = partition (has _RedeemAddress) addrs
 
     updates <- getUtxoModifier
     commonUtxo <- if null commonAddrs then pure mempty


### PR DESCRIPTION
Testing results:
* Money sending on pubkey addresses still works
* Money sending to random redeem addresses generated in ghci fails
* Same thing for txFee endpoint