### PR TITLE
Revert "Add `--init-delay` command line arg"

### DIFF
--- a/src/Pos/Launcher/Param.hs
+++ b/src/Pos/Launcher/Param.hs
@@ -13,7 +13,6 @@ module Pos.Launcher.Param
 import           Universum
 
 import           Control.Lens            (makeLensesWith)
-import           Data.Time               (UTCTime)
 import           Ether.Internal          (HasLens (..))
 import qualified Network.Transport.TCP   as TCP
 import           System.Wlog             (LoggerName)
@@ -70,7 +69,6 @@ data NodeParams = NodeParams
     , npEkgParams      :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
     , npStatsdParams   :: !(Maybe StatsdParams) -- ^ statsd statistics backend.
     , npNetworkConfig  :: !(NetworkConfig KademliaParams)
-    , npInitDelay      :: !(Maybe UTCTime)      -- ^ delay node startup
     } -- deriving (Show)
 
 makeLensesWith postfixLFields ''NodeParams

--- a/src/Pos/Launcher/Resource.hs
+++ b/src/Pos/Launcher/Resource.hs
@@ -23,7 +23,6 @@ module Pos.Launcher.Resource
 
 import           Universum                  hiding (bracket, finally)
 
-import           Control.Concurrent         (threadDelay)
 import           Control.Concurrent.STM     (newEmptyTMVarIO, newTBQueueIO)
 import           Data.Tagged                 (untag)
 import qualified Data.Time                  as Time
@@ -38,8 +37,7 @@ import qualified Network.Transport          as NT (closeTransport)
 import           System.IO                  (Handle, hClose, hSetBuffering, BufferMode (..))
 import qualified System.Metrics             as Metrics
 import           System.Wlog                (CanLog, LoggerConfig (..), WithLogger,
-                                             getLoggerName, logError, logNotice, logWarning,
-                                             productionB,
+                                             getLoggerName, logError, productionB,
                                              releaseAllHandlers, setupLogging,
                                              usingLoggerName)
 
@@ -204,31 +202,11 @@ bracketNodeResources :: forall ssc m a.
     -> SscParams ssc
     -> (NodeResources ssc m -> Production a)
     -> Production a
-bracketNodeResources np sp k =
-    bracketTransport tcpAddr $ \transport ->
+bracketNodeResources np sp k = bracketTransport tcpAddr $ \transport ->
     bracketKademlia (npBaseParams np) (npNetworkConfig np) $ \networkConfig ->
-    bracket (allocateNodeResources transport networkConfig np sp) releaseNodeResources $ \nodeRes -> do
-      case npInitDelay np of
-        Nothing ->
-          -- Start node immediately
-          return ()
-        Just initDelay -> do
-          now <- liftIO $ Time.getCurrentTime
-          let delay = (toUSec . toSec) (initDelay `Time.diffUTCTime` now)
-          if delay >= 0 then do
-            logNotice $ sformat ("Delaying node startup until " % shown) initDelay
-            liftIO $ threadDelay delay
-          else do
-            logWarning $ sformat ("--init-delay parameter in the past")
-      k nodeRes
+        bracket (allocateNodeResources transport networkConfig np sp) releaseNodeResources k
   where
     tcpAddr = tpTcpAddr (npTransport np)
-
-    toSec :: Time.NominalDiffTime -> Double
-    toSec = realToFrac
-
-    toUSec :: Double -> Int
-    toUSec = round . (* 1000000)
 
 ----------------------------------------------------------------------------
 -- Logging

--- a/src/node/NodeOptions.hs
+++ b/src/node/NodeOptions.hs
@@ -11,14 +11,13 @@ module NodeOptions
 
 import           Universum                    hiding (show)
 
-import           Data.Time                    (UTCTime, parseTimeM, defaultTimeLocale)
 import           Data.Version                 (showVersion)
 import           NeatInterpolation            (text)
 import           Options.Applicative          (Parser, auto, execParser, footerDoc,
                                                fullDesc, header, help, helper, info,
                                                infoOption, long, metavar, option,
                                                progDesc, showDefault, strOption, switch,
-                                               value, str, ReadM)
+                                               value)
 import           Prelude                      (show)
 import           Serokell.Util.OptParse       (fromParsec)
 import qualified Text.Parsec.Char             as P
@@ -79,9 +78,6 @@ data Args = Args
     , enableMetrics             :: !Bool
     , ekgParams                 :: !(Maybe EkgParams)
     , statsdParams              :: !(Maybe StatsdParams)
-    , initDelay                 :: !(Maybe UTCTime)
-      -- ^ Delay startup of the node until the specified time
-      -- (but after opening the network port, so that other nodes can connect)
     } deriving Show
 
 argsParser :: Parser Args
@@ -193,7 +189,6 @@ argsParser = do
 
     ekgParams <- optional ekgParamsOption
     statsdParams <- optional statsdParamsOption
-    initDelay <- optional initDelayOption
 
     pure Args{..}
   where
@@ -212,16 +207,6 @@ nodeTypeOption =
             (NodeCore  <$ P.string "core")
         <|> (NodeRelay <$ P.string "relay")
         <|> (NodeEdge  <$ P.string "edge")
-
-initDelayOption :: Parser UTCTime
-initDelayOption =
-    option (str >>= parse) $
-        long "init-delay" <>
-        metavar "yyyy-mm-ddThh:mm:ss-zzzz" <>
-        help "Delay starting the node until specified time (after opening network ports)"
-  where
-    parse :: String -> ReadM UTCTime
-    parse = parseTimeM True defaultTimeLocale "%FT%T%z"
 
 peerOption :: String -> (NetworkAddress -> (NodeId, NodeType)) -> Parser (NodeId, NodeType)
 peerOption longName mk =

--- a/src/node/Params.hs
+++ b/src/node/Params.hs
@@ -71,7 +71,6 @@ getNodeParams args@Args {..} systemStart = do
         peekUserSecret (getKeyfilePath args)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
     let npTransport = getTransportParams args npNetworkConfig
-        npInitDelay = initDelay
         devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr commonArgs)


### PR DESCRIPTION
Reverts input-output-hk/cardano-sl#1318

After discussing this with @georgeee , it seems the `--system-start` command flag already satisfies this purpose; see https://github.com/input-output-hk/cardano-sl/blob/master/src/Pos/Launcher/Scenario.hs#L93 .

Pinging @dcoutts .