### PR TITLE
derive CanJsonLog (TaggedTrans tag t m) instance

### DIFF
--- a/src/Pos/Util/JsonLog.hs
+++ b/src/Pos/Util/JsonLog.hs
@@ -26,9 +26,11 @@ import           Data.Aeson                    (encode)
 import           Data.Aeson.TH                 (deriveJSON)
 import           Data.Aeson.Types              (ToJSON)
 import qualified Data.ByteString.Lazy          as LBS
+import           Ether                         (TaggedTrans (..))
 import           Formatting                    (sformat)
 import           JsonLog.JsonLogT              (JsonLogConfig (..))
 import qualified JsonLog.JsonLogT              as JL
+import           JsonLog.CanJsonLog            (CanJsonLog)
 import           Mockable                      (Catch, Mockable, realTime)
 import           Serokell.Aeson.Options        (defaultOptions)
 import           System.Wlog                   (WithLogger)
@@ -173,3 +175,5 @@ jsonLogDefault
 jsonLogDefault x = do
     jlc <- view jsonLogConfig
     JL.jsonLogDefault jlc x
+
+deriving instance CanJsonLog (t m) => CanJsonLog (TaggedTrans tag t m)


### PR DESCRIPTION
It used to be derived in time-warp-nt, but was removed along with the
dependency on ether.