### PR TITLE
[CSL-1505] update for time-warp change

### DIFF
--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -1,0 +1,205 @@
+module Pos.Network.Policy
+    ( defaultEnqueuePolicyCore
+    , defaultEnqueuePolicyRelay
+    , defaultEnqueuePolicyEdgeBehindNat
+    , defaultEnqueuePolicyEdgeP2P
+    , defaultEnqueuePolicyEdgeExchange
+    , defaultDequeuePolicyCore
+    , defaultDequeuePolicyRelay
+    , defaultDequeuePolicyEdgeBehindNat
+    , defaultDequeuePolicyEdgeP2P
+    , defaultDequeuePolicyEdgeExchange
+    , defaultFailurePolicy
+
+    ) where
+
+import           Universum
+import           Network.Broadcast.OutboundQueue.Types
+import           Network.Broadcast.OutboundQueue
+
+-- | Default enqueue policy for core nodes
+defaultEnqueuePolicyCore :: EnqueuePolicy nid
+defaultEnqueuePolicyCore = go
+  where
+    go :: EnqueuePolicy nid
+    go (MsgAnnounceBlockHeader _) = [
+        EnqueueAll NodeCore  (MaxAhead 0) PHighest
+      , EnqueueAll NodeRelay (MaxAhead 0) PHigh
+      ]
+    go MsgRequestBlockHeaders = [
+        EnqueueAll NodeCore  (MaxAhead 1) PHigh
+      , EnqueueAll NodeRelay (MaxAhead 1) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- We never ask for data from edge nodes
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
+      ]
+    go (MsgMPC _) = [
+        EnqueueAll NodeCore (MaxAhead 1) PMedium
+        -- not sent to relay nodes
+      ]
+    go (MsgTransaction _) = [
+        EnqueueAll NodeCore (MaxAhead 20) PLow
+        -- not sent to relay nodes
+      ]
+
+-- | Default enqueue policy for relay nodes
+defaultEnqueuePolicyRelay :: EnqueuePolicy nid
+defaultEnqueuePolicyRelay = go
+  where
+    -- Enqueue policy for relay nodes
+    go :: EnqueuePolicy nid
+    go (MsgAnnounceBlockHeader _) = [
+        EnqueueAll NodeRelay (MaxAhead 0) PHighest
+      , EnqueueAll NodeCore  (MaxAhead 0) PHigh
+      , EnqueueAll NodeEdge  (MaxAhead 0) PMedium
+      ]
+    go MsgRequestBlockHeaders = [
+        EnqueueAll NodeCore  (MaxAhead 1) PHigh
+      , EnqueueAll NodeRelay (MaxAhead 1) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- We never ask for blocks from edge nodes
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 1) PHigh
+      ]
+    go (MsgTransaction _) = [
+        EnqueueAll NodeCore  (MaxAhead 20) PLow
+      , EnqueueAll NodeRelay (MaxAhead 20) PLow
+        -- transactions not forwarded to edge nodes
+      ]
+    go (MsgMPC _) = [
+        -- Relay nodes never sent any MPC messages to anyone
+      ]
+
+-- | Default enqueue policy for standard behind-NAT edge nodes
+defaultEnqueuePolicyEdgeBehindNat
+    :: Maybe MaxAhead -- ^ Maximum number of transactions ahead (default: 1)
+    -> EnqueuePolicy nid
+defaultEnqueuePolicyEdgeBehindNat mMaxTrans = go
+  where
+    -- Enqueue policy for edge nodes
+    go :: EnqueuePolicy nid
+    go (MsgTransaction OriginSender) = [
+        EnqueueAll NodeRelay (fromMaybe (MaxAhead 1) mMaxTrans) PLow
+      ]
+    go (MsgTransaction (OriginForward _)) = [
+        -- don't forward transactions that weren't created at this node
+      ]
+    go (MsgAnnounceBlockHeader _) = [
+        -- not forwarded
+      ]
+    go MsgRequestBlockHeaders = [
+        EnqueueAll NodeRelay (MaxAhead 0) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- Edge nodes can only talk to relay nodes
+        EnqueueOne [NodeRelay] (MaxAhead 0) PHigh
+      ]
+    go (MsgMPC _) = [
+        -- not relevant
+      ]
+
+-- | Default enqueue policy for exchange nodes
+defaultEnqueuePolicyEdgeExchange :: EnqueuePolicy nid
+defaultEnqueuePolicyEdgeExchange = go
+  where
+    -- Enqueue policy for edge nodes
+    go :: EnqueuePolicy nid
+    go (MsgTransaction OriginSender) = [
+        EnqueueAll NodeRelay (MaxAhead 6) PLow
+      ]
+    go (MsgTransaction (OriginForward _)) = [
+        -- don't forward transactions that weren't created at this node
+      ]
+    go (MsgAnnounceBlockHeader _) = [
+        -- not forwarded
+      ]
+    go MsgRequestBlockHeaders = [
+        EnqueueAll NodeRelay (MaxAhead 0) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- Edge nodes can only talk to relay nodes
+        EnqueueOne [NodeRelay] (MaxAhead 0) PHigh
+      ]
+    go (MsgMPC _) = [
+        -- not relevant
+      ]
+
+-- | Default enqueue policy for edge nodes using P2P
+defaultEnqueuePolicyEdgeP2P :: EnqueuePolicy nid
+defaultEnqueuePolicyEdgeP2P = go
+  where
+    -- Enqueue policy for edge nodes
+    go :: EnqueuePolicy nid
+    go (MsgTransaction _) = [
+        EnqueueAll NodeRelay (MaxAhead 3) PLow
+      ]
+    go (MsgAnnounceBlockHeader _) = [
+        EnqueueAll NodeRelay (MaxAhead 0) PHighest
+      ]
+    go MsgRequestBlockHeaders = [
+        EnqueueAll NodeRelay (MaxAhead 1) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- Edge nodes can only talk to relay nodes
+        EnqueueOne [NodeRelay] (MaxAhead 1) PHigh
+      ]
+    go (MsgMPC _) = [
+        -- not relevant
+      ]
+
+-- | Default dequeue policy for core nodes
+defaultDequeuePolicyCore :: DequeuePolicy
+defaultDequeuePolicyCore = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = Dequeue NoRateLimiting (MaxInFlight 3)
+    go NodeRelay = Dequeue NoRateLimiting (MaxInFlight 2)
+    go NodeEdge  = error "defaultDequeuePolicy: core to edge not applicable"
+
+-- | Dequeueing policy for relay nodes
+defaultDequeuePolicyRelay :: DequeuePolicy
+defaultDequeuePolicyRelay = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+    go NodeRelay = Dequeue (MaxMsgPerSec 3) (MaxInFlight 2)
+    go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+
+-- | Dequeueing policy for standard behind-NAT edge nodes
+defaultDequeuePolicyEdgeBehindNat
+    :: Maybe RateLimit    -- ^ Max messages per second (per thread); default: 1
+    -> Maybe MaxInFlight  -- ^ Max number of convs to the relay; default: 2
+    -> DequeuePolicy
+defaultDequeuePolicyEdgeBehindNat mMaxMsgPerSec mMaxInFlight = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
+    go NodeRelay = Dequeue (fromMaybe (MaxMsgPerSec 1) mMaxMsgPerSec)
+                           (fromMaybe (MaxInFlight 2) mMaxInFlight)
+    go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
+
+-- | Dequeueing policy for exchange edge nodes
+defaultDequeuePolicyEdgeExchange :: DequeuePolicy
+defaultDequeuePolicyEdgeExchange = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
+    go NodeRelay = Dequeue (MaxMsgPerSec 5) (MaxInFlight 3)
+    go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
+
+-- | Dequeueing policy for P2P edge nodes
+defaultDequeuePolicyEdgeP2P :: DequeuePolicy
+defaultDequeuePolicyEdgeP2P = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = error "defaultDequeuePolicy: edge to core not applicable"
+    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+    go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
+
+-- | Default failure policy
+--
+-- TODO: Implement proper policy
+defaultFailurePolicy :: NodeType -- ^ Our node type
+                     -> FailurePolicy nid
+defaultFailurePolicy _ourType _theirType _msgType _err = ReconsiderAfter 200

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -77,7 +77,7 @@ data StaticPeers = forall m. (MonadIO m, WithLogger m) => StaticPeers {
       --
       -- The handler will also be called on registration
       -- (with the current value).
-      staticPeersOnChange :: ((Map NodeId NodeType, [(NodeType, Alts NodeId)]) -> m ()) -> IO ()
+      staticPeersOnChange :: (Peers NodeId -> m ()) -> IO ()
     }
 
 instance Show StaticPeers where
