### PR TITLE
Build only relevant packages in buildbench.sh script

### DIFF
--- a/scripts/bench/buildbench.sh
+++ b/scripts/bench/buildbench.sh
@@ -2,6 +2,6 @@
 
 # dev-mode : allow to generate custom genesis block
 # CONFIG=.. selects section from config file (core/constants.yaml)
-# dev-custom-config needed to override config file section 
+# dev-custom-config needed to override config file section
 
-stack build --flag cardano-sl-core:dev-mode --flag cardano-sl-core:dev-custom-config --ghc-options=-DCONFIG=benchmark --flag cardano-sl-core:-asserts
+stack build --flag cardano-sl-core:dev-mode --flag cardano-sl-core:dev-custom-config --ghc-options=-DCONFIG=benchmark --flag cardano-sl-core:-asserts cardano-sl cardano-sl-lwallet


### PR DESCRIPTION
In order to run benchmarks it's enough to build only cardano-sl and light wallet (which generates transactions).
By default 'stack build' builds everything, including explorer, etc.