### PR TITLE
[CSLD-125] Correct script for README.md generation

### DIFF
--- a/scripts/ci/update-cardano-sl-readme.sh
+++ b/scripts/ci/update-cardano-sl-readme.sh
@@ -7,6 +7,7 @@ readonly CARDANO_DOCS_REPO_NAME=cardanodocs.com
 readonly CARDANO_SL_REPO_NAME=cardano-sl
 readonly PATH_TO_CARDANO_DOCS_REPO="${HOME}"/"${CARDANO_DOCS_REPO_NAME}"
 readonly PATH_TO_CARDANO_SL_REPO="${HOME}"/"${CARDANO_SL_REPO_NAME}"
+readonly PATH_TO_NODE_SUBDIR="${PATH_TO_CARDANO_SL_REPO}"/node/
 readonly README=README.md
 readonly PATH_TO_DOCS_CHAPTERS="${PATH_TO_CARDANO_DOCS_REPO}"/_docs/
 
@@ -46,7 +47,7 @@ for i in {1..5}; do
 done
 
 echo "**** Copy new ${README} in ${CARDANO_SL_REPO_NAME} ****"
-mv -f "${README}" "${PATH_TO_CARDANO_SL_REPO}"
+mv -f "${README}" "${PATH_TO_NODE_SUBDIR}"
 
 echo "**** Push all changes, if required ****"
 cd "${PATH_TO_CARDANO_SL_REPO}"


### PR DESCRIPTION
@gromakovsky said:

> The thing is that `README.md` was moved into `node` directory, while root of the repository now contains a symlink to that file. I guess it shouldn't matter, but I don't know in which cases something that work with a normal file doesn't work with a symlink to that file