### PR TITLE
[CSL-1526] Change TxIn encoding to accommodate future expansions

### DIFF
--- a/txp/Pos/Binary/Txp/Core.hs
+++ b/txp/Pos/Binary/Txp/Core.hs
@@ -6,9 +6,10 @@ module Pos.Binary.Txp.Core
 
 import           Universum
 
-import           Pos.Binary.Class   (Bi (..), Cons (..), Field (..), decodeListLen,
-                                     deriveSimpleBi, deserialize', encodeListLen,
-                                     enforceSize, matchSize, serialize')
+import           Pos.Binary.Class   (Bi (..), Cons (..), Field (..), decodeCBORDataItem,
+                                     decodeFull, decodeListLen, deriveSimpleBi,
+                                     deserialize', encodeListLen, encodeTag, enforceSize,
+                                     matchSize, serialize', toLazyByteString)
 import           Pos.Binary.Core    ()
 import           Pos.Binary.Merkle  ()
 import qualified Pos.Core.Types     as T
@@ -22,15 +23,21 @@ import qualified Pos.Txp.Core.Types as T
 instance Bi T.TxIn where
   -- [CSL-1526] Support the "unknown" pattern for encoding a `TxIn`, so that
   -- we can down the line extend the `TxIn` type is a backward-compatible way.
-  encode txIn =  encodeListLen 3
+  encode txIn =  encodeListLen 2
               <> encode (0 :: Word8)
-              <> encode (T.txInHash txIn)
-              <> encode (T.txInIndex txIn)
+              <> encode binaryBlob
+    where
+      binaryBlob = toLazyByteString (encodeTag 24 <> innerType)
+      innerType  = encode (T.txInHash txIn, T.txInIndex txIn)
+
   decode = do
-    enforceSize "TxIn" 3
-    tag <- decode @Word8
+    enforceSize "TxIn" 2
+    tag       <- decode @Word8
+    dataItem  <- decodeCBORDataItem =<< decode @ByteString
     case tag of
-        0 -> T.TxIn <$> decode <*> decode
+        0 -> case decodeFull dataItem of
+            Left e           -> fail (toString e)
+            Right (hsh, idx) -> pure (T.TxIn hsh idx)
         _ -> fail $ "Error decoding TxIn, tag not supported: " <> show tag
 
 deriveSimpleBi ''T.TxOut [

--- a/txp/Pos/Binary/Txp/Core.hs
+++ b/txp/Pos/Binary/Txp/Core.hs
@@ -27,15 +27,15 @@ instance Bi T.TxIn where
               <> encode (0 :: Word8)
               <> encode binaryBlob
     where
-      binaryBlob = toLazyByteString (encodeTag 24 <> innerType)
-      innerType  = encode (T.txInHash txIn, T.txInIndex txIn)
+      binaryBlob = toLazyByteString (encodeTag 24 <> encode innerType)
+      innerType  = serialize' (T.txInHash txIn, T.txInIndex txIn)
 
   decode = do
     enforceSize "TxIn" 2
     tag       <- decode @Word8
     dataItem  <- decodeCBORDataItem =<< decode @ByteString
     case tag of
-        0 -> case decodeFull dataItem of
+        0 -> case decodeFull (deserialize' dataItem) of
             Left e           -> fail (toString e)
             Right (hsh, idx) -> pure (T.TxIn hsh idx)
         _ -> fail $ "Error decoding TxIn, tag not supported: " <> show tag


### PR DESCRIPTION
This tiny PR does one thing: it changes the encoding format of `TxIn` to accommodate future extension of the type.

See [the relevant issue for the full context](https://issues.serokell.io/issue/CSL-1526#comment=96-6583). It's important to notice that in the wildcard case during decoding we `fail` due to lack of a better story. As far as I know, part of the work @pva701 is doing is to extend `TxIn` to add a `TxInUnknown` type constructor so that in the future we can modify the decoder of `TxIn` like so:

``` haskell
case tag of
  0 -> T.TxIn <$> decode <*> decode
  1 -> T.TxReward <$> decode -- decode the reward
  2 -> TxInUnknown <$> tag <*> decode -- do interesting stuff
```

Let me know if I'm on a hot trail of if I have missed the whole point!