### PR TITLE
[CSM-401] Fix wallet password deserialization

### DIFF
--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -28,7 +28,8 @@ import           Pos.Crypto.Hashing       (AbstractHash (..), HashAlgorithm,
 import           Pos.Crypto.HD            (HDAddressPayload (..))
 import           Pos.Crypto.RedeemSigning (RedeemPublicKey (..), RedeemSecretKey (..),
                                            RedeemSignature (..))
-import           Pos.Crypto.SafeSigning   (EncryptedSecretKey (..), PassPhrase)
+import           Pos.Crypto.SafeSigning   (EncryptedSecretKey (..), PassPhrase,
+                                           passphraseLength)
 import           Pos.Crypto.SecretSharing (EncShare (..), Secret (..), SecretProof (..),
                                            SecretSharingExtra (..), Share (..),
                                            VssKeyPair (..), VssPublicKey (..))
@@ -125,9 +126,6 @@ deriving instance Bi (AsBinary SecretSharingExtra)
 -- Signing
 ----------------------------------------------------------------------------
 
-passphraseLength :: Int
-passphraseLength = 32
-
 instance Bi Ed25519.PointCompressed where
   encode (Ed25519.unPointCompressed -> k) = encode k
   decode = Ed25519.pointCompressed <$> decode
@@ -206,7 +204,7 @@ instance Bi PassPhrase where
     decode = do
         bs <- decode @ByteString
         let bl = BS.length bs
-        -- Currently passphrase may be 32-byte long, or empty (for
+        -- Currently passphrase may be either 32-byte long or empty (for
         -- unencrypted keys).
         if bl == 0 || bl == passphraseLength
             then pure $ ByteArray.convert bs

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -4,6 +4,7 @@ module Pos.Crypto.SafeSigning
        ( EncryptedSecretKey (..)
        , PassPhrase
        , SafeSigner
+       , passphraseLength
        , emptyPassphrase
        , noPassEncrypt
        , checkPassMatches
@@ -53,6 +54,9 @@ instance B.Buildable EncryptedSecretKey where
 
 newtype PassPhrase = PassPhrase ScrubbedBytes
     deriving (Eq, Ord, Monoid, NFData, ByteArray, ByteArrayAccess)
+
+passphraseLength :: Int
+passphraseLength = 32
 
 instance Show PassPhrase where
     show _ = "<passphrase>"


### PR DESCRIPTION
The initial idea was to get rid of `instance Bi PassPhrase` altogether and move its code into `FromCType` / `ToCType`. However, this instance is used in several other places. In all of these cases the only reason for why `Bi PassPhrase` is needed is that `hash` is called on passphrases, and internally `hash` calls `serialize'`. So, in fact, only `encode` is ever used. However, I don't know how to get rid of `instance Bi PassPhrase` without splitting `Bi` into `encode` and `decode` and changing the constraint on the current `hash` function to only require `encode` to be implemented.

There is some (albeit small) code duplication. I was thinking whether it could be extracted and put into separate functions, but I'm not sure where I could put it. An obvious candidate is `Pos.Binary.Crypto`, however currently it doesn't export any identifiers, and I'm not sure whether it is a good idea to start doing that.

An alternative solution would be to fix `daedalus-bridge` to send the following to the backend:

    passphrase & hash & cbor.serialize & base16

(currently it skips the `cbor.serialize` step and dumps hash as raw bytes, hence the original error).