### PR TITLE
[CSL-1478] Switch to use upstream revision of cborg

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -20,12 +20,6 @@ packages:
 - txp
 
 - location:
-    git: https://github.com/arybczak/binary-serialise-cbor
-    commit: a1770a6ab0a6f457fe56269fb684a9f8dad0da17
-  subdirs:
-  - cborg
-  extra-dep: true
-- location:
     git: https://github.com/serokell/time-units.git
     commit: 6c3747c1ac794f952de996dd7ba8a2f6d63bf132
   extra-dep: true
@@ -114,6 +108,7 @@ extra-deps:
 - generic-arbitrary-0.1.0
 - happy-1.19.5                    # https://github.com/commercialhaskell/stack/issues/3151
 - entropy-0.3.7                   # https://github.com/commercialhaskell/stack/issues/3151
+- cborg-0.1.1.0
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything


### PR DESCRIPTION
See https://issues.serokell.io/issue/CSL-1478 for context.

As `cborg` has been officially released on the 1st of August and such release includes the work @arybczak committed in the previously-used revision (commit SHA: `a1770a6ab0a6f457fe56269fb684a9f8dad0da17`) we might just as well use a proper Hackage release.