### PR TITLE
[CSL-1508] retry joining kademlia indefinitely

### DIFF
--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -3,6 +3,8 @@
 
 module Pos.DHT.Real.Real
        ( kademliaJoinNetwork
+       , kademliaJoinNetworkNoThrow
+       , kademliaJoinNetworkRetry
        , K.lookupNode
        , kademliaGetKnownPeers
        , startDHTInstance
@@ -13,16 +15,17 @@ module Pos.DHT.Real.Real
        , foreverRejoinNetwork
        , rejoinNetwork
        , withKademliaLogger
-       , kademliaJoinNetworkNoThrow
        ) where
 
 import qualified Data.ByteString.Char8     as B8 (unpack)
 import qualified Data.ByteString.Lazy      as BS
 import           Data.List                 (intersect, (\\))
+import           Data.Time.Units           (Second)
 import           Formatting                (build, int, sformat, shown, (%))
 import           Mockable                  (Catch, Mockable, MonadMockable,
                                             Throw, catch, catchAll, throw, try,
-                                            waitAnyUnexceptional, withAsync)
+                                            waitAnyUnexceptional, withAsync,
+                                            Delay, delay)
 import qualified Network.Kademlia          as K
 import qualified Network.Kademlia.Instance as K (KademliaInstance (state),
                                                  KademliaState (sTree))
@@ -201,6 +204,8 @@ fromKPeer K.Peer{..} = (encodeUtf8 peerHost, fromIntegral peerPort)
 toKPeer :: NetworkAddress -> K.Peer
 toKPeer (peerHost, peerPort) = K.Peer (decodeUtf8 peerHost) (fromIntegral peerPort)
 
+-- | Attempt to join a Kademlia network by contacting this list of peers.
+--   If none of them are up, throw 'AllPeersUnavailable'.
 kademliaJoinNetwork
     :: ( MonadIO m
        , Mockable Catch m
@@ -234,11 +239,13 @@ kademliaJoinNetwork' inst peer = do
         K.NodeDown -> throw NodeDown
         K.NodeBanned ->
             logInfo $
-            sformat ("joinNetwork: peer " % build % " is banned") peer
+            sformat ("kademliaJoinNetwork: peer " % build % " is banned") peer
         K.IDClash ->
             logInfo $
-            sformat ("joinNetwork: peer " % build % " already contains us") peer
+            sformat ("kademliaJoinNetwork: peer " % build % " already contains us") peer
 
+-- | Attempt to join a Kademlia network by contacting this list of peers.
+--   If none of them are up, a warning is logged but no exception is thrown.
 kademliaJoinNetworkNoThrow
     :: ( MonadIO m
        , Mockable Catch m
@@ -253,5 +260,30 @@ kademliaJoinNetworkNoThrow
 kademliaJoinNetworkNoThrow inst peers = kademliaJoinNetwork inst peers `catch` handleJoinE
     where
     handleJoinE AllPeersUnavailable =
-        logWarning $ sformat ("Not connected to any of peers "%listJson) peers
+        logWarning $ sformat ("kademliaJoinNetwork: not connected to any of peers "%listJson) peers
     handleJoinE e = throw e
+
+-- | Attempt to join a Kademlia network by contacting this list of peers.
+--   If none of them are up, retry after a fixed delay.
+kademliaJoinNetworkRetry
+    :: ( MonadIO m
+       , Mockable Catch m
+       , Mockable Throw m
+       , Mockable Delay m
+       , WithLogger m
+       , Bi DHTKey
+       , Bi DHTData
+       )
+    => KademliaDHTInstance
+    -> [NetworkAddress]
+    -> Second
+    -> m ()
+kademliaJoinNetworkRetry inst peers interval = do
+    result <- try $ kademliaJoinNetwork inst peers
+    case result of
+      Right _ -> return ()
+      Left AllPeersUnavailable -> do
+          logWarning $ sformat ("kademliaJoinNetwork: could not connect to any peers, will retry in "%shown) interval
+          delay interval
+          kademliaJoinNetworkRetry inst peers interval
+      Left e -> throw e

--- a/src/Pos/Launcher/Scenario.hs
+++ b/src/Pos/Launcher/Scenario.hs
@@ -13,6 +13,7 @@ module Pos.Launcher.Scenario
 import           Universum
 
 import           Control.Lens          (views)
+import           Data.Time.Units       (Second)
 import           Development.GitRev    (gitBranch, gitHash)
 import           Ether.Internal        (HasLens (..))
 import           Formatting            (build, int, sformat, shown, (%))
@@ -27,7 +28,7 @@ import           Pos.Communication     (ActionSpec (..), OutSpecs, WorkerSpec,
 import qualified Pos.Constants         as Const
 import           Pos.Context           (BlkSemaphore (..), getOurPubKeyAddress,
                                         getOurPublicKey, ncNetworkConfig)
-import           Pos.DHT.Real          (KademliaDHTInstance (..), kademliaJoinNetwork,
+import           Pos.DHT.Real          (KademliaDHTInstance (..), kademliaJoinNetworkRetry,
                                         kademliaJoinNetworkNoThrow)
 import           Pos.Genesis           (GenesisWStakeholders (..), bootDustThreshold)
 import qualified Pos.GState            as GS
@@ -73,8 +74,10 @@ runNode' NodeResources {..} workers' plugins' = ActionSpec $ \vI sendActions -> 
     -- iff it's essential that at least one of the initial peers is contacted.
     -- Otherwise, it's OK to not find any initial peers and the program can
     -- continue.
+    let retryInterval :: Second
+        retryInterval = 5
     case topologyRunKademlia (ncTopology (ncNetworkConfig nrContext)) of
-        Just (kInst, True)  -> kademliaJoinNetwork kInst (kdiInitialPeers kInst)
+        Just (kInst, True)  -> kademliaJoinNetworkRetry kInst (kdiInitialPeers kInst) retryInterval
         Just (kInst, False) -> kademliaJoinNetworkNoThrow kInst (kdiInitialPeers kInst)
         Nothing             -> return ()
 


### PR DESCRIPTION
For P2P nodes. The node will not try to do any business logic until it
joins the network, so a misconfiguration of kademlia will result in
repeated log warnings about failure to join.