### PR TITLE
Remove unused DHT-related NodeOptions

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -74,33 +74,6 @@ function dht_key {
   $(find_binary cardano-dht-keygen) -n 000000000000$i2 | tr -d '\n'
 }
 
-function peer_config {
-  local j=$1
-  echo -n " --kademlia-peer 127.0.0.1:"`get_port $j`
-}
-
-function dht_config {
-  local i="$1"
-  shift
-  local j=0
-  if [[ "$1" == "all" ]]; then
-    n=$2
-    while [[ $j -lt $n ]]; do
-        peer_config $j
-        j=$((j+1))
-    done
-  else
-    while [[ $# -gt 0 ]]; do
-      peer_config $1
-      shift
-    done
-  fi
-
-  if [[ "$i" != "rand" ]]; then
-    echo -n " --kademlia-id "`dht_key $i`
-  fi
-}
-
 function node_cmd {
   local i=$1
   local is_stat=$2
@@ -152,13 +125,11 @@ function node_cmd {
 
   echo -n " --address 127.0.0.1:"`get_port $i`
   echo -n " --listen 127.0.0.1:"`get_port $i`
-  echo -n " --kademlia-address 127.0.0.1:"`get_port $i`
   echo -n " $(logs node$i.log) $time_lord $stats"
   echo -n " $stake_distr $ssc_algo "
   echo -n " $web "
   echo -n " $report_server "
   echo -n " $wallet_args "
-  echo -n " --kademlia-dump-path  $(dump_path $kademlia_dump_path)"
   echo -n " --system-start $system_start"
   echo -n " --metrics +RTS -T -RTS"
   echo -n " --ekg-server $ekg_server"

--- a/src/Pos/CLI.hs
+++ b/src/Pos/CLI.hs
@@ -137,7 +137,6 @@ data CommonArgs = CommonArgs
     { logConfig          :: !(Maybe FilePath)
     , logPrefix          :: !(Maybe FilePath)
     , sscAlgo            :: !SscAlgo
-    , disablePropagation :: !Bool
     , reportServers      :: ![Text]
     , updateServers      :: ![Text]
     -- distributions, only used in dev mode
@@ -155,8 +154,6 @@ commonArgsParser = do
     logPrefix <- optionalLogPrefix
     --
     sscAlgo <- sscAlgoOption
-    --
-    disablePropagation <- disablePropagationOption
     --
     reportServers <- reportServersOption
     updateServers <- updateServersOption
@@ -229,14 +226,6 @@ sscAlgoOption =
                        "Shared Seed Calculation algorithm which nodes will use."
         <> Opt.value GodTossingAlgo
         <> Opt.showDefault
-
-disablePropagationOption :: Opt.Parser Bool
-disablePropagationOption =
-    Opt.switch
-        (Opt.long "disable-propagation" <>
-         Opt.help "Disable network propagation (transactions, SSC data, blocks). I.e.\
-                  \ all data is to be sent only by entity who creates data and entity is\
-                  \ yosend it to all peers on his own.")
 
 reportServersOption :: Opt.Parser [Text]
 reportServersOption =

--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -60,7 +60,6 @@ data NodeParams = NodeParams
     , npBaseParams     :: !BaseParams           -- ^ See 'BaseParams'
     , npGenesisTxpCtx  :: !GenesisTxpContext    -- ^ Predefined genesis context related to txp data.
     , npJLFile         :: !(Maybe FilePath)     -- TODO COMMENT
-    , npPropagation    :: !Bool                 -- ^ Whether to propagate txs, ssc data, blocks to neighbors
     , npReportServers  :: ![Text]               -- ^ List of report server URLs
     , npUpdateParams   :: !UpdateParams         -- ^ Params for update system
     , npSecurityParams :: !SecurityParams       -- ^ Params for "Pos.Security"

--- a/src/node/Params.hs
+++ b/src/node/Params.hs
@@ -88,7 +88,6 @@ getNodeParams args@Args {..} systemStart = do
         , npSystemStart = systemStart
         , npBaseParams = getBaseParams "node" args
         , npJLFile = jlPath
-        , npPropagation = not (CLI.disablePropagation commonArgs)
         , npReportServers = CLI.reportServers commonArgs
         , npUpdateParams = UpdateParams
             { upUpdatePath    = updateLatestPath


### PR DESCRIPTION
They're all deprecated in favour of the kademlia yaml configuration
(specified by the --kademlia option)