@@ -309,13 +309,13 @@ initQueue NetworkConfig{..} mStore = do
         -- Kademlia worker is responsible for adding peers
         return ()
       TopologyCore StaticPeers{..} _ -> liftIO $
-        staticPeersOnChange $ \(directory, peers) -> do
+        staticPeersOnChange $ \peers -> do
           OQ.clearRecentFailures oq
-          void $ OQ.updatePeersBucket oq BucketStatic (\_ -> peersFromList directory peers)
+          void $ OQ.updatePeersBucket oq BucketStatic (\_ -> peers)
       TopologyRelay StaticPeers{..} _ -> liftIO $
-        staticPeersOnChange $ \(directory, peers) -> do
+        staticPeersOnChange $ \peers -> do
           OQ.clearRecentFailures oq
-          void $ OQ.updatePeersBucket   oq BucketStatic (\_ -> peersFromList directory peers)
+          void $ OQ.updatePeersBucket oq BucketStatic (\_ -> peers)
 
     return oq
 

--- a/infra/Pos/Subscription/Dht.hs
+++ b/infra/Pos/Subscription/Dht.hs
@@ -186,7 +186,7 @@ dhtSubscriptionWorker kademliaInst peerType valency fallbacks _sendActions = do
         return newPeers
 
     mkPeers :: [NodeId] -> Peers NodeId
-    mkPeers = peersFromList . fmap ((,) peerType) . transpose . take (1 + fallbacks) . mkGroupsOf valency
+    mkPeers = peersFromList mempty . fmap ((,) peerType) . transpose . take (1 + fallbacks) . mkGroupsOf valency
 
     mkGroupsOf :: Int -> [a] -> [[a]]
     mkGroupsOf _ [] = []

--- a/infra/Pos/Subscription/Dns.hs
+++ b/infra/Pos/Subscription/Dns.hs
@@ -70,7 +70,7 @@ dnsSubscriptionWorker networkCfg dnsDomains _valency _fallbacks sendActions =
 
       -- Declare all active relays as a single list of alternative relays
       void $ updatePeersBucket BucketBehindNatWorker $ \_ ->
-        peersFromList [(NodeRelay, activeRelays updatedRelays)]
+        peersFromList mempty [(NodeRelay, activeRelays updatedRelays)]
 
       -- Subscribe only to a single relay (if we found one)
       --

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -73,6 +73,7 @@ library
 
                         -- Network topology
                         Pos.Network.DnsDomains
+                        Pos.Network.Policy
                         Pos.Network.Types
                         Pos.Network.Yaml
                         Pos.Network.CLI

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4809,8 +4809,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "0r73r12ja6qydficbiimm1xl93dhgm26f9crnssfjzqpyn174gaw";
-            rev = "00f9911afa62ff6af5d53d4c9bb2d5c8aa72ec57";
+            sha256 = "0xm6f35r68icqaamcfh6y4wf90xm1941b1dx2z5ssv9n7mr2m9mq";
+            rev = "7ec342c59823d9890836038122ebad7eb3f187ca";
           };
           isLibrary = true;
           isExecutable = true;

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 00f9911afa62ff6af5d53d4c9bb2d5c8aa72ec57 # master
+    commit: bdb4d149c9b05084864d487fb184defefa31e96c
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: bdb4d149c9b05084864d487fb184defefa31e96c
+    commit: 7ec342c59823d9890836038122ebad7eb3f187ca # master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
The Peers datatype has changed along with the interface for updating a
bucket. Now static routing variants core/relay get the directory of all
known peers, even those to which they do not route traffic, and keep it
so that they can classify those peers, which *may* send traffic inbound.

Other noise in this pull request is the migration of policies from
tiem-warp-nt to here in Pos.Network.Policy