### PR TITLE
[CSM-352] Rewrite `mkCTxs` without `isRedemptionTx` flag

### DIFF
--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -224,7 +224,7 @@ mkCTxs diff THEntry {..} meta wAddrMetas = do
         isIncoming = incomingMoney >= outgoingMoney
 
         ctAmount = mkCCoin . unsafeIntegerToCoin $
-            if | isOutgoing && isIncoming -> outgoingMoney
+            if | isOutgoing && isIncoming -> 0
                | isOutgoing -> outgoingMoney - incomingMoney
                | isIncoming -> incomingMoney - outgoingMoney
 

--- a/src/Pos/Wallet/Web/ClientTypes.hs
+++ b/src/Pos/Wallet/Web/ClientTypes.hs
@@ -207,52 +207,43 @@ mkCTxs
     -> TxHistoryEntry     -- ^ Tx history entry
     -> CTxMeta            -- ^ Transaction metadata
     -> [CWAddressMeta]    -- ^ Addresses of wallet
-    -> Bool               -- ^ Workaround for redemption txs (introduced in CSM-330)
     -> Either Text CTxs
-mkCTxs diff THEntry {..} meta wAddrMetas isRedemptionTx = do
+mkCTxs diff THEntry {..} meta wAddrMetas = do
     ctInputAddrsNe <-
         nonEmpty ctInputAddrs
         `whenNothing` throwError "No input addresses in tx!"
     let isLocalAddr = isTxLocalAddress wAddrMetas ctInputAddrsNe
         isLocalTxOutput = isLocalAddr . addressToCId . txOutAddress
-        -- We check against `wAddrsSet` instead of using `isLocalAddr` here
-        -- because of the redeem transactions. `isLocalAddr` checks whether
-        -- the address belongs to the same _wallet_ as the _inputs_ of the
-        -- current transaction, which is never the case for redeem txs.
-        -- TODO(thatguy): since there is only one special case, perhaps we
-        -- want to consider it separately and use `isLocalAddr` in other cases.
-        -- [CSM-309] Bad for multiple-destinations transactions
-        allOutputsBelongToUs = all (`S.member` wAddrsSet) ctOutputAddrs
-        outputsForAmountCalc =
-            outputs &
-            if isRedemptionTx then identity else filter (not . isLocalTxOutput)
-        ctAmount =
-            mkCCoin . unsafeIntegerToCoin . sumCoins . map txOutValue $
-            outputsForAmountCalc
-        mkCTx isOutgoing mbSignificantAddrs = do  -- Maybe monad starts here
-            -- Return `Nothing` if none of the significantAddrs belong to us.
-            guard $
-                maybe True
-                (\significantAddrs ->
-                    not . null $ wAddrsSet `S.intersection` S.fromList significantAddrs)
-                mbSignificantAddrs
-            return CTx {ctIsOutgoing = isOutgoing, ..}
-        -- Output addresses whose presence makes us display the transaction
-        -- (incoming half, i.e. one with 'isOutgoing' set to @false@).
-        ctSignificantOutputAddrs =
-            ctOutputAddrs &
-            if allOutputsBelongToUs then identity else filter (not . isLocalAddr)
-        ctsOutgoing = mkCTx True $ Just ctInputAddrs
-        ctsIncoming = mkCTx False $ if isRedemptionTx then Nothing else Just ctSignificantOutputAddrs
+
+        ownInputs = filter isLocalTxOutput inputs
+        ownOutputs = filter isLocalTxOutput outputs
+
+    when (null ownInputs && null ownOutputs) $
+        throwError "Transaction is irrelevant to given wallet!"
+
+    let sumMoney = sumCoins . map txOutValue
+        outgoingMoney = sumMoney ownInputs
+        incomingMoney = sumMoney ownOutputs
+        isOutgoing = outgoingMoney >= incomingMoney
+        isIncoming = incomingMoney >= outgoingMoney
+
+        ctAmount = mkCCoin . unsafeIntegerToCoin $
+            if | isOutgoing && isIncoming -> outgoingMoney
+               | isOutgoing -> outgoingMoney - incomingMoney
+               | isIncoming -> incomingMoney - outgoingMoney
+
+        mkCTx ctIsOutgoing cond = guard cond >> pure CTx {..}
+        ctsOutgoing = mkCTx True isOutgoing
+        ctsIncoming = mkCTx False isIncoming
     return CTxs {..}
   where
     ctId = txIdToCTxId _thTxId
+    inputs = _thInputs
     outputs = toList $ _txOutputs _thTx
     ctInputAddrs = map addressToCId _thInputAddrs
     ctOutputAddrs = map addressToCId _thOutputAddrs
     ctConfirmations = maybe 0 fromIntegral $ (diff -) <$> _thDifficulty
     ctMeta = meta
-    wAddrsSet = S.fromList $ map cwamId wAddrMetas
 
 newtype CPassPhrase = CPassPhrase Text
     deriving (Eq, Generic)

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -643,7 +643,7 @@ sendMoney sendActions passphrase moneySource dstDistr = do
                     let txHash    = hash tx
                         srcWallet = getMoneySourceWallet moneySource
                     ts <- Just <$> liftIO getCurrentTimestamp
-                    ctxs <- addHistoryTx srcWallet False $
+                    ctxs <- addHistoryTx srcWallet $
                         THEntry txHash tx srcTxOuts Nothing (toList srcAddrs) dstAddrs ts
                     ctsOutgoing ctxs `whenNothing` throwM noOutgoingTx
 
@@ -678,7 +678,7 @@ getFullWalletHistory cWalId = do
     localHistory <- getLocalHistory addrs
 
     let fullHistory = DL.toList $ localHistory <> blockHistory
-    ctxs <- forM fullHistory $ addHistoryTx cWalId False
+    ctxs <- forM fullHistory $ addHistoryTx cWalId
     let cHistory = concatMap toList ctxs
     pure (cHistory, fromIntegral $ length cHistory)
 
@@ -734,10 +734,9 @@ getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit =
 addHistoryTx
     :: WalletWebMode m
     => CId Wal
-    -> Bool            -- ^ Workaround for redemption txs (introduced in CSM-330)
     -> TxHistoryEntry
     -> m CTxs
-addHistoryTx cWalId isRedemptionTx wtx@THEntry{..} = do
+addHistoryTx cWalId wtx@THEntry{..} = do
     -- TODO: this should be removed in production
     diff <- maybe localChainDifficulty pure =<<
             networkChainDifficulty
@@ -748,7 +747,7 @@ addHistoryTx cWalId isRedemptionTx wtx@THEntry{..} = do
     addOnlyNewTxMeta cWalId cId meta
     meta' <- fromMaybe meta <$> getTxMeta cWalId cId
     walAddrMetas <- getWalletAddrMetas Ever cWalId
-    mkCTxs diff wtx meta' walAddrMetas isRedemptionTx & either (throwM . InternalError) pure
+    mkCTxs diff wtx meta' walAddrMetas & either (throwM . InternalError) pure
 
 newAddress
     :: WalletWebMode m
@@ -960,10 +959,8 @@ redeemAdaInternal sendActions passphrase cAccId seedBs = do
     _ <- getAccount accId
 
     let srcAddr = makeRedeemAddress $ redeemToPublic redeemSK
-    dstCWAddrMeta <- genUniqueAccountAddress RandomSeed passphrase accId
-    -- TODO(thatguy): the absence of `addWAddress` here is probably a bug.
-    -- Need to talk to @martoon about this. Discovered in CSM-330.
-    dstAddr <- decodeCIdOrFail $ cwamId dstCWAddrMeta
+    dstAddr <- decodeCIdOrFail . cadId =<<
+               newAddress RandomSeed passphrase accId
     na <- getPeers
     etx <- submitRedemptionTx sendActions redeemSK (toList na) dstAddr
     case etx of
@@ -973,8 +970,8 @@ redeemAdaInternal sendActions passphrase cAccId seedBs = do
             -- add redemption transaction to the history of new wallet
             let txInputs = [TxOut redeemAddress redeemBalance]
             ts <- Just <$> liftIO getCurrentTimestamp
-            ctxs <- addHistoryTx (aiWId accId) True
-                (THEntry (hash taTx) taTx txInputs Nothing [srcAddr] [dstAddr] ts)
+            ctxs <- addHistoryTx (aiWId accId) $
+                THEntry (hash taTx) taTx txInputs Nothing [srcAddr] [dstAddr] ts
             ctsIncoming ctxs `whenNothing` throwM noIncomingTx
   where
     noIncomingTx = InternalError "Can't report incoming transaction"

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -598,9 +598,11 @@ sendMoney sendActions passphrase moneySource dstDistr = do
                    do let remCoins = reqCoins `unsafeSubCoin` balance
                       ((acc, balance) :|) . toList <<$>>
                           selectSrcAccounts remCoins accs
-               | otherwise ->
-                   return
-                       (balance `unsafeSubCoin` reqCoins, (acc, reqCoins) :| [])
+               | otherwise -> return
+                   ( balance `unsafeSubCoin` reqCoins
+                   , (acc, balance) :| []  -- all coins from this address will
+                                           -- be spent
+                   )
 
     mkRemainingTx remaining
         | remaining == mkCoin 0 = return Nothing


### PR DESCRIPTION
This is crucial fix since it fixes CSM-392 as well