### PR TITLE
[CSM-405] Sort transactions on timestamp if known

### DIFF
--- a/core/Pos/Core/Timestamp.hs
+++ b/core/Pos/Core/Timestamp.hs
@@ -6,13 +6,16 @@ module Pos.Core.Timestamp
        , getCurrentTimestamp
        , diffTimestamp
        , addMicrosecondsToTimestamp
+
+       -- * Convertions
+       , timestampToPosix
        ) where
 
 import           Universum
 
 import           Data.Text.Buildable   (Buildable)
 import qualified Data.Text.Buildable   as Buildable
-import           Data.Time.Clock.POSIX (getPOSIXTime)
+import           Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 import           Data.Time.Units       (Microsecond)
 import           Formatting            (Format, build)
 import qualified Prelude
@@ -53,3 +56,6 @@ diffTimestamp t1 t2 = getTimestamp t1 - getTimestamp t2
 
 addMicrosecondsToTimestamp :: Microsecond -> Timestamp -> Timestamp
 addMicrosecondsToTimestamp m t = Timestamp { getTimestamp = (getTimestamp t) + m }
+
+timestampToPosix :: Timestamp -> POSIXTime
+timestampToPosix (Timestamp ts) = fromIntegral ts / 1000000

--- a/src/Pos/Wallet/Web/Server/Methods.hs
+++ b/src/Pos/Wallet/Web/Server/Methods.hs
@@ -69,7 +69,7 @@ import           Pos.Constants                    (curSoftwareVersion, isDevelop
 import           Pos.Context                      (GenesisUtxo)
 import           Pos.Core                         (Address (..), Coin, addressF,
                                                    decodeTextAddress, getCurrentTimestamp,
-                                                   getTimestamp, mkCoin, sumCoins,
+                                                   mkCoin, sumCoins, timestampToPosix,
                                                    unsafeAddCoin, unsafeIntegerToCoin,
                                                    unsafeSubCoin)
 import           Pos.Crypto                       (EncryptedSecretKey, PassPhrase,
@@ -743,7 +743,7 @@ addHistoryTx cWalId wtx@THEntry{..} = do
             networkChainDifficulty
     meta <- CTxMeta <$> case _thTimestamp of
       Nothing -> liftIO $ getPOSIXTime
-      Just ts -> return $ fromIntegral (getTimestamp ts) / 1000000
+      Just ts -> return $ timestampToPosix ts
     let cId = txIdToCTxId _thTxId
     addOnlyNewTxMeta cWalId cId meta
     meta' <- fromMaybe meta <$> getTxMeta cWalId cId


### PR DESCRIPTION
In tracking, when get transactions from new block, in general we have no idea about order of those transactions. Only wallet db may know that, since it stores tx timestamps - I use them to achieve correct order.

_I didn't run DAT because they work unevenly (_