### PR TITLE
[DEVOPS-246] fixes for kademlia on relay nodes

### DIFF
--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -141,15 +141,17 @@ topologySubscriptionWorker = go
     go (TopologyTraditional v f kademlia) = Just $ SubscriptionWorkerKademlia kademlia NodeCore v f
     go TopologyLightWallet{}              = Nothing
 
--- | Should we register to the Kademlia network?
-topologyRunKademlia :: Topology kademlia -> Maybe kademlia
+-- | Should we register to the Kademlia network? If so, is it essential that we
+-- successfully join it (contact at least one existing peer)? Second component
+-- is 'True' if yes.
+topologyRunKademlia :: Topology kademlia -> Maybe (kademlia, Bool)
 topologyRunKademlia = go
   where
-    go (TopologyCore  _        mKademlia) = mKademlia
-    go (TopologyRelay _        mKademlia) = mKademlia
+    go (TopologyCore  _        mKademlia) = flip (,) False <$> mKademlia
+    go (TopologyRelay _        mKademlia) = flip (,) False <$> mKademlia
     go TopologyBehindNAT{}                = Nothing
-    go (TopologyP2P _ _         kademlia) = Just kademlia
-    go (TopologyTraditional _ _ kademlia) = Just kademlia
+    go (TopologyP2P _ _         kademlia) = Just (kademlia, True)
+    go (TopologyTraditional _ _ kademlia) = Just (kademlia, True)
     go TopologyLightWallet{}              = Nothing
 
 -- | Variation on resolveDnsDomains that returns node IDs

--- a/src/Pos/Worker.hs
+++ b/src/Pos/Worker.hs
@@ -81,7 +81,7 @@ allWorkers NodeResources {..} = mconcatPair
       -- spawned when the DHT instance is created and killed when it's
       -- released.
     , case topologyRunKademlia (ncTopology ncNetworkConfig) of
-        Just kinst -> dhtWorkers kinst
+        Just (kinst, _) -> dhtWorkers kinst
         Nothing -> mempty
     ]
   where


### PR DESCRIPTION
When joining the kademlia network, failing to contact any listed peers is not fatal for relay nodes (it *is* fatal for p2p nodes).

TODO: the kademlia configuration must accept host names, but resolve them before using them.