### PR TITLE
Make flat stake distribution default in dev mode

### DIFF
--- a/scripts/bench/runbench.sh
+++ b/scripts/bench/runbench.sh
@@ -18,7 +18,7 @@
 #
 # node_cmd , bench_cmd defined in scripts/common_functions.sh
 
-CONC=4 scripts/launch/demo.sh 3 `dirname $0`/topology
+CONC=4 scripts/launch/demo.sh 3 `dirname $0`/topology rich_poor
 
 # transaction generator generates file tps-sent.csv
 #

--- a/scripts/launch/demo-with-wallet-api.sh
+++ b/scripts/launch/demo-with-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_TEST=1 "$base"/demo.sh
+WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -85,10 +85,10 @@ while [[ $i -lt $panesCnt ]]; do
       fi
   fi
 
-  if [[ $stake_distr_param == "flat" ]]; then
-    stake_distr=$flat_distr
-  else
+  if [[ $stake_distr_param == "rich_poor" ]]; then
     stake_distr=$rich_poor_distr
+  else
+    stake_distr=$flat_distr
   fi
 
   if [[ "$CSL_PRODUCTION" != "" ]]; then


### PR DESCRIPTION
Distribution is still `rich-poor` when running benchmark scripts.