### PR TITLE
[CSM-411] Override distributions in boot era before counting fees

### DIFF
--- a/src/Pos/Client/Txp/Util.hs
+++ b/src/Pos/Client/Txp/Util.hs
@@ -6,6 +6,7 @@ module Pos.Client.Txp.Util
        -- * Tx creation
          TxCreateMode
        , makeAbstractTx
+       , runTxCreator
        , overrideTxOutDistrBoot
        , overrideTxDistrBoot
        , makePubKeyTx
@@ -68,12 +69,14 @@ type TxWithSpendings = (TxAux, NonEmpty TxOut)
 
 -- This datatype corresponds to raw transaction.
 data TxRaw = TxRaw
-    { trInputs    :: !(TxOwnedInputs TxOut)
+    { trInputs         :: !(TxOwnedInputs TxOut)
     -- ^ Selected inputs from Utxo
-    , trOutputs   :: !TxOutputs
+    , trOutputs        :: !TxOutputs
     -- ^ Output addresses of tx (without remaing output)
-    , trRemaining :: !Coin
+    , trRemainingMoney :: !Coin
     -- ^ Remaining money
+    , trRemainingDistr :: !TxOutDistribution
+    -- ^ Proper distribution for remaining money
     }
 
 data TxError
@@ -127,29 +130,53 @@ makeAbstractTx mkWit txInputs outputs = TxAux tx txWitness txDistr
         { txSigTxHash = hash tx
         , txSigTxDistrHash = hash txDistr }
 
--- | Overrides 'txDistr' with correct ones (according to the boot era
--- stake distribution) or leaves it as it is if in post-boot era.
-overrideTxOutDistrBoot
+-- | Datatype which contains all data from DB which is necessary
+-- to create transactions
+data TxCreatorData = TxCreatorData
+    { _tcdBootEra      :: !Bool
+    , _tcdStakeholders :: !GenesisWStakeholders
+    , _tcdFeePolicy    :: !TxFeePolicy
+    }
+
+makeLenses ''TxCreatorData
+
+-- | Transformer which holds data necessary for creating transactions
+type TxCreator m = ReaderT TxCreatorData (ExceptT TxError m)
+
+runTxCreator
     :: TxDistrMode ctx m
-    => Coin
-    -> TxOutDistribution
-    -> ExceptT TxError m TxOutDistribution
-overrideTxOutDistrBoot c oldDistr = do
+    => TxCreator m a
+    -> m (Either TxError a)
+runTxCreator action = runExceptT $ do
     -- Blocking here should be fine for now (@volhovm)
     -- 1. Code in tx generator must have current slot.
     -- 2. Code in wallet will block on "synchronizing" on the
     --    frontend so it's fine too.
     epoch <- siEpoch <$> lift getCurrentSlotBlocking
-    bootEra <- lift $ gsIsBootstrapEra epoch
-    genStakeholders <- view (lensOf @GenesisWStakeholders)
+    _tcdBootEra <- lift $ gsIsBootstrapEra epoch
+    _tcdStakeholders <- view (lensOf @GenesisWStakeholders)
+    _tcdFeePolicy <- bvdTxFeePolicy <$> gsAdoptedBVData
+    runReaderT action TxCreatorData{..}
+
+-- | Overrides 'txDistr' with correct ones (according to the boot era
+-- stake distribution) or leaves it as it is if in post-boot era.
+overrideTxOutDistrBoot
+    :: Monad m
+    => Coin
+    -> TxOutDistribution
+    -> TxCreator m TxOutDistribution
+overrideTxOutDistrBoot c oldDistr = do
+    bootEra <- view tcdBootEra
+    genStakeholders <- view tcdStakeholders
     pure $ if bootEra
            then genesisSplitBoot genStakeholders c
            else oldDistr
 
 -- | Same as 'overrideTxOutDistrBoot' but changes 'TxOutputs' all at once
 overrideTxDistrBoot
-    :: TxDistrMode ctx m
-    => TxOutputs -> ExceptT TxError m TxOutputs
+    :: Monad m
+    => TxOutputs
+    -> TxCreator m TxOutputs
 overrideTxDistrBoot outputs = do
     forM outputs $ \TxOutAux{..} -> do
         newStakeDistr <- overrideTxOutDistrBoot (txOutValue toaOut) toaDistr
@@ -218,11 +245,11 @@ type InputPicker = StateT InputPickerState (Either TxError)
 -- prepare correct inputs and outputs for transaction
 -- (and tell how much to send to remaining address)
 prepareTxRaw
-    :: MonadError TxError m
+    :: Monad m
     => Utxo
     -> TxOutputs
     -> TxFee
-    -> m TxRaw
+    -> TxCreator m TxRaw
 prepareTxRaw utxo outputs (TxFee fee) = do
     totalMoney <- sumTxOuts outputs
     when (totalMoney == mkCoin 0) $
@@ -236,8 +263,9 @@ prepareTxRaw utxo outputs (TxFee fee) = do
         Just inputsNE -> do
             totalTxAmount <- sumTxOuts $ map snd inputsNE
             let trInputs = map formTxInputs inputsNE
-                trOutputs = outputs
-                trRemaining = totalTxAmount `unsafeSubCoin` totalMoneyWithFee
+                trRemainingMoney = totalTxAmount `unsafeSubCoin` totalMoneyWithFee
+            trOutputs <- overrideTxDistrBoot outputs
+            trRemainingDistr <- overrideTxOutDistrBoot trRemainingMoney []
             pure TxRaw {..}
   where
     sumTxOuts = either throwTxError pure .
@@ -270,22 +298,23 @@ mkOutputsWithRem
     -> TxRaw
     -> m TxOutputs
 mkOutputsWithRem addrData TxRaw {..}
-    | trRemaining == mkCoin 0 = pure trOutputs
+    | trRemainingMoney == mkCoin 0 = pure trOutputs
     | otherwise = do
           changeAddr <- getNewAddress addrData
-          pure $ (TxOutAux (TxOut changeAddr trRemaining) []) :| toList trOutputs
+          pure $
+              (TxOutAux (TxOut changeAddr trRemainingMoney) trRemainingDistr) :|
+              toList trOutputs
 
 prepareInpsOuts
     :: TxCreateMode ctx m
     => Utxo
     -> TxOutputs
     -> AddrData m
-    -> ExceptT TxError m (TxOwnedInputs TxOut, TxOutputs)
+    -> TxCreator m (TxOwnedInputs TxOut, TxOutputs)
 prepareInpsOuts utxo outputs addrData = do
     txRaw@TxRaw {..} <- prepareTxWithFee utxo outputs
-    outputsWithRem <- lift $ mkOutputsWithRem addrData txRaw
-    properOutputs <- overrideTxDistrBoot outputsWithRem
-    pure (trInputs, properOutputs)
+    outputsWithRem <- lift . lift $ mkOutputsWithRem addrData txRaw
+    pure (trInputs, outputsWithRem)
 
 createGenericTx
     :: TxCreateMode ctx m
@@ -293,7 +322,7 @@ createGenericTx
     -> Utxo
     -> TxOutputs
     -> AddrData m
-    -> ExceptT TxError m TxWithSpendings
+    -> TxCreator m TxWithSpendings
 createGenericTx creator utxo outputs addrData = do
     (inps, outs) <- prepareInpsOuts utxo outputs addrData
     pure (creator inps outs, map fst inps)
@@ -304,7 +333,7 @@ createGenericTxSingle
     -> Utxo
     -> TxOutputs
     -> AddrData m
-    -> ExceptT TxError m TxWithSpendings
+    -> TxCreator m TxWithSpendings
 createGenericTxSingle creator = createGenericTx (creator . map snd)
 
 -- | Make a multi-transaction using given secret key and info for outputs.
@@ -316,7 +345,7 @@ createMTx
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMTx utxo hdwSigners outputs addrData = runExceptT $
+createMTx utxo hdwSigners outputs addrData = runTxCreator $
     createGenericTx (makeMPubKeyTxAddrs hdwSigners)
     utxo outputs addrData
 
@@ -329,7 +358,7 @@ createTx
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createTx utxo ss outputs addrData = runExceptT $
+createTx utxo ss outputs addrData = runTxCreator $
     createGenericTxSingle (makePubKeyTx ss)
     utxo outputs addrData
 
@@ -341,7 +370,7 @@ createMOfNTx
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMOfNTx utxo keys outputs addrData = runExceptT $
+createMOfNTx utxo keys outputs addrData = runTxCreator $
     createGenericTxSingle (makeMOfNTx validator sks)
     utxo outputs addrData
   where
@@ -357,11 +386,10 @@ createRedemptionTx
     -> RedeemSecretKey
     -> TxOutputs
     -> m (Either TxError TxAux)
-createRedemptionTx utxo rsk outputs = runExceptT $ do
+createRedemptionTx utxo rsk outputs = runTxCreator $ do
     TxRaw {..} <- prepareTxRaw utxo outputs (TxFee $ mkCoin 0)
     let bareInputs = snd <$> trInputs
-    properOutputs <- overrideTxDistrBoot trOutputs
-    pure $ makeRedemptionTx rsk bareInputs properOutputs
+    pure $ makeRedemptionTx rsk bareInputs trOutputs
 
 -----------------------------------------------------------------------------
 -- Fees logic
@@ -369,10 +397,10 @@ createRedemptionTx utxo rsk outputs = runExceptT $ do
 
 -- | Helper function to reduce code duplication
 withLinearFeePolicy
-    :: (TxDistrMode ctx m, MonadError TxError m)
-    => (TxSizeLinear -> m a)
-    -> m a
-withLinearFeePolicy action = bvdTxFeePolicy <$> gsAdoptedBVData >>= \case
+    :: Monad m
+    => (TxSizeLinear -> TxCreator m a)
+    -> TxCreator m a
+withLinearFeePolicy action = view tcdFeePolicy >>= \case
     TxFeePolicyUnknown w _ -> throwTxError $
         sformat ("Unknown fee policy, tag: "%build) w
     TxFeePolicyTxSizeLinear linearPolicy ->
@@ -380,20 +408,20 @@ withLinearFeePolicy action = bvdTxFeePolicy <$> gsAdoptedBVData >>= \case
 
 -- | Prepare transaction considering fees
 prepareTxWithFee
-    :: TxDistrMode ctx m
+    :: Monad m
     => Utxo
     -> TxOutputs
-    -> ExceptT TxError m TxRaw
+    -> TxCreator m TxRaw
 prepareTxWithFee utxo outputs = withLinearFeePolicy $ \linearPolicy ->
     stabilizeTxFee linearPolicy utxo outputs
 
 -- | Compute, how much fees we should pay to send money to given
 -- outputs
 computeTxFee
-    :: TxDistrMode ctx m
+    :: Monad m
     => Utxo
     -> TxOutputs
-    -> ExceptT TxError m TxFee
+    -> TxCreator m TxFee
 computeTxFee utxo outputs = withLinearFeePolicy $ \linearPolicy -> do
     txAux <- createFakeTxFromRawTx <$>
              stabilizeTxFee linearPolicy utxo outputs
@@ -401,15 +429,15 @@ computeTxFee utxo outputs = withLinearFeePolicy $ \linearPolicy -> do
 
 -- | Search such spendings that transaction's fee would be stable.
 stabilizeTxFee
-    :: forall m. MonadError TxError m
+    :: forall m. Monad m
     => TxSizeLinear
     -> Utxo
     -> TxOutputs
-    -> m TxRaw
+    -> TxCreator m TxRaw
 stabilizeTxFee linearPolicy utxo outputs =
     stabilizeTxFeeDo 5 (TxFee $ mkCoin 0)
   where
-    stabilizeTxFeeDo :: Int -> TxFee -> m TxRaw
+    stabilizeTxFeeDo :: Int -> TxFee -> TxCreator m TxRaw
     stabilizeTxFeeDo 0 _ = throwTxError "Couldn't stabilize tx fee after 5 attempts"
     stabilizeTxFeeDo attempt expectedFee = do
         txRaw <- prepareTxRaw utxo outputs expectedFee
@@ -439,8 +467,8 @@ createFakeTxFromRawTx :: TxRaw -> TxAux
 createFakeTxFromRawTx TxRaw{..} =
     let fakeAddr = txOutAddress . toaOut . NE.head $ trOutputs
         fakeOutMB
-            | trRemaining == mkCoin 0 = Nothing
-            | otherwise = Just $ TxOutAux (TxOut fakeAddr trRemaining) []
+            | trRemainingMoney == mkCoin 0 = Nothing
+            | otherwise = Just $ TxOutAux (TxOut fakeAddr trRemainingMoney) trRemainingDistr
         txOutsWithRem = maybe trOutputs (\remTx -> remTx :| toList trOutputs) fakeOutMB
 
         -- We create fake signers instead of safe signers,

--- a/src/Pos/Generator/Block/Payload.hs
+++ b/src/Pos/Generator/Block/Payload.hs
@@ -23,7 +23,7 @@ import           Formatting                 (build, sformat, (%))
 import           System.Random              (RandomGen (..))
 
 import           Pos.Client.Txp.Util        (makeAbstractTx, overrideTxDistrBoot,
-                                             txToLinearFee, unTxError)
+                                             runTxCreator, txToLinearFee, unTxError)
 import           Pos.Core                   (Address (..), Coin, SlotId (..),
                                              TxFeePolicy (..), addressDetailedF,
                                              bvdTxFeePolicy, coinToInteger,
@@ -211,7 +211,7 @@ genTxPayload = do
                 let txOuts = NE.fromList $ zipWith TxOut outputAddrs coins
                 let txOutAuxsPre = map (\o -> TxOutAux o []) txOuts
                 either (lift . throwM . BGFailedToCreate . unTxError) pure =<<
-                    runExceptT (overrideTxDistrBoot txOutAuxsPre)
+                    runTxCreator (overrideTxDistrBoot txOutAuxsPre)
 
         ----- TX
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -20,7 +20,7 @@ import           Pos.Aeson.WalletBackup         ()
 import           Pos.Client.Txp.Addresses       (MonadAddresses (..))
 import           Pos.Client.Txp.Balances        (getOwnUtxos)
 import           Pos.Client.Txp.History         (TxHistoryEntry (..))
-import           Pos.Client.Txp.Util            (computeTxFee)
+import           Pos.Client.Txp.Util            (computeTxFee, runTxCreator)
 import           Pos.Communication              (SendActions (..), submitMTx)
 import           Pos.Core                       (Coin, HasCoreConstants, addressF,
                                                  getCurrentTimestamp)
@@ -67,7 +67,7 @@ getTxFee
 getTxFee srcAccount dstAccount coin = do
     utxo <- getMoneySourceUtxo (AccountMoneySource srcAccount)
     outputs <- coinDistrToOutputs $ one (dstAccount, coin)
-    TxFee fee <- eitherToThrow =<< runExceptT (computeTxFee utxo outputs)
+    TxFee fee <- eitherToThrow =<< runTxCreator (computeTxFee utxo outputs)
     pure $ mkCCoin fee
 
 data MoneySource


### PR DESCRIPTION
This fixes possible bug when output distributions change after fee is computed, which change transaction size and may possibly invalidate computed fee.

Tested manually via `daedalus-bridge` (acceptance tests in master are not working currently due to not yet merged fix for webpack issue)