### PR TITLE
[CSL-1447] Restore CRC for Address serialisation

### DIFF
--- a/core/Pos/Binary/Core/Address.hs
+++ b/core/Pos/Binary/Core/Address.hs
@@ -3,6 +3,8 @@ module Pos.Binary.Core.Address () where
 
 import           Universum
 
+import           Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Write    as CBOR.Write
 import           Data.Default        (def)
 import           Data.Digest.CRC32   (CRC32 (..))
 import           Data.Word           (Word8)
@@ -44,7 +46,7 @@ addresses and save a byte).
 -}
 
 instance CRC32 Address where
-    crc32Update seed = crc32Update seed . serialize'
+    crc32Update seed = crc32Update seed . CBOR.Write.toLazyByteString . encodeAddr
 
 ----------------------------------------
 
@@ -54,29 +56,34 @@ instance Bi (Attributes AddrPkAttrs) where
         0 -> Just $ acc { addrPkDerivationPath = deserialize' v }
         _ -> Nothing
 
-instance Bi Address where
-    encode addr =
-        encodeListLen 3 <> encode (crc32 addr) <> encodeAddr
-      where
-        encodeAddr = case addr of
-            PubKeyAddress keyHash attrs ->
-                   encode (0 :: Word8)
-                <> encode (serialize' (keyHash, attrs))
-            ScriptAddress scrHash ->
-                   encode (1 :: Word8)
-                <> encode (serialize' scrHash)
-            RedeemAddress keyHash ->
-                   encode (2 :: Word8)
-                <> encode (serialize' keyHash)
-            UnknownAddressType t bs ->
-                   encode t
-                <> encode bs
 
+-- | Encodes the `Address` _without_ the CRC32.
+-- It's important to keep this function separated from the `encode`
+-- definition to avoid that `encode` would call `crc32` and
+-- the latter invoke `crc32Update`, which would then try to call `encode`
+-- indirectly once again, in an infinite loop.
+encodeAddr :: Address -> Encoding
+encodeAddr addr = case addr of
+    PubKeyAddress keyHash attrs ->
+           encode (0 :: Word8)
+        <> encode (serialize' (keyHash, attrs))
+    ScriptAddress scrHash ->
+           encode (1 :: Word8)
+        <> encode (serialize' scrHash)
+    RedeemAddress keyHash ->
+           encode (2 :: Word8)
+        <> encode (serialize' keyHash)
+    UnknownAddressType t bs ->
+           encode t
+        <> encode bs
+
+instance Bi Address where
+    encode addr = encodeListLen 3 <> encodeAddr addr <> encode (crc32 addr)
     decode = do
         enforceSize "Address" 3
         t           <- decode @Word8
-        expectedCRC <- decode @Word32
         bs          <- decode @ByteString
+        expectedCRC <- decode @Word32
         let address = case t of
                           0 -> uncurry PubKeyAddress $ deserialize' bs
                           1 -> ScriptAddress         $ deserialize' bs


### PR DESCRIPTION
This PR fixes [CSL-1447](https://issues.serokell.io/issue/CSL-1447) by restoring the CRC check inside the `decode` function in the `Bi Address` instance.

The only thing I had to watch out was to avoid the infinite loop which I've explained in the comment. I learnt the hard way why the pilgrim fathers of Cardano originally separated the `Address` encoding in the [previous serialisation revision](https://github.com/input-output-hk/cardano-sl/blob/1a345036d95647aa7ea00d182013ee822995e577/core/Pos/Binary/Core/Address.hs#L48) 😂  😂   