### PR TITLE
[CSL-1458] Allow txs with outputs less then bootDustThd

### DIFF
--- a/src/Pos/Client/Txp/Util.hs
+++ b/src/Pos/Client/Txp/Util.hs
@@ -143,9 +143,9 @@ overrideTxOutDistrBoot c oldDistr = do
     epoch <- siEpoch <$> lift getCurrentSlotBlocking
     bootEra <- lift $ gsIsBootstrapEra epoch
     genStakeholders <- view (lensOf @GenesisWStakeholders)
-    if not bootEra
-      then pure oldDistr
-      else either throwTxError pure (genesisSplitBoot genStakeholders c)
+    pure $ if bootEra
+           then genesisSplitBoot genStakeholders c
+           else oldDistr
 
 -- | Same as 'overrideTxOutDistrBoot' but changes 'TxOutputs' all at once
 overrideTxDistrBoot

--- a/src/Pos/Generator/Block/Payload.hs
+++ b/src/Pos/Generator/Block/Payload.hs
@@ -172,14 +172,10 @@ genTxPayload = do
                     utxoGet txIn
                 let (inputsSum :: Integer) = sumCoins $ map txOutValue inputsResolved
                     minInputsSum = coinToInteger fee + 1
-                -- if we've just took inputs that have sum less than number
-                -- of stakeholders, it's dust case and we forbid these txs
-                -- in boot era
-                -- Also we need to ensure that sum of inputs is enough to pay expected fee
-                -- and leave some money for outputs
-                if (inputsSum < minInputsSum) || (bootEra && inputsSum < dustThd)
+                -- We need to ensure that sum of inputs is enough to
+                -- pay expected fee and leave some money for outputs
+                if inputsSum < minInputsSum
                     -- just retry
-                    -- should we also check here that there are inputs in utxo that we can take?
                     then generateInputs (attempts - 1) expectedFee
                     else pure (txIns, inputsResolved, inputsSum)
 

--- a/src/Pos/Genesis.hs
+++ b/src/Pos/Genesis.hs
@@ -167,12 +167,7 @@ genesisUtxo gws@(GenesisWStakeholders bootStakeholders) ad
     utxoEntry (addr, coin) =
         ( TxIn (unsafeHash addr) 0
         , TxOutAux (TxOut addr coin) (outDistr coin))
-    genesisSplitBoot' x c =
-        either (\e -> error $ "genesisUtxo can't split: " <> show e <>
-                              ", genesis utxo " <> show ad)
-               identity
-               (genesisSplitBoot x c)
-    outDistr = genesisSplitBoot' gws
+    outDistr = genesisSplitBoot gws
 
 -- | Same as 'genesisUtxo' but generates 'GenesisWStakeholders' set
 -- using 'generateWStakeholders' inside and wraps it all in

--- a/txp/Pos/Txp/Toil/Failure.hs
+++ b/txp/Pos/Txp/Toil/Failure.hs
@@ -7,15 +7,13 @@ module Pos.Txp.Toil.Failure
 import           Universum
 
 import qualified Data.Text.Buildable
-import           Formatting                 (bprint, build, int, sformat, shown, stext,
-                                             (%))
+import           Formatting                 (bprint, build, int, shown, stext, (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
-import           Serokell.Util.Text         (listJson, pairF)
 import           Serokell.Util.Verify       (formatAllErrors)
 
 import           Pos.Core                   (HeaderHash, TxFeePolicy)
 import           Pos.Data.Attributes        (UnparsedFields)
-import           Pos.Txp.Core               (TxIn, TxOutDistribution)
+import           Pos.Txp.Core               (TxIn)
 import           Pos.Txp.Toil.Types         (TxFee)
 
 -- | Result of transaction processing

--- a/txp/Pos/Txp/Toil/Failure.hs
+++ b/txp/Pos/Txp/Toil/Failure.hs
@@ -7,8 +7,8 @@ module Pos.Txp.Toil.Failure
 import           Universum
 
 import qualified Data.Text.Buildable
-import           Formatting                 (bprint, build, int, sformat,
-                                             shown, stext, (%))
+import           Formatting                 (bprint, build, int, sformat, shown, stext,
+                                             (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
 import           Serokell.Util.Text         (listJson, pairF)
 import           Serokell.Util.Verify       (formatAllErrors)
@@ -42,7 +42,7 @@ data ToilVerFailure
                           , tifMinFee :: !TxFee
                           , tifSize   :: !Byte }
     | ToilUnknownAttributes !UnparsedFields
-    | ToilBootDifferentStake !TxOutDistribution
+    | ToilBootInappropriate !Text
     deriving (Show, Eq)
 
 instance Exception ToilVerFailure
@@ -86,6 +86,5 @@ instance Buildable ToilVerFailure where
             tifMinFee
     build (ToilUnknownAttributes uf) =
         bprint ("transaction has unknown attributes: "%shown) uf
-    build (ToilBootDifferentStake distr) =
-        bprint ("transaction has non-boot stake distr in boot era: "%listJson)
-               (map (sformat pairF) distr)
+    build (ToilBootInappropriate msg) =
+        bprint ("transaction is not suitable for boot era: "%stext) msg

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -183,10 +183,13 @@ verifyGState curEpoch txAux txFee = do
 -- it's defined in txp module above.
 bootRelatedDistr :: GenesisWStakeholders -> [(StakeholderId, Coin)] -> Bool
 bootRelatedDistr g@(GenesisWStakeholders bootHolders) txOutDistr
-    -- We allow small outputs to attribute stake to whoever because
-    -- it's not likely they will shift overall stake distribution
-    -- much.
-    | coinSum < unsafeGetCoin (bootDustThreshold g) = True
+    | coinSum < unsafeGetCoin (bootDustThreshold g) =
+        -- We allow small outputs to attribute stake in any proportion
+        -- user wants because it's not likely they will shift overall
+        -- stake distribution much. Anyway we require that all
+        -- addresses in txDistr are keys of boot stakeholders.
+        let bootHoldersKeys = getKeys bootHolders
+        in all (`HS.member` bootHoldersKeys) stakeholders
     | otherwise =
         -- All addresses in txDistr are from bootHolders and every boot
         -- stakeholder is mentioned in txOutDistr


### PR DESCRIPTION
* `genesisSplitCoin` doesn't fail when asked to split coin less then `bootDustThd`
* Transaction outputs wth value less then `bootDustThd` are now considered valid.