### PR TITLE
Handy script to analyse the project dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ TAGS
 # Misc
 .DS_Store
 *.swp
+
+# Compiled-scripts cruft
+scripts/haskell/dependencies.hs
+scripts/haskell/dependencies.hi
+scripts/haskell/dependencies.o
+scripts/haskell/dependencies

--- a/scripts/haskell/dependencies.sh
+++ b/scripts/haskell/dependencies.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env stack
--- stack runghc --package turtle --package algebraic-graphs
+-- stack runghc --package turtle --package algebraic-graphs-0.0.5 --package parallel
 
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 import           Algebra.Graph
+import           Algebra.Graph.Export.Dot    (Attribute (..), Style (..), export)
 import           Control.Monad
+import           Control.Parallel.Strategies (parMap, rpar)
 import           Data.Functor.Identity
 import           Data.List
-import qualified Data.Map.Strict       as M
-import qualified Data.Set              as Set
-import qualified Data.Text             as T
+import qualified Data.Map.Strict             as M
+import qualified Data.Set                    as Set
+import qualified Data.Text                   as T
 import           Text.Printf
 import           Text.Read
-import           Turtle                hiding (printf)
+import           Turtle                      hiding (export, printf)
 
 type PackageName = T.Text
 data Version = V [Int] deriving (Eq, Ord)
@@ -61,18 +63,19 @@ directDependenciesFor (name, ver) = do
             concatMap (map (mkPackage . normalisePackage) . T.splitOn " ") (takeWhile (/= "depends:") deps)
         _ -> mempty
 
-type DAG = Graph Package
+type DAG    = Graph Package
+type DepMap = M.Map Package [Package]
 
 --------------------------------------------------------------------------------
-buildDependencyContext :: [Package] -> IO (M.Map PackageName [Package], DAG)
+buildDependencyContext :: [Package] -> IO (DepMap, DAG)
 buildDependencyContext [] = return (M.empty, Algebra.Graph.empty)
 buildDependencyContext pkgs = go pkgs (M.empty, Set.empty)
   where
-    go :: [Package] -> (M.Map PackageName [Package], Set.Set (Package, Package)) -> IO (M.Map PackageName [Package], DAG)
+    go :: [Package] -> (DepMap, Set.Set (Package, Package)) -> IO (DepMap, DAG)
     go [] (depMap, dag) = return (depMap, edges (Set.toList dag))
-    go (pkg@(pkgName,_):xs) (depMap, dag) = do
+    go (pkg:xs) (depMap, dag) = do
       directDeps <- directDependenciesFor pkg
-      let !newMap = M.insert pkgName directDeps $! depMap
+      let !newMap = M.insert pkg directDeps $! depMap
       let !newDag = dag <> Set.fromList (map (pkg,) directDeps)
       go xs (newMap, newDag)
 
@@ -88,19 +91,66 @@ normalisePackage txt = case T.breakOnEnd "-" txt of
         Just _  -> txt
         Nothing -> if x == "" then error ("normalisePackage: " <> show txt) else T.init x
 
+--------------------------------------------------------------------------------
+reverseDependenciesFor :: Package -> [Package] -> DepMap -> DAG -> [Package]
+reverseDependenciesFor pkg allDeps directDeps dag = go allDeps mempty
+  where
+    go [] revDeps     = revDeps
+    go (x:xs) revDeps = case reachableFrom x pkg directDeps of
+        True  -> go xs (x : revDeps)
+        False -> go xs revDeps
+        -- For each package x, check the graph to see if there is a path going
+        -- from x to `pkg`. If there is, we found a reverse dep.
+
+reachableFrom :: Package -> Package -> DepMap -> Bool
+reachableFrom start end directDeps = go (M.findWithDefault mempty start directDeps)
+  where
+    go :: [Package] -> Bool
+    go [] = False
+    go (x:xs) = case x == end of
+        True  -> True
+        False -> any (\newStart -> reachableFrom newStart end directDeps) xs
+
+--------------------------------------------------------------------------------
+style :: Style Package String
+style = Style
+    { graphName               = ""
+    , preamble                = ""
+    , graphAttributes         = ["label" := "Example", "labelloc" := "top"]
+    , defaultVertexAttributes = ["shape" := "circle"]
+    , defaultEdgeAttributes   = mempty
+    , vertexName              = \(name,_)   -> T.unpack name
+    , vertexAttributes        = \_   -> ["color" := "blue"]
+    , edgeAttributes          = \_ _ -> ["style" := "dashed"]
+    }
+
+--------------------------------------------------------------------------------
+dottify :: DAG -> IO ()
+dottify dag = writeFile "dep_dot.graphviz" (export style dag)
+
+--------------------------------------------------------------------------------
 main :: IO ()
 main = do
     allDeps <- getTotalPackages
     putStrLn "Building direct dependency map..."
     (directDepMap, depDag) <- buildDependencyContext allDeps
 
-    let tableHeader         = printf "%-40s" ("Package" :: String) <> printf "%-10s" ("Direct dependencies" :: String)
-    let tableEntry pkg deps = printf "%-40s" (T.unpack pkg) <> printf "%-10s" (show deps)
+    let tableHeader         =  printf "%-40s" ("Package" :: String)
+                            <> printf "%-20s" ("Direct dependencies"  :: String)
+                            <> printf "%-20s" ("Reverse dependencies" :: String)
+    let tableEntry pkg deps revDeps =  printf "%-40s" (T.unpack pkg)
+                                    <> printf "%-20s" (show deps)
+                                    <> printf "%-20s\n" (show (revDeps :: Int))
     putStrLn tableHeader
 
     let depsMap = M.map length directDepMap
 
-    forM_ (sortOn snd $ M.toList depsMap) $ \(pkgName, deps) -> do
-        putStrLn (tableEntry pkgName deps)
+    let sortedDepList = reverse (sortOn snd $ M.toList depsMap)
+    let mkTableEntry  (pkg@(pkgName,_), deps) =
+            let revDeps = reverseDependenciesFor pkg allDeps directDepMap depDag
+            in tableEntry pkgName deps (length revDeps)
+    let table         = parMap rpar mkTableEntry sortedDepList
+
+    putStrLn $ mconcat table
     -- Display the total deps
-    putStrLn $ tableEntry "Total project deps" (length allDeps + length blacklistedPackages)
+    putStrLn $ tableEntry "Total project deps" (length allDeps + length blacklistedPackages) 0

--- a/scripts/haskell/dependencies.sh
+++ b/scripts/haskell/dependencies.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env stack
+-- stack runghc --package turtle
+
+{-# LANGUAGE OverloadedStrings #-}
+import           Control.Monad
+import           Data.Functor.Identity
+import qualified Data.Text             as T
+import           Text.Read
+import           Turtle
+
+type PackageName = T.Text
+data Version = V [Int] deriving (Eq, Ord)
+type Package = (PackageName, Version)
+
+readVersionM :: Monad m => (String -> m Int) -> T.Text -> m Version
+readVersionM f = fmap V . sequence . map (f . T.unpack) . T.splitOn "."
+
+readVersionMaybe :: T.Text -> Maybe Version
+readVersionMaybe = readVersionM readMaybe
+
+readVersion :: T.Text -> Version
+readVersion = runIdentity . readVersionM (liftM read . pure)
+
+mkPackage :: T.Text -> Package
+mkPackage t = case T.splitOn " " (T.strip t) of
+    [name, ver] -> (name, readVersion ver)
+    _           -> error $ "Cannot mkPackage: " <> show t
+
+-- Filter `cardano-sl-lwallet` & `cardano-sl-tools` as they cannot be
+-- found by `ghc-pkg`, for some reason.
+getTotalPackages :: IO [Package]
+getTotalPackages = do
+    (_, rawList) <- shellStrict "stack list-dependencies --test --bench" mempty
+    return $ map mkPackage (filter (not . blacklisted) (T.lines rawList))
+    where
+      blacklisted x = or [ T.isInfixOf "cardano-sl-lwallet" x
+                         , T.isInfixOf "cardano-sl-tools" x
+                         ]
+
+directDependenciesFor :: Package -> IO [Package]
+directDependenciesFor (name, ver) = do
+    (_, rawOutput) <- shellStrict ("stack exec ghc-pkg field " <> name <> " depends") mempty
+    return $ case map T.strip (T.lines rawOutput) of
+        ("depends:" : deps) ->
+            concatMap (map (mkPackage . normalisePackage) . T.splitOn " ") deps
+        _ -> mempty
+
+-- | >>> normalisePackage "conduit-1.2.10-GgLn1U1QYcf9wsQecuZ1A4"
+-- "conduit-1.2.10"
+-- >>> normalisePackage "conduit-1.2.10"
+-- "conduit-1.2.10"
+normalisePackage :: T.Text -> T.Text
+normalisePackage txt = case T.breakOnEnd "-" txt of
+    (x, xs) -> case readVersionMaybe xs of
+        Just _  -> txt
+        Nothing -> T.init x
+
+main :: IO ()
+main = do
+    allDeps <- getTotalPackages
+    forM_ allDeps $ \pkg@(name, _) -> do
+        deps <- directDependenciesFor pkg
+        putStr $ T.unpack $ name <> " -> "
+        putStrLn (show $ length deps)

--- a/scripts/haskell/dependencies.sh
+++ b/scripts/haskell/dependencies.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env stack
--- stack runghc --package turtle
+-- stack runghc --package turtle --package algebraic-graphs
 
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+import           Algebra.Graph
 import           Control.Monad
 import           Data.Functor.Identity
 import           Data.List
 import qualified Data.Map.Strict       as M
+import qualified Data.Set              as Set
 import qualified Data.Text             as T
 import           Text.Printf
 import           Text.Read
@@ -28,10 +32,16 @@ readVersion = runIdentity . readVersionM (liftM read . pure)
 mkPackage :: T.Text -> Package
 mkPackage t = case T.splitOn " " (T.strip t) of
     [name, ver] -> (name, readVersion ver)
-    _           -> error $ "Cannot mkPackage: " <> show t
+    _           -> case T.breakOnEnd "-" (T.strip t) of
+        ("", _)     -> error $ "mkPackage: " <> show t
+        (name, ver) -> (T.init name, readVersion ver)
 
 blacklistedPackages :: [T.Text]
-blacklistedPackages = ["cardano-sl-lwallet", "cardano-sl-tools"]
+blacklistedPackages = [ "cardano-sl-lwallet"
+                      , "cardano-sl-tools"
+                      , "Cabal"
+                      , "base"
+                      , "Glob"]
 
 -- Filter `cardano-sl-lwallet` & `cardano-sl-tools` as they cannot be
 -- found by `ghc-pkg`, for some reason.
@@ -47,8 +57,22 @@ directDependenciesFor (name, ver) = do
     (_, rawOutput) <- shellStrict ("stack exec ghc-pkg field " <> name <> " depends") mempty
     return $ case map T.strip (T.lines rawOutput) of
         ("depends:" : deps) ->
-            concatMap (map (mkPackage . normalisePackage) . T.splitOn " ") deps
+            concatMap (map (mkPackage . normalisePackage) . T.splitOn " ") (takeWhile (/= "depends:") deps)
         _ -> mempty
+
+type DAG = Graph Package
+
+buildDependencyContext :: [Package] -> IO (M.Map PackageName [Package], DAG)
+buildDependencyContext [] = return (M.empty, Algebra.Graph.empty)
+buildDependencyContext pkgs = go pkgs (M.empty, Set.empty)
+  where
+    go :: [Package] -> (M.Map PackageName [Package], Set.Set (Package, Package)) -> IO (M.Map PackageName [Package], DAG)
+    go [] (depMap, dag) = return (depMap, edges (Set.toList dag))
+    go (pkg@(pkgName,_):xs) (depMap, dag) = do
+      directDeps <- directDependenciesFor pkg
+      let !newMap = M.insert pkgName directDeps $! depMap
+      let !newDag = dag <> Set.fromList (map (pkg,) directDeps)
+      go xs (newMap, newDag)
 
 -- | >>> normalisePackage "conduit-1.2.10-GgLn1U1QYcf9wsQecuZ1A4"
 -- "conduit-1.2.10"
@@ -58,16 +82,13 @@ normalisePackage :: T.Text -> T.Text
 normalisePackage txt = case T.breakOnEnd "-" txt of
     (x, xs) -> case readVersionMaybe xs of
         Just _  -> txt
-        Nothing -> T.init x
+        Nothing -> if x == "" then error ("normalisePackage: " <> show txt) else T.init x
 
 main :: IO ()
 main = do
     allDeps <- getTotalPackages
     putStrLn "Building direct dependency map..."
-    directDepMap <- foldM (\acc pkg@(pkgName, ver) -> do
-                                  d <- directDependenciesFor pkg
-                                  return $ M.insert pkgName d acc
-                          ) M.empty allDeps
+    (directDepMap, depDag) <- buildDependencyContext allDeps
 
     let tableHeader         = printf "%-40s" ("Package" :: String) <> printf "%-10s" ("Direct dependencies" :: String)
     let tableEntry pkg deps = printf "%-40s" (T.unpack pkg) <> printf "%-10s" (show deps)


### PR DESCRIPTION
Hi all,

I have been working on a script to complement the information `stack dot` produces under the form of a Graphviz graph (which @domenkozar already showed me). This script enumerates all the dependencies in cardano (by piggybacking on `stack list-dependencies --test --bench` and also tracks the direct & indirect dependencies (mostly relying on `ghc-pkg field`). It finally produces a table like this (which we can customise later):

![screen shot 2017-07-31 at 17 16 05](https://user-images.githubusercontent.com/29383371/28784522-f9e0fcec-7613-11e7-9357-f467e4162968.png)

I have deliberately filtered the cardano-* project family from the reverse dep list (thus some packages has a 0 in the `rev deps` section) so actually focus a bit better (in the future it's easy to add an option like `--exclude-cardano` and by default show everything). The game would be to start from the top (the table is sorted by number of direct deps) and for those check the packages which have the minor number of reverse dependencies, which means that, if we eliminate those, we can effectively get rid of the package from the codebase. For example, the screenshot shows the case of `store` (which in other branches has been already removed): It has as reverse deps `timewarp` and `kademlia`, so dropping store from both will allow us to remove `store` (disclaimer: it's basically what actually happened in other wip-branches).

To run the script, first build the project as usual, and then:

```
./scripts/haskell/dependencies.sh
```

I hope we can use this as a starting point to optimise our CI times and the project in general. Let me know what you think! cc @georgeee @neongreen 