### PR TITLE
Add `--init-delay` command line arg

### DIFF
--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -13,6 +13,7 @@ module Pos.Launcher.Param
 import           Universum
 
 import           Control.Lens            (makeLensesWith)
+import           Data.Time               (UTCTime)
 import           Ether.Internal          (HasLens (..))
 import qualified Network.Transport.TCP   as TCP
 import           System.Wlog             (LoggerName)
@@ -69,6 +70,7 @@ data NodeParams = NodeParams
     , npEkgParams      :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
     , npStatsdParams   :: !(Maybe StatsdParams) -- ^ statsd statistics backend.
     , npNetworkConfig  :: !(NetworkConfig KademliaParams)
+    , npInitDelay      :: !(Maybe UTCTime)      -- ^ delay node startup
     } -- deriving (Show)
 
 makeLensesWith postfixLFields ''NodeParams

--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -23,6 +23,7 @@ module Pos.Launcher.Resource
 
 import           Universum                  hiding (bracket, finally)
 
+import           Control.Concurrent         (threadDelay)
 import           Control.Concurrent.STM     (newEmptyTMVarIO, newTBQueueIO)
 import           Data.Tagged                 (untag)
 import qualified Data.Time                  as Time
@@ -37,7 +38,8 @@ import qualified Network.Transport          as NT (closeTransport)
 import           System.IO                  (Handle, hClose, hSetBuffering, BufferMode (..))
 import qualified System.Metrics             as Metrics
 import           System.Wlog                (CanLog, LoggerConfig (..), WithLogger,
-                                             getLoggerName, logError, productionB,
+                                             getLoggerName, logError, logNotice, logWarning,
+                                             productionB,
                                              releaseAllHandlers, setupLogging,
                                              usingLoggerName)
 
@@ -202,11 +204,31 @@ bracketNodeResources :: forall ssc m a.
     -> SscParams ssc
     -> (NodeResources ssc m -> Production a)
     -> Production a
-bracketNodeResources np sp k = bracketTransport tcpAddr $ \transport ->
+bracketNodeResources np sp k =
+    bracketTransport tcpAddr $ \transport ->
     bracketKademlia (npBaseParams np) (npNetworkConfig np) $ \networkConfig ->
-        bracket (allocateNodeResources transport networkConfig np sp) releaseNodeResources k
+    bracket (allocateNodeResources transport networkConfig np sp) releaseNodeResources $ \nodeRes -> do
+      case npInitDelay np of
+        Nothing ->
+          -- Start node immediately
+          return ()
+        Just initDelay -> do
+          now <- liftIO $ Time.getCurrentTime
+          let delay = (toUSec . toSec) (initDelay `Time.diffUTCTime` now)
+          if delay >= 0 then do
+            logNotice $ sformat ("Delaying node startup until " % shown) initDelay
+            liftIO $ threadDelay delay
+          else do
+            logWarning $ sformat ("--init-delay parameter in the past")
+      k nodeRes
   where
     tcpAddr = tpTcpAddr (npTransport np)
+
+    toSec :: Time.NominalDiffTime -> Double
+    toSec = realToFrac
+
+    toUSec :: Double -> Int
+    toUSec = round . (* 1000000)
 
 ----------------------------------------------------------------------------
 -- Logging

--- a/src/node/Params.hs
+++ b/src/node/Params.hs
@@ -71,6 +71,7 @@ getNodeParams args@Args {..} systemStart = do
         peekUserSecret (getKeyfilePath args)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
     let npTransport = getTransportParams args npNetworkConfig
+        npInitDelay = initDelay
         devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr commonArgs)


### PR DESCRIPTION
This can be used to delay initialization of the node until a certain
time (but after the node has initialized its network interface, so that
other nodes can connect to it).

This is useful to avoid the network layer deciding that it cannot reach
other nodes (because they have not yet finished booting up) and putting
them on in failure mode, and subsequently refusing to send messages to
them for a while.