### PR TITLE
[CSL-1453] Drop unused lifted-async dep

### DIFF
--- a/lwallet/cardano-sl-lwallet.cabal
+++ b/lwallet/cardano-sl-lwallet.cabal
@@ -54,7 +54,6 @@ executable cardano-wallet
                      , containers
                      , formatting
                      , lens
-                     , lifted-async
                      , log-warper
                      , mmorph
                      , monad-control

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -164,7 +164,6 @@ executable cardano-dht-keygen
                      , formatting
                      , kademlia
                      , lens
-                     , lifted-async
                      , log-warper
                      , optparse-applicative
                      , parsec


### PR DESCRIPTION
This is a low-hanging fruit I've spotted. We don't seem to be using `lifted-async` anymore, but yet its dep was lurking in the manifests of `cardano-sl-lwallet` and `cardano-sl-tools`. I've tried to manually build those projects with:

```
stack build cardano-sl-tools
stack build cardano-sl-lwallet
```

as well as grepping for `Lifted`, but it looks like we should be OK.