### PR TITLE
[CSL-1445] Restore "label" in Bi decoding

### DIFF
--- a/core/Pos/Binary/Class/Primitive.hs
+++ b/core/Pos/Binary/Class/Primitive.hs
@@ -33,7 +33,6 @@ import qualified Data.ByteString.Lazy.Internal as BSL
 import           Data.SafeCopy                 (Contained, SafeCopy (..), contain,
                                                 safeGet, safePut)
 import qualified Data.Serialize                as Cereal (Get, Put)
-import           Data.Typeable                 (typeRep)
 
 import           Pos.Binary.Class.Core         (Bi (..))
 import           Serokell.Data.Memory.Units    (Byte)
@@ -69,14 +68,14 @@ deserialize' = deserialize . BSL.fromStrict
 -- failing if there are leftovers. In a nutshell, the `full` here implies
 -- the contract of this function is that what you feed as input needs to
 -- be consumed entirely.
-decodeFull :: Bi a => BS.ByteString -> Either Text a
+decodeFull :: forall a. Bi a => BS.ByteString -> Either Text a
 decodeFull bs0 = case deserializeOrFail' bs0 of
   Right (x, leftover) -> case BS.null leftover of
       True  -> pure x
       False ->
-          let msg = "decodeFull failed! Leftover found: " <> show leftover
+          let msg = "decodeFull failed for " <> label (Proxy @a) <> "! Leftover found: " <> show leftover
           in Left $ fromString msg
-  Left  (e, _) -> Left $ fromString (show e)
+  Left  (e, _) -> Left $ fromString $ "decodeFull failed for " <> label (Proxy @a) <> ": " <> show e
 
 -- | Deserialize a Haskell value from the external binary representation,
 -- returning either (leftover, value) or a (leftover, @'DeserialiseFailure'@).
@@ -110,11 +109,11 @@ deserializeOrFail' = deserializeOrFail . BSL.fromStrict
 putCopyBi :: Bi a => a -> Contained Cereal.Put
 putCopyBi = contain . safePut . serialize
 
-getCopyBi :: forall a. (Bi a, Typeable a) => Contained (Cereal.Get a)
+getCopyBi :: forall a. Bi a => Contained (Cereal.Get a)
 getCopyBi = contain $ do
     bs <- safeGet
     case deserializeOrFail bs of
-        Left (err, _) -> fail $ "getCopy@" ++ show (typeRep $ Proxy @a) <> ": " <> show err
+        Left (err, _) -> fail $ "getCopy@" ++ (label (Proxy @a)) <> ": " <> show err
         Right (x, _)  -> return x
 
 ----------------------------------------

--- a/core/Pos/Binary/Core/Block.hs
+++ b/core/Pos/Binary/Core/Block.hs
@@ -18,7 +18,8 @@ instance Bi T.BlockHeaderStub where
   encode = error "somebody tried to binary encode BlockHeaderStub"
   decode = fail  "somebody tried to binary decode BlockHeaderStub"
 
-instance ( Bi (T.BHeaderHash b)
+instance ( Typeable b
+         , Bi (T.BHeaderHash b)
          , Bi (T.BodyProof b)
          , Bi (T.ConsensusData b)
          , Bi (T.ExtraHeaderData b)
@@ -42,7 +43,8 @@ instance ( Bi (T.BHeaderHash b)
     extra     <- decode
     eitherToFail $ T.recreateGenericHeader prevBlock bodyProof consensus extra
 
-instance ( Bi (T.BHeaderHash b)
+instance ( Typeable b
+         , Bi (T.BHeaderHash b)
          , Bi (T.BodyProof b)
          , Bi (T.ConsensusData b)
          , Bi (T.ExtraHeaderData b)

--- a/core/Pos/Binary/Core/Script.hs
+++ b/core/Pos/Binary/Core/Script.hs
@@ -12,9 +12,10 @@ import qualified Utils.Names        as Names
 import qualified Utils.Vars         as Vars
 
 import           Data.Hashable      (Hashable, hashWithSalt)
-import           Data.SafeCopy      (SafeCopy(..))
-import           Pos.Binary.Class   (Bi (..), deriveSimpleBi, Cons(..), Field(..),
-                                     serialize', getCopyBi, putCopyBi, genericEncode, genericDecode)
+import           Data.SafeCopy      (SafeCopy (..))
+import           Pos.Binary.Class   (Bi (..), Cons (..), Field (..), deriveSimpleBi,
+                                     genericDecode, genericEncode, getCopyBi, putCopyBi,
+                                     serialize')
 import           Pos.Core.Script    ()
 import           Pos.Core.Types     (Script (..), ScriptVersion)
 
@@ -59,15 +60,15 @@ instance Bi ABT.Variable where
   encode = genericEncode
   decode = genericDecode
 
-instance Bi (f (ABT.Scope f)) => Bi (ABT.ABT f) where
+instance (Typeable f, Bi (f (ABT.Scope f))) => Bi (ABT.ABT f) where
   encode = genericEncode
   decode = genericDecode
 
-instance Bi (f (ABT.Scope f)) => Bi (ABT.Scope f) where
+instance (Typeable f, Bi (f (ABT.Scope f))) => Bi (ABT.Scope f) where
   encode = genericEncode
   decode = genericDecode
 
-instance Bi r => Bi (PLCore.ClauseF r) where
+instance (Typeable r, Bi r) => Bi (PLCore.ClauseF r) where
   encode = genericEncode
   decode = genericDecode
 

--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -49,7 +49,7 @@ instance (Typeable a, Bi a) => SafeCopy (WithHash a) where
 -- Hashing
 ----------------------------------------------------------------------------
 
-instance HashAlgorithm algo => Bi (AbstractHash algo a) where
+instance (Typeable algo, Typeable a, HashAlgorithm algo) => Bi (AbstractHash algo a) where
     encode (AbstractHash digest) = encode (ByteArray.convert digest :: ByteString)
     decode = do
         bs <- decode @ByteString
@@ -154,7 +154,7 @@ instance Bi CC.XSignature where
     encode (CC.unXSignature -> bs) = encode bs
     decode = either fail pure . CC.xsignature =<< decode
 
-deriving instance Bi (Signature a)
+deriving instance Typeable a => Bi (Signature a)
 deriving instance Bi PublicKey
 deriving instance Bi SecretKey
 
@@ -176,7 +176,7 @@ instance Bi a => Bi (Signed a) where
          <*> decode
          <*> decode
 
-deriving instance Bi (ProxyCert w)
+deriving instance Typeable w => Bi (ProxyCert w)
 
 instance Bi w => Bi (ProxySecretKey w) where
     encode ProxySecretKey{..} = encodeListLen 4
@@ -190,7 +190,7 @@ instance Bi w => Bi (ProxySecretKey w) where
                             <*> decode
                             <*> decode
 
-instance Bi w => Bi (ProxySignature w a) where
+instance (Typeable a, Bi w) => Bi (ProxySignature w a) where
     encode ProxySignature{..} = encodeListLen 2
                              <> encode psigPsk
                              <> encode psigSig
@@ -238,4 +238,4 @@ instance Bi EdStandard.Signature where
 
 deriving instance Bi RedeemPublicKey
 deriving instance Bi RedeemSecretKey
-deriving instance Bi (RedeemSignature a)
+deriving instance Typeable a => Bi (RedeemSignature a)

--- a/infra/Pos/Binary/Infra/Relay.hs
+++ b/infra/Pos/Binary/Infra/Relay.hs
@@ -15,7 +15,7 @@ instance Bi key => Bi (ReqMsg key) where
   encode = encode . rmKey
   decode = ReqMsg <$> decode
 
-instance Bi (MempoolMsg tag) where
+instance Typeable tag => Bi (MempoolMsg tag) where
   -- The extra byte is needed because time-warp doesn't work with
   -- possibly-empty messages. 228 was chosen as homage to @pva701
   encode MempoolMsg = encode (228 :: Word8)

--- a/lwallet/Command.hs
+++ b/lwallet/Command.hs
@@ -101,7 +101,7 @@ coin = mkCoin <$> num
 txout :: Parser TxOut
 txout = TxOut <$> address <*> coin
 
-hash :: Parser (Hash a)
+hash :: Typeable a => Parser (Hash a)
 hash = decodeHash <$> anyText
 
 switch :: Parser Bool

--- a/src/Pos/Util/BackupPhrase.hs
+++ b/src/Pos/Util/BackupPhrase.hs
@@ -23,7 +23,7 @@ import           Pos.Crypto          (AbstractHash, EncryptedSecretKey, PassPhra
                                       deterministicVssKeyGen, safeDeterministicKeyGen,
                                       unsafeAbstractHash)
 import           Pos.Util.Mnemonics  (fromMnemonic, toMnemonic)
-import           Test.QuickCheck     (Arbitrary(..), genericShrink)
+import           Test.QuickCheck     (Arbitrary (..), genericShrink)
 
 -- | Datatype to contain a valid backup phrase
 newtype BackupPhrase = BackupPhrase
@@ -68,7 +68,7 @@ toSeed = first toText . fromMnemonic . unwords . bpToList
 
 toHashSeed :: BackupPhrase -> Either Text ByteString
 toHashSeed bp = serialize' . blake2b <$> toSeed bp
-  where blake2b :: Bi a => a -> AbstractHash Blake2b_256 b
+  where blake2b :: Bi a => a -> AbstractHash Blake2b_256 ()
         blake2b = unsafeAbstractHash
 
 keysFromPhrase :: BackupPhrase -> Either Text (SecretKey, VssKeyPair)


### PR DESCRIPTION
This PR brings back some functionality of the old `Bi` implementation, which is the possibility of "annotate" deserialisation failures via a `label` which would pinpoint the type we tried to decode back from the network.

This PR is mostly complete although we might need to improve what we have currently by adding even more precise error reporting exploiting the newly-added `label`. So far, there is already improvement. This is an example, real-world failure which is now more informative:

Before:

```
*** Exception: Failed to read genesis: DeserialiseFailure 2554 "expected list len"
```

After:

```
*** Exception: Failed to read genesis: decodeFull failed for GenesisCoreData: DeserialiseFailure 2554 "expected list len"
```

## Technical notes

The PR, in brief, works by adding a `Typeable` constraint to `Bi`, so that we can implement `label` in terms of `show . typeRep`. This works for 99% of the types and we almost surely want to use the default implementation (which we can override case-per-case, if we want).

Let me know what you guys think!