### PR TITLE
[CSL-1502] Match on stake distr in generateWStakeholders

### DIFF
--- a/core/Pos/Arbitrary/Core.hs
+++ b/core/Pos/Arbitrary/Core.hs
@@ -477,7 +477,6 @@ instance Arbitrary G.GenesisCoreData where
             wordILen = fromIntegral innerLen
             distributionGen = oneof
                 [ G.FlatStakes wordILen <$> arbitrary
-                , G.BitcoinStakes wordILen <$> arbitrary
                 , do a <- choose (0, wordILen)
                      G.RichPoorStakes a
                          <$> arbitrary
@@ -497,9 +496,6 @@ instance Arbitrary G.StakeDistribution where
       [ do stakeholders <- choose (1, 10000)
            coins <- Types.mkCoin <$> choose (stakeholders, 20*1000*1000*1000)
            return (G.FlatStakes (fromIntegral stakeholders) coins)
-      , do stakeholders <- choose (1, 10000)
-           coins <- Types.mkCoin <$> choose (stakeholders, 20*1000*1000*1000)
-           return (G.BitcoinStakes (fromIntegral stakeholders) coins)
       , do sdRichmen <- choose (0, 20)
            sdRichStake <- Types.mkCoin <$> choose (100000, 5000000)
            sdPoor <- choose (0, 20)

--- a/core/Pos/Binary/Core/Genesis.hs
+++ b/core/Pos/Binary/Core/Genesis.hs
@@ -15,14 +15,13 @@ import           Pos.Core.Genesis.Types  (GenesisCoreData (..), GenesisWStakehol
 instance Bi StakeDistribution where
     encode input = case input of
       FlatStakes w c             -> encodeListLen 3 <> encode (0 :: Word8) <> encode w <> encode c
-      BitcoinStakes w c          -> encodeListLen 3 <> encode (1 :: Word8) <> encode w <> encode c
-      RichPoorStakes w1 c1 w2 c2 -> encodeListLen 5 <> encode (2 :: Word8)
+      RichPoorStakes w1 c1 w2 c2 -> encodeListLen 5 <> encode (1 :: Word8)
                                                     <> encode w1
                                                     <> encode c1
                                                     <> encode w2
                                                     <> encode c2
-      ExponentialStakes w mc     -> encodeListLen 3 <> encode (3 :: Word8) <> encode w <> encode mc
-      CustomStakes c             -> encodeListLen 2 <> encode (4 :: Word8) <> encode c
+      ExponentialStakes w mc     -> encodeListLen 3 <> encode (2 :: Word8) <> encode w <> encode mc
+      CustomStakes c             -> encodeListLen 2 <> encode (3 :: Word8) <> encode c
     decode = do
       len <- decodeListLen
       tag <- decode @Word8
@@ -31,15 +30,12 @@ instance Bi StakeDistribution where
               matchSize 3 "StakeDistribution.FlatStakes" len
               FlatStakes        <$> decode <*> decode
           1 -> do
-              matchSize 3 "StakeDistribution.BitcoinStakes" len
-              BitcoinStakes     <$> decode <*> decode
-          2 -> do
               matchSize 5 "StakeDistribution.RichPoorStakes" len
               RichPoorStakes    <$> decode <*> decode <*> decode <*> decode
-          3 -> do
+          2 -> do
               matchSize 3 "StakeDistribution.ExponentialStakes" len
               ExponentialStakes <$> decode <*> decode
-          4 -> do
+          3 -> do
               matchSize 2 "StakeDistribution.CustomStakes" len
               CustomStakes      <$> decode
           _ -> fail "Pos.Binary.Genesis: StakeDistribution: invalid tag"

--- a/core/Pos/Core/Genesis/Types.hs
+++ b/core/Pos/Core/Genesis/Types.hs
@@ -33,9 +33,6 @@ data StakeDistribution
     -- same amount of coins.
     = FlatStakes !Word     -- ^ Number of stakeholders
                  !Coin     -- ^ Total number of coins
-    -- | Distribution mimicking bitcoin mining pool style.
-    | BitcoinStakes !Word  -- ^ Number of stakeholders
-                    !Coin  -- ^ Total number of coins
     -- | Rich/poor distribution, for testnet mostly.
     | RichPoorStakes
         { sdRichmen   :: !Word
@@ -53,7 +50,6 @@ data StakeDistribution
 -- | Get the amount of stakeholders in a distribution.
 getDistributionSize :: StakeDistribution -> Word
 getDistributionSize (FlatStakes n _)         = n
-getDistributionSize (BitcoinStakes n _)      = n
 getDistributionSize (RichPoorStakes a _ b _) = a + b
 getDistributionSize (ExponentialStakes n _)  = n
 getDistributionSize (CustomStakes cs)        = fromIntegral (length cs)
@@ -61,7 +57,6 @@ getDistributionSize (CustomStakes cs)        = fromIntegral (length cs)
 -- | Get total amount of stake in a distribution.
 getTotalStake :: StakeDistribution -> Coin
 getTotalStake (FlatStakes _ st) = st
-getTotalStake (BitcoinStakes _ st) = st
 getTotalStake RichPoorStakes {..} = unsafeIntegerToCoin $
     coinToInteger sdRichStake * fromIntegral sdRichmen +
     coinToInteger sdPoorStake * fromIntegral sdPoor

--- a/explorer/src/explorer/Params.hs
+++ b/explorer/src/explorer/Params.hs
@@ -10,7 +10,7 @@ module Params
 
 import           Universum
 
-import           Mockable              (Fork, Mockable, Catch)
+import           Mockable              (Catch, Fork, Mockable)
 import           System.Wlog           (LoggerName, WithLogger)
 
 import qualified Data.ByteString.Char8 as BS8 (unpack)
@@ -20,7 +20,8 @@ import           Pos.Constants         (isDevelopment)
 import           Pos.Core.Types        (Timestamp (..))
 import           Pos.Crypto            (VssKeyPair)
 import           Pos.Genesis           (GenesisContext (..), devAddrDistr, devStakesDistr,
-                                        genesisContextProduction, genesisUtxo)
+                                        genesisContextImplicit, genesisContextProduction,
+                                        genesisUtxo)
 import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
                                         NodeParams (..), TransportParams (..))
 import           Pos.Network.CLI       (intNetworkConfigOpts)
@@ -99,9 +100,7 @@ getNodeParams args@Args {..} systemStart = do
 
     let npGenesisCtx
             | isDevelopment =
-              let (aDistr,bootStakeholders) = devAddrDistr devStakeDistr
-              in GenesisContext (genesisUtxo bootStakeholders aDistr)
-                                bootStakeholders
+              genesisContextImplicit (devAddrDistr devStakeDistr)
             | otherwise = genesisContextProduction
 
     return NodeParams

--- a/explorer/src/explorer/Params.hs
+++ b/explorer/src/explorer/Params.hs
@@ -19,9 +19,8 @@ import qualified Pos.Client.CLI        as CLI
 import           Pos.Constants         (isDevelopment)
 import           Pos.Core.Types        (Timestamp (..))
 import           Pos.Crypto            (VssKeyPair)
-import           Pos.Genesis           (GenesisContext (..), devAddrDistr, devStakesDistr,
-                                        genesisContextImplicit, genesisContextProduction,
-                                        genesisUtxo)
+import           Pos.Genesis           (devGenesisContext, devStakesDistr,
+                                        genesisContextProduction)
 import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
                                         NodeParams (..), TransportParams (..))
 import           Pos.Network.CLI       (intNetworkConfigOpts)
@@ -99,8 +98,7 @@ getNodeParams args@Args {..} systemStart = do
                 (CLI.expDistr commonArgs)
 
     let npGenesisCtx
-            | isDevelopment =
-              genesisContextImplicit (devAddrDistr devStakeDistr)
+            | isDevelopment = devGenesisContext devStakeDistr
             | otherwise = genesisContextProduction
 
     return NodeParams

--- a/explorer/src/explorer/Params.hs
+++ b/explorer/src/explorer/Params.hs
@@ -94,7 +94,6 @@ getNodeParams args@Args {..} systemStart = do
     let devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr commonArgs)
-                (CLI.bitcoinDistr commonArgs)
                 (CLI.richPoorDistr commonArgs)
                 (CLI.expDistr commonArgs)
 

--- a/lwallet/Main.hs
+++ b/lwallet/Main.hs
@@ -426,7 +426,6 @@ main = giveStaticConsts $ do
     let devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr woCommonArgs)
-                (CLI.bitcoinDistr woCommonArgs)
                 (CLI.richPoorDistr woCommonArgs)
                 (CLI.expDistr woCommonArgs)
     let wpGenesisContext =

--- a/lwallet/Main.hs
+++ b/lwallet/Main.hs
@@ -62,12 +62,11 @@ import           Pos.Crypto                       (Hash, SecretKey, SignTag (Sig
                                                    safeToPublic, toPublic, unsafeHash,
                                                    withSafeSigner)
 import           Pos.Data.Attributes              (mkAttributes)
-import           Pos.Genesis                      (GenesisContext (..),
-                                                   StakeDistribution (..), devAddrDistr,
-                                                   devStakesDistr,
+import           Pos.Genesis                      (StakeDistribution (..), devAddrDistr,
+                                                   devStakesDistr, genesisContextImplicit,
                                                    genesisContextProduction,
-                                                   genesisDevSecretKeys, genesisUtxo,
-                                                   gtcUtxo, stakeDistribution)
+                                                   genesisDevSecretKeys, gtcUtxo,
+                                                   stakeDistribution)
 import           Pos.Launcher                     (BaseParams (..), LoggingParams (..),
                                                    bracketTransport, loggerBracket)
 import           Pos.Network.Types                (MsgType (..), Origin (..))
@@ -430,9 +429,7 @@ main = giveStaticConsts $ do
                 (CLI.expDistr woCommonArgs)
     let wpGenesisContext =
             if isDevelopment
-            then let (aDistr,bootStakeholders) = devAddrDistr devStakeDistr
-                 in GenesisContext (genesisUtxo bootStakeholders aDistr)
-                                   bootStakeholders
+            then genesisContextImplicit (devAddrDistr devStakeDistr)
             else genesisContextProduction
     let params =
             WalletParams

--- a/lwallet/Main.hs
+++ b/lwallet/Main.hs
@@ -62,8 +62,8 @@ import           Pos.Crypto                       (Hash, SecretKey, SignTag (Sig
                                                    safeToPublic, toPublic, unsafeHash,
                                                    withSafeSigner)
 import           Pos.Data.Attributes              (mkAttributes)
-import           Pos.Genesis                      (StakeDistribution (..), devAddrDistr,
-                                                   devStakesDistr, genesisContextImplicit,
+import           Pos.Genesis                      (StakeDistribution (..),
+                                                   devGenesisContext, devStakesDistr,
                                                    genesisContextProduction,
                                                    genesisDevSecretKeys, gtcUtxo,
                                                    stakeDistribution)
@@ -427,10 +427,9 @@ main = giveStaticConsts $ do
                 (CLI.flatDistr woCommonArgs)
                 (CLI.richPoorDistr woCommonArgs)
                 (CLI.expDistr woCommonArgs)
-    let wpGenesisContext =
-            if isDevelopment
-            then genesisContextImplicit (devAddrDistr devStakeDistr)
-            else genesisContextProduction
+    let wpGenesisContext
+            | isDevelopment = devGenesisContext devStakeDistr
+            | otherwise = genesisContextProduction
     let params =
             WalletParams
             { wpDbPath      = Just woDbPath

--- a/node/src/Pos/Client/CLI/Options.hs
+++ b/node/src/Pos/Client/CLI/Options.hs
@@ -46,7 +46,6 @@ data CommonArgs = CommonArgs
     , updateServers :: ![Text]
     -- distributions, only used in dev mode
     , flatDistr     :: !(Maybe (Int, Int))
-    , bitcoinDistr  :: !(Maybe (Int, Int))
     , richPoorDistr :: !(Maybe (Int, Int, Integer, Double))
     , expDistr      :: !(Maybe Int)
     , sysStart      :: !Timestamp
@@ -62,7 +61,6 @@ commonArgsParser = do
     updateServers <- updateServersOption
     -- distributions
     flatDistr     <- if isDevelopment then flatDistrOptional else pure Nothing
-    bitcoinDistr  <- if isDevelopment then btcDistrOptional  else pure Nothing
     richPoorDistr <- if isDevelopment then rnpDistrOptional  else pure Nothing
     expDistr      <- if isDevelopment then expDistrOption    else pure Nothing
     --
@@ -155,15 +153,6 @@ flatDistrOptional =
                 "flat-distr"
                 "(INT,INT)"
                 "Use flat stake distribution with given parameters (nodes, coins)."
-
-btcDistrOptional :: Opt.Parser (Maybe (Int, Int))
-btcDistrOptional =
-    Opt.optional $
-        Opt.option Opt.auto $
-            templateParser
-                "bitcoin-distr"
-                "(INT,INT)"
-                "Use bitcoin stake distribution with given parameters (nodes,coins)."
 
 rnpDistrOptional :: Opt.Parser (Maybe (Int, Int, Integer, Double))
 rnpDistrOptional =

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -19,8 +19,7 @@ import           System.Wlog                (LoggerName, WithLogger)
 import           Pos.Constants              (isDevelopment)
 import           Pos.Core.Types             (Timestamp (..))
 import           Pos.Crypto                 (VssKeyPair)
-import           Pos.Genesis                (devAddrDistr, devStakesDistr,
-                                             genesisContextImplicit,
+import           Pos.Genesis                (devGenesisContext, devStakesDistr,
                                              genesisContextProduction)
 import           Pos.Launcher               (BaseParams (..), LoggingParams (..),
                                              NodeParams (..), TransportParams (..))
@@ -84,8 +83,7 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
                 (richPoorDistr commonArgs)
                 (expDistr commonArgs)
     let npGenesisCtx
-            | isDevelopment =
-              genesisContextImplicit undefined (devAddrDistr devStakeDistr)
+            | isDevelopment = devGenesisContext devStakeDistr
             | otherwise = genesisContextProduction
     pure NodeParams
         { npDbPathM = dbPath

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -11,29 +11,32 @@ module Pos.Client.CLI.Params
 
 import           Universum
 
-import qualified Data.ByteString.Char8 as BS8 (unpack)
-import           Mockable              (Fork, Mockable, Catch)
-import qualified Network.Transport.TCP as TCP (TCPAddr (..), TCPAddrInfo (..))
-import           System.Wlog           (LoggerName, WithLogger)
+import qualified Data.ByteString.Char8      as BS8 (unpack)
+import           Mockable                   (Catch, Fork, Mockable)
+import qualified Network.Transport.TCP      as TCP (TCPAddr (..), TCPAddrInfo (..))
+import           System.Wlog                (LoggerName, WithLogger)
 
-import           Pos.Constants         (isDevelopment)
-import           Pos.Core.Types        (Timestamp (..))
-import           Pos.Crypto            (VssKeyPair)
-import           Pos.Genesis           (GenesisContext (..), devAddrDistr, devStakesDistr,
-                                        genesisContextProduction, genesisUtxo)
-import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
-                                        NodeParams (..), TransportParams (..))
-import           Pos.Network.CLI       (intNetworkConfigOpts)
-import           Pos.Network.Types     (NetworkConfig (..), Topology (..))
-import           Pos.Security          (SecurityParams (..))
-import           Pos.Ssc.GodTossing    (GtParams (..))
-import           Pos.Update.Params     (UpdateParams (..))
-import           Pos.Util.UserSecret   (peekUserSecret)
+import           Pos.Constants              (isDevelopment)
+import           Pos.Core.Types             (Timestamp (..))
+import           Pos.Crypto                 (VssKeyPair)
+import           Pos.Genesis                (GenesisContext (..), devAddrDistr,
+                                             devStakesDistr, genesisContextProduction,
+                                             genesisUtxo)
+import           Pos.Launcher               (BaseParams (..), LoggingParams (..),
+                                             NodeParams (..), TransportParams (..))
+import           Pos.Network.CLI            (intNetworkConfigOpts)
+import           Pos.Network.Types          (NetworkConfig (..), Topology (..))
+import           Pos.Security               (SecurityParams (..))
+import           Pos.Ssc.GodTossing         (GtParams (..))
+import           Pos.Update.Params          (UpdateParams (..))
+import           Pos.Util.UserSecret        (peekUserSecret)
 
-import           Pos.Client.CLI.NodeOptions  (CommonNodeArgs (..), NodeArgs (..),
-                                              maliciousEmulationAttacks, maliciousEmulationTargets)
-import           Pos.Client.CLI.Secrets (updateUserSecretVSS, userSecretWithGenesisKey)
-import           Pos.Client.CLI.Options (CommonArgs(..))
+import           Pos.Client.CLI.NodeOptions (CommonNodeArgs (..), NodeArgs (..),
+                                             maliciousEmulationAttacks,
+                                             maliciousEmulationTargets)
+import           Pos.Client.CLI.Options     (CommonArgs (..))
+import           Pos.Client.CLI.Secrets     (updateUserSecretVSS,
+                                             userSecretWithGenesisKey)
 
 
 loggingParams :: LoggerName -> CommonNodeArgs -> LoggingParams
@@ -78,7 +81,6 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
         devStakeDistr =
             devStakesDistr
                 (flatDistr commonArgs)
-                (bitcoinDistr commonArgs)
                 (richPoorDistr commonArgs)
                 (expDistr commonArgs)
     let npGenesisCtx

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -19,9 +19,9 @@ import           System.Wlog                (LoggerName, WithLogger)
 import           Pos.Constants              (isDevelopment)
 import           Pos.Core.Types             (Timestamp (..))
 import           Pos.Crypto                 (VssKeyPair)
-import           Pos.Genesis                (GenesisContext (..), devAddrDistr,
-                                             devStakesDistr, genesisContextProduction,
-                                             genesisUtxo)
+import           Pos.Genesis                (devAddrDistr, devStakesDistr,
+                                             genesisContextImplicit,
+                                             genesisContextProduction)
 import           Pos.Launcher               (BaseParams (..), LoggingParams (..),
                                              NodeParams (..), TransportParams (..))
 import           Pos.Network.CLI            (intNetworkConfigOpts)
@@ -85,9 +85,7 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
                 (expDistr commonArgs)
     let npGenesisCtx
             | isDevelopment =
-              let (aDistr,bootStakeholders) = devAddrDistr devStakeDistr
-              in GenesisContext (genesisUtxo bootStakeholders aDistr)
-                                bootStakeholders
+              genesisContextImplicit undefined (devAddrDistr devStakeDistr)
             | otherwise = genesisContextProduction
     pure NodeParams
         { npDbPathM = dbPath

--- a/node/src/Pos/Genesis.hs
+++ b/node/src/Pos/Genesis.hs
@@ -288,8 +288,8 @@ genesisDevHdwAccountKeyDatas =
 -- | Address distribution for dev mode. It's supposed that you pass
 -- the distribution from 'devStakesDistr' here. This function will add
 -- dev genesis addresses and hd addrs/distr.
-devAddrDistr :: StakeDistribution -> ([AddrDistribution], GenesisWStakeholders)
-devAddrDistr distr = (aDistr, gws)
+devAddrDistr :: StakeDistribution -> [AddrDistribution]
+devAddrDistr distr = aDistr
   where
     distrSize = length $ stakeDistribution distr
     tailPks = map (fst . generateGenesisKeyPair) [Const.genesisKeysN ..]

--- a/node/src/Pos/Genesis.hs
+++ b/node/src/Pos/Genesis.hs
@@ -41,22 +41,23 @@ import           Universum
 
 import           Control.Lens               (at, makeLenses)
 import qualified Data.HashMap.Strict        as HM
-import           Data.List                  (genericLength, genericReplicate)
+import           Data.List                  (genericReplicate)
 import qualified Data.Map.Strict            as M
 import qualified Data.Ratio                 as Ratio
 import           Ether.Internal             (HasLens (..))
-import           Formatting                 (sformat)
-import           Serokell.Util              (enumerate, listJson, pairF)
+import           Formatting                 (build, sformat, (%))
+import           Serokell.Util              (listJson, pairF)
 
 import           Pos.AllSecrets             (InvAddrSpendingData (unInvAddrSpendingData),
                                              mkInvAddrSpendingData)
 import qualified Pos.Constants              as Const
 import           Pos.Core                   (AddrSpendingData (PubKeyASD), Address (..),
                                              Coin, HasCoreConstants, SlotLeaders,
-                                             addressHash, applyCoinPortionUp,
-                                             coinToInteger, deriveLvl2KeyPair, divCoin,
+                                             StakeholderId, addressHash,
+                                             applyCoinPortionUp, coinToInteger,
+                                             deriveLvl2KeyPair, divCoin,
                                              makePubKeyAddress, mkCoin, safeExpStakes,
-                                             unsafeAddCoin, unsafeMulCoin)
+                                             unsafeMulCoin)
 import           Pos.Crypto                 (EncryptedSecretKey, emptyPassphrase,
                                              firstHardened, unsafeHash)
 import           Pos.Lrc.FtsPure            (followTheSatoshi)
@@ -92,38 +93,6 @@ instance HasLens GenesisWStakeholders GenesisContext GenesisWStakeholders where
 -- Static state & funcitons
 ----------------------------------------------------------------------------
 
-
-bitcoinDistribution20 :: [Coin]
-bitcoinDistribution20 = map mkCoin
-    [200,163,120,105,78,76,57,50,46,31,26,13,11,11,7,4,2,0,0,0]
-
-bitcoinDistribution1000Coins :: Word -> [Coin]
-bitcoinDistribution1000Coins stakeholders
-    | stakeholders < 20 = stakeDistribution
-          (FlatStakes stakeholders (mkCoin 1000))
-    | stakeholders == 20 = bitcoinDistribution20
-    | otherwise =
-        foldl' (bitcoinDistributionImpl ratio) [] $
-        enumerate bitcoinDistribution20
-  where
-    ratio = fromIntegral stakeholders / 20
-
-bitcoinDistributionImpl :: Double -> [Coin] -> (Int, Coin) -> [Coin]
-bitcoinDistributionImpl ratio coins (coinIdx, coin) =
-    coins ++ toAddValMax : replicate (toAddNum - 1) toAddValMin
-  where
-    toAddNumMax = ceiling ratio
-    toAddNumMin = floor ratio
-    toAddNum :: Int
-    toAddNum =
-        if genericLength coins + realToFrac toAddNumMax >
-           realToFrac (coinIdx + 1) * ratio
-            then toAddNumMin
-            else toAddNumMax
-    toAddValMin = coin `divCoin` toAddNum
-    toAddValMax = coin `unsafeAddCoin`
-                  (toAddValMin `unsafeMulCoin` (toAddNum - 1))
-
 -- | Given 'StakeDistribution', calculates a list containing amounts
 -- of coins (balances) belonging to genesis addresses.
 stakeDistribution :: StakeDistribution -> [Coin]
@@ -131,11 +100,6 @@ stakeDistribution (FlatStakes stakeholders coins) =
     genericReplicate stakeholders val
   where
     val = coins `divCoin` stakeholders
-stakeDistribution (BitcoinStakes stakeholders coins) =
-    map normalize $ bitcoinDistribution1000Coins stakeholders
-  where
-    normalize x =
-        x `unsafeMulCoin` coinToInteger (coins `divCoin` (1000 :: Int))
 stakeDistribution (ExponentialStakes n mc) =
     reverse $ take (fromIntegral n) $
     iterate (`unsafeMulCoin` (2::Integer)) mc
@@ -177,20 +141,50 @@ genesisUtxo gws@(GenesisWStakeholders bootStakeholders) ad
 -- using 'generateWStakeholders' inside and wraps it all in
 -- 'GenesisContext'.
 genesisContextImplicit :: InvAddrSpendingData -> [AddrDistribution] -> GenesisContext
+genesisContextImplicit _ [] = error "genesisContextImplicit: empty list passed"
 genesisContextImplicit invAddrSpendingData addrDistr =
     GenesisContext utxo genStakeholders
   where
-    genStakeholders = generateWStakeholders invAddrSpendingData addrDistr
+    mergeStakeholders :: HashMap StakeholderId Word16
+                      -> HashMap StakeholderId Word16
+                      -> HashMap StakeholderId Word16
+    mergeStakeholders =
+        HM.unionWithKey $ \_ a b ->
+        error $ "genesisContextImplicit: distributions have " <>
+                "common keys which is forbidden " <>
+                pretty a <> ", " <> pretty b
+    genStakeholders =
+        GenesisWStakeholders $
+        foldr1 mergeStakeholders $
+        map (getGenesisWStakeholders .
+             generateWStakeholders invAddrSpendingData) addrDistr
     utxo = genesisUtxo genStakeholders addrDistr
 
 -- | Generate weighted stakeholders using passed address distribution.
-generateWStakeholders :: InvAddrSpendingData -> [AddrDistribution] -> GenesisWStakeholders
-generateWStakeholders (unInvAddrSpendingData -> addrToSpending) addrDistrs =
-    if null withCoins
-        then GenesisWStakeholders mempty
-        else GenesisWStakeholders $ foldr step mempty withCoins
+generateWStakeholders :: InvAddrSpendingData -> AddrDistribution -> GenesisWStakeholders
+generateWStakeholders iasd@(unInvAddrSpendingData -> addrToSpending) (addrs,stakeDistr) =
+    case stakeDistr of
+        FlatStakes _ _    ->
+            createList $ map ((,1) . toStakeholderId) addrs
+        RichPoorStakes{..} ->
+            createList $ map ((,1) . toStakeholderId) $
+            take (fromIntegral sdRichmen) addrs
+        e@(ExponentialStakes _ _) ->
+            GenesisWStakeholders $
+            assignWeights iasd $ addrs `zip` stakeDistribution e
+        CustomStakes coins ->
+            GenesisWStakeholders $ assignWeights iasd $ addrs `zip` coins
   where
-    withCoins = concatAddrDistrs addrDistrs
+    createList = GenesisWStakeholders . HM.fromList
+    toStakeholderId addr = case addrToSpending ^. at addr of
+        Just (PubKeyASD (addressHash -> sId)) -> sId
+        _ -> error $ sformat ("generateWStakeholders: "%build%
+                              " is not a pubkey addr or not in the map") addr
+
+assignWeights :: InvAddrSpendingData -> [(Address,Coin)] -> HashMap StakeholderId Word16
+assignWeights (unInvAddrSpendingData -> addrToSpending) withCoins =
+    foldr step mempty withCoins
+  where
     coins = map snd withCoins
     intCoins = map coinToInteger coins
     commonGcd = foldr1 gcd intCoins
@@ -198,17 +192,16 @@ generateWStakeholders (unInvAddrSpendingData -> addrToSpending) addrDistrs =
     safeConvert :: Integer -> Word16
     safeConvert i
         | i <= 0 =
-            error $
-            "generateWStakeholders can't convert: non-positive coin " <> show i
+          error $ "generateWStakeholders can't convert: non-positive coin " <> show i
         | i > fromIntegral targetTotalWeight =
-            error $
-            "generateWStakeholders can't convert: too big " <> show i <>
-            ", withCoins: " <>
-            sformat listJson (map (sformat pairF) withCoins)
+          error $ "generateWStakeholders can't convert: too big " <> show i <>
+                  ", withCoins: " <> sformat listJson (map (sformat pairF) withCoins)
         | otherwise = fromIntegral i
     calcWeight :: Coin -> Word16
     calcWeight balance =
-        safeConvert $ floor $ (coinToInteger balance) Ratio.% (commonGcd)
+        safeConvert $ floor $
+        (coinToInteger balance) Ratio.%
+        (commonGcd)
     step (addr, balance) =
         case addrToSpending ^. at addr of
             Just (PubKeyASD (addressHash -> sId)) ->
@@ -250,16 +243,13 @@ wAddressGenesisIndex = firstHardened
 -- | Chooses among common distributions for dev mode.
 devStakesDistr
     :: Maybe (Int, Int)                   -- flat distr
-    -> Maybe (Int, Int)                   -- bitcoin distr
     -> Maybe (Int, Int, Integer, Double)  -- rich/poor distr
     -> Maybe Int                          -- exp distr
     -> StakeDistribution
-devStakesDistr Nothing Nothing Nothing Nothing = genesisDevFlatDistr
-devStakesDistr (Just (nodes, coins)) Nothing Nothing Nothing =
+devStakesDistr Nothing Nothing Nothing = genesisDevFlatDistr
+devStakesDistr (Just (nodes, coins)) Nothing Nothing =
     FlatStakes (fromIntegral nodes) (mkCoin (fromIntegral coins))
-devStakesDistr Nothing (Just (nodes, coins)) Nothing Nothing =
-    BitcoinStakes (fromIntegral nodes) (mkCoin (fromIntegral coins))
-devStakesDistr Nothing Nothing (Just (richs, poors, coins, richShare)) Nothing =
+devStakesDistr Nothing (Just (richs, poors, coins, richShare)) Nothing =
     checkConsistency $ RichPoorStakes {..}
   where
     sdRichmen = fromIntegral richs
@@ -276,8 +266,8 @@ devStakesDistr Nothing Nothing (Just (richs, poors, coins, richShare)) Nothing =
         if poorStake <= 0 || richStake <= 0
         then error "Impossible to make RichPoorStakes with given parameters."
         else identity
-devStakesDistr Nothing Nothing Nothing (Just n) = safeExpStakes n
-devStakesDistr _ _ _ _ =
+devStakesDistr Nothing Nothing (Just n) = safeExpStakes n
+devStakesDistr _ _ _ =
     error "Conflicting distribution options were enabled. \
           \Choose one at most or nothing."
 
@@ -315,7 +305,7 @@ devAddrDistr distr = (aDistr, gws)
 
     -- Genesis stakeholders
     gws :: GenesisWStakeholders
-    gws = generateWStakeholders invAddrSpendingData [(mainAddrs, distr)]
+    gws = generateWStakeholders invAddrSpendingData (mainAddrs, distr)
 
     -- HD wallets
     hdwSize = 2 -- should be positive

--- a/scripts/bench/runbench.sh
+++ b/scripts/bench/runbench.sh
@@ -18,7 +18,7 @@
 #
 # node_cmd , bench_cmd defined in scripts/common_functions.sh
 
-CORE_NODES=3 CONC=4 NUM_TXS=$1 scripts/launch/demo.sh 5 `dirname $0`/topology rich_poor
+RICH_NODES=3 CONC=4 NUM_TXS=$1 scripts/launch/demo.sh 5 `dirname $0`/topology rich_poor
 
 # transaction generator generates file tps-sent.csv
 #

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -25,9 +25,9 @@ if [[ "$n" == "" ]]; then
   n=$DEFAULT_NODES_N
 fi
 
-# CORE_NODES specifies how many nodes should be core nodes, i.e., have non-negligible stake in the rich_poor_distr
-if [[ "$CORE_NODES" == "" ]]; then
-  CORE_NODES == 3
+# RICH_NODES specifies how many nodes should be core nodes, i.e., have non-negligible stake in the rich_poor_distr
+if [[ "$RICH_NODES" == "" ]]; then
+  RICH_NODES == 3
 fi
 
 config_dir=$2
@@ -41,7 +41,7 @@ fi
 # Use "flat" for flat_distr. Anything else will use rich_poor_distr
 stake_distr_param=$3
 flat_distr=" --flat-distr \"($n, 100000)\" "
-rich_poor_distr=" --rich-poor-distr \"($CORE_NODES,50000,6000000000,0.99)\" "
+rich_poor_distr=" --rich-poor-distr \"($RICH_NODES,50000,6000000000,0.99)\" "
 
 # Stats are not mandatory either
 stats=$4

--- a/wallet/node/Params.hs
+++ b/wallet/node/Params.hs
@@ -6,20 +6,20 @@ module Params
 
 import           Universum
 
-import           Mockable              (Fork, Mockable, Catch)
-import           System.Wlog           (WithLogger)
+import           Mockable            (Catch, Fork, Mockable)
+import           System.Wlog         (WithLogger)
 
-import           Pos.Client.CLI        (CommonNodeArgs (..))
-import qualified Pos.Client.CLI        as CLI
-import           Pos.Constants         (isDevelopment)
-import           Pos.Core.Types        (Timestamp (..))
-import           Pos.Genesis           (GenesisContext (..), devAddrDistr, devStakesDistr,
-                                        genesisContextProduction, genesisUtxo)
-import           Pos.Launcher          (NodeParams (..))
-import           Pos.Network.CLI       (intNetworkConfigOpts)
-import           Pos.Security          (SecurityParams (..))
-import           Pos.Update.Params     (UpdateParams (..))
-import           Pos.Util.UserSecret   (peekUserSecret)
+import           Pos.Client.CLI      (CommonNodeArgs (..))
+import qualified Pos.Client.CLI      as CLI
+import           Pos.Constants       (isDevelopment)
+import           Pos.Core.Types      (Timestamp (..))
+import           Pos.Genesis         (devGenesisContext, devStakesDistr,
+                                      genesisContextProduction)
+import           Pos.Launcher        (NodeParams (..))
+import           Pos.Network.CLI     (intNetworkConfigOpts)
+import           Pos.Security        (SecurityParams (..))
+import           Pos.Update.Params   (UpdateParams (..))
+import           Pos.Util.UserSecret (peekUserSecret)
 
 getNodeParams ::
        ( MonadIO m
@@ -42,14 +42,10 @@ getNodeParams args@CommonNodeArgs{..} systemStart = do
         devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr commonArgs)
-                (CLI.bitcoinDistr commonArgs)
                 (CLI.richPoorDistr commonArgs)
                 (CLI.expDistr commonArgs)
     let npGenesisCtx
-            | isDevelopment =
-              let (aDistr,bootStakeholders) = devAddrDistr devStakeDistr
-              in GenesisContext (genesisUtxo bootStakeholders aDistr)
-                                bootStakeholders
+            | isDevelopment = devGenesisContext devStakeDistr
             | otherwise = genesisContextProduction
     pure NodeParams
         { npDbPathM = dbPath


### PR DESCRIPTION
Now boot stakeholders generation (for dev/tests/bench) matches on real distribution. Which in turn gives possibility to set `genesisStakeholders` to rich in `richPoor` distribution. Before this, implementation gave stake to everybody thus producing huge stakeholders weights and `bootDustThd` which led to a bunch of problems.
I also removed support for bitcoin distribution as it's not used by anyone and can be emulated by `CustomStakes`.