### PR TITLE
[CSL-1417] Modify block event type

### DIFF
--- a/cardano-sl.cabal
+++ b/cardano-sl.cabal
@@ -63,6 +63,7 @@ library
                         Pos.Generator
                         Pos.Generator.Block
                         Pos.Generator.BlockEvent
+                        Pos.Generator.BlockEvent.DSL
 
                         -- Genesis data
                         Pos.Genesis

--- a/core/Pos/Util/Chrono.hs
+++ b/core/Pos/Util/Chrono.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- | Chronological sequences.
 
@@ -12,6 +13,10 @@ module Pos.Util.Chrono
        , toNewestFirst
        , toOldestFirst
        , NE
+       , nonEmptyOldestFirst
+       , nonEmptyNewestFirst
+       , splitAtNewestFirst
+       , splitAtOldestFirst
        ) where
 
 import           Universum          hiding (mapMaybe)
@@ -19,6 +24,7 @@ import           Universum          hiding (mapMaybe)
 import           Control.Lens       (makePrisms, makeWrapped, _Wrapped)
 import qualified Control.Lens       as Lens (Each (..))
 import           Data.Binary        (Binary)
+import           Data.Coerce        (coerce)
 import qualified Data.List.NonEmpty as NE
 import           Data.Semigroup     (Semigroup)
 import qualified GHC.Exts           as IL
@@ -85,3 +91,29 @@ instance Chrono NonEmpty where
     toOldestFirst = OldestFirst . NE.reverse . getNewestFirst
 
 type NE = NonEmpty
+
+nonEmptyOldestFirst ::
+    forall a.
+       OldestFirst [] a
+    -> Maybe (OldestFirst NE a)
+nonEmptyOldestFirst = coerce (nonEmpty @a)
+
+nonEmptyNewestFirst ::
+    forall a.
+       NewestFirst [] a
+    -> Maybe (NewestFirst NE a)
+nonEmptyNewestFirst = coerce (nonEmpty @a)
+
+splitAtOldestFirst ::
+    forall a.
+       Int
+    -> OldestFirst NE a
+    -> (OldestFirst [] a, OldestFirst [] a)
+splitAtOldestFirst = coerce (NE.splitAt @a)
+
+splitAtNewestFirst ::
+    forall a.
+       Int
+    -> NewestFirst NE a
+    -> (NewestFirst [] a, NewestFirst [] a)
+splitAtNewestFirst = coerce (NE.splitAt @a)

--- a/db/Pos/DB/Pure.hs
+++ b/db/Pos/DB/Pure.hs
@@ -19,6 +19,7 @@ module Pos.DB.Pure
 
        , MonadPureDB
        , dbPureDump
+       , dbPureReset
 
        , DBPureVar
        , newDBPureVar
@@ -102,6 +103,11 @@ type MonadPureDB ctx m =
 
 dbPureDump :: MonadPureDB ctx m => m DBPure
 dbPureDump = view (lensOf @DBPureVar) >>= readIORef
+
+dbPureReset :: MonadPureDB ctx m => DBPure -> m ()
+dbPureReset dbPure = do
+    ref <- view (lensOf @DBPureVar)
+    writeIORef ref dbPure
 
 ----------------------------------------------------------------------------
 -- MonadDBRead / MonadDB

--- a/src/Pos/Generator/BlockEvent.hs
+++ b/src/Pos/Generator/BlockEvent.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFoldable      #-}
 {-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Pos.Generator.BlockEvent
@@ -18,47 +19,199 @@ module Pos.Generator.BlockEvent
        , BlockEventRollback
        , berInput
        , berOutValid
+       -- * Snapshot management
+       , SnapshotId(..)
+       , SnapshotOperation(..)
+       , enrichWithSnapshotChecking
+       , CheckCount(..)
        -- * Block event sum
        , BlockEvent'(..)
        , BlockEvent
-       -- * Generation
-       , BlockEventCount(..)
+       -- * Block scenario
+       , BlockScenario'(..)
+       , BlockScenario
+       , _BlockScenario
+       -- * Path
+       , PathSegment(..)
+       , Path(..)
+       , pathSequence
+       -- * Chance
        , Chance(..)
-       , BlockEventGenParams(..)
-       , begpBlockCountMax
-       , begpBlockEventCount
-       , begpRollbackChance
-       , begpFailureChance
-       , begpSecrets
-       , genBlockEvents
+       , byChance
+       -- * Block description
+       , BlockDesc(..)
+       -- * Generation
+       , MonadGenBlockchain
+       , BlockEventCount(..)
+       , genBlocksInStructure
        ) where
 
 import           Universum
 
-import           Control.Lens                (folded, makeLenses)
-import           Control.Monad.Random.Strict (MonadRandom (..), RandT, Random (..),
-                                              RandomGen, runRand, uniform, weighted)
-import           Control.Monad.State         (MonadState (..))
-import           Data.Coerce                 (coerce)
+import           Control.Lens                (foldMapOf, folded, makeLenses, makePrisms)
+import           Control.Monad.Random.Strict (RandT, Random (..), RandomGen, mapRandT,
+                                              weighted)
 import           Data.Default                (def)
-import           Data.List                   ((!!))
 import qualified Data.List.NonEmpty          as NE
-import qualified Data.Semigroup              as Smg
+import qualified Data.Map                    as Map
+import qualified Data.Sequence               as Seq
 import qualified Data.Text.Buildable
-import           Formatting                  (bprint, build, formatToString, int, (%))
+import           Formatting                  (bprint, build, sformat, shown, (%))
 import qualified Prelude
+import           Serokell.Util               (listJson)
 
 import           Pos.Block.Types             (Blund)
-import           Pos.Core                    (BlockCount (..))
+import           Pos.Core                    (HeaderHash, headerHash, prevBlockL)
+import           Pos.Crypto.Hashing          (hashHexF)
 import           Pos.Generator.Block         (AllSecrets, BlockGenParams (..),
-                                              MonadBlockGen, genBlocks)
+                                              MonadBlockGen, TxGenParams, genBlocks)
+import           Pos.GState.Context          (withClonedGState)
 import           Pos.Ssc.GodTossing.Type     (SscGodTossing)
 import           Pos.Util.Chrono             (NE, NewestFirst (..), OldestFirst (..),
-                                              toNewestFirst, toOldestFirst, _NewestFirst,
-                                              _OldestFirst)
-import           Pos.Util.Util               (minMaxOf)
+                                              toNewestFirst, toOldestFirst, _OldestFirst)
 
 type BlundDefault = Blund SscGodTossing
