### PR TITLE
[CSL-1203] Test delegation with distribution

### DIFF
--- a/lwallet/cardano-sl-lwallet.cabal
+++ b/lwallet/cardano-sl-lwallet.cabal
@@ -65,7 +65,6 @@ executable cardano-wallet
                      , optparse-applicative
                      , parsec
                      , random
-                     , readline
                      , resourcet
                      , safecopy
                      , serokell-util >= 0.1.3.4

--- a/lwallet/cardano-sl-lwallet.cabal
+++ b/lwallet/cardano-sl-lwallet.cabal
@@ -65,6 +65,7 @@ executable cardano-wallet
                      , optparse-applicative
                      , parsec
                      , random
+                     , readline
                      , resourcet
                      , safecopy
                      , serokell-util >= 0.1.3.4

--- a/scripts/launch/demo-with-wallet-api.sh
+++ b/scripts/launch/demo-with-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_TEST=1 "$base"/demo.sh
+WALLET_TEST=1 "$base"/demo.sh $*

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -42,6 +42,8 @@ fi
 if [ -z "$system_start" ]
   then
     system_start=$((`date +%s` + 1))
+    mkdir -p "$base/../../run/"
+    echo $system_start > "$base/../../run/system_start"
 fi
 
 echo "Using system start time "$system_start

--- a/scripts/launch/wallet.sh
+++ b/scripts/launch/wallet.sh
@@ -9,7 +9,11 @@ if [[ "$SSC_ALGO" != "" ]]; then
     ssc_algo=" --ssc-algo $SSC_ALGO "
 fi
 
-$(find_binary cardano-wallet) $(peer_config 0) $(logs smartwallet$i.log) \
+$(find_binary cardano-wallet) --system-start $(cat "$base/../../run/system_start") \
+                              --log-config log-config-prod.yaml --logs-prefix "run/wallet-logs" \
                               --db-path "run/wallet-db" --rebuild-db \
-                              --flat-distr "(3, 100000)" $ssc_algo "$@" \
-                              --system-start 100500  # random value, not used, but mandatory
+                              --flat-distr "(4, 100000)" $ssc_algo "$@" \
+                              --peer 127.0.0.1:3000 \
+                              --peer 127.0.0.1:3001 \
+                              --peer 127.0.0.1:3002 \
+                              repl


### PR DESCRIPTION
A few changes to wallet and demo launch scripts.
Integrating `readline` for proper lwallet CLI
Introducing `send-distr` command for transactions with non-default stake distribution.