### PR TITLE
[CSLD-119] Enable swagger & client doc autobuild by travis

### DIFF
--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -70,11 +70,11 @@ for trgt in $targets; do
 
 done
 
-#if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-  #./update-wallet-web-api-docs.sh
-  #./update-cli-docs.sh
+if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+  ./update-wallet-web-api-docs.sh
+  ./update-cli-docs.sh
   #./update-haddock.sh
-#fi
+fi
 
 stack exec --nix -- cardano-wallet-hs2purs
 


### PR DESCRIPTION
My only purpose is to update https://cardanodocs.com/technical/wallet/api/
And this PR seems to be the easiest way to do that