### PR TITLE
[CSL-1346] expect response after inv/data

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/Listeners.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Listeners.hs
@@ -24,7 +24,7 @@ import           Pos.Communication.Limits.Types        (MessageLimited)
 import           Pos.Communication.Relay               (DataMsg, InvOrData,
                                                         InvReqDataParams (..),
                                                         MempoolParams (NoMempool),
-                                                        Relay (..), ReqMsg)
+                                                        Relay (..), ReqMsg, ReqOrRes)
 import           Pos.Core                              (StakeholderId, addressHash)
 import           Pos.Security.Util                     (shouldIgnorePkAddress)
 import           Pos.Ssc.Class.Listeners               (SscListenersClass (..))
@@ -97,6 +97,7 @@ sscRelay
        , MessageLimited (DataMsg contents)
        , Bi (DataMsg contents)
        , Message (InvOrData (Tagged contents StakeholderId) contents)
+       , Message (ReqOrRes (Tagged contents StakeholderId))
        , Message (ReqMsg (Tagged contents StakeholderId))
        )
     => GtTag

--- a/godtossing/Pos/Ssc/GodTossing/Network/Constraint.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Network/Constraint.hs
@@ -10,7 +10,7 @@ import           Data.Tagged                      (Tagged)
 import           Node.Message.Class               (Message)
 
 import           Pos.Communication.Limits.Types   (MessageLimited)
-import           Pos.Communication.Types.Relay    (DataMsg, InvOrData, ReqMsg)
+import           Pos.Communication.Types.Relay    (DataMsg, InvOrData, ReqMsg, ReqOrRes)
 import           Pos.Core                         (StakeholderId)
 import           Pos.Ssc.GodTossing.Types.Message (MCCommitment, MCOpening, MCShares,
                                                    MCVssCertificate)
@@ -33,4 +33,9 @@ type GtMessageConstraints =
         , ReqMsg (Tagged MCOpening        StakeholderId)
         , ReqMsg (Tagged MCShares         StakeholderId)
         , ReqMsg (Tagged MCVssCertificate StakeholderId) ]
+    , Each '[Message]
+        [ ReqOrRes (Tagged MCCommitment     StakeholderId)
+        , ReqOrRes (Tagged MCOpening        StakeholderId)
+        , ReqOrRes (Tagged MCShares         StakeholderId)
+        , ReqOrRes (Tagged MCVssCertificate StakeholderId) ]
     )

--- a/infra/Pos/Binary/Infra/Relay.hs
+++ b/infra/Pos/Binary/Infra/Relay.hs
@@ -5,7 +5,8 @@ module Pos.Binary.Infra.Relay
 import           Universum
 
 import           Pos.Binary.Class              (Bi (..))
-import           Pos.Communication.Types.Relay (InvMsg (..), MempoolMsg (..), ReqMsg (..))
+import           Pos.Communication.Types.Relay (InvMsg (..), MempoolMsg (..),
+                                                ReqMsg (..), ResMsg (..))
 
 instance Bi key => Bi (InvMsg key) where
   encode = encode . imKey
@@ -14,6 +15,10 @@ instance Bi key => Bi (InvMsg key) where
 instance Bi key => Bi (ReqMsg key) where
   encode = encode . rmKey
   decode = ReqMsg <$> decode
+
+instance Bi key => Bi (ResMsg key) where
+  encode (ResMsg {..}) = encode (resKey, resOk)
+  decode = uncurry ResMsg <$> decode
 
 instance Typeable tag => Bi (MempoolMsg tag) where
   -- The extra byte is needed because time-warp doesn't work with

--- a/infra/Pos/Communication/Limits/Instances.hs
+++ b/infra/Pos/Communication/Limits/Instances.hs
@@ -15,7 +15,8 @@ import qualified Pos.Communication.Constants    as Const
 import           Pos.Communication.Limits.Types (Limit (..), MessageLimited (..),
                                                  MessageLimitedPure (..))
 import           Pos.Communication.Types.Relay  (DataMsg (..), InvMsg, InvOrData,
-                                                 MempoolMsg (..), ReqMsg)
+                                                 MempoolMsg (..), ReqMsg, ResMsg,
+                                                 ReqOrRes)
 
 ----------------------------------------------------------------------------
 -- Instances of MessageLimited for the relay types.
@@ -23,6 +24,7 @@ import           Pos.Communication.Types.Relay  (DataMsg (..), InvMsg, InvOrData
 
 instance MessageLimited (InvMsg key)
 instance MessageLimited (ReqMsg key)
+instance MessageLimited (ResMsg key)
 instance MessageLimited (MempoolMsg tag)
 
 instance MessageLimited (DataMsg contents)
@@ -33,6 +35,13 @@ instance MessageLimited (DataMsg contents)
         -- 1 byte is added because of `Either`
         return $ Limit (1 + (invLim `max` dataLim))
 
+instance MessageLimited (ReqOrRes key) where
+    getMsgLenLimit _ = do
+        Limit reqLim <- getMsgLenLimit $ Proxy @(ReqMsg key)
+        Limit resLim <- getMsgLenLimit $ Proxy @(ResMsg key)
+        -- 1 byte is added because of `Either`
+        return $ Limit (1 + (reqLim `max` resLim))
+
 ----------------------------------------------------------------------------
 -- Instances of MessageLimitedPure for the relay types.
 ----------------------------------------------------------------------------
@@ -41,7 +50,12 @@ instance MessageLimitedPure (InvMsg key) where
     msgLenLimit = Limit Const.maxInvSize
 
 instance MessageLimitedPure (ReqMsg key) where
-    msgLenLimit = Limit Const.maxReqSize
+    -- Add 1 because ReqMsg contains a 'Maybe key'
+    msgLenLimit = Limit (Const.maxReqSize + 1)
+
+instance MessageLimitedPure (ResMsg key) where
+    -- It's a ResMsg key, with an extra bool, and overhead for the tuple.
+    msgLenLimit = Limit (Const.maxReqSize + 2)
 
 instance MessageLimitedPure (MempoolMsg tag) where
     msgLenLimit = Limit Const.maxMempoolMsgSize

--- a/infra/Pos/Communication/Limits/Types.hs
+++ b/infra/Pos/Communication/Limits/Types.hs
@@ -99,7 +99,7 @@ instance MessageLimitedPure Bool where
 --   an exception is raised.
 recvLimited
     :: forall rcv snd m .
-       ( Monad m, DB.MonadGState m, MessageLimited rcv )
+       ( DB.MonadGState m, MessageLimited rcv )
     => ConversationActions snd rcv m -> m (Maybe rcv)
 recvLimited conv = getMsgLenLimit (Proxy @rcv) >>= recv conv . getLimit
 

--- a/infra/Pos/Communication/Listener.hs
+++ b/infra/Pos/Communication/Listener.hs
@@ -11,16 +11,12 @@ import qualified Node                           as N
 import           System.Wlog                    (WithLogger)
 import           Universum
 
-import           Mockable.Class                 (Mockable)
-import           Mockable.Exception             (Throw)
 import           Pos.Binary.Class               (Bi)
 import           Pos.Binary.Infra               ()
-import           Pos.Communication.Limits.Types (MessageLimited)
 import           Pos.Communication.Protocol     (ConversationActions, HandlerSpec (..),
                                                  ListenerSpec (..), Message, NodeId,
                                                  OutSpecs, VerInfo, checkingInSpecs,
                                                  messageCode)
-import           Pos.DB.Class                   (MonadGState)
 
 -- TODO automatically provide a 'recvLimited' here by using the
 -- 'MessageLimited'?
@@ -30,10 +26,7 @@ listenerConv
        , Bi rcv
        , Message snd
        , Message rcv
-       , MonadGState m
-       , MessageLimited rcv
        , WithLogger m
-       , Mockable Throw m
        )
     => (VerInfo -> NodeId -> ConversationActions snd rcv m -> m ())
     -> (ListenerSpec m, OutSpecs)

--- a/infra/Pos/Communication/Relay/Class.hs
+++ b/infra/Pos/Communication/Relay/Class.hs
@@ -16,7 +16,7 @@ import           Pos.Binary.Class               (Bi)
 
 import           Pos.Communication.Limits.Types (MessageLimited)
 import           Pos.Communication.Types.Relay  (DataMsg, InvMsg, InvOrData, MempoolMsg,
-                                                 ReqMsg (..))
+                                                 ReqMsg, ReqOrRes)
 import           Pos.Communication.Types.Protocol (NodeId, Msg, EnqueueMsg)
 import           Pos.Network.Types              (Origin)
 
@@ -30,8 +30,10 @@ data Relay m where
       , Typeable key
       , Eq key
       , Bi (ReqMsg key)
+      , Bi (ReqOrRes key)
       , Bi (InvOrData key contents)
       , Message (ReqMsg key)
+      , Message (ReqOrRes key)
       , Message (InvOrData key contents)
       , MessageLimited (DataMsg contents)
       ) => MempoolParams m -> InvReqDataParams key contents m -> Relay m

--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -183,9 +183,8 @@ handleDataDo provenance mkMsg enqueue contentsToKey handleData dmContents = do
         -- IMPORTANT that we propagate it asynchronously.
         -- enqueueMsg can do that: simply don't force the values in
         -- the resulting map.
-        (void $ propagateData enqueue $ InvReqDataPM (mkMsg (OriginForward provenance)) dmKey dmContents) $
-            logDebug $ sformat
-                ("Ignoring data "%build%" for key "%build) dmContents dmKey
+        (void $ propagateData enqueue $ InvReqDataPM (mkMsg (OriginForward provenance)) dmKey dmContents)
+        (logDebug $ sformat ("Ignoring data "%build%" for key "%build) dmContents dmKey)
 
 -- | Synchronously propagate data.
 relayMsg

--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -9,20 +9,20 @@ module Pos.Communication.Relay.Logic
        ( Relay (..)
        , InvMsg (..)
        , ReqMsg (..)
+       , ResMsg (..)
        , MempoolMsg (..)
        , DataMsg (..)
+       , InvOrData
+       , ReqOrRes
        , relayListeners
        , relayMsg
        , propagateData
        , relayPropagateOut
-       , InvOrData
        , handleDataDo
        , handleInvDo
 
        , invReqDataFlow
        , invReqDataFlowTK
-       , invReqDataFlowNeighbors
-       , invReqDataFlowNeighborsTK
        , dataFlow
        , InvReqDataFlowLog (..)
        ) where
@@ -32,10 +32,11 @@ import           Data.Proxy                         (asProxyTypeOf)
 import           Data.Tagged                        (Tagged, tagWith)
 import           Data.Typeable                      (typeRep)
 import           Formatting                         (build, sformat, shown, stext, (%))
-import           Mockable                           (MonadMockable, handleAll)
+import           Mockable                           (MonadMockable, handleAll, throw,
+                                                     try)
 import           Node.Message.Class                 (Message)
 import           System.Wlog                        (WithLogger, logDebug,
-                                                     logWarning)
+                                                     logWarning, logError)
 import           Universum
 
 import           Pos.Binary.Class                   (Bi (..))
@@ -56,7 +57,8 @@ import           Pos.Communication.Relay.Class      (DataParams (..),
 import           Pos.Communication.Relay.Types      (PropagationMsg (..))
 import           Pos.Communication.Relay.Util       (expectData, expectInv)
 import           Pos.Communication.Types.Relay      (DataMsg (..), InvMsg (..), InvOrData,
-                                                     MempoolMsg (..), ReqMsg (..))
+                                                     MempoolMsg (..), ReqMsg (..),
+                                                     ResMsg (..), ReqOrRes)
 import           Pos.DB.Class                       (MonadGState)
 import           Pos.Util.TimeWarp                  (CanJsonLog (..))
 
@@ -70,6 +72,15 @@ type MinRelayWorkMode m =
 type RelayWorkMode ctx m =
     ( MinRelayWorkMode m
     )
+
+data InvReqCommunicationException =
+      UnexpectedRequest
+    | UnexpectedResponse
+    | UnexpectedEnd
+    | MismatchedKey
+    deriving (Show)
+
+instance Exception InvReqCommunicationException
 
 handleReqL
     :: forall key contents m .
@@ -86,12 +97,14 @@ handleReqL
 handleReqL handleReq = listenerConv $ \__ourVerInfo nodeId conv ->
     let handlingLoop = do
             mbMsg <- recvLimited conv
-            whenJust mbMsg $ \ReqMsg{..} -> do
-                dtMB <- handleReq nodeId rmKey
-                case dtMB of
-                    Nothing -> logNoData rmKey
-                    Just dt -> logHaveData rmKey >> send conv (constructDataMsg dt)
-                handlingLoop
+            case mbMsg of
+                Just (ReqMsg (Just key)) -> do
+                    dtMB <- handleReq nodeId key
+                    case dtMB of
+                        Nothing -> logNoData key
+                        Just dt -> logHaveData key >> send conv (constructDataMsg dt)
+                    handlingLoop
+                _ -> return ()
     in handlingLoop
   where
     constructDataMsg :: contents -> InvOrData key contents
@@ -165,10 +178,11 @@ handleDataDo
        , Eq key
        , Buildable contents
        , Message (InvOrData key contents)
-       , Message (ReqMsg key)
+       , Message (ReqOrRes key)
        , Bi (InvOrData key contents)
-       , Bi (ReqMsg key)
+       , Bi (ReqOrRes key)
        , Message Void
+       , MonadGState m
        )
     => NodeId
     -> (Origin NodeId -> Msg)
@@ -176,20 +190,21 @@ handleDataDo
     -> (contents -> m key)
     -> (contents -> m Bool)
     -> contents
-    -> m ()
+    -> m (ResMsg key)
 handleDataDo provenance mkMsg enqueue contentsToKey handleData dmContents = do
     dmKey <- contentsToKey dmContents
     ifM (handleData dmContents)
         -- IMPORTANT that we propagate it asynchronously.
         -- enqueueMsg can do that: simply don't force the values in
         -- the resulting map.
-        (void $ propagateData enqueue $ InvReqDataPM (mkMsg (OriginForward provenance)) dmKey dmContents)
-        (logDebug $ sformat ("Ignoring data "%build%" for key "%build) dmContents dmKey)
+        (ResMsg dmKey True <$ propagateData enqueue (InvReqDataPM (mkMsg (OriginForward provenance)) dmKey dmContents))
+        (ResMsg dmKey False <$ logDebug (sformat ("Ignoring data "%build%" for key "%build) dmContents dmKey))
 
 -- | Synchronously propagate data.
 relayMsg
     :: ( RelayWorkMode ctx m
        , Message Void
+       , MonadGState m
        )
     => EnqueueMsg m
     -> PropagationMsg
@@ -200,6 +215,7 @@ relayMsg enqueue pm = void $ propagateData enqueue pm >>= waitForConversations
 propagateData
     :: forall ctx m.
        ( RelayWorkMode ctx m
+       , MonadGState m
        , Message Void
        )
     => EnqueueMsg m
@@ -209,8 +225,8 @@ propagateData enqueue pm = case pm of
     InvReqDataPM msg key contents -> do
         logDebug $ sformat
             ("Propagation data with key: "%build) key
-        enqueue msg $ \__node _ ->
-            pure $ Conversation $ irdHandler key contents
+        enqueue msg $ \peer _ ->
+            pure $ Conversation $ (void <$> invReqDataFlowDo "propagation" key contents peer)
     DataOnlyPM msg contents -> do
         logDebug $ sformat
             ("Propagation data: "%build) contents
@@ -225,22 +241,6 @@ propagateData enqueue pm = case pm of
              (DataMsg contents1) Void m
         -> m ()
     doHandler contents conv = send conv $ DataMsg contents
-
-    irdHandler
-        :: Eq key1 => key1 -> contents1
-        -> ConversationActions
-             (InvOrData key1 contents1) (ReqMsg key1) m
-        -> m ()
-    irdHandler key conts conv = do
-        send conv $ Left $ InvMsg key
-        let whileNotK = do
-              rm <- recv conv maxBound
-              whenJust rm $ \ReqMsg{..} -> do
-                if rmKey == key
-                   then send conv $ Right $ DataMsg conts
-                   else whileNotK
-        whileNotK
-
 
 handleInvDo
     :: forall key ctx m .
@@ -264,8 +264,7 @@ handleInvDo handleInv imKey =
 
 relayListenersOne
   :: forall ctx m.
-     ( WithLogger m
-     , RelayWorkMode ctx m
+     ( RelayWorkMode ctx m
      , MonadGState m
      , Message Void
      )
@@ -291,9 +290,9 @@ invDataListener
   :: forall key contents ctx m.
      ( RelayWorkMode ctx m
      , MonadGState m
-     , Message (ReqMsg key)
+     , Message (ReqOrRes key)
      , Message (InvOrData key contents)
-     , Bi (ReqMsg key)
+     , Bi (ReqOrRes key)
      , Bi (InvOrData key contents)
      , Buildable contents
      , Buildable key
@@ -309,17 +308,20 @@ invDataListener enqueue InvReqDataParams{..} = listenerConv $ \__ourVerInfo node
             inv' <- recvLimited conv
             whenJust inv' $ expectInv $ \InvMsg{..} -> do
                 useful <- handleInvDo (handleInv nodeId) imKey
-                whenJust useful $ \ne -> do
-                    send conv $ ReqMsg ne
-                    dt' <- recvLimited conv
-                    whenJust dt' $ expectData $ \DataMsg{..} -> do
-                          handleDataDo nodeId invReqMsgType enqueue contentsToKey (handleData nodeId) dmContents
-                          -- handlingLoop
+                case useful of
+                    Nothing -> send conv (Left (ReqMsg Nothing))
+                    Just ne -> do
+                        send conv $ Left (ReqMsg (Just ne))
+                        dt' <- recvLimited conv
+                        whenJust dt' $ expectData $ \DataMsg{..} -> do
+                              res <- handleDataDo nodeId invReqMsgType enqueue contentsToKey (handleData nodeId) dmContents
+                              send conv $ Right res
+                              -- handlingLoop
 
-                          -- TODO CSL-1148 Improve relaing: support multiple data
-                          -- Need to receive Inv and Data messages simultaneously
-                          -- Maintain state of sent Reqs
-                          -- And check data we are sent is what we expect (currently not)
+                              -- TODO CSL-1148 Improve relaing: support multiple data
+                              -- Need to receive Inv and Data messages simultaneously
+                              -- Maintain state of sent Reqs
+                              -- And check data we are sent is what we expect (currently not)
     in handlingLoop
 
 relayPropagateOut :: Message Void => [Relay m] -> OutSpecs
@@ -327,19 +329,85 @@ relayPropagateOut = mconcat . map propagateOutImpl
 
 propagateOutImpl :: Message Void => Relay m -> OutSpecs
 propagateOutImpl (InvReqData _ irdp) = toOutSpecs
-      [ convH invProxy reqProxy
-      ]
+      [ convH invProxy reqResProxy ]
   where
-    invProxy = (const Proxy :: InvReqDataParams key contents m
-                            -> Proxy (InvOrData key contents)) irdp
-    reqProxy = (const Proxy :: InvReqDataParams key contents m
-                            -> Proxy (ReqMsg key)) irdp
+    invProxy    = (const Proxy :: InvReqDataParams key contents m
+                               -> Proxy (InvOrData key contents)) irdp
+    reqResProxy = (const Proxy :: InvReqDataParams key contents m
+                               -> Proxy (ReqOrRes key)) irdp
 propagateOutImpl (Data dp) = toOutSpecs
       [ convH dataProxy (Proxy @Void)
       ]
   where
     dataProxy = (const Proxy :: DataParams contents m
                             -> Proxy (DataMsg contents)) dp
+
+invReqDataFlowDo
+    :: ( Buildable key
+       , MinRelayWorkMode m
+       , MonadGState m
+       , Eq key
+       )
+    => Text
+    -> key
+    -> contents
+    -> NodeId
+    -> ConversationActions (InvOrData key contents) (ReqOrRes key) m
+    -> m (Maybe (ResMsg key))
+invReqDataFlowDo what key dt peer conv = do
+    send conv $ Left $ InvMsg key
+    it <- recvLimited conv
+    maybe handleD replyWithData it
+  where
+    replyWithData (Left (ReqMsg (Just key'))) = do
+        -- Stop if the peer sends the wrong key. Basically a protocol error.
+        unless (key' == key) (throw MismatchedKey)
+        send conv $ Right $ DataMsg dt
+        it <- recvLimited conv
+        maybe handleD checkResponse it
+    -- The peer indicated that he doesn't want the data.
+    replyWithData (Left (ReqMsg Nothing)) = return Nothing
+    -- The peer sent a ResMsg where a ReqMsg was expected.
+    replyWithData (Right (ResMsg _ _)) = do
+        logError $
+            sformat ("InvReqDataFlow ("%stext%"): "%shown %" unexpected response")
+                    what peer
+        throw UnexpectedResponse
+
+    checkResponse (Right resMsg) = return (Just resMsg)
+    -- The peer sent a ReqMsg where a ResMsg was expected.
+    checkResponse (Left (ReqMsg _)) = do
+        logError $
+            sformat ("InvReqDataFlow ("%stext%"): "%shown %" unexpected request")
+                    what peer
+        throw UnexpectedRequest
+
+    handleD = do
+        logError $
+            sformat ("InvReqDataFlow ("%stext%"): "%shown %" closed conversation on \
+                     \Inv key = "%build)
+                    what peer key
+        throw UnexpectedEnd
+
+dataFlow
+    :: forall contents m.
+       ( Message (DataMsg contents)
+       , Bi (DataMsg contents)
+       , Buildable contents
+       , MinRelayWorkMode m
+       , Message Void
+       )
+    => Text -> EnqueueMsg m -> Msg -> contents -> m ()
+dataFlow what enqueue msg dt = handleAll handleE $ do
+    its <- enqueue msg $
+        \_ _ -> pure $ Conversation $ \(conv :: ConversationActions (DataMsg contents) Void m) ->
+            send conv $ DataMsg dt
+    void $ waitForConversations its
+  where
+    handleE e =
+        logWarning $
+        sformat ("Error sending "%stext%", data = "%build%": "%shown)
+                what dt e
 
 ----------------------------------------------------------------------------
 -- Helpers for Communication.Methods
@@ -361,122 +429,60 @@ data InvReqDataFlowLog =
 
 $(deriveJSON defaultOptions ''InvReqDataFlowLog)
 
-invReqDataFlowNeighborsTK
-    :: forall key contents m.
-       ( Message (InvOrData (Tagged contents key) contents)
-       , Message (ReqMsg (Tagged contents key))
-       , Buildable key
-       , Typeable contents
-       , MinRelayWorkMode m
-       , MonadGState m
-       , Bi (InvOrData (Tagged contents key) contents)
-       , Bi (ReqMsg (Tagged contents key))
-       )
-    => Text -> EnqueueMsg m -> Msg -> key -> contents -> m ()
-invReqDataFlowNeighborsTK what enqueue msg key dt =
-    invReqDataFlowNeighbors what enqueue msg key' dt
-  where
-    contProxy = (const Proxy :: contents -> Proxy contents) dt
-    key' = tagWith contProxy key
-
 invReqDataFlowTK
     :: forall key contents m.
        ( Message (InvOrData (Tagged contents key) contents)
-       , Message (ReqMsg (Tagged contents key))
+       , Message (ReqOrRes (Tagged contents key))
        , Buildable key
        , Typeable contents
        , MinRelayWorkMode m
        , MonadGState m
        , Bi (InvOrData (Tagged contents key) contents)
-       , Bi (ReqMsg (Tagged contents key))
+       , Bi (ReqOrRes (Tagged contents key))
+       , Eq key
        )
-    => Text -> EnqueueMsg m -> Msg -> key -> contents -> m ()
+    => Text
+    -> EnqueueMsg m
+    -> Msg
+    -> key
+    -> contents
+    -> m (Map NodeId (Either SomeException (Maybe (ResMsg (Tagged contents key)))))
 invReqDataFlowTK what enqueue msg key dt =
     invReqDataFlow what enqueue msg key' dt
   where
     contProxy = (const Proxy :: contents -> Proxy contents) dt
     key' = tagWith contProxy key
 
-invReqDataFlowNeighbors
-    :: forall key contents m.
-       ( Message (InvOrData key contents)
-       , Message (ReqMsg key)
-       , Buildable key
-       , MinRelayWorkMode m
-       , MonadGState m
-       , Bi (InvOrData key contents)
-       , Bi (ReqMsg key)
-       )
-    => Text -> EnqueueMsg m -> Msg -> key -> contents -> m ()
-invReqDataFlowNeighbors what enqueue msg key dt = handleAll handleE $
-    void $ enqueue msg (\addr _ -> pure (Conversation (invReqDataFlowDo what key dt addr))) >>= waitForConversations
-  where
-    handleE e = logWarning $
-        sformat ("Error sending "%stext%", key = "%build%" to neighbors: "%shown) what key e
-
+-- | Do an Inv/Req/Data/Res conversation (peers determined by the 'EnqueueMsg m'
+-- argument) and wait for the results.
+-- This will wait for all conversations to finish. Exceptions in the conversations
+-- themselves are caught and returned as Left. If the peer did not ask for the
+-- data, then Right Nothing is given, otherwise their response to the data is
+-- given.
 invReqDataFlow
     :: forall key contents m.
        ( Message (InvOrData key contents)
-       , Message (ReqMsg key)
+       , Message (ReqOrRes key)
        , Bi (InvOrData key contents)
-       , Bi (ReqMsg key)
+       , Bi (ReqOrRes key)
        , Buildable key
        , MinRelayWorkMode m
        , MonadGState m
+       , Eq key
        )
-    => Text -> EnqueueMsg m -> Msg -> key -> contents -> m ()
+    => Text
+    -> EnqueueMsg m
+    -> Msg
+    -> key
+    -> contents
+    -> m (Map NodeId (Either SomeException (Maybe (ResMsg key))))
 invReqDataFlow what enqueue msg key dt = handleAll handleE $ do
     its <- enqueue msg $
         \addr _ -> pure $ Conversation $ invReqDataFlowDo what key dt addr
-    void $ waitForConversations its
+    waitForConversations (fmap try its)
   where
-    handleE e = logWarning $
-        sformat ("Error sending "%stext%", key = "%build%": "%shown)
-                what key e
-
-invReqDataFlowDo
-    :: ( Message (InvOrData key contents)
-       , Message (ReqMsg key)
-       , Bi (InvOrData key contents)
-       , Bi (ReqMsg key)
-       , Buildable key
-       , MinRelayWorkMode m
-       , MonadGState m
-       )
-    => Text
-    -> key
-    -> contents
-    -> NodeId
-    -> ConversationActions (InvOrData key contents) (ReqMsg key) m
-    -> m ()
-invReqDataFlowDo what key dt peer conv = do
-    send conv $ Left $ InvMsg key
-    recvLimited conv >>= maybe handleD replyWithData
-  where
-    -- TODO need to check we're asked for same key we have
-    replyWithData (ReqMsg _) = send conv $ Right $ DataMsg dt
-    handleD =
-        logDebug $
-        sformat ("InvReqDataFlow ("%stext%"): "%shown %" closed conversation on \
-                 \Inv key = "%build)
-                what peer key
-
-dataFlow
-    :: forall contents m.
-       ( Message (DataMsg contents)
-       , Bi (DataMsg contents)
-       , Buildable contents
-       , MinRelayWorkMode m
-       , Message Void
-       )
-    => Text -> EnqueueMsg m -> Msg -> contents -> m ()
-dataFlow what enqueue msg dt = handleAll handleE $ do
-    its <- enqueue msg $
-        \_ _ -> pure $ Conversation $ \(conv :: ConversationActions (DataMsg contents) Void m) ->
-            send conv $ DataMsg dt
-    void $ waitForConversations its
-  where
-    handleE e =
+    handleE e = do
         logWarning $
-        sformat ("Error sending "%stext%", data = "%build%": "%shown)
-                what dt e
+            sformat ("Error sending "%stext%", key = "%build%": "%shown)
+                what key e
+        throw e

--- a/infra/Pos/Communication/Relay/Types.hs
+++ b/infra/Pos/Communication/Relay/Types.hs
@@ -14,7 +14,7 @@ import           Node                          (Message)
 
 import           Pos.Binary.Class              (Bi)
 import           Pos.Communication.Types.Protocol (Msg)
-import           Pos.Communication.Types.Relay (DataMsg, InvOrData, ReqMsg)
+import           Pos.Communication.Types.Relay (DataMsg, InvOrData, ReqOrRes)
 
 data RelayError = UnexpectedInv
                 | UnexpectedData
@@ -28,8 +28,8 @@ data PropagationMsg where
         , Bi (InvOrData key contents)
         , Buildable key
         , Eq key
-        , Message (ReqMsg key)
-        , Bi (ReqMsg key))
+        , Message (ReqOrRes key)
+        , Bi (ReqOrRes key))
         => !Msg
         -> !key
         -> !contents

--- a/infra/Pos/Communication/Specs.hs
+++ b/infra/Pos/Communication/Specs.hs
@@ -8,14 +8,20 @@ import           Node.Message.Class            (Message (..))
 import           Universum
 
 import           Pos.Communication.Protocol    (OutSpecs, convH, toOutSpecs)
-import           Pos.Communication.Types.Relay (InvOrData, ReqMsg)
+import           Pos.Communication.Types.Relay (InvOrData, ReqOrRes)
 
+-- FIXME (avieth)
+-- This looks to be misplaced and misnamed.
+-- Apparently it's creating the out specs for certain relay handlers.
 createOutSpecs :: forall key contents .
                ( Message (InvOrData key contents)
-               , Message (ReqMsg key))
+               , Message (ReqOrRes key)
+               )
                => Proxy (InvOrData key contents)
                -> OutSpecs
-createOutSpecs proxy = toOutSpecs [convH proxy (toReqProxy proxy)]
+createOutSpecs proxy = toOutSpecs [
+      convH proxy (toReqResProxy proxy)
+    ]
   where
-    toReqProxy :: Proxy (InvOrData key contents) -> Proxy (ReqMsg key)
-    toReqProxy _ = Proxy
+    toReqResProxy :: Proxy (InvOrData key contents) -> Proxy (ReqOrRes key)
+    toReqResProxy _ = Proxy

--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -273,7 +273,12 @@ instance Monoid OutSpecs where
                     (name, h1) (name, h2)
 
 toOutSpecs :: [(MessageCode, HandlerSpec)] -> OutSpecs
-toOutSpecs = OutSpecs . HM.fromList
+toOutSpecs = OutSpecs . merge . fmap (uncurry HM.singleton)
+  where
+    merge = foldr (HM.unionWithKey merger) mempty
+    merger name h1 h2 = error $ sformat
+        ("Conflicting key output spec in toOutSpecs: "%build%" at "%build%" "%build)
+        name h1 h2
 
 -- | Data type to represent listeners, provided upon our version info and peerData
 -- received from other node, in and out specs for all listeners which may be provided

--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -104,7 +104,7 @@ data SendActions m = SendActions {
 --
 -- You probably do not want to use this. Use 'enqueueMsg' instead.
 immediateConcurrentConversations
-    :: ( Applicative m, Mockable Async m )
+    :: ( Mockable Async m )
     => SendActions m
     -> [NodeId]
     -> EnqueueMsg m

--- a/infra/Pos/Communication/Types/Relay.hs
+++ b/infra/Pos/Communication/Types/Relay.hs
@@ -4,6 +4,8 @@
 module Pos.Communication.Types.Relay
        ( InvMsg (..)
        , ReqMsg (..)
+       , ResMsg (..)
+       , ReqOrRes
        , MempoolMsg (..)
        , DataMsg (..)
        , InvOrData
@@ -22,13 +24,15 @@ import           Universum
 -- some data.
 data InvMsg key = InvMsg
     { imKey :: !key
+    -- ^ Key for the data that you wish to announce.
     }
     deriving (Show, Eq)
 
 -- | Request message. Can be used to request data (ideally data which
 -- was previously announced by inventory message).
 data ReqMsg key = ReqMsg
-    { rmKey :: !key
+    { rmKey :: !(Maybe key)
+    -- ^ Optional key for the data that you request.
     }
     deriving (Show, Eq)
 
@@ -44,6 +48,18 @@ type InvOrData key contents = Either (InvMsg key) (DataMsg contents)
 
 -- | InvOrData with key tagged by contents
 type InvOrDataTK key contents = InvOrData (Tagged contents key) contents
+
+-- | Response to a 'ReqMsg' indicating whether it was successfully processed.
+data ResMsg key = ResMsg
+    { resKey :: !key
+    -- ^ The key for the data to which this response is relevant (maybe it
+    -- comes from a previous ReqMsg).
+    , resOk  :: !Bool
+    -- ^ True if the request was successfully processed.
+    }
+    deriving (Show, Eq)
+
+type ReqOrRes key = Either (ReqMsg key) (ResMsg key)
 
 instance (Buildable contents) =>
          Buildable (DataMsg contents) where

--- a/infra/Pos/Communication/Util.hs
+++ b/infra/Pos/Communication/Util.hs
@@ -9,9 +9,8 @@ module Pos.Communication.Util
 import           Universum
 
 import           Formatting                  (sformat, shown, hex, (%))
-import           Mockable                    (Async, Bracket, Delay, Mockable)
 import qualified Node                        as N
-import           System.Wlog                 (LoggerName, WithLogger, modifyLoggerName)
+import           System.Wlog                 (LoggerName, modifyLoggerName)
 
 import           Pos.Communication.Constants (networkWaitLogInterval)
 import           Pos.Communication.Protocol  (ActionSpec (..), Listener, Message (..),
@@ -71,22 +70,14 @@ _convWithWaitLogL nodeId conv = conv { N.send = send', N.recv = recv' }
         ((\_ -> Proxy) :: N.ConversationActions snd rcv m -> Proxy rcv) conv
 
 wrapListener
-  :: ( CanLogInParallel m
-     , Mockable Async m
-     , Mockable Bracket m
-     , Mockable Delay m
-     , MonadIO m
-     , WithLogger m
-     )
+  :: ( CanLogInParallel m )
   => LoggerName -> Listener m -> Listener m
 wrapListener lname = modifyLogger lname
   where
     modifyLogger _name = mapListener $ modifyLoggerName (<> lname)
 
 wrapActionSpec
-  :: ( CanLogInParallel m
-     , Mockable Bracket m
-     )
+  :: ( CanLogInParallel m )
   => LoggerName -> ActionSpec m a -> ActionSpec m a
 wrapActionSpec lname = modifyLogger lname
   where
@@ -94,13 +85,7 @@ wrapActionSpec lname = modifyLogger lname
                                     (<> lname)
 
 wrapSendActions
-  :: ( CanLogInParallel m
-     , Mockable Async m
-     , Mockable Bracket m
-     , Mockable Delay m
-     , MonadIO m
-     , WithLogger m
-     )
+  :: ( CanLogInParallel m )
   => SendActions m
   -> SendActions m
 wrapSendActions =

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -20,8 +20,8 @@ import qualified Data.ByteString.Char8     as B8 (unpack)
 import qualified Data.ByteString.Lazy      as BS
 import           Data.List                 (intersect, (\\))
 import           Formatting                (build, int, sformat, shown, (%))
-import           Mockable                  (Async, Catch, Mockable, MonadMockable,
-                                            Promise, Throw, catch, catchAll, throw, try,
+import           Mockable                  (Catch, Mockable, MonadMockable,
+                                            Throw, catch, catchAll, throw, try,
                                             waitAnyUnexceptional, withAsync)
 import qualified Network.Kademlia          as K
 import qualified Network.Kademlia.Instance as K (KademliaInstance (state),
@@ -54,7 +54,6 @@ kademliaConfig = K.defaultConfig { K.k = 16 }
 --   the action is finished.
 foreverRejoinNetwork
     :: ( MonadMockable m
-       , Eq (Promise m (Maybe ()))
        , MonadIO m
        , WithLogger m
        )
@@ -123,10 +122,8 @@ startDHTInstance kconf@KademliaParams {..} = do
 
 rejoinNetwork
     :: ( MonadIO m
-       , Mockable Async m
        , Mockable Catch m
        , Mockable Throw m
-       , Eq (Promise m (Maybe ()))
        , WithLogger m
        , Bi DHTData
        , Bi DHTKey
@@ -246,8 +243,6 @@ kademliaJoinNetworkNoThrow
     :: ( MonadIO m
        , Mockable Catch m
        , Mockable Throw m
-       , Mockable Async m
-       , Eq (Promise m (Maybe ()))
        , WithLogger m
        , Bi DHTKey
        , Bi DHTData

--- a/infra/Pos/Util/LogSafe.hs
+++ b/infra/Pos/Util/LogSafe.hs
@@ -34,7 +34,7 @@ instance (MonadIO m) => CanLog (SecureLogWrapped m) where
           acceptable _                   = True
       in liftIO $ logMCond name severity msg acceptable
 
-instance (Monad m, HasLoggerName m) => HasLoggerName (SecureLogWrapped m) where
+instance (HasLoggerName m) => HasLoggerName (SecureLogWrapped m) where
     getLoggerName = SecureLogWrapped getLoggerName
     modifyLoggerName foo (SecureLogWrapped m) =
         SecureLogWrapped (modifyLoggerName foo m)

--- a/infra/Pos/Util/TimeLimit.hs
+++ b/infra/Pos/Util/TimeLimit.hs
@@ -23,7 +23,7 @@ import           Universum         hiding (bracket, finally)
 
 import           Data.Time.Units   (Microsecond, Second, convertUnit)
 import           Formatting        (sformat, shown, stext, (%))
-import           Mockable          (Async, Async, Bracket, Delay, Mockable, delay, race,
+import           Mockable          (Async, Async, Delay, Mockable, delay, race,
                                     withAsync)
 import           System.Wlog       (WithLogger, logWarning)
 
@@ -108,7 +108,6 @@ logWarningWaitInf = logWarningLongAction False . (`WaitGeometric` 1.3) . convert
 execWithTimeLimit
     :: ( Mockable Async m
        , Mockable Delay m
-       , Mockable Bracket m
        )
     => Microsecond -> m a -> m (Maybe a)
 execWithTimeLimit timeout action = do

--- a/lwallet/Command.hs
+++ b/lwallet/Command.hs
@@ -72,7 +72,7 @@ lexeme p = spaces *> p >>= \x -> spaces $> x
 text :: String -> Parser Text
 text = lexeme . fmap toText . string
 
-many1Till :: Show b => Parser a -> Parser b -> Parser [a]
+many1Till :: Parser a -> Parser b -> Parser [a]
 many1Till p end = (:) <$> p <*> manyTill p end
 
 anyText :: Parser Text

--- a/lwallet/Pos/Wallet/Light/Redirect.hs
+++ b/lwallet/Pos/Wallet/Light/Redirect.hs
@@ -31,7 +31,7 @@ import qualified Pos.Wallet.Light.State    as LWS
 getOwnUtxosWallet :: (MonadIO m, MonadReader ctx m, HasLens LWS.WalletState ctx LWS.WalletState) => [Address] -> m Utxo
 getOwnUtxosWallet addrs = filterUtxoByAddrs addrs <$> LWS.getUtxo
 
-getBalanceWallet :: (MonadIO m, MonadBalances m) => Address -> m Coin
+getBalanceWallet :: (MonadBalances m) => Address -> m Coin
 getBalanceWallet = getBalanceFromUtxo
 
 ----------------------------------------------------------------------------
@@ -50,8 +50,7 @@ getBlockHistoryWallet addrs = do
     pure $ error "getBlockHistory is not implemented for light wallet"
 
 getLocalHistoryWallet
-    :: (MonadReader ctx m, HasLens LWS.WalletState ctx LWS.WalletState, MonadIO m)
-    => [Address] -> m (DList TxHistoryEntry)
+    :: [Address] -> m (DList TxHistoryEntry)
 getLocalHistoryWallet = pure $
     error "getLocalHistory is not implemented for light wallet"
 

--- a/src/Pos/Arbitrary/Block.hs
+++ b/src/Pos/Arbitrary/Block.hs
@@ -42,7 +42,7 @@ newtype BodyDependsOnSlot b = BodyDependsOnSlot
 -- Arbitrary instances for Blockchain related types
 ------------------------------------------------------------------------------------------
 
-instance (Arbitrary (SscProof ssc), Bi Raw, Ssc ssc) =>
+instance (Arbitrary (SscProof ssc), Ssc ssc) =>
     Arbitrary (T.BlockSignature ssc) where
     arbitrary = genericArbitrary
     shrink = genericShrink
@@ -112,7 +112,7 @@ instance Arbitrary T.MainExtraBodyData where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance (Arbitrary (SscProof ssc), Bi Raw) =>
+instance (Arbitrary (SscProof ssc)) =>
     Arbitrary (T.BodyProof (T.MainBlockchain ssc)) where
     arbitrary = genericArbitrary
     shrink T.MainProof {..} =
@@ -121,12 +121,12 @@ instance (Arbitrary (SscProof ssc), Bi Raw) =>
             shrink (mpTxProof, mpMpcProof, mpProxySKsProof, mpUpdateProof)
         ]
 
-instance (Arbitrary (SscProof ssc), Bi Raw, Ssc ssc) =>
+instance (Arbitrary (SscProof ssc), Ssc ssc) =>
     Arbitrary (T.ConsensusData (T.MainBlockchain ssc)) where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance (Ssc ssc, Arbitrary (SscProof ssc)) => Arbitrary (T.MainToSign ssc) where
+instance (Arbitrary (SscProof ssc)) => Arbitrary (T.MainToSign ssc) where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/src/Pos/Client/CLI/Params.hs
+++ b/src/Pos/Client/CLI/Params.hs
@@ -59,7 +59,7 @@ getKeyfilePath SimpleNodeArgs {..}
     | otherwise = keyfilePath
 
 getSimpleNodeParams ::
-       (MonadIO m, MonadFail m, MonadThrow m, WithLogger m, Mockable Fork m)
+       (MonadIO m, WithLogger m, Mockable Fork m)
     => SimpleNodeArgs
     -> Timestamp
     -> m NodeParams

--- a/src/Pos/Client/CLI/Secrets.hs
+++ b/src/Pos/Client/CLI/Secrets.hs
@@ -17,7 +17,7 @@ import           Pos.Util.UserSecret (UserSecret, usPrimKey, usVss, writeUserSec
 import           Pos.Client.CLI.NodeOptions         (SimpleNodeArgs (..))
 
 userSecretWithGenesisKey
-    :: (MonadIO m, MonadFail m) => SimpleNodeArgs -> UserSecret -> m (SecretKey, UserSecret)
+    :: (MonadIO m) => SimpleNodeArgs -> UserSecret -> m (SecretKey, UserSecret)
 userSecretWithGenesisKey SimpleNodeArgs{..} userSecret
     | isDevelopment = case devSpendingGenesisI of
           Nothing -> fetchPrimaryKey userSecret
@@ -29,14 +29,14 @@ userSecretWithGenesisKey SimpleNodeArgs{..} userSecret
     | otherwise = fetchPrimaryKey userSecret
 
 updateUserSecretVSS
-    :: (MonadIO m, MonadFail m) => SimpleNodeArgs -> UserSecret -> m UserSecret
+    :: (MonadIO m) => SimpleNodeArgs -> UserSecret -> m UserSecret
 updateUserSecretVSS SimpleNodeArgs{..} us
     | isDevelopment = case devVssGenesisI of
           Nothing -> fillUserSecretVSS us
           Just i  -> return $ us & usVss .~ Just (genesisDevVssKeyPairs !! i)
     | otherwise = fillUserSecretVSS us
 
-fetchPrimaryKey :: (MonadIO m, MonadFail m) => UserSecret -> m (SecretKey, UserSecret)
+fetchPrimaryKey :: (MonadIO m) => UserSecret -> m (SecretKey, UserSecret)
 fetchPrimaryKey userSecret = case userSecret ^. usPrimKey of
     Just sk -> return (sk, userSecret)
     Nothing -> do
@@ -46,7 +46,7 @@ fetchPrimaryKey userSecret = case userSecret ^. usPrimKey of
         writeUserSecret us
         return (sk, us)
 
-fillUserSecretVSS :: (MonadIO m, MonadFail m) => UserSecret -> m UserSecret
+fillUserSecretVSS :: (MonadIO m) => UserSecret -> m UserSecret
 fillUserSecretVSS userSecret = case userSecret ^. usVss of
     Just _  -> return userSecret
     Nothing -> do

--- a/src/Pos/Client/Txp/Balances.hs
+++ b/src/Pos/Client/Txp/Balances.hs
@@ -72,7 +72,7 @@ getOwnUtxosDefault addrs = do
 -- 1) It doesn't represent actual balances of addresses, but it represents _stakes_
 -- 2) Local utxo is now cached, and deriving balances from it is not
 --    so bad for performance now
-getBalanceDefault :: (BalancesEnv ext ctx m, MonadBalances m) => Address -> m Coin
+getBalanceDefault :: (MonadBalances m) => Address -> m Coin
 getBalanceDefault addr = getBalanceFromUtxo addr
 
 getOwnUtxo :: MonadBalances m => Address -> m Utxo

--- a/src/Pos/Client/Txp/History.hs
+++ b/src/Pos/Client/Txp/History.hs
@@ -205,7 +205,7 @@ class (Monad m, SscHelpersClass ssc) => MonadTxHistory ssc m | m -> ssc where
     saveTx :: (TxId, TxAux) -> m ()
 
     default getBlockHistory
-        :: (SscHelpersClass ssc, MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
+        :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
         => [Address] -> m (DList TxHistoryEntry)
     getBlockHistory = lift . getBlockHistory
 

--- a/src/Pos/Communication/Limits.hs
+++ b/src/Pos/Communication/Limits.hs
@@ -359,7 +359,7 @@ instance MessageLimited MsgSubscribe
 --     in  fromList <$> T.vectorOf k pairs
 
 -- | Given a limit for a list item, generate limit for a list with N elements
-vectorOf :: IsList l => Int -> Limit (Item l) -> Limit l
+vectorOf :: Int -> Limit (Item l) -> Limit l
 vectorOf k (Limit x) =
     Limit $ encodedListLength + x * (fromIntegral k)
   where
@@ -367,12 +367,11 @@ vectorOf k (Limit x) =
     encodedListLength = 20
 
 -- | Generate limit for a list of messages with N elements
-vector :: (IsList l, MessageLimitedPure (Item l)) => Int -> Limit l
+vector :: (MessageLimitedPure (Item l)) => Int -> Limit l
 vector k = vectorOf k msgLenLimit
 
 multiMap
-    :: (IsList l, Item l ~ (k, l0), IsList l0,
-        MessageLimitedPure k, MessageLimitedPure (Item l0))
+    :: (Item l ~ (k, l0), MessageLimitedPure k, MessageLimitedPure (Item l0))
     => Int -> Limit l
 multiMap k =
     -- max message length is reached when each key has single value

--- a/src/Pos/Communication/Message.hs
+++ b/src/Pos/Communication/Message.hs
@@ -12,7 +12,7 @@ import           Node.Message.Class               (Message (..))
 import           Pos.Block.Network.Types          (MsgBlock, MsgGetBlocks, MsgGetHeaders,
                                                    MsgHeaders)
 import           Pos.Communication.Types.Relay    (DataMsg, InvMsg, InvOrData, MempoolMsg,
-                                                   ReqMsg)
+                                                   ReqMsg, ReqOrRes)
 import           Pos.Communication.Types.Protocol (MsgSubscribe)
 import           Pos.Delegation.Types             (ProxySKLightConfirmation)
 import           Pos.Ssc.GodTossing.Types.Message (MCCommitment, MCOpening, MCShares,
@@ -49,259 +49,303 @@ instance Message MsgSubscribe where
 
 instance Message k => Message (ReqMsg (Tagged k v)) where
     messageCode _ = messageCode (Proxy :: Proxy k)
-    formatMessage _ = "Tagged"
+    formatMessage _ = "Tagged ReqMsg"
+
+instance Message k => Message (ReqOrRes (Tagged k v)) where
+    messageCode _ = messageCode (Proxy :: Proxy k)
+    formatMessage _ = "Tagged ReqOrRes"
 
 instance Message k => Message (MempoolMsg (Tagged k v)) where
     messageCode _ = messageCode (Proxy :: Proxy k)
-    formatMessage _ = "Tagged"
+    formatMessage _ = "Tagged MempoolMsg"
 
 instance Message k => Message (DataMsg (Tagged k v)) where
     messageCode _ = messageCode (Proxy :: Proxy k)
-    formatMessage _ = "Tagged"
+    formatMessage _ = "Tagged DataMsg"
 
 instance Message k => Message (InvMsg (Tagged k v)) where
     messageCode _ = messageCode (Proxy :: Proxy k)
-    formatMessage _ = "Tagged"
+    formatMessage _ = "Tagged InvMsg"
 
 instance Message k => Message (InvOrData key (Tagged k v)) where
     messageCode _ = messageCode (Proxy :: Proxy k)
-    formatMessage _ = "Tagged"
+    formatMessage _ = "Tagged InvOrData"
 
 
 instance Message (ReqMsg TxMsgContents) where
     messageCode _ = 32
     formatMessage _ = "Request"
 
-instance Message (MempoolMsg TxMsgContents) where
+instance Message (ReqOrRes TxMsgContents) where
     messageCode _ = 33
+    formatMessage _ = "ReqOrRes"
+
+instance Message (MempoolMsg TxMsgContents) where
+    messageCode _ = 34
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg TxMsgContents) where
-    messageCode _ = 34
+    messageCode _ = 35
     formatMessage _ = "Data"
 
 instance Message (InvMsg TxMsgContents) where
-    messageCode _ = 35
+    messageCode _ = 36
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key TxMsgContents) where
-    messageCode _ = 36
+    messageCode _ = 37
     formatMessage _ = "TxMsgContents"
 
 
 instance Message (ReqMsg (UpdateProposal, [UpdateVote])) where
-    messageCode _ = 37
+    messageCode _ = 38
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes (UpdateProposal, [UpdateVote])) where
+    messageCode _ = 39
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg (UpdateProposal, [UpdateVote])) where
-    messageCode _ = 38
+    messageCode _ = 40
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg (UpdateProposal, [UpdateVote])) where
-    messageCode _ = 39
+    messageCode _ = 41
     formatMessage _ = "Data"
 
 instance Message (InvMsg (UpdateProposal, [UpdateVote])) where
-    messageCode _ = 40
+    messageCode _ = 42
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key (UpdateProposal, [UpdateVote])) where
-    messageCode _ = 41
+    messageCode _ = 43
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg UpdateVote) where
-    messageCode _ = 42
+    messageCode _ = 44
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes UpdateVote) where
+    messageCode _ = 45
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg UpdateVote) where
-    messageCode _ = 43
+    messageCode _ = 46
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg UpdateVote) where
-    messageCode _ = 44
+    messageCode _ = 47
     formatMessage _ = "Data"
 
 instance Message (InvMsg UpdateVote) where
-    messageCode _ = 45
+    messageCode _ = 48
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key UpdateVote) where
-    messageCode _ = 46
+    messageCode _ = 49
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg MCCommitment) where
-    messageCode _ = 47
+    messageCode _ = 50
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes MCCommitment) where
+    messageCode _ = 51
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg MCCommitment) where
-    messageCode _ = 48
+    messageCode _ = 52
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg MCCommitment) where
-    messageCode _ = 49
+    messageCode _ = 53
     formatMessage _ = "Data"
 
 instance Message (InvMsg MCCommitment) where
-    messageCode _ = 50
+    messageCode _ = 54
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key MCCommitment) where
-    messageCode _ = 51
+    messageCode _ = 55
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg MCOpening) where
-    messageCode _ = 52
+    messageCode _ = 56
     formatMessage _ = "Request"
+
+instance Message (ReqOrRes MCOpening) where
+    messageCode _ = 57
+    formatMessage _ = "ReqOrRes"
 
 instance Message (MempoolMsg MCOpening) where
-    messageCode _ = 53
-    formatMessage _ = "Mempool"
-
-instance Message (DataMsg MCOpening) where
-    messageCode _ = 54
-    formatMessage _ = "Data"
-
-instance Message (InvMsg MCOpening) where
-    messageCode _ = 55
-    formatMessage _ = "Inventory"
-
-instance Message (InvOrData key MCOpening) where
-    messageCode _ = 56
-    formatMessage _ = "Inventory/Data"
-
-
-instance Message (ReqMsg MCShares) where
-    messageCode _ = 57
-    formatMessage _ = "Request"
-
-instance Message (MempoolMsg MCShares) where
     messageCode _ = 58
     formatMessage _ = "Mempool"
 
-instance Message (DataMsg MCShares) where
+instance Message (DataMsg MCOpening) where
     messageCode _ = 59
     formatMessage _ = "Data"
 
-instance Message (InvMsg MCShares) where
+instance Message (InvMsg MCOpening) where
     messageCode _ = 60
     formatMessage _ = "Inventory"
 
-instance Message (InvOrData key MCShares) where
+instance Message (InvOrData key MCOpening) where
     messageCode _ = 61
     formatMessage _ = "Inventory/Data"
 
 
-instance Message (ReqMsg MCVssCertificate) where
+instance Message (ReqMsg MCShares) where
     messageCode _ = 62
     formatMessage _ = "Request"
 
-instance Message (MempoolMsg MCVssCertificate) where
+instance Message (ReqOrRes MCShares) where
     messageCode _ = 63
+    formatMessage _ = "ReqOrRes"
+
+instance Message (MempoolMsg MCShares) where
+    messageCode _ = 64
+    formatMessage _ = "Mempool"
+
+instance Message (DataMsg MCShares) where
+    messageCode _ = 65
+    formatMessage _ = "Data"
+
+instance Message (InvMsg MCShares) where
+    messageCode _ = 66
+    formatMessage _ = "Inventory"
+
+instance Message (InvOrData key MCShares) where
+    messageCode _ = 67
+    formatMessage _ = "Inventory/Data"
+
+
+instance Message (ReqMsg MCVssCertificate) where
+    messageCode _ = 68
+    formatMessage _ = "Request"
+
+instance Message (ReqOrRes MCVssCertificate) where
+    messageCode _ = 69
+    formatMessage _ = "ReqOrRes"
+
+instance Message (MempoolMsg MCVssCertificate) where
+    messageCode _ = 70
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg MCVssCertificate) where
-    messageCode _ = 64
+    messageCode _ = 71
     formatMessage _ = "Data"
 
 instance Message (InvMsg MCVssCertificate) where
-    messageCode _ = 65
+    messageCode _ = 72
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key MCVssCertificate) where
-    messageCode _ = 66
+    messageCode _ = 73
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg ProxySKLight) where
-    messageCode _ = 67
+    messageCode _ = 74
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes ProxySKLight) where
+    messageCode _ = 75
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg ProxySKLight) where
-    messageCode _ = 68
+    messageCode _ = 76
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg ProxySKLight) where
-    messageCode _ = 69
+    messageCode _ = 77
     formatMessage _ = "Data"
 
 instance Message (InvMsg ProxySKLight) where
-    messageCode _ = 70
+    messageCode _ = 78
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key ProxySKLight) where
-    messageCode _ = 71
+    messageCode _ = 79
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg ProxySKHeavy) where
-    messageCode _ = 72
+    messageCode _ = 80
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes ProxySKHeavy) where
+    messageCode _ = 81
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg ProxySKHeavy) where
-    messageCode _ = 73
+    messageCode _ = 82
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg ProxySKHeavy) where
-    messageCode _ = 74
+    messageCode _ = 83
     formatMessage _ = "Data"
 
 instance Message (InvMsg ProxySKHeavy) where
-    messageCode _ = 75
+    messageCode _ = 84
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key ProxySKHeavy) where
-    messageCode _ = 76
+    messageCode _ = 85
     formatMessage _ = "Inventory/Data"
 
 
 instance Message (ReqMsg ProxySKLightConfirmation) where
-    messageCode _ = 77
+    messageCode _ = 86
     formatMessage _ = "Request"
 
+instance Message (ReqOrRes ProxySKLightConfirmation) where
+    messageCode _ = 87
+    formatMessage _ = "ReqOrRes"
+
 instance Message (MempoolMsg ProxySKLightConfirmation) where
-    messageCode _ = 78
+    messageCode _ = 88
     formatMessage _ = "Mempool"
 
 instance Message (DataMsg ProxySKLightConfirmation) where
-    messageCode _ = 79
+    messageCode _ = 89
     formatMessage _ = "Data"
 
 instance Message (InvMsg ProxySKLightConfirmation) where
-    messageCode _ = 80
+    messageCode _ = 90
     formatMessage _ = "Inventory"
 
 instance Message (InvOrData key ProxySKLightConfirmation) where
-    messageCode _ = 81
+    messageCode _ = 91
     formatMessage _ = "Inventory/Data"
 
 
 instance Message UpdateVote where
-    messageCode _ = 82
+    messageCode _ = 92
     formatMessage _ = "UpdateVote"
 
 instance Message (UpdateProposal, [UpdateVote]) where
-    messageCode _ = 83
+    messageCode _ = 93
     formatMessage _ = "UpdateProposal"
 
 instance Message TxMsgContents where
-    messageCode _ = 84
+    messageCode _ = 94
     formatMessage _ = "TxMsgContents"
 
 instance Message MCVssCertificate where
-    messageCode _ = 85
+    messageCode _ = 95
     formatMessage _ = "MCVssCertificate"
 
 instance Message MCShares where
-    messageCode _ = 86
+    messageCode _ = 96
     formatMessage _ = "MCShares"
 
 instance Message MCOpening where
-    messageCode _ = 87
+    messageCode _ = 97
     formatMessage _ = "MCOpening"
 
 instance Message MCCommitment where
-    messageCode _ = 88
+    messageCode _ = 98
     formatMessage _ = "MCCommitment"

--- a/src/Pos/Communication/Methods.hs
+++ b/src/Pos/Communication/Methods.hs
@@ -31,7 +31,7 @@ sendTx
     :: (MinWorkMode m, MonadGState m)
     => EnqueueMsg m -> TxAux -> m ()
 sendTx enqueue txAux =
-    invReqDataFlowTK
+    void $ invReqDataFlowTK
         "tx"
         enqueue
         (MsgTransaction OriginSender)
@@ -43,7 +43,7 @@ sendVote
     :: (MinWorkMode m, MonadGState m)
     => EnqueueMsg m -> UpdateVote -> m ()
 sendVote enqueue vote =
-    invReqDataFlowTK
+    void $ invReqDataFlowTK
         "UpdateVote"
         enqueue
         (MsgMPC OriginSender)
@@ -60,7 +60,7 @@ sendUpdateProposal
     -> m ()
 sendUpdateProposal enqueue upid proposal votes = do
     logInfo $ sformat ("Announcing proposal with id "%hashHexF) upid
-    invReqDataFlowTK
+    void $ invReqDataFlowTK
         "UpdateProposal"
         enqueue
         (MsgMPC OriginSender)

--- a/src/Pos/Communication/Tx.hs
+++ b/src/Pos/Communication/Tx.hs
@@ -104,7 +104,7 @@ submitRedemptionTx enqueue rsk output = do
 
 -- | Send the ready-to-use transaction
 submitTxRaw
-    :: (MinWorkMode m, MonadGState m, MonadThrow m)
+    :: (MinWorkMode m, MonadGState m)
     => EnqueueMsg m -> TxAux -> m ()
 submitTxRaw enqueue txAux@TxAux {..} = do
     let txId = hash taTx

--- a/src/Pos/DB/DB.hs
+++ b/src/Pos/DB/DB.hs
@@ -74,14 +74,14 @@ initNodeDBs = do
 -- | Load blunds from BlockDB starting from tip and while the @condition@ is
 -- true.
 loadBlundsFromTipWhile
-    :: (MonadBlockDB ssc m, MonadDBRead m)
+    :: (MonadBlockDB ssc m)
     => (Block ssc -> Bool) -> m (NewestFirst [] (Blund ssc))
 loadBlundsFromTipWhile condition = getTip >>= loadBlundsWhile condition
 
 -- | Load blunds from BlockDB starting from tip which have depth less than
 -- given.
 loadBlundsFromTipByDepth
-    :: (MonadBlockDB ssc m, MonadDBRead m)
+    :: (MonadBlockDB ssc m)
     => BlockCount -> m (NewestFirst [] (Blund ssc))
 loadBlundsFromTipByDepth d = getTip >>= loadBlundsByDepth d
 

--- a/src/Pos/Delegation/Logic/Common.hs
+++ b/src/Pos/Delegation/Logic/Common.hs
@@ -102,7 +102,7 @@ invalidateProxyCaches curTime = do
 -- * Sets '_dwEpochId' to epoch of tip.
 -- * Initializes mempools/LRU caches.
 mkDelegationVar ::
-       forall ssc m. (MonadIO m, DB.MonadBlockDB ssc m, MonadMask m)
+       forall ssc m. (MonadIO m, DB.MonadBlockDB ssc m)
     => m DelegationVar
 mkDelegationVar = do
     tip <- DB.getTipHeader @ssc

--- a/src/Pos/Delegation/Logic/VAR.hs
+++ b/src/Pos/Delegation/Logic/VAR.hs
@@ -298,7 +298,6 @@ getNoLongerRichmen ::
        ( Monad m
        , MonadIO m
        , MonadDBRead m
-       , WithLogger m
        , MonadReader ctx m
        , HasLens LrcContext ctx LrcContext
        )
@@ -334,11 +333,9 @@ makeLenses ''DlgVerState
 dlgVerifyBlocks ::
        forall ssc ctx m.
        ( DB.MonadBlockDB ssc m
-       , DB.MonadDBRead m
        , MonadIO m
        , MonadReader ctx m
        , HasLens LrcContext ctx LrcContext
-       , WithLogger m
        )
     => OldestFirst NE (Block ssc)
     -> m (Either Text (OldestFirst NE DlgUndo))
@@ -485,7 +482,6 @@ dlgApplyBlocks ::
        , MonadDBRead m
        , WithLogger m
        , MonadMask m
-       , HasLens LrcContext ctx LrcContext
        )
     => OldestFirst NE (Blund ssc)
     -> m (NonEmpty SomeBatchOp)
@@ -537,12 +533,7 @@ dlgRollbackBlocks
     :: forall ssc ctx m.
        ( MonadDelegation ctx m
        , DB.MonadBlockDB ssc m
-       , DB.MonadDBRead m
-       , MonadIO m
-       , MonadMask m
        , WithLogger m
-       , MonadReader ctx m
-       , HasLens LrcContext ctx LrcContext
        )
     => NewestFirst NE (Blund ssc) -> m (NonEmpty SomeBatchOp)
 dlgRollbackBlocks blunds = do
@@ -569,12 +560,9 @@ dlgNormalizeOnRollback ::
        forall ssc ctx m.
        ( MonadDelegation ctx m
        , DB.MonadBlockDB ssc m
-       , DB.MonadDBRead m
        , DB.MonadGState m
        , MonadIO m
        , MonadMask m
-       , WithLogger m
-       , MonadReader ctx m
        , HasLens LrcContext ctx LrcContext
        , Mockable CurrentTime m
        )

--- a/src/Pos/Explorer/BListener.hs
+++ b/src/Pos/Explorer/BListener.hs
@@ -22,7 +22,6 @@ import qualified Data.Map                     as M
 import qualified Ether
 import           System.Wlog                  (WithLogger)
 
-import           Mockable                     (MonadMockable)
 import           Pos.Block.BListener          (MonadBListener (..))
 import           Pos.Block.Core               (Block, MainBlock,
                                                mainBlockTxPayload)
@@ -63,7 +62,6 @@ type MonadBListenerT m ssc =
 
 -- Explorer implementation for usual node. Combines the operations.
 instance ( MonadDBRead m
-         , MonadMockable m
          , MonadCatch m
          , WithLogger m
          )
@@ -338,8 +336,7 @@ getExistingBlocks keys = do
     -- Get exisiting key blocks paired with the key. If there are no
     -- saved blocks on the key return an empty list.
     getExistingKeyBlocks
-        :: (MonadDBRead m)
-        => k
+        :: k
         -> m (M.Map k [HeaderHash])
     getExistingKeyBlocks key = do
         mKeyBlocks    <- getKeyBlocksF key

--- a/src/Pos/Generator/Block/Payload.hs
+++ b/src/Pos/Generator/Block/Payload.hs
@@ -57,7 +57,7 @@ import           Pos.Util.Util              (eitherToThrow)
 ----------------------------------------------------------------------------
 
 -- | Generates list of distinct ints in the given range [a,b].
-selectDistinct :: forall m. (MonadRandom m, MonadIO m) => Int -> (Int,Int) -> m [Int]
+selectDistinct :: forall m. (MonadRandom m) => Int -> (Int,Int) -> m [Int]
 selectDistinct n0 p@(a, b)
     | b - a < 0 = error $ "selectDistinct: b < a " <> show p
     | otherwise = do
@@ -77,7 +77,7 @@ selectDistinct n0 p@(a, b)
 
 -- | Separates coin into provided number of coins. All resulting coins
 -- are nonzero.
-splitCoins :: (MonadRandom m, MonadIO m) => Int -> Coin -> m [Coin]
+splitCoins :: (MonadRandom m) => Int -> Coin -> m [Coin]
 splitCoins n c0
     | c == (0::Int) = error "splitCoins, c = 0"
     | c < n = error $ "splitCoins: can't split " <> pretty c0 <>

--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -28,7 +28,7 @@ import           Data.Tagged                 (untag)
 import qualified Data.Time                  as Time
 import           Formatting                 (sformat, shown, (%))
 import           Mockable                   (Catch, Mockable, Production (..), Throw,
-                                             throw, Bracket, bracket, MonadMockable)
+                                             throw, Bracket, bracket)
 import           Network.QDisc.Fair         (fairQDisc)
 import           Network.Transport.Abstract (Transport, hoistTransport)
 import           Network.Transport.Concrete (concrete)
@@ -74,7 +74,6 @@ import           Pos.Txp                    (txpGlobalSettings)
 
 import           Pos.Launcher.Mode          (InitMode, InitModeContext (..),
                                              newInitFuture, runInitMode)
-import           Pos.Security               (SecurityWorkersClass)
 import           Pos.Update.Context         (mkUpdateContext)
 import qualified Pos.Update.DB              as GState
 import           Pos.WorkMode               (TxpExtra_TMP)
@@ -115,10 +114,6 @@ hoistNodeResources nat nr =
 allocateNodeResources
     :: forall ssc m.
        ( SscConstraint ssc
-       , SecurityWorkersClass ssc
-       , WithLogger m
-       , MonadIO m
-       , MonadMockable m
        )
     => Transport m
     -> NetworkConfig KademliaDHTInstance
@@ -181,7 +176,7 @@ allocateNodeResources transport networkConfig np@NodeParams {..} sscnp = do
 
 -- | Release all resources used by node. They must be released eventually.
 releaseNodeResources ::
-       forall ssc m. (SscConstraint ssc, MonadIO m)
+       forall ssc m. ( )
     => NodeResources ssc m -> Production ()
 releaseNodeResources NodeResources {..} = do
     releaseAllHandlers
@@ -193,10 +188,7 @@ releaseNodeResources NodeResources {..} = do
 -- resources will be released eventually.
 bracketNodeResources :: forall ssc m a.
       ( SscConstraint ssc
-      , SecurityWorkersClass ssc
-      , WithLogger m
       , MonadIO m
-      , MonadMockable m
       )
     => NodeParams
     -> SscParams ssc
@@ -233,7 +225,7 @@ loggerBracket lp = bracket_ (setupLoggers lp) releaseAllHandlers
 
 allocateNodeContext
     :: forall ssc .
-      (SscConstraint ssc, SecurityWorkersClass ssc)
+      (SscConstraint ssc)
     => NodeParams
     -> SscParams ssc
     -> ((Timestamp, TVar SlottingData) -> SlottingContextSum -> InitMode ssc ())

--- a/src/Pos/Launcher/Runner.hs
+++ b/src/Pos/Launcher/Runner.hs
@@ -54,7 +54,6 @@ import           Pos.Launcher.Param              (BaseParams (..), LoggingParams
                                                   NodeParams (..))
 import           Pos.Launcher.Resource           (NodeResources (..), hoistNodeResources)
 import           Pos.Network.Types               (NetworkConfig (..), NodeId, initQueue)
-import           Pos.Security                    (SecurityWorkersClass)
 import           Pos.Ssc.Class                   (SscConstraint)
 import           Pos.Statistics                  (EkgParams (..), StatsdParams (..))
 import           Pos.Util.JsonLog                (JsonLogConfig (..),
@@ -70,7 +69,7 @@ import           Pos.WorkMode                    (RealMode, RealModeContext (..)
 -- | Run activity in 'RealMode'.
 runRealMode
     :: forall ssc a.
-       (SscConstraint ssc, SecurityWorkersClass ssc)
+       (SscConstraint ssc)
     => NodeResources ssc (RealMode ssc)
     -> (ActionSpec (RealMode ssc) a, OutSpecs)
     -> Production a
@@ -79,7 +78,7 @@ runRealMode = runRealBasedMode identity identity
 -- | Run activity in something convertible to 'RealMode' and back.
 runRealBasedMode
     :: forall ssc ctx m a.
-       (SscConstraint ssc, SecurityWorkersClass ssc, WorkMode ssc ctx m)
+       (SscConstraint ssc, WorkMode ssc ctx m)
     => (forall b. m b -> RealMode ssc b)
     -> (forall b. RealMode ssc b -> m b)
     -> NodeResources ssc m
@@ -93,7 +92,7 @@ runRealBasedMode unwrap wrap nr@NodeResources {..} (ActionSpec action, outSpecs)
 -- | RealMode runner.
 runRealModeDo
     :: forall ssc a.
-       (SscConstraint ssc, SecurityWorkersClass ssc)
+       (SscConstraint ssc)
     => NodeResources ssc (RealMode ssc)
     -> OutSpecs
     -> ActionSpec (RealMode ssc) a

--- a/src/Pos/Launcher/Scenario.hs
+++ b/src/Pos/Launcher/Scenario.hs
@@ -25,9 +25,8 @@ import           System.Wlog           (WithLogger, getLoggerName, logError, log
 import           Pos.Communication     (ActionSpec (..), OutSpecs, WorkerSpec,
                                         wrapActionSpec)
 import qualified Pos.Constants         as Const
-import           Pos.Context           (BlkSemaphore (..), HasNodeContext (..),
-                                        NodeContext (..), getOurPubKeyAddress,
-                                        getOurPublicKey)
+import           Pos.Context           (BlkSemaphore (..), getOurPubKeyAddress,
+                                        getOurPublicKey, ncNetworkConfig)
 import           Pos.DHT.Real          (KademliaDHTInstance (..), kademliaJoinNetwork)
 import           Pos.Genesis           (GenesisWStakeholders (..), bootDustThreshold)
 import qualified Pos.GState            as GS
@@ -42,7 +41,6 @@ import           Pos.Ssc.Class         (SscConstraint)
 import           Pos.Types             (addressHash)
 import           Pos.Util              (inAssertMode)
 import           Pos.Util.LogSafe      (logInfoS)
-import           Pos.Util.UserSecret   (HasUserSecret (..))
 import           Pos.Worker            (allWorkers)
 import           Pos.WorkMode.Class    (WorkMode)
 
@@ -50,11 +48,7 @@ import           Pos.WorkMode.Class    (WorkMode)
 -- Initialization, running of workers, running of plugins.
 runNode'
     :: forall ssc ctx m.
-       ( SscConstraint ssc
-       , SecurityWorkersClass ssc
-       , WorkMode ssc ctx m
-       , HasNodeContext ssc ctx
-       , HasUserSecret ctx
+       ( WorkMode ssc ctx m
        )
     => NodeResources ssc m
     -> [WorkerSpec m]
@@ -121,8 +115,6 @@ runNode ::
        ( SscConstraint ssc
        , SecurityWorkersClass ssc
        , WorkMode ssc ctx m
-       , HasNodeContext ssc ctx
-       , HasUserSecret ctx
        )
     => NodeResources ssc m
     -> ([WorkerSpec m], OutSpecs)
@@ -156,7 +148,6 @@ nodeStartMsg = logInfo msg
 --        ( MonadDB m
 --        , MonadReader ctx m
 --        , MonadIO m
---        , HasUserSecret ctx
 --        , HasPrimaryKey ctx )
 --     => m ()
 -- putProxySecretKeys = do

--- a/src/Pos/Txp/Worker.hs
+++ b/src/Pos/Txp/Worker.hs
@@ -5,14 +5,11 @@ module Pos.Txp.Worker
 import           Universum
 
 import           Pos.Communication   (OutSpecs, WorkerSpec)
-import           Pos.Ssc.Class       (SscWorkersClass)
 import           Pos.Util            (mconcatPair)
-import           Pos.WorkMode.Class  (WorkMode)
 
 -- | All workers specific to transaction processing.
 txpWorkers
-    :: (SscWorkersClass ssc, WorkMode ssc ctx m)
-    => ([WorkerSpec m], OutSpecs)
+    :: ([WorkerSpec m], OutSpecs)
 txpWorkers =
     merge $ []
   where

--- a/src/node/Main.hs
+++ b/src/node/Main.hs
@@ -49,8 +49,7 @@ actionWithoutWallet sscParams nodeParams = do
     plugins = updateTriggerWorker
 
 updateTriggerWorker
-    :: SscConstraint ssc
-    => ([WorkerSpec (RealMode ssc)], OutSpecs)
+    :: ([WorkerSpec (RealMode ssc)], OutSpecs)
 updateTriggerWorker = first pure $ worker mempty $ \_ -> do
     logInfo "Update trigger worker is locked"
     void $ takeMVar =<< views (lensOf @UpdateContext) ucUpdateSemaphore

--- a/wallet/src/Pos/Wallet/Web/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/BListener.hs
@@ -42,7 +42,6 @@ import           Pos.Wallet.Web.Util        (getWalletAddrMetas)
 
 walletGuard ::
     ( AccountMode ctx m
-    , WithLogger m
     )
     => HeaderHash
     -> CId Wal
@@ -110,9 +109,7 @@ onApplyTracking blunds = setLogger $ do
 -- Perform this action under block lock.
 onRollbackTracking
     :: forall ssc ctx m .
-    ( SscHelpersClass ssc
-    , AccountMode ctx m
-    , WithLogger m
+    ( AccountMode ctx m
     , MonadDBRead m
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp

--- a/wallet/src/Pos/Wallet/Web/Server/Full.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Full.hs
@@ -59,7 +59,7 @@ walletServeWebFull sendActions debug = walletServeImpl action
     action = do
         logInfo "DAEDALUS has STARTED!"
         when debug $ addInitialRichAccount 0
-        walletApplication $ walletServer @WalletWebModeContext sendActions nat
+        walletApplication $ walletServer @WalletWebMode sendActions nat
 
 nat :: WalletWebMode (WalletWebMode :~> Handler)
 nat = do

--- a/wallet/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Methods.hs
@@ -37,7 +37,6 @@ import qualified Data.List.NonEmpty               as NE
 import qualified Data.Text.Buildable
 import           Data.Time.Clock.POSIX            (getPOSIXTime)
 import           Data.Time.Units                  (Microsecond, Second)
-import           Ether.Internal                   (HasLens (..))
 import           Formatting                       (bprint, build, sformat, shown, stext,
                                                    (%))
 import qualified Formatting                       as F
@@ -68,7 +67,6 @@ import           Pos.Client.Txp.Util              (computeTxFee)
 import           Pos.Communication                (OutSpecs, SendActions (..), sendTxOuts,
                                                    submitMTx, submitRedemptionTx)
 import           Pos.Constants                    (curSoftwareVersion, isDevelopment)
-import           Pos.Context                      (GenesisUtxo)
 import           Pos.Core                         (Address (..), Coin, addressF,
                                                    decodeTextAddress, getCurrentTimestamp,
                                                    getTimestamp, makeRedeemAddress,
@@ -211,9 +209,8 @@ walletApplication serv = do
     upgradeApplicationWS wsConn . serve walletApi <$> serv
 
 walletServer
-    :: forall ctx m.
-       ( WalletWebMode m
-       , HasLens GenesisUtxo ctx GenesisUtxo)
+    :: forall m.
+       ( WalletWebMode m )
     => SendActions m
     -> m (m :~> Handler)
     -> m (Server WalletApi)


### PR DESCRIPTION
A ResMsg is expected following the DataMsg if the peer send a ReqMsg. It
includes a Bool to indicate whether the data was successfully processed,
in particular whether a transaction was successfully included in the
peer's mempool.

I judged the design in here to be the shortest path to a working
solution but I don't believe it's ideal. We may want to consider opening
up time-warp-nt to allow for conversations on heterogeneous send/recv
types so that we don't have to create these unions InvOrData, ReqOrRes
and explicitly handle the possibility that the peer sends a value of
the wrong type.