+
+----------------------------------------------------------------------------
+-- Blockchain tree
+----------------------------------------------------------------------------
+
+-- NB. not a monoid, so the user can be sure that `(<>)` acts as expected
+-- on string literals for paths (not path segments).
+newtype PathSegment = PathSegment Text
+    deriving (Eq, Ord, IsString)
+
+instance Show PathSegment where
+    showsPrec p (PathSegment s) = Prelude.showsPrec p s
+
+-- | Construct a path using string literals and monoidal/semigroupoidal
+--   operations: @"first" <> "next"@, @stimes 15 "next"@.
+--   An empty path does not point at any block, don't use it on its own! (but
+--   it's a valid 'mempty')
+newtype Path = Path (Seq PathSegment)
+    deriving (Eq, Ord, Semigroup, Monoid)
+
+instance IsString Path where
+    fromString = Path . Seq.singleton . fromString
+
+instance Buildable Path where
+    build (Path segs) = bprint build (fold . intersperse "/" . toList $ segs <&> \(PathSegment t) -> t)
+
+-- | Convert a sequence of relative paths into a sequence of absolute paths:
+--   @pathSequence "base" ["a", "b", "c"] = ["base" <> "a", "base" <> "a" <> "b", "base" <> "a" <> "b" <> "c"]
+pathSequence ::
+       Path -- ^ base path
+    -> OldestFirst NE Path -- ^ relative paths
+    -> OldestFirst NE Path -- ^ absolute paths
+pathSequence basePath = over _OldestFirst $
+    NE.fromList . fmap (mappend basePath . mconcat) . NE.tail . NE.inits
+
+type BlockchainForest a = Map PathSegment (BlockchainTree a)
+
+data BlockchainTree a = BlockchainTree a (BlockchainForest a)
+  deriving (Show, Functor, Foldable)
+
+data BlockDesc
+    = BlockDescDefault -- a random valid block
+    | BlockDescCustom TxGenParams -- a random valid block with custom gen params
+    deriving (Show)
+
+-- Precondition: input paths are non-empty
+buildBlockchainForest :: a -> Map Path a -> BlockchainForest a
+buildBlockchainForest defElem elements =
+    fmap (buildBlockchainTree defElem) . Map.fromListWith Map.union $ do
+        (Path path, a) <- Map.toList elements
+        case Seq.viewl path of
+            Seq.EmptyL -> error
+                "buildBlockchainForest: precondition violated, empty path"
+            pathSegment Seq.:< path' ->
+                [(pathSegment, Map.singleton (Path path') a)]
+
+buildBlockchainTree :: a -> Map Path a -> BlockchainTree a
+buildBlockchainTree defElem elements =
+    let
+        topPath = Path Seq.empty
+        topElement = Map.findWithDefault defElem topPath elements
+        -- 'otherElements' has its empty path deleted (if there was one in the
+        -- first place), so it satisfies the precondition of 'buildBlockchainForest'
+        otherElements = Map.delete topPath elements
+    in
+        BlockchainTree topElement (buildBlockchainForest defElem otherElements)
+
+-- Inverse to 'buildBlockchainForest'.
+flattenBlockchainForest' :: BlockchainForest a -> Map Path a
+flattenBlockchainForest' =
+    Map.fromList . flattenBlockchainForest (Path Seq.empty)
+
+flattenBlockchainForest :: Path -> BlockchainForest a -> [(Path, a)]
+flattenBlockchainForest (Path prePath) forest = do
+    (pathSegment, subtree) <- Map.toList forest
+    flattenBlockchainTree (Path $ prePath Seq.|> pathSegment) subtree
+
+flattenBlockchainTree :: Path -> BlockchainTree a -> [(Path, a)]
+flattenBlockchainTree prePath tree = do
+    let BlockchainTree a forest = tree
+    (prePath, a) : flattenBlockchainForest prePath forest
+
+type MonadGenBlockchain ctx m =
+    ( MonadBlockGen ctx m
+    , MonadThrow m )
+
+genBlocksInForest ::
+       (MonadGenBlockchain ctx m, RandomGen g)
+    => AllSecrets
+    -> BlockchainForest BlockDesc
+    -> RandT g m (BlockchainForest BlundDefault)
+genBlocksInForest secrets =
+    traverse $ mapRandT withClonedGState . genBlocksInTree secrets
+
+genBlocksInTree ::
+       (MonadGenBlockchain ctx m, RandomGen g)
+    => AllSecrets
+    -> BlockchainTree BlockDesc
+    -> RandT g m (BlockchainTree BlundDefault)
+genBlocksInTree secrets blockchainTree = do
+    let
+        BlockchainTree blockDesc blockchainForest = blockchainTree
+        txGenParams = case blockDesc of
+            BlockDescDefault  -> def
+            BlockDescCustom p -> p
+        blockGenParams = BlockGenParams
+            { _bgpSecrets     = secrets
+            , _bgpBlockCount  = 1
+            , _bgpTxGenParams = txGenParams
+            , _bgpInplaceDB   = True
+            }
+    -- Partial pattern-matching is safe because we specify
+    -- blockCount = 1 in the generation parameters.
+    OldestFirst [block] <- genBlocks blockGenParams
+    forestBlocks <- genBlocksInForest secrets blockchainForest
+    return $ BlockchainTree block forestBlocks
+
+-- Precondition: paths in the structure are non-empty.
+genBlocksInStructure ::
+       ( MonadGenBlockchain ctx m
+       , Functor t, Foldable t
+       , RandomGen g )
+    => AllSecrets
+    -> Map Path BlockDesc
+    -> t Path
+    -> RandT g m (t BlundDefault)
+genBlocksInStructure secrets annotations s = do
+    let
+        getAnnotation path =
+            Map.findWithDefault BlockDescDefault path annotations
+        paths = foldMapOf folded
+            (\path -> Map.singleton path (getAnnotation path))
+            s
+        descForest = buildBlockchainForest BlockDescDefault paths
+    blockForest <- genBlocksInForest secrets descForest
+    let
+        getBlock path = Map.findWithDefault
+            (error "genBlocksInStructure: impossible happened")
+            path
+            (flattenBlockchainForest' blockForest)
+    return $ fmap getBlock s
 
 ----------------------------------------------------------------------------
 -- Block event types
@@ -74,6 +227,7 @@ data BlockApplyResult
                             * block is not a continuation of the chain
                             * block signature is invalid
                             * etc -}
+    deriving (Show)
 
 instance IsBlockEventFailure BlockApplyResult where
     isBlockEventFailure = \case
@@ -83,7 +237,7 @@ instance IsBlockEventFailure BlockApplyResult where
 data BlockEventApply' blund = BlockEventApply
     { _beaInput    :: !(OldestFirst NE blund)
     , _beaOutValid :: !BlockApplyResult
-    } deriving (Functor, Foldable)
+    } deriving (Show, Functor, Foldable)
 
 makeLenses ''BlockEventApply'
 
@@ -99,6 +253,7 @@ data BlockRollbackResult
                                 * rollback limit exceeded
                                 * genesis block rollback
                                 * etc -}
+    deriving (Show)
 
 instance IsBlockEventFailure BlockRollbackResult where
     isBlockEventFailure = \case
@@ -108,7 +263,7 @@ instance IsBlockEventFailure BlockRollbackResult where
 data BlockEventRollback' blund = BlockEventRollback
     { _berInput    :: !(NewestFirst NE blund)
     , _berOutValid :: !BlockRollbackResult
-    } deriving (Functor, Foldable)
+    } deriving (Show, Functor, Foldable)
 
 makeLenses ''BlockEventRollback'
 
@@ -117,30 +272,59 @@ instance IsBlockEventFailure (BlockEventRollback' blund) where
 
 type BlockEventRollback = BlockEventRollback' BlundDefault
 
+newtype SnapshotId = SnapshotId Text
+    deriving (Eq, Ord, IsString)
+
+instance Show SnapshotId where
+    showsPrec p (SnapshotId s) = Prelude.showsPrec p s
+
+data SnapshotOperation
+    = SnapshotSave SnapshotId {- Save the current db state into a snapshot
+    under the specified identifier. Overwrites an existing snapshot with the
+    same name or creates a new one. -}
+    | SnapshotLoad SnapshotId {- Set the current db state to a state saved in
+    a snapshot earlier. -}
+    | SnapshotEq SnapshotId {- Compare the current db state to a state saved
+    in a snapshot earlier, checking for equivalence. If logical discrepancies
+    are found, throw an error. -}
+    deriving (Show)
+
+instance Buildable SnapshotOperation where
+    build = bprint shown
+
 data BlockEvent' blund
     = BlkEvApply (BlockEventApply' blund)
     | BlkEvRollback (BlockEventRollback' blund)
-    deriving (Functor, Foldable)
+    | BlkEvSnap SnapshotOperation
+    deriving (Show, Functor, Foldable)
+
+instance Buildable blund => Buildable (BlockEvent' blund) where
+    build = \case
+        BlkEvApply ev -> bprint ("Apply blocks: "%listJson) (getOldestFirst $ ev ^. beaInput)
+        BlkEvRollback ev -> bprint ("Rollback blocks: "%listJson) (getNewestFirst $ ev ^. berInput)
+        BlkEvSnap s -> bprint build s
 
 instance IsBlockEventFailure (BlockEvent' blund) where
     isBlockEventFailure = \case
         BlkEvApply    a -> isBlockEventFailure a
         BlkEvRollback a -> isBlockEventFailure a
+        BlkEvSnap     _ -> False
 
 type BlockEvent = BlockEvent' BlundDefault
+
+newtype BlockScenario' blund = BlockScenario [BlockEvent' blund]
+    deriving (Show, Functor, Foldable)
+
+instance Buildable blund => Buildable (BlockScenario' blund) where
+    build (BlockScenario xs) = bprint listJson xs
+
+type BlockScenario = BlockScenario' BlundDefault
+
+makePrisms ''BlockScenario'
 
 ----------------------------------------------------------------------------
 -- Block event generation
 ----------------------------------------------------------------------------
-
-{- |
-  Block indices. They're neither 0-based nor 1-based, they can start from any
-  index (even negative). Therefore it's necessary to adjust them before using
-  for lookup in a data structure.
--}
-newtype BlockIndex = BlockIndex {getBlockIndex :: Int}
-    deriving (Eq, Ord, Num, Real, Integral, Enum, Read, Show,
-              Buildable, Generic, Typeable, NFData, Hashable, Random)
 
 newtype BlockEventCount = BlockEventCount {getBlockEventCount :: Word64}
     deriving (Eq, Ord, Num, Real, Integral, Enum, Read, Show,
@@ -155,360 +339,49 @@ newtype Chance = Chance {getChance :: Rational}
 byChance :: (Monad m, RandomGen g) => Chance -> RandT g m Bool
 byChance (Chance c) = weighted [(False, 1 - c), (True, c)]
 
-data BlockEventGenParams = BlockEventGenParams
-    { _begpSecrets         :: !AllSecrets
-    , _begpBlockCountMax   :: !BlockCount {- ^ the maximum possible amount of
-    blocks in a BlockApply event. Must be 1 or more. Can be violated by 1 in
-    some cases (see Note on reordering corner cases), so if you specify '52'
-    here, some rare events may contain up to '53' blocks. -}
-    , _begpBlockEventCount :: !BlockEventCount {- ^ the amount of events to
-    generate excluding the last complete rollback event. There can be less
-    events if we generate an expected failure. For example, if you specify '10'
-    here, you'll either get 11 events (the last is a complete rollback) or
-    some amount of events from 1 to 10 (the last is an expected failure).
-    If you set the failure chance to '0', you'll always get the requested
-    amount of events. -}
-    , _begpRollbackChance  :: !Chance
-    , _begpFailureChance   :: !Chance
-    }
+newtype CheckCount = CheckCount Word
+    deriving (Eq, Ord, Show, Num)
 
-makeLenses ''BlockEventGenParams
+blkEvTip :: BlockEvent -> Maybe HeaderHash
+blkEvTip = \case
+    BlkEvApply bea -> Just $
+        (headerHash . NE.head . getNewestFirst . toNewestFirst . view beaInput) bea
+    BlkEvRollback ber -> Just $
+        (headerHash . view prevBlockL . NE.head . getOldestFirst . toOldestFirst . view berInput) ber
+    _ -> Nothing
 
-instance Buildable BlockEventGenParams where
-    build BlockEventGenParams {..} =
-        bprint ("BlockEventGenParams {\n"%
-                "  secrets: "%build%"\n"%
-                "  block count max: "%int%"\n"%
-                "  block event count: "%int%"\n"%
-                "  rollback chance: "%build%"\n"%
-                "  failure chance: "%build%"\n"%
-                "}\n")
-            _begpSecrets
-            _begpBlockCountMax
-            _begpBlockEventCount
-            _begpRollbackChance
-            _begpFailureChance
+-- | Empty: hash snapshot unavailable
+--   Zero: hash snapshot available but unused
+--   Other: hash snapshot was used N times
+type HhStatusMap = Map HeaderHash CheckCount
 
-instance Show BlockEventGenParams where
-    show = formatToString build
+hhSnapshotId :: HeaderHash -> SnapshotId
+hhSnapshotId = SnapshotId . sformat hashHexF
 
-{- |
-  Return the range of block indices as a half-open interval (closed on the
-  lower bound, open on the upper bound). For example, for block indices
-  @[0, -2, 4, 7]@ the range is a tuple @(-2, 8)@. The reasons for the interval
-  to be half-open:
-    * it's possible to encode an empty range as @(k, k)@
-    * to compute the amount of elements, one can use simple subtraction
--}
-
-getBlockIndexRange ::
-       [BlockEvent' BlockIndex]
-    -> (BlockIndex, BlockIndex)
-getBlockIndexRange =
-    maybe (0, 0) (\(lower, upper) -> (lower, upper+1)) . minMaxOf (folded.folded)
-
--- | Generate a random sequence of block events. The final event is either an
--- expected failure or a rollback of the entire chain to the initial (empty)
--- state. There's no forking at the moment.
-genBlockEvents ::
-       (MonadBlockGen ctx m, RandomGen g)
-    => BlockEventGenParams
-    -> RandT g m [BlockEvent]
-genBlockEvents begp = do
-    preBlockEvents <- genBlockEvents' begp
-    let
-        (blockIndexStart, blockIndexEnd) =
-            getBlockIndexRange preBlockEvents
-        blockCount = BlockCount $
-            fromIntegral (blockIndexEnd - blockIndexStart)
-    blocks <- genBlocks $ BlockGenParams
-        { _bgpSecrets     = begp ^. begpSecrets
-        , _bgpBlockCount  = blockCount
-        , _bgpTxGenParams = def -- should be better, right?
-        , _bgpInplaceDB   = False
-        }
-    let
-        toZeroBased :: BlockIndex -> Int
-        toZeroBased i =
-            getBlockIndex i - getBlockIndex blockIndexStart
-        getBlock :: BlockIndex -> BlundDefault
-        getBlock i =
-            -- Indexing is safe here because by construction we have enough
-            -- blocks for the lookup to succeed.
-            getOldestFirst blocks !! toZeroBased i
-    return $ fmap getBlock <$> preBlockEvents
-
-data GenBlockEventState
-    = GbesStartingState
-    | GbesBlockchain (OldestFirst NE BlockIndex)
-    | GbesExpectedFailure
-
--- | A version of 'genBlockEvents' that generates event with block indices
--- instead of actual blocks.
-genBlockEvents' ::
-       (Monad m, RandomGen g)
-    => BlockEventGenParams
-    -> RandT g m [BlockEvent' BlockIndex]
-genBlockEvents' begp =
-    flip evalStateT GbesStartingState $ do
-        events <- replicateWhileM
-            (fromIntegral $ begp ^. begpBlockEventCount)
-            (genBlockEvent begp)
-        finalEvent <- get <&> \case
-            GbesStartingState -> []
-            GbesExpectedFailure -> []
-            GbesBlockchain blockchain ->
-                -- Rollback the entire blockchain.
-                [BlkEvRollback $ BlockEventRollback
-                    { _berInput    = toNewestFirst blockchain
-                    , _berOutValid = BlockRollbackSuccess
-                    }]
-        return $ events ++ finalEvent
-
-replicateWhileM :: Monad m => Int -> m (Maybe a) -> m [a]
-replicateWhileM n m = go n
+-- | Whenever the resulting tips of apply/rollback operations coincide,
+-- add a snapshot equivalence comparison.
+enrichWithSnapshotChecking :: BlockScenario -> (BlockScenario, CheckCount)
+enrichWithSnapshotChecking (BlockScenario bs) = (BlockScenario bs', checkCount)
   where
-    go k | k < 1 = return []
-         | otherwise =
-             m >>= \case
-                 Nothing -> return []
-                 Just a  -> (a:) <$> go (k-1)
-
-data RollbackFailureType
-    = RftRollbackExcess
-    | RftRollbackDrop
-    deriving (Enum, Bounded)
-
-instance Random RollbackFailureType where
-    random = randomR (minBound, maxBound)
-    randomR (lo,hi) = runRand $ uniform [lo..hi]
-
-data ApplyFailureType
-    = AftApplyBad
-    | AftApplyNonCont
-    deriving (Enum, Bounded)
-
-instance Random ApplyFailureType where
-    random = randomR (minBound, maxBound)
-    randomR (lo,hi) = runRand $ uniform [lo..hi]
-
-newtype IsFailure = IsFailure Bool
-newtype IsRollback = IsRollback Bool
-
-genBlockEvent ::
-       (Monad m, RandomGen g)
-    => BlockEventGenParams
-    -> StateT GenBlockEventState (RandT g m) (Maybe (BlockEvent' BlockIndex))
-genBlockEvent begp = do
-    gbes <- get
-    failure <- lift $ IsFailure <$> byChance (begp ^. begpFailureChance)
-    rollback <- lift $ IsRollback <$> byChance (begp ^. begpRollbackChance)
-    (mBlockEvent, gbes') <- case gbes of
-        GbesExpectedFailure ->
-            return (Nothing, gbes)
-        GbesStartingState ->
-            genBlockStartingState failure rollback
-        GbesBlockchain blockchain ->
-            genBlockInBlockchain blockchain failure rollback
-    put gbes' $> mBlockEvent
-  where
-    genBlockIndices blockIndexStart = do
-        len <- getRandomR (1, fromIntegral $ begp ^. begpBlockCountMax)
-        -- 'NE.fromList' assumes that 'len >= 1', which holds because we require
-        -- 'begpBlockCountMax >= 1'.
-        return $ OldestFirst . NE.fromList . take len $ [blockIndexStart..]
-
-    -- Fail with rollback. In the starting state it's easy,
-    -- because any rollback will fail when we don't have any
-    -- blocks yet.
-    genBlockStartingState (IsFailure True) (IsRollback True) = do
-        blockIndices <- genBlockIndices 0
-        let
-            ev = BlkEvRollback $ BlockEventRollback
-                { _berInput    = toNewestFirst blockIndices
-                , _berOutValid = BlockRollbackFailure
-                }
-            gbes = GbesExpectedFailure
-        return (Just ev, gbes)
-    -- Fail without rollback (with apply). In the starting state,
-    -- the only way to do this is to generate a sequence of blocks
-    -- invalid by itself.
-    genBlockStartingState (IsFailure True) (IsRollback False) = do
-        blockIndices <- genBlockIndices 1
-        let
-            blkZeroth = BlockIndex 0 :| []
-            blockIndices' =
-                -- Those block indices are broken by construction
-                -- because we append the 0-th block to the end.
-                -- Sometimes we can violate the maximum bound on
-                -- block count, but this is a documented infelicity.
-                -- See NOTE on reordering corner cases.
-                over _OldestFirst (Smg.<> blkZeroth) blockIndices
-            ev =
-                BlkEvApply $ BlockEventApply
-                { _beaInput    = blockIndices'
-                , _beaOutValid = BlockApplyFailure
-                }
-            gbes = GbesExpectedFailure
-        return (Just ev, gbes)
-    -- Succeed with or without rollback. Unfortunately, it's
-    -- impossible to successfully rollback any blocks when
-    -- there are no blocks, so we will generate a block apply
-    -- event in both cases.
-    genBlockStartingState (IsFailure False) (IsRollback _) = do
-        blockIndices <- genBlockIndices 0
-        let
-            ev = BlkEvApply $ BlockEventApply
-                { _beaInput    = blockIndices
-                , _beaOutValid = BlockApplySuccess
-                }
-            gbes = GbesBlockchain blockIndices
-        return (Just ev, gbes)
-
-    -- Fail with rollback.
-    genBlockInBlockchain blockchain (IsFailure True) (IsRollback True) = do
-        rft <- getRandom
-        case rft of
-            RftRollbackExcess -> do
-                -- Attempt to rollback the entire blockchain and then
-                -- some more. Example: suppose we have blockchain [0, 1, 2],
-                -- we may generate rollback [2, 1, 0, -1], rollback of the
-                -- -1-st block will be unsuccessful.
-                let
-                    blockIndices = blockchain & over _OldestFirst
-                        (\(x :| xs) -> x-1 :| x : xs)
-                    ev = BlkEvRollback $ BlockEventRollback
-                        { _berInput    = toNewestFirst blockIndices
-                        , _berOutValid = BlockRollbackFailure
-                        }
-                    gbes = GbesExpectedFailure
-                return (Just ev, gbes)
-            RftRollbackDrop -> do
-                -- Attempt to rollback a part of the blockchain which
-                -- is not its prefix (drop some blocks from the tip).
-                -- The corner case here is that we may have a
-                -- one-element blockchain: then we ensure failure by
-                -- asking to rollback more blocks.
-                case blockchain of
-                    OldestFirst (x :| []) -> do -- oops, the corner case
-                        let
-                            gbes = GbesExpectedFailure
-                            ev = BlkEvRollback $ BlockEventRollback
-                                { _berInput    = NewestFirst $ x :| [x-1]
-                                , _berOutValid = BlockRollbackFailure
-                                }
-                        return (Just ev, gbes)
-                    _ -> do
-                        -- Here we decide how many blocks to rollback.
-                        -- This will yield a valid rollback, so we're
-                        -- going to drop a single block from the tip.
-                        -- Therefore, 'len' should be no less than 2,
-                        -- otherwise we won't have a non-empty list
-                        -- after the drop.
-                        len <- getRandomR (2, length blockchain)
-                        let
-                            -- 'NE.fromList' is valid here because:
-                            --    * the input has more than two elements
-                            --    * 'len >= 2'
-                            select = NE.fromList . drop 1 . NE.take len
-                            blockIndices = toNewestFirst blockchain &
-                                over _NewestFirst select
-                            ev = BlkEvRollback $ BlockEventRollback
-                                { _berInput    = blockIndices
-                                , _berOutValid = BlockRollbackFailure
-                                }
-                            gbes = GbesExpectedFailure
-                        return (Just ev, gbes)
-    -- Fail without rollback (with apply).
-    genBlockInBlockchain blockchain (IsFailure True) (IsRollback False) = do
-        aft <- getRandom
-        case aft of
-            AftApplyBad -> do
-                -- Attempt to apply an invalid sequence of blocks.
-                let tip = NE.last (getOldestFirst blockchain)
-                blockIndices <- genBlockIndices (tip + 1)
-                let
-                    blockIndices' =
-                        -- Those block indices are broken by construction
-                        -- because we append the current tip to the end.
-                        -- Sometimes we can violate the maximum bound on
-                        -- block count, but this is a documented infelicity.
-                        -- See NOTE on reordering corner cases.
-                        over _OldestFirst (Smg.<> pure tip) blockIndices
-                    ev = BlkEvApply $ BlockEventApply
-                        { _beaInput    = blockIndices'
-                        , _beaOutValid = BlockApplyFailure
-                        }
-                    gbes = GbesExpectedFailure
-                return (Just ev, gbes)
-            AftApplyNonCont -> do
-                -- Attempt to apply blocks which are not a valid
-                -- contuniation of our chain.
-                let
-                    tip  = NE.last (getOldestFirst blockchain)
-                    -- The amount of blocks to skip. One is enough.
-                    skip = 1
-                blockIndices <- genBlockIndices (tip + 1 + skip)
-                let
-                    ev = BlkEvApply $ BlockEventApply
-                        { _beaInput    = blockIndices
-                        , _beaOutValid = BlockApplyFailure
-                        }
-                    gbes = GbesExpectedFailure
-                return (Just ev, gbes)
-    -- Success with rollback.
-    genBlockInBlockchain blockchain (IsFailure False) (IsRollback True) = do
-        len <- getRandomR (1, length blockchain)
-        let
-            (blockIndices, remainingBlockchain) = splitAtNewestFirst len $
-                toNewestFirst blockchain
-            -- 'NE.fromList' is valid here because 'len >= 1'.
-            blockIndices' = over _NewestFirst NE.fromList blockIndices
-            remainingBlockchain' = nonEmptyOldestFirst $
-                toOldestFirst remainingBlockchain
-            ev = BlkEvRollback $ BlockEventRollback
-                { _berInput    = blockIndices'
-                , _berOutValid = BlockRollbackSuccess
-                }
-            gbes = maybe GbesStartingState GbesBlockchain remainingBlockchain'
-        return (Just ev, gbes)
-    -- Success without rollback (with apply).
-    genBlockInBlockchain blockchain (IsFailure False) (IsRollback False) = do
-        let tip = NE.last (getOldestFirst blockchain)
-        blockIndices <- genBlockIndices (tip + 1)
-        let
-            ev = BlkEvApply $ BlockEventApply
-                { _beaInput = blockIndices
-                , _beaOutValid = BlockApplySuccess
-                }
-            gbes = GbesBlockchain (blockchain Smg.<> blockIndices)
-        return (Just ev, gbes)
-
-splitAtNewestFirst ::
-    forall a.
-       Int
-    -> NewestFirst NE a
-    -> (NewestFirst [] a, NewestFirst [] a)
-splitAtNewestFirst = coerce (NE.splitAt @a)
-
-nonEmptyOldestFirst ::
-    forall a.
-       OldestFirst [] a
-    -> Maybe (OldestFirst NE a)
-nonEmptyOldestFirst = coerce (nonEmpty @a)
-
-{- NOTE: Reordering corner cases
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When reordering blocks to get an invalid sequence, there's a corner case:
-if there's only one block, it's impossible to get an invalid ordering.
-The reason one might have only one block depends on the means of generation,
-but for 'genBlockIndices' there are two possible causes:
-
-* we rolled 'blockIndexEnd' equal to 'blockIndexStart'
-* 'blockIndexMax' is 1
-
-To avoid dealing with this, we append one more block. The downside is that
-appending this block may cause the sequence to be longer than 'blockIndexMax'.
-
--}
+    checkCount = sum (hhStatusEnd :: HhStatusMap)
+    (hhStatusEnd, revBs') = go Map.empty [] bs
+    bs' = reverse revBs'
+    -- NB. 'go' is tail-recursive.
+    go hhStatusSoFar revNewBs = \case
+        [] -> (hhStatusSoFar, revNewBs)
+        (ev:evs) -> case blkEvTip ev of
+            Nothing -> go hhStatusSoFar (ev:revNewBs) evs
+            Just tipHh -> case Map.lookup tipHh hhStatusSoFar of
+                Nothing ->
+                    let
+                        snapSave = BlkEvSnap (SnapshotSave (hhSnapshotId tipHh))
+                        needSnapSave =
+                            -- We tie the know here to determine whether to actually emit
+                            -- the command to save the snapshot.
+                            Map.findWithDefault 0 tipHh hhStatusEnd > 0
+                        appendSnapSave = if needSnapSave then (snapSave:) else identity
+                    in
+                        go (Map.insert tipHh 0 hhStatusSoFar) (appendSnapSave $ ev:revNewBs) evs
+                Just k ->
+                    let snapEq = BlkEvSnap (SnapshotEq (hhSnapshotId tipHh))
+                    in go (Map.insert tipHh (1+k) hhStatusSoFar) (snapEq:ev:revNewBs) evs

--- a/src/Pos/Generator/BlockEvent/DSL.hs
+++ b/src/Pos/Generator/BlockEvent/DSL.hs
@@ -32,16 +32,15 @@ import           Control.Lens                (at, makeLenses, (%=), (.=))
 import           Control.Monad.Random.Strict (RandT, RandomGen, mapRandT)
 import qualified Data.Map                    as Map
 
-import           Pos.Generator.Block         (AllSecrets)
+import           Pos.Generator.Block         (AllSecrets, MonadBlockGen)
 import           Pos.Generator.BlockEvent    (BlockApplyResult (..), BlockDesc (..),
                                               BlockEvent' (..), BlockEventApply' (..),
                                               BlockEventRollback' (..),
                                               BlockRollbackResult (..), BlockScenario,
                                               BlockScenario' (..), Chance (..),
-                                              CheckCount (..), MonadGenBlockchain, Path,
-                                              PathSegment, SnapshotId,
-                                              SnapshotOperation (..), byChance,
-                                              enrichWithSnapshotChecking,
+                                              CheckCount (..), Path, PathSegment,
+                                              SnapshotId, SnapshotOperation (..),
+                                              byChance, enrichWithSnapshotChecking,
                                               genBlocksInStructure, pathSequence)
 import           Pos.Util.Chrono             (NE, NewestFirst (..), OldestFirst (..),
                                               toOldestFirst, _NewestFirst)
@@ -113,7 +112,7 @@ snapshotEq snapshotId = emitEvent $
     BlkEvSnap (SnapshotEq snapshotId)
 
 runBlockEventGenT ::
-    (RandomGen g, MonadGenBlockchain ctx m) =>
+    (RandomGen g, MonadBlockGen ctx m) =>
     AllSecrets ->
     BlockEventGenT g m () ->
     RandT g m BlockScenario
@@ -122,7 +121,7 @@ runBlockEventGenT secrets m = do
     genBlocksInStructure secrets annotations preBlockScenario
 
 runBlockEventGenT' ::
-    (RandomGen g, MonadGenBlockchain ctx m) =>
+    (RandomGen g, MonadBlockGen ctx m) =>
     BlockEventGenT g m () ->
     RandT g m (Map Path BlockDesc, BlockScenario' Path)
 runBlockEventGenT' m = do

--- a/src/Pos/Generator/BlockEvent/DSL.hs
+++ b/src/Pos/Generator/BlockEvent/DSL.hs
@@ -1,0 +1,140 @@
+module Pos.Generator.BlockEvent.DSL
+       (
+         -- * Core re-exports
+         BlockDesc(..)
+       , PathSegment
+       , Path
+       , pathSequence
+       , BlockApplyResult(..)
+       , BlockRollbackResult(..)
+       , BlockScenario
+       , BlockScenario'
+       , CheckCount(..)
+       , enrichWithSnapshotChecking
+       , Chance(..)
+       , byChance
+         -- * The monad
+       , BlockEventGenT
+       , runBlockEventGenT
+       , runBlockEventGenT'
+         -- * The operations
+       , describeBlock
+       , emitBlockApply
+       , emitBlockRollback
+       , snapshotSave
+       , snapshotLoad
+       , snapshotEq
+       ) where
+
+import           Universum
+
+import           Control.Lens                (at, makeLenses, (%=), (.=))
+import           Control.Monad.Random.Strict (RandT, RandomGen, mapRandT)
+import qualified Data.Map                    as Map
+
+import           Pos.Generator.Block         (AllSecrets)
+import           Pos.Generator.BlockEvent    (BlockApplyResult (..), BlockDesc (..),
+                                              BlockEvent' (..), BlockEventApply' (..),
+                                              BlockEventRollback' (..),
+                                              BlockRollbackResult (..), BlockScenario,
+                                              BlockScenario' (..), Chance (..),
+                                              CheckCount (..), MonadGenBlockchain, Path,
+                                              PathSegment, SnapshotId,
+                                              SnapshotOperation (..), byChance,
+                                              enrichWithSnapshotChecking,
+                                              genBlocksInStructure, pathSequence)
+import           Pos.Util.Chrono             (NE, NewestFirst (..), OldestFirst (..),
+                                              toOldestFirst, _NewestFirst)
+
+data BlockEventGenState = BlockEventGenState
+    { _begsEvents      :: !(NewestFirst [] (BlockEvent' Path))
+    , _begsAnnotations :: !(Map Path BlockDesc)
+    } deriving ()
+
+makeLenses 'BlockEventGenState
+
+type BlockEventGenT g m = RandT g (StateT BlockEventGenState m)
+
+describeBlock ::
+       MonadState BlockEventGenState m
+    => Path -- ^ path to the block in the blockchain tree
+    -> BlockDesc -- ^ block description
+    -> m ()
+describeBlock path blockDesc =
+    begsAnnotations . at path .= Just blockDesc
+
+emitEvent ::
+       MonadState BlockEventGenState m
+    => BlockEvent' Path
+    -> m ()
+emitEvent ev = begsEvents . _NewestFirst %= (ev:)
+
+emitBlockApply ::
+       MonadState BlockEventGenState m
+    => BlockApplyResult -- ^ expected result
+    -> OldestFirst NE Path -- ^ blocks to apply
+    -> m ()
+emitBlockApply res blocks = emitEvent $
+    BlkEvApply BlockEventApply
+        { _beaInput = blocks
+        , _beaOutValid = res
+        }
+
+emitBlockRollback ::
+       MonadState BlockEventGenState m
+    => BlockRollbackResult -- ^ expected result
+    -> NewestFirst NE Path -- ^ blocks to rollback
+    -> m ()
+emitBlockRollback res blocks = emitEvent $
+    BlkEvRollback BlockEventRollback
+        { _berInput = blocks
+        , _berOutValid = res
+        }
+
+snapshotSave ::
+       MonadState BlockEventGenState m
+    => SnapshotId
+    -> m ()
+snapshotSave snapshotId = emitEvent $
+    BlkEvSnap (SnapshotSave snapshotId)
+
+snapshotLoad ::
+       MonadState BlockEventGenState m
+    => SnapshotId
+    -> m ()
+snapshotLoad snapshotId = emitEvent $
+    BlkEvSnap (SnapshotLoad snapshotId)
+
+snapshotEq ::
+       MonadState BlockEventGenState m
+    => SnapshotId
+    -> m ()
+snapshotEq snapshotId = emitEvent $
+    BlkEvSnap (SnapshotEq snapshotId)
+
+runBlockEventGenT ::
+    (RandomGen g, MonadGenBlockchain ctx m) =>
+    AllSecrets ->
+    BlockEventGenT g m () ->
+    RandT g m BlockScenario
+runBlockEventGenT secrets m = do
+    (annotations, preBlockScenario) <- runBlockEventGenT' m
+    genBlocksInStructure secrets annotations preBlockScenario
+
+runBlockEventGenT' ::
+    (RandomGen g, MonadGenBlockchain ctx m) =>
+    BlockEventGenT g m () ->
+    RandT g m (Map Path BlockDesc, BlockScenario' Path)
+runBlockEventGenT' m = do
+    let
+        initialBlockEventGenState = BlockEventGenState
+            { _begsEvents = NewestFirst []
+            , _begsAnnotations = Map.empty
+            }
+    begs <-
+        let reorder (((), g), begs) = (begs, g)
+        in mapRandT (fmap reorder . flip runStateT initialBlockEventGenState) m
+    let
+        OldestFirst preBlockEvents = toOldestFirst (begs ^. begsEvents)
+        annotations = begs ^. begsAnnotations
+    return (annotations, BlockScenario preBlockEvents)

--- a/test/Test/Pos/Block/Logic/Event.hs
+++ b/test/Test/Pos/Block/Logic/Event.hs
@@ -1,36 +1,57 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module Test.Pos.Block.Logic.Event
-    ( runBlockEvent
-    , runBlockScenario
-    , BlockScenarioResult(..)
-    ) where
+       (
+       -- * Running events and scenarios
+         runBlockEvent
+       , runBlockScenario
+       , BlockScenarioResult(..)
+
+       -- * Exceptions
+       , SnapshotMissingEx(..)
+       , DbNotEquivalentToSnapshot(..)
+       ) where
 
 import           Universum
 
 import           Control.Lens              (_Right)
 import           Control.Monad.Catch       (catch)
 import qualified Data.List.NonEmpty        as NE
+import qualified Data.Map                  as Map
 
 import           Pos.Block.Logic.VAR       (BlockLrcMode, rollbackBlocks,
                                             verifyAndApplyBlocks)
 import           Pos.Block.Types           (Blund)
 import           Pos.Core                  (HeaderHash, getEpochOrSlot, unEpochOrSlot)
 import           Pos.DB.Pure               (DBPureDiff, MonadPureDB, dbPureDiff,
-                                            dbPureDump)
-import           Pos.Generator.BlockEvent  (BlockEvent, BlockEvent' (..),
-                                            IsBlockEventFailure (..), beaInput, berInput)
+                                            dbPureDump, dbPureReset)
+import           Pos.Generator.BlockEvent  (BlockEvent, BlockEvent' (..), BlockScenario,
+                                            BlockScenario' (..), IsBlockEventFailure (..),
+                                            SnapshotId, SnapshotOperation (..), beaInput,
+                                            berInput)
 import           Pos.Ssc.GodTossing.Type   (SscGodTossing)
 import           Pos.Util.Chrono           (NE, OldestFirst, getOldestFirst)
-import           Pos.Util.Util             (eitherToThrow)
-import           Test.Pos.Block.Logic.Mode (BlockTestContext)
+import           Pos.Util.Util             (eitherToThrow, lensOf)
+import           Test.Pos.Block.Logic.Mode (BlockTestContext, PureDBSnapshotsVar (..))
 import           Test.Pos.Block.Logic.Util (withCurrentSlot)
+
+data SnapshotMissingEx = SnapshotMissingEx SnapshotId
+    deriving (Show)
+
+instance Exception SnapshotMissingEx
+
+data DbNotEquivalentToSnapshot = DbNotEquivalentToSnapshot SnapshotId DBPureDiff
+    deriving (Show)
+
+instance Exception DbNotEquivalentToSnapshot
 
 newtype IsExpected = IsExpected Bool
 
 data BlockEventResult
     = BlockEventSuccess
     | BlockEventFailure IsExpected SomeException
+    | BlockEventDbChanged DbNotEquivalentToSnapshot
 
 mkBlockEventFailure ::
        IsBlockEventFailure ev
@@ -41,7 +62,7 @@ mkBlockEventFailure ev =
     BlockEventFailure (IsExpected (isBlockEventFailure ev))
 
 verifyAndApplyBlocks' ::
-       (BlockLrcMode SscGodTossing ctx m, MonadReader BlockTestContext m)
+       BlockLrcMode SscGodTossing BlockTestContext m
     => OldestFirst NE (Blund SscGodTossing)
     -> m ()
 verifyAndApplyBlocks' bs = do
@@ -53,7 +74,7 @@ verifyAndApplyBlocks' bs = do
 
 -- | Execute a single block event.
 runBlockEvent ::
-       (BlockLrcMode SscGodTossing ctx m, MonadReader BlockTestContext m)
+       BlockLrcMode SscGodTossing BlockTestContext m
     => BlockEvent
     -> m BlockEventResult
 runBlockEvent (BlkEvApply ev) =
@@ -62,32 +83,54 @@ runBlockEvent (BlkEvApply ev) =
 runBlockEvent (BlkEvRollback ev) =
    (BlockEventSuccess <$ rollbackBlocks (ev ^. berInput))
       `catch` (return . mkBlockEventFailure ev)
+runBlockEvent (BlkEvSnap ev) =
+   (BlockEventSuccess <$ runSnapshotOperation ev)
+      `catch` (return . BlockEventDbChanged)
+
+-- | Execute a snapshot operation.
+runSnapshotOperation ::
+       MonadPureDB BlockTestContext m
+    => SnapshotOperation
+    -> m ()
+runSnapshotOperation snapOp = do
+    PureDBSnapshotsVar snapsRef <- view (lensOf @PureDBSnapshotsVar)
+    case snapOp of
+        SnapshotSave snapId -> do
+            currentDbState <- dbPureDump
+            modifyIORef snapsRef $ Map.insert snapId currentDbState
+        SnapshotLoad snapId -> do
+            snap <- getSnap snapsRef snapId
+            dbPureReset snap
+        SnapshotEq snapId -> do
+            currentDbState <- dbPureDump
+            snap <- getSnap snapsRef snapId
+            whenJust (dbPureDiff snap currentDbState) $ \dbDiff ->
+                throwM $ DbNotEquivalentToSnapshot snapId dbDiff
+  where
+    getSnap snapsRef snapId = do
+        mSnap <- Map.lookup snapId <$> readIORef snapsRef
+        maybe (throwM $ SnapshotMissingEx snapId) return mSnap
 
 data BlockScenarioResult
     = BlockScenarioFinishedOk
     | BlockScenarioUnexpectedFailure SomeException
-    | BlockScenarioDbChanged DBPureDiff
+    | BlockScenarioDbChanged DbNotEquivalentToSnapshot
 
 -- | Execute a block scenario: a sequence of block events that either ends with
 -- an expected failure or with a rollback to the initial state.
 runBlockScenario ::
-       (BlockLrcMode SscGodTossing ctx m, MonadPureDB ctx m, MonadReader BlockTestContext m)
-    => [BlockEvent]
+       (BlockLrcMode SscGodTossing ctx m, MonadPureDB ctx m, ctx ~ BlockTestContext)
+    => BlockScenario
     -> m BlockScenarioResult
-runBlockScenario events = do
-    dbBeforeEvents <- dbPureDump
-    let
-        runBlockScenario' [] = do
-            dbAfterEvents <- dbPureDump
-            return $ case dbPureDiff dbBeforeEvents dbAfterEvents of
-                Nothing     -> BlockScenarioFinishedOk
-                Just dbDiff -> BlockScenarioDbChanged dbDiff
-        runBlockScenario' (ev:evs) = do
-            evRes <- runBlockEvent ev
-            case evRes of
-                BlockEventSuccess -> runBlockScenario' evs
-                BlockEventFailure (IsExpected isExp) e ->
-                    return $ if isExp
-                        then BlockScenarioFinishedOk
-                        else BlockScenarioUnexpectedFailure e
-    runBlockScenario' events
+runBlockScenario (BlockScenario []) =
+    return BlockScenarioFinishedOk
+runBlockScenario (BlockScenario (ev:evs)) = do
+    runBlockEvent ev >>= \case
+        BlockEventSuccess ->
+            runBlockScenario (BlockScenario evs)
+        BlockEventFailure (IsExpected isExp) e ->
+            return $ if isExp
+                then BlockScenarioFinishedOk
+                else BlockScenarioUnexpectedFailure e
+        BlockEventDbChanged d ->
+            return $ BlockScenarioDbChanged d

--- a/test/Test/Pos/Block/Logic/Mode.hs
+++ b/test/Test/Pos/Block/Logic/Mode.hs
@@ -11,6 +11,7 @@ module Test.Pos.Block.Logic.Mode
        , HasTestParams (..)
        , TestInitModeContext (..)
        , BlockTestContextTag
+       , PureDBSnapshotsVar(..)
        , BlockTestContext(..)
        , btcSlotId_L
        , BlockTestMode
@@ -23,6 +24,7 @@ module Test.Pos.Block.Logic.Mode
 import           Universum
 
 import           Control.Lens                   (lens, makeClassy, makeLensesWith)
+import qualified Data.Map                       as Map
 import qualified Data.Text.Buildable
 import           Data.Time.Units                (Microsecond, TimeUnit (..))
 import           Ether.Internal                 (HasLens (..))
@@ -45,7 +47,7 @@ import           Pos.Core                       (IsHeader, SlotId, StakeDistribu
                                                  Timestamp (..), makePubKeyAddress,
                                                  mkCoin, unsafeGetCoin)
 import           Pos.Crypto                     (SecretKey, toPublic)
-import           Pos.DB                         (MonadBlockDBGeneric (..),
+import           Pos.DB                         (DBPure, MonadBlockDBGeneric (..),
                                                  MonadBlockDBGenericWrite (..),
                                                  MonadDB (..), MonadDBRead (..),
                                                  MonadGState (..))
@@ -56,6 +58,7 @@ import           Pos.DB.Pure                    (DBPureVar, newDBPureVar)
 import           Pos.Delegation                 (DelegationVar, mkDelegationVar)
 import           Pos.Generator.Block            (AllSecrets (..), HasAllSecrets (..),
                                                  mkInvSecretsMap)
+import           Pos.Generator.BlockEvent       (SnapshotId)
 import           Pos.Genesis                    (genesisUtxo)
 import qualified Pos.GState                     as GS
 import           Pos.KnownPeers                 (MonadFormatPeers (..))
@@ -191,6 +194,10 @@ runTestInitMode ctx = runProduction . flip runReaderT ctx
 -- Main context
 ----------------------------------------------------------------------------
 
+newtype PureDBSnapshotsVar = PureDBSnapshotsVar
+    { getPureDBSnapshotsVar :: IORef (Map SnapshotId DBPure)
+    }
+
 data BlockTestContext = BlockTestContext
     { btcGState            :: !GS.GStateContext
     , btcSystemStart       :: !Timestamp
@@ -206,6 +213,7 @@ data BlockTestContext = BlockTestContext
     , btcParams            :: !TestParams
     , btcReportingContext  :: !ReportingContext
     , btcDelegation        :: !DelegationVar
+    , btcPureDBSnapshots   :: !PureDBSnapshotsVar
     }
 
 makeLensesWith postfixLFields ''BlockTestContext
@@ -254,6 +262,7 @@ initBlockTestContext tp@TestParams {..} callback = do
             let btcParams = tp
             let btcGState = GS.GStateContext {_gscDB = DB.PureDB dbPureVar, ..}
             btcDelegation <- mkDelegationVar @SscGodTossing
+            btcPureDBSnapshots <- PureDBSnapshotsVar <$> newIORef Map.empty
             let btCtx = BlockTestContext {btcSystemStart = systemStart, ..}
             liftIO $ flip runReaderT clockVar $ unEmulation $ callback btCtx
     sudoLiftIO $ runTestInitMode @SscGodTossing initCtx $ initBlockTestContextDo
@@ -369,6 +378,9 @@ instance HasLens DBPureVar BlockTestContext DBPureVar where
         setter _ pdb = DB.PureDB pdb
         pureDBLens = lens getter setter
         realDBInTestsError = error "You are using real db in tests"
+
+instance HasLens PureDBSnapshotsVar BlockTestContext PureDBSnapshotsVar where
+    lensOf = btcPureDBSnapshots_L
 
 instance HasLens LoggerName BlockTestContext LoggerName where
       lensOf = btcLoggerName_L

--- a/test/Test/Pos/Block/Logic/VarSpec.hs
+++ b/test/Test/Pos/Block/Logic/VarSpec.hs
@@ -1,37 +1,53 @@
+{-# LANGUAGE OverloadedLists     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Specification of 'Pos.Block.Logic.VAR'.
 
 module Test.Pos.Block.Logic.VarSpec
        ( spec
        ) where
 
-import           Universum
+import           Universum                    hiding ((<>))
 
-import           Control.Monad.Random.Strict (evalRandT)
-import           Data.List                   (span)
-import           Data.List.NonEmpty          (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty          as NE
-import           Test.Hspec                  (Spec, describe)
-import           Test.Hspec.QuickCheck       (modifyMaxSuccess, prop)
-import           Test.QuickCheck.Gen         (Gen (MkGen))
-import           Test.QuickCheck.Monadic     (assert, pick, pre)
+import           Control.Monad.Random.Strict  (MonadRandom (..), RandomGen, evalRandT,
+                                               uniform)
+import           Data.List                    (span)
+import           Data.List.NonEmpty           (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty           as NE
+import qualified Data.Ratio                   as Ratio
+import           Data.Semigroup               ((<>))
+import           Test.Hspec                   (Spec, describe)
+import           Test.Hspec.QuickCheck        (modifyMaxSuccess, prop)
+import           Test.QuickCheck.Gen          (Gen (MkGen))
+import           Test.QuickCheck.Monadic      (assert, pick, pre)
+import           Test.QuickCheck.Random       (QCGen)
 
-import           Pos.Block.Logic             (verifyAndApplyBlocks, verifyBlocksPrefix)
-import           Pos.Block.Types             (Blund)
-import           Pos.Core                    (blkSecurityParam)
-import           Pos.DB.Pure                 (dbPureDump)
-import           Pos.Generator.BlockEvent    (BlockEventCount (..),
-                                              BlockEventGenParams (..), genBlockEvents)
-import qualified Pos.GState                  as GS
-import           Pos.Ssc.GodTossing          (SscGodTossing)
-import           Pos.Util.Chrono             (NE, OldestFirst (..))
+import           Pos.Block.Logic              (verifyAndApplyBlocks, verifyBlocksPrefix)
+import           Pos.Block.Types              (Blund)
+import           Pos.Core                     (blkSecurityParam, headerHash)
+import           Pos.DB.Pure                  (dbPureDump)
+import           Pos.Generator.BlockEvent.DSL (BlockApplyResult (..), BlockEventGenT,
+                                               BlockRollbackResult (..), BlockScenario,
+                                               Path, byChance, emitBlockApply,
+                                               emitBlockRollback,
+                                               enrichWithSnapshotChecking, pathSequence,
+                                               runBlockEventGenT)
+import qualified Pos.GState                   as GS
+import           Pos.Ssc.GodTossing           (SscGodTossing)
+import           Pos.Util.Chrono              (NE, NewestFirst (..), OldestFirst (..),
+                                               nonEmptyNewestFirst, nonEmptyOldestFirst,
+                                               splitAtNewestFirst, toNewestFirst,
+                                               _NewestFirst)
 
-import           Test.Pos.Block.Logic.Event  (BlockScenarioResult (..), runBlockScenario)
-import           Test.Pos.Block.Logic.Mode   (BlockProperty, BlockTestMode)
-import           Test.Pos.Block.Logic.Util   (EnableTxPayload (..), InplaceDB (..),
-                                              bpGenBlock, bpGenBlocks,
-                                              bpGoToArbitraryState, getAllSecrets,
-                                              satisfySlotCheck)
-import           Test.Pos.Util               (splitIntoChunks, stopProperty)
+import           Test.Pos.Block.Logic.Event   (BlockScenarioResult (..),
+                                               DbNotEquivalentToSnapshot (..),
+                                               runBlockScenario)
+import           Test.Pos.Block.Logic.Mode    (BlockProperty, BlockTestMode)
+import           Test.Pos.Block.Logic.Util    (EnableTxPayload (..), InplaceDB (..),
+                                               bpGenBlock, bpGenBlocks,
+                                               bpGoToArbitraryState, getAllSecrets,
+                                               satisfySlotCheck)
+import           Test.Pos.Util                (splitIntoChunks, stopProperty)
 
 spec :: Spec
 -- Unfortunatelly, blocks generation is quite slow nowdays.
@@ -168,22 +184,92 @@ blockEventSuccessSpec = do
         "a sequence of interleaved block applications and rollbacks " <>
         "results in the original state of the blockchain"
 
+{- | This generator is carefully designed to cover multitude of success
+   scenarios. Apply/rollback are interleaved in various ways, shown by diagrams below:
+
+   0 -----a----> 2
+   |             |        Synchronous apply/rollback
+   0 <----r----- 2
+
+   0 -a-> 1 -a-> 2
+   |             |        Multiple apply per rollback
+   0 <----r----- 2
+
+   0 -----a----> 2
+   |             |        Multiple rollback per apply
+   0 <-r- 1 <-r- 2
+
+   0 -a-> 3 -a-> 6 -a-> 9
+   |                    |        Desynchronous apply/rollback
+   0 <--r--- 4 <---r--- 9
+
+   Furthermore, it allows nested forks (forks of forks), generates both unique
+   and repeated forks, respects the 'blkSecurityParam', and can be used with
+   'enrichWithSnapshotChecking'. (I would draw diagrams for these features as
+   well, but they're barely readable in the ASCII format). Just trust me that
+   this generator gives diverse block event sequences -- I spent an entire night
+   and a few sheets of paper trying to figure out how to write it.
+-}
+
+genSuccessWithForks :: forall g m. (RandomGen g, Monad m) => BlockEventGenT g m ()
+genSuccessWithForks = do
+      emitBlockApply BlockApplySuccess $ pathSequence mempty ["0"]
+      generateFork "0" []
+      emitBlockApply BlockApplySuccess $ pathSequence "0" ["1", "2"]
+      generateFork ("0" <> "1" <> "2") []
+  where
+    generateFork ::
+           Path -- base path (from the main chain)
+        -> NewestFirst [] Path -- current fork state
+        -> BlockEventGenT g m ()
+    generateFork basePath rollbackFork = do
+        let
+            forkLen    = length rollbackFork
+            wiggleRoom = fromIntegral blkSecurityParam - forkLen
+        stopFork <- byChance (if forkLen > 0 then 0.1 else 0)
+        if stopFork
+            then whenJust (nonEmptyNewestFirst rollbackFork) $
+                 emitBlockRollback BlockRollbackSuccess
+            else do
+                needRollback <-
+                    -- forkLen=0                => needRollback 0%
+                    -- forkLen=blkSecurityParam => needRollback 100%
+                    byChance (realToFrac $ forkLen Ratio.% fromIntegral blkSecurityParam)
+                if needRollback
+                    then do
+                        retreat <- getRandomR (1, forkLen)
+                        whenJust (nonEmptyNewestFirst rollbackFork) $ \rollbackFork' -> do
+                            -- forkLen > 0, therefore retreat > 0
+                            let (over _NewestFirst NE.fromList -> before, after) = splitAtNewestFirst retreat rollbackFork'
+                            emitBlockRollback BlockRollbackSuccess before
+                            generateFork basePath after
+                    else do
+                        advance <- getRandomR (1, wiggleRoom)
+                        relPaths <- OldestFirst <$> replicateM advance generateRelativePath1
+                        whenJust (nonEmptyOldestFirst relPaths) $ \relPaths' -> do
+                            let
+                                curPath = maybe basePath NE.head $ nonEmpty (getNewestFirst rollbackFork)
+                                paths = pathSequence curPath relPaths'
+                            emitBlockApply BlockApplySuccess paths
+                            generateFork basePath (over _NewestFirst toList (toNewestFirst paths) <> rollbackFork)
+    generateRelativePath1 :: BlockEventGenT g m Path
+    generateRelativePath1 =
+        uniform (["rekt", "kek", "mems", "peka"] :: NE Path)
+
+blockPropertyScenarioGen :: BlockEventGenT QCGen BlockTestMode () -> BlockProperty BlockScenario
+blockPropertyScenarioGen m = do
+    allSecrets <- getAllSecrets
+    g <- pick $ MkGen $ \qc _ -> qc
+    lift $ flip evalRandT g $ runBlockEventGenT allSecrets m
+
 blockEventSuccessProp :: BlockProperty ()
 blockEventSuccessProp = do
-    allSecrets <- getAllSecrets
-    let
-        eventCount = min (BlockEventCount 10) (fromIntegral blkSecurityParam)
-        blockEventGenParams = BlockEventGenParams
-            { _begpSecrets = allSecrets
-            , _begpBlockCountMax =
-                  blkSecurityParam `div` fromIntegral eventCount
-            , _begpBlockEventCount = eventCount
-            , _begpRollbackChance = 0.4
-            , _begpFailureChance = 0
-            }
-    g <- pick $ MkGen $ \qc _ -> qc
-    scenario <- lift $ evalRandT (genBlockEvents blockEventGenParams) g
-    verifyBlockScenarioResult =<< lift (runBlockScenario scenario)
+    scenario <- blockPropertyScenarioGen $ genSuccessWithForks
+    let (scenario', checkCount) = enrichWithSnapshotChecking scenario
+    when (checkCount <= 0) $ stopProperty $
+        "No checks were generated, this is a bug in the test suite: " <>
+        pretty (fmap (headerHash . fst) scenario')
+    verifyBlockScenarioResult =<< lift (runBlockScenario scenario')
 
 verifyBlockScenarioResult :: BlockScenarioResult -> BlockProperty ()
 verifyBlockScenarioResult = \case
@@ -191,6 +277,9 @@ verifyBlockScenarioResult = \case
     BlockScenarioUnexpectedFailure e -> stopProperty $
         "Block scenario unexpected failure: " <>
         pretty e
-    BlockScenarioDbChanged dbDiff -> stopProperty $
-        "Block scenario resulted in a change to the blockchain:\n" <>
-        show dbDiff
+    BlockScenarioDbChanged d ->
+        let DbNotEquivalentToSnapshot snapId dbDiff = d in
+        stopProperty $
+            "Block scenario resulted in a change to the blockchain" <>
+            " relative to the " <> show snapId <> " snapshot:\n" <>
+            show dbDiff


### PR DESCRIPTION
This PR introduces the tree-based block event generator and a DSL for using it, making it possible to model forks.

Features include:

* Snapshot management (manual and semi-automatic)
* Building the blockchain tree from paths
* Generator of diverse apply/rollback sequences with forks
* Pretty-printing block event sequences with paths or block hashes
* Reasonably efficient implementation that takes advantage of laziness
* <s>Superb path naming scheme: `kek/rekt/mems`.</s>