### PR TITLE
Make (Hash)Map and (Hash)Set decoding stricter

### DIFF
--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -137,7 +137,7 @@ library
                      , cardano-crypto
                      , cereal
                      , concurrent-extra
-                     , containers
+                     , containers >= 0.5.8.1
                      , contravariant
                      , cryptonite
                      , cryptonite-openssl >= 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -84,6 +84,7 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
+- containers-0.5.10.2
 - universum-0.4.3
 - time-units-1.0.0
 - serokell-util-0.2.0.0

--- a/test/Test/Pos/CborSpec.hs
+++ b/test/Test/Pos/CborSpec.hs
@@ -304,6 +304,11 @@ testAgainstFile name x expected =
 spec :: Spec
 spec = describe "Cbor.Bi instances" $ do
     modifyMaxSuccess (const 1000) $ do
+        describe "(Hash)Map and (Hash)Set instances are sound" $ do
+            prop "HashMap Int Int" (soundInstanceProperty @(HashMap Int Int) Proxy)
+            prop "HashSet Int" (soundInstanceProperty @(HashSet Int) Proxy)
+            prop "Map Int Int" (soundInstanceProperty @(Map Int Int) Proxy)
+            prop "Set Int" (soundInstanceProperty @(Set Int) Proxy)
         describe "Test instances are sound" $ do
             prop "User" (let u1 = Login "asd" 34 in (deserialize $ serialize u1) === u1)
             prop "MyScript" (soundInstanceProperty @MyScript Proxy)


### PR DESCRIPTION
Fix for decoding of (Hash)Maps and (Hash)Sets that would allow different encodings to deserialize to the same object.