### PR TITLE
[CSL-1502] Change genesis stakeholder weight from Word16 to Word32

### DIFF
--- a/core/Pos/Arbitrary/Core.hs
+++ b/core/Pos/Arbitrary/Core.hs
@@ -443,7 +443,8 @@ instance Arbitrary G.GenesisCoreData where
                 , G.CustomStakes <$> vector innerLen
                 ]
         stakeDistrs <- vectorOf outerLen distributionGen
-        hashmapOfHolders <- arbitrary :: Gen (HashMap Types.StakeholderId Word16)
+        hashmapOfHolders <-
+            arbitrary :: Gen (HashMap Types.StakeholderId G.GenesisStakeholderWeight)
         return $ leftToPanic "arbitrary@GenesisCoreData: " $
             G.mkGenesisCoreData (zip listOfAddrList stakeDistrs)
                                 hashmapOfHolders

--- a/core/Pos/Core/Genesis.hs
+++ b/core/Pos/Core/Genesis.hs
@@ -39,6 +39,7 @@ import           Pos.Core.Coin           (unsafeAddCoin, unsafeMulCoin)
 import           Pos.Core.Constants      (genesisKeysN)
 import           Pos.Core.Genesis.Parser (compileGenCoreData)
 import           Pos.Core.Genesis.Types  (AddrDistribution, GenesisCoreData (..),
+                                          GenesisStakeholderWeight,
                                           GenesisWStakeholders (..),
                                           StakeDistribution (..), bootDustThreshold,
                                           getTotalStake, mkGenesisCoreData, safeExpStakes)

--- a/core/Pos/Core/Genesis/Types.hs
+++ b/core/Pos/Core/Genesis/Types.hs
@@ -7,6 +7,7 @@ module Pos.Core.Genesis.Types
        , safeExpStakes
 
        , AddrDistribution
+       , GenesisStakeholderWeight
        , GenesisWStakeholders (..)
        , GenesisCoreData (..)
        , bootDustThreshold
@@ -91,10 +92,12 @@ safeExpStakes n =
 -- distribute and how).
 type AddrDistribution = ([Address], StakeDistribution)
 
+type GenesisStakeholderWeight = Word32
+
 -- | Wrapper around weighted stakeholders map to be used in genesis
 -- core data.
 newtype GenesisWStakeholders = GenesisWStakeholders
-    { getGenesisWStakeholders :: HashMap StakeholderId Word16
+    { getGenesisWStakeholders :: HashMap StakeholderId GenesisStakeholderWeight
     } deriving (Show, Eq)
 
 instance Buildable GenesisWStakeholders where
@@ -124,7 +127,7 @@ bootDustThreshold (GenesisWStakeholders bootHolders) =
 -- goes wrong.
 mkGenesisCoreData ::
        [AddrDistribution]
-    -> HashMap StakeholderId Word16
+    -> HashMap StakeholderId GenesisStakeholderWeight
     -> Either String GenesisCoreData
 mkGenesisCoreData distribution bootStakeholders = do
     -- Every set of addresses should match the stakeholders count

--- a/src/Pos/Genesis.hs
+++ b/src/Pos/Genesis.hs
@@ -190,8 +190,8 @@ generateWStakeholders addrDistrs =
     coins = map snd withCoins
     intCoins = map coinToInteger coins
     commonGcd = foldr1 gcd intCoins
-    targetTotalWeight = maxBound @Word16 -- for the maximal precision
-    safeConvert :: Integer -> Word16
+    targetTotalWeight = maxBound @GenesisStakeholderWeight -- for the maximal precision
+    safeConvert :: Integer -> GenesisStakeholderWeight
     safeConvert i
         | i <= 0 =
           error $ "generateWStakeholders can't convert: non-positive coin " <> show i
@@ -199,7 +199,7 @@ generateWStakeholders addrDistrs =
           error $ "generateWStakeholders can't convert: too big " <> show i <>
                   ", withCoins: " <> sformat listJson (map (sformat pairF) withCoins)
         | otherwise = fromIntegral i
-    calcWeight :: Coin -> Word16
+    calcWeight :: Coin -> GenesisStakeholderWeight
     calcWeight balance =
         safeConvert $ floor $
         (coinToInteger balance) Ratio.%

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -23,8 +23,8 @@ import           Pos.Binary           (decodeFull, serialize')
 import           Pos.Core             (StakeholderId, mkCoin)
 import           Pos.Crypto           (redeemPkB64F)
 import           Pos.Genesis          (AddrDistribution, GenesisCoreData (..),
-                                       GenesisGtData (..), StakeDistribution (..),
-                                       genesisDevHdwSecretKeys, genesisDevHdwSecretKeys,
+                                       GenesisGtData (..), GenesisStakeholderWeight,
+                                       StakeDistribution (..), genesisDevHdwSecretKeys,
                                        genesisDevSecretKeys, mkGenesisCoreData)
 import           Pos.Types            (addressDetailedF, addressHash, makePubKeyAddress,
                                        makeRedeemAddress)
@@ -60,7 +60,9 @@ getTestnetData ::
        (MonadIO m, MonadFail m, WithLogger m)
     => FilePath
     -> TestStakeOptions
-    -> m ([AddrDistribution], HashMap StakeholderId Word16, GenesisGtData)
+    -> m ( [AddrDistribution]
+         , HashMap StakeholderId GenesisStakeholderWeight
+         , GenesisGtData)
 getTestnetData dir tso@TestStakeOptions{..} = do
 
     let keysDir = dir </> "keys-testnet"
@@ -199,7 +201,7 @@ genGenesisFiles GenesisGenOptions{..} = do
             | null ggoBootStakeholders =
                 mconcat $ catMaybes [ view _2 <$> mTestnetData ]
             | otherwise =
-                HM.fromList ggoBootStakeholders
+                map fromIntegral $ HM.fromList ggoBootStakeholders
     when (null gcdBootstrapStakeholders) $
         error "gcdBootstrapStakeholders is empty. Current keygen implementation \
               \doesn't support explicit boot stakeholders, so if testnet is not \


### PR DESCRIPTION
It is needed to be able to use rich-poor distribution with 50000 poor nodes.

P. S. I haven't tested it yet, going to do it after it builds.