### PR TITLE
[CSM-319] Remove searches both by id and passphrase in sk storage

### DIFF
--- a/src/Pos/Wallet/Web/Account.hs
+++ b/src/Pos/Wallet/Web/Account.hs
@@ -3,8 +3,7 @@
 module Pos.Wallet.Web.Account
        ( myRootAddresses
        , getAddrIdx
-       , getSKByAddr
-       , getSKByAccAddr
+       , getSKById
        , genSaveRootKey
        , genUniqueAccountId
        , genUniqueAccountAddress
@@ -29,7 +28,7 @@ import           Pos.Util                   (maybeThrow)
 import           Pos.Util.BackupPhrase      (BackupPhrase, safeKeysFromPhrase)
 import           Pos.Wallet.KeyStorage      (MonadKeys, addSecretKey, getSecretKeys)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
-                                             addrMetaToAccount, addressToCId, encToCId)
+                                             addressToCId, encToCId)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), WebWalletModeDB,
                                              doesWAddressExist, getAccountMeta)
@@ -47,33 +46,17 @@ myRootAddresses = encToCId <<$>> getSecretKeys
 getAddrIdx :: AccountMode ctx m => CId Wal -> m Int
 getAddrIdx addr = elemIndex addr <$> myRootAddresses >>= maybeThrow notFound
   where notFound =
-          RequestError $ sformat ("No wallet set with address "%build%" found") addr
+          RequestError $ sformat ("No wallet with address "%build%" found") addr
 
-getSKByAddr
+getSKById
     :: AccountMode ctx m
     => CId Wal
     -> m EncryptedSecretKey
-getSKByAddr addr = do
-    msk <- find (\k -> encToCId k == addr) <$> getSecretKeys
+getSKById wid = do
+    msk <- find (\k -> encToCId k == wid) <$> getSecretKeys
     maybeThrow notFound msk
   where notFound =
-          RequestError $ sformat ("No wallet set with address "%build%" found") addr
-
-getSKByAccAddr
-    :: AccountMode ctx m
-    => PassPhrase
-    -> CWAddressMeta
-    -> m EncryptedSecretKey
-getSKByAccAddr passphrase addrMeta@CWAddressMeta {..} = do
-    (addr, accKey) <-
-        deriveAccountSK passphrase (addrMetaToAccount addrMeta) cwamAccountIndex
-    let accCAddr = addressToCId addr
-    if accCAddr /= cwamId
-             -- if you see this error, maybe you generated public key address with
-             -- no hd wallet attribute (if so, address would be ~half shorter than
-             -- others)
-        then throwM . InternalError $ "Account is contradictory!"
-        else return accKey
+          RequestError $ sformat ("No wallet with address "%build%" found") wid
 
 genSaveRootKey
     :: AccountMode ctx m
@@ -155,14 +138,10 @@ deriveAccountSK
     -> Word32
     -> m (Address, EncryptedSecretKey)
 deriveAccountSK passphrase AccountId{..} accIndex = do
-    -- this function is used in conditions when several secret keys with same
-    -- public key are stored, thus checking for passphrase here as well
-    let niceSK k = encToCId k == aiWId
-    key <- maybeThrow noKey . find niceSK =<< getSecretKeys
+    key <- getSKById aiWId
     maybeThrow badPass $
         deriveLvl2KeyPair passphrase key aiIndex accIndex
   where
-    noKey   = RequestError "No secret key with such address found"
     badPass = RequestError "Passphrase doesn't match"
 
 deriveAccountAddress
@@ -178,12 +157,12 @@ deriveAccountAddress passphrase accId@AccountId{..} cwamAccountIndex = do
         cwamId          = addressToCId addr
     return CWAddressMeta{..}
 
--- | Allows to find a key related ti given @id@ item.
+-- | Allows to find a key related to given @id@ item.
 class MonadKeySearch id m where
     findKey :: id -> m EncryptedSecretKey
 
 instance AccountMode ctx m => MonadKeySearch (CId Wal) m where
-    findKey = getSKByAddr
+    findKey = getSKById
 
 instance AccountMode ctx m => MonadKeySearch AccountId m where
     findKey = findKey . aiWId

--- a/src/Pos/Wallet/Web/BListener.hs
+++ b/src/Pos/Wallet/Web/BListener.hs
@@ -31,7 +31,7 @@ import           Pos.Ssc.Class.Helpers      (SscHelpersClass)
 import           Pos.Txp.Core               (TxAux (..), TxUndo, flattenTxPayload)
 import           Pos.Util.Chrono            (NE, NewestFirst (..), OldestFirst (..))
 
-import           Pos.Wallet.Web.Account     (AccountMode, getSKByAddr)
+import           Pos.Wallet.Web.Account     (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes (CId, Wal)
 import qualified Pos.Wallet.Web.State       as WS
 import           Pos.Wallet.Web.Tracking    (CAccModifier (..), applyModifierToWallet,
@@ -92,7 +92,7 @@ onApplyTracking blunds = do
             blkHeaderTs = either (const Nothing) mainBlkHeaderTs
 
         allAddresses <- getWalletAddrMetasDB WS.Ever wAddr
-        encSK <- getSKByAddr wAddr
+        encSK <- getSKById wAddr
         let mapModifier =
                 trackingApplyTxs encSK allAddresses gbDiff blkHeaderTs blkTxsWUndo
         applyModifierToWallet wAddr (headerHash newTipH) mapModifier
@@ -130,7 +130,7 @@ onRollbackTracking blunds = do
     syncWallet :: HeaderHash -> HeaderHash -> [(TxAux, TxUndo)] -> CId Wal -> m ()
     syncWallet curTip newTip txs wid = walletGuard curTip wid $ do
         allAddresses <- getWalletAddrMetasDB WS.Ever wid
-        encSK <- getSKByAddr wid
+        encSK <- getSKById wid
         let mapModifier = trackingRollbackTxs encSK allAddresses $
                           map (\(aux, undo) -> (aux, undo, newTip)) txs
         rollbackModifierFromWallet wid newTip mapModifier

--- a/src/Pos/Wallet/Web/Backup.hs
+++ b/src/Pos/Wallet/Web/Backup.hs
@@ -14,7 +14,7 @@ import qualified Data.HashMap.Strict        as HM
 
 import           Pos.Crypto                 (EncryptedSecretKey)
 import           Pos.Util.Util              (maybeThrow)
-import           Pos.Wallet.Web.Account     (AccountMode, getSKByAddr)
+import           Pos.Wallet.Web.Account     (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountMeta (..), CId,
                                              CWalletMeta (..), Wal)
 import           Pos.Wallet.Web.Error       (WalletError (..))
@@ -40,7 +40,7 @@ data StateBackup = FullStateBackup [WalletBackup]
 
 getWalletBackup :: AccountMode ctx m => CId Wal -> m WalletBackup
 getWalletBackup wId = do
-    sk <- getSKByAddr wId
+    sk <- getSKById wId
     meta <- maybeThrow (InternalError "Wallet have no meta") =<<
             getWalletMeta wId
     accountIds <- getWalletAccountIds wId

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -113,8 +113,7 @@ import           Pos.Wallet.Web.Account           (AddrGenSeed, GenSeed (..),
                                                    MonadKeySearch (..), genSaveRootKey,
                                                    genUniqueAccountAddress,
                                                    genUniqueAccountId, getAddrIdx,
-                                                   getSKByAccAddr, getSKByAddr,
-                                                   myRootAddresses)
+                                                   getSKById, myRootAddresses)
 import           Pos.Wallet.Web.Api               (WalletApi, walletApi)
 import           Pos.Wallet.Web.Backup            (AccountMetaBackup (..),
                                                    StateBackup (..), WalletBackup (..),
@@ -226,7 +225,7 @@ walletServer
     -> m (m :~> Handler)
     -> m (Server WalletApi)
 walletServer sendActions nat = do
-    syncWalletsWithGState @WalletSscType =<< mapM getSKByAddr =<< myRootAddresses
+    syncWalletsWithGState @WalletSscType =<< mapM getSKById =<< myRootAddresses
     nat >>= launchNotifier
     (`enter` servantHandlers sendActions) <$> nat
 
@@ -478,7 +477,7 @@ getWallet cAddr = do
     let walletsNum = length wallets
     balance    <- mkCCoin . unsafeIntegerToCoin . sumCoins <$>
                      mapM (decodeCCoinOrFail . caAmount) wallets
-    hasPass    <- isNothing . checkPassMatches emptyPassphrase <$> getSKByAddr cAddr
+    hasPass    <- isNothing . checkPassMatches emptyPassphrase <$> getSKById cAddr
     passLU     <- getWalletPassLU cAddr >>= maybeThrow noWSet
     pure $ CWallet cAddr meta walletsNum balance hasPass passLU
   where
@@ -627,7 +626,7 @@ sendMoney SendActions {..} passphrase moneySource dstDistr = do
     sendDo spendings outputs = do
         let inputMetas = NE.map fst spendings
         let inpTxOuts = toList $ NE.map snd spendings
-        sks <- forM inputMetas $ getSKByAccAddr passphrase
+        sks <- mapM findKey inputMetas
         srcAddrs <- forM inputMetas $ decodeCIdOrFail . cwamId
         let dstAddrs = txOutAddress . toaOut <$> toList outputs
         withSafeSigners passphrase sks $ \ss -> do
@@ -1078,7 +1077,7 @@ changeWalletPassphrase
     :: WalletWebMode m
     => CId Wal -> PassPhrase -> PassPhrase -> m ()
 changeWalletPassphrase wid oldPass newPass = do
-    oldSK <- getSKByAddr wid
+    oldSK <- getSKById wid
 
     unless (isJust $ checkPassMatches newPass oldSK) $ do
         newSK <- maybeThrow badPass $ changeEncPassphrase oldPass newPass oldSK


### PR DESCRIPTION
Redundant legacy of strange `changeWalletPassphrase` endpoint