### PR TITLE
Infer kademlia configuration from static topology; warn about unnecessary net address

### DIFF
--- a/explorer/src/explorer/Params.hs
+++ b/explorer/src/explorer/Params.hs
@@ -10,7 +10,7 @@ module Params
 
 import           Universum
 
-import           Mockable              (Catch, Fork, Mockable)
+import           Mockable              (Catch, Fork, Mockable, Throw)
 import           System.Wlog           (LoggerName, WithLogger)
 
 import qualified Data.ByteString.Char8 as BS8 (unpack)
@@ -80,6 +80,7 @@ getNodeParams
        , WithLogger     m
        , Mockable Fork  m
        , Mockable Catch m
+       , Mockable Throw m
        )
     => Args -> Timestamp -> m NodeParams
 getNodeParams args@Args {..} systemStart = do

--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -49,7 +49,7 @@ import qualified Data.Map                   as M
 import qualified Data.Text.Buildable        as B
 import qualified Data.Text.Encoding         as Text (decodeUtf8, encodeUtf8)
 import qualified Data.Text.Internal.Builder as B
-import           Formatting                 (bprint, build, hex, sformat, (%))
+import           Formatting                 (bprint, build, hex, shown, sformat, (%))
 -- TODO should not have to import outboundqueue stuff here. MsgType and
 -- NodeType should be a cardano-sl notion.
 import           Mockable.Class             (Mockable)
@@ -177,7 +177,7 @@ instance Buildable PeerId where
     build (PeerId bs) = buildBS bs
 
 instance Buildable NodeId where
-    build (NodeId (EndPointAddress bs)) = buildBS bs
+    build (NodeId (EndPointAddress bs)) = bprint shown bs
 
 buildBS :: ByteString -> B.Builder
 buildBS = bprint base16F

--- a/infra/Pos/DHT/Real/Param.hs
+++ b/infra/Pos/DHT/Real/Param.hs
@@ -38,7 +38,7 @@ fromYamlConfig yamlParams = do
         , kpExternalAddress = kademliaAddressToNetworkAddress <$> Y.kpAddress yamlParams
         , kpPeers           = kademliaAddressToNetworkAddress <$> Y.kpPeers yamlParams
         , kpDumpFile        = Y.kpDumpFile yamlParams
-        , kpExplicitInitial = maybe False identity (Y.kpExplicitInitial yamlParams)
+        , kpExplicitInitial = fromMaybe False (Y.kpExplicitInitial yamlParams)
         }
 
 kademliaAddressToNetworkAddress :: Y.KademliaAddress -> NetworkAddress

--- a/infra/Pos/DHT/Real/Param.hs
+++ b/infra/Pos/DHT/Real/Param.hs
@@ -14,7 +14,7 @@ import           Universum
 
 -- | Parameters for the Kademlia DHT subsystem.
 data KademliaParams = KademliaParams
-    { kpNetworkAddress  :: !(NetworkAddress)
+    { kpNetworkAddress  :: !(Maybe NetworkAddress)
     , kpPeers           :: ![NetworkAddress]
     -- ^ Peers passed from CLI
     , kpKey             :: !(Maybe DHTKey)
@@ -34,11 +34,11 @@ fromYamlConfig yamlParams = do
         Just key -> Just <$> kademliaIdToDHTKey key
     return $ KademliaParams
         { kpKey             = parsedKey
-        , kpNetworkAddress  = kademliaAddressToNetworkAddress (Y.kpBind yamlParams)
+        , kpNetworkAddress  = kademliaAddressToNetworkAddress <$> Y.kpBind yamlParams
         , kpExternalAddress = kademliaAddressToNetworkAddress <$> Y.kpAddress yamlParams
         , kpPeers           = kademliaAddressToNetworkAddress <$> Y.kpPeers yamlParams
         , kpDumpFile        = Y.kpDumpFile yamlParams
-        , kpExplicitInitial = Y.kpExplicitInitial yamlParams
+        , kpExplicitInitial = maybe False identity (Y.kpExplicitInitial yamlParams)
         }
 
 kademliaAddressToNetworkAddress :: Y.KademliaAddress -> NetworkAddress

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -81,9 +81,10 @@ startDHTInstance
        , Bi DHTKey
        )
     => KademliaParams
+    -> NetworkAddress -- ^ Default NetworkAddress to bind.
     -> m KademliaDHTInstance
-startDHTInstance kconf@KademliaParams {..} = do
-    let bindAddr = first B8.unpack kpNetworkAddress
+startDHTInstance kconf@KademliaParams {..} defaultBind = do
+    let bindAddr = first B8.unpack (maybe defaultBind identity kpNetworkAddress)
         extAddr  = maybe bindAddr (first B8.unpack) kpExternalAddress
     logInfo "Generating dht key.."
     kdiKey <- maybe randomDHTKey pure kpKey

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -84,7 +84,7 @@ startDHTInstance
     -> NetworkAddress -- ^ Default NetworkAddress to bind.
     -> m KademliaDHTInstance
 startDHTInstance kconf@KademliaParams {..} defaultBind = do
-    let bindAddr = first B8.unpack (maybe defaultBind identity kpNetworkAddress)
+    let bindAddr = first B8.unpack (fromMaybe defaultBind kpNetworkAddress)
         extAddr  = maybe bindAddr (first B8.unpack) kpExternalAddress
     logInfo "Generating dht key.."
     kdiKey <- maybe randomDHTKey pure kpKey

--- a/infra/Pos/Network/CLI.hs
+++ b/infra/Pos/Network/CLI.hs
@@ -10,7 +10,7 @@ module Pos.Network.CLI (
     NetworkConfigOpts(..)
   , NetworkConfigException(..)
   , networkConfigOption
-  , ipv4ToNodeId
+  , ipv4ToNetworkAddress
   , intNetworkConfigOpts
     -- * Exported primilary for testing
   , readTopology
@@ -23,10 +23,11 @@ import           Control.Exception               (Exception (..))
 import qualified Data.ByteString.Char8           as BS.C8
 import           Data.IP                         (IPv4)
 import qualified Data.Map.Strict                 as M
-import           Data.Maybe                      (fromJust)
+import           Data.Maybe                      (fromJust, mapMaybe)
 import qualified Data.Yaml                       as Yaml
 import           Formatting                      (sformat, shown, (%))
-import           Mockable                        (Catch, Mockable, fork, try)
+import           Mockable                        (Catch, Mockable, fork, try,
+                                                  Throw, throw)
 import           Mockable.Concurrent
 import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS                     as DNS
@@ -43,6 +44,7 @@ import           Pos.Util.TimeWarp               (addressToNodeId)
 import           System.Wlog.CanLog              (WithLogger, logError, logNotice)
 import           Universum
 
+import           Pos.Util.TimeWarp               (NetworkAddress)
 #ifdef POSIX
 import           Pos.Util.SigHandler             (Signal (..), installHandler)
 #endif
@@ -156,7 +158,7 @@ monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
               mParsedTopology <- try $ liftIO $ readTopology fp
               case mParsedTopology of
                 Right (Y.TopologyStatic allPeers) -> do
-                  (newMetadata, newPeers) <-
+                  (newMetadata, newPeers, _) <-
                     liftIO $ fromPovOf cfg allPeers
 
                   unless (nmType newMetadata == nmType origMetadata) $
@@ -214,6 +216,7 @@ intNetworkConfigOpts :: forall m. (
                        , MonadIO        m
                        , Mockable Fork  m
                        , Mockable Catch m
+                       , Mockable Throw m
                        )
                      => NetworkConfigOpts
                      -> m (T.NetworkConfig DHT.KademliaParams)
@@ -223,22 +226,33 @@ intNetworkConfigOpts cfg@NetworkConfigOpts{..} = do
                         Just fp -> liftIO $ readTopology fp
     ourTopology <- case parsedTopology of
       Y.TopologyStatic{..} -> do
-        (md@NodeMetadata{..}, initPeers) <- liftIO $ fromPovOf cfg topologyAllPeers
+        (md@NodeMetadata{..}, initPeers, kademliaPeers) <- liftIO $ fromPovOf cfg topologyAllPeers
         topologyStaticPeers <- monitorStaticConfig cfg md initPeers
+        -- If kademlia is enabled here then we'll try to read the configuration
+        -- file. However it's not necessary that the file exists. If it doesn't,
+        -- we can fill in some sensible defaults using the static routing and
+        -- kademlia flags for other nodes.
         topologyOptKademlia <- if nmKademlia
-                                 then liftIO $ Just <$> getKademliaParams cfg
-                                 else return Nothing
+            then do
+                ekparams <- liftIO $ getKademliaParamsFromFile cfg
+                case ekparams of
+                    Right kparams -> return $ Just kparams
+                    Left MissingKademliaConfig ->
+                        let ekparams' = getKademliaParamsFromStatic kademliaPeers
+                        in  either (throw . CannotParseKademliaConfig . Left) (return . Just) ekparams'
+                    Left err -> throw err
+            else return Nothing
         case nmType of
           T.NodeCore  -> return $ T.TopologyCore{..}
           T.NodeRelay -> return $ T.TopologyRelay{topologyMaxSubscrs = nmMaxSubscrs, ..}
-          T.NodeEdge  -> liftIO $ throwM NetworkConfigSelfEdge
+          T.NodeEdge  -> throw NetworkConfigSelfEdge
       Y.TopologyBehindNAT{..} ->
         return T.TopologyBehindNAT{..}
       Y.TopologyP2P{..} -> do
-        kparams <- liftIO $ getKademliaParams cfg
+        kparams <- either throw return =<< liftIO (getKademliaParamsFromFile cfg)
         return T.TopologyP2P{topologyKademlia = kparams, ..}
       Y.TopologyTraditional{..} -> do
-        kparams <- liftIO $ getKademliaParams cfg
+        kparams <- either throw return =<< liftIO (getKademliaParamsFromFile cfg)
         return T.TopologyTraditional{topologyKademlia = kparams, ..}
 
     (enqueuePolicy, dequeuePolicy, failurePolicy) <- case networkConfigOptsPolicies of
@@ -262,38 +276,74 @@ intNetworkConfigOpts cfg@NetworkConfigOpts{..} = do
       , ncFailurePolicy = failurePolicy
       }
 
--- | Come up with kademlia parameters, possibly throwing an exception in case
+-- | Come up with kademlia parameters, possibly giving 'Left' in case
 -- there's no configuration file path given, or if it couldn't be parsed.
-getKademliaParams :: NetworkConfigOpts
-                  -> IO DHT.KademliaParams
-getKademliaParams cfg = case networkConfigOptsKademlia cfg of
-    Nothing -> throwM MissingKademliaConfig
+getKademliaParamsFromFile :: NetworkConfigOpts
+                          -> IO (Either NetworkConfigException DHT.KademliaParams)
+getKademliaParamsFromFile cfg = case networkConfigOptsKademlia cfg of
+    Nothing -> return $ Left MissingKademliaConfig
     Just fp -> do
       kconf <- parseKademlia fp
-      either (throwM . DHT.MalformedDHTKey) return (DHT.fromYamlConfig kconf)
+      either (return . Left . CannotParseKademliaConfig . Left . DHT.MalformedDHTKey)
+             (return . Right)
+             (DHT.fromYamlConfig kconf)
+
+-- | Derive kademlia parameters from the set of kademlia-enabled peers. They
+-- are used as the initial peers, and everything else is unspecified, and will
+-- be defaulted.
+getKademliaParamsFromStatic :: [Y.KademliaAddress]
+                            -> Either DHT.MalformedDHTKey DHT.KademliaParams
+-- Since 'Nothing' is given for the kpId, it's impossible to get a 'Left'
+getKademliaParamsFromStatic kpeers = either (Left . DHT.MalformedDHTKey) Right kparams
+  where
+    kparams = DHT.fromYamlConfig $ Y.KademliaParams
+        { Y.kpId              = Nothing
+        , Y.kpPeers           = kpeers
+        , Y.kpAddress         = Nothing
+        , Y.kpBind            = Nothing
+        , Y.kpExplicitInitial = Nothing
+        , Y.kpDumpFile        = Nothing
+        }
 
 -- | Perspective on 'AllStaticallyKnownPeers' from the point of view of
--- a single node
+-- a single node.
+--
+-- First component is this node's metadata.
+-- Second component is the set of all known peers (routes included).
+-- Third component is the set of addresses of peers running kademlia.
+--   If this node runs kademlia, its address will appear as the last entry in
+--   the list.
 fromPovOf :: NetworkConfigOpts
           -> Y.AllStaticallyKnownPeers
-          -> IO (NodeMetadata, Peers NodeId)
+          -> IO (NodeMetadata, Peers NodeId, [Y.KademliaAddress])
 fromPovOf cfg@NetworkConfigOpts{..} allPeers =
     case networkConfigOptsSelf of
       Nothing   -> throwM NetworkConfigSelfUnknown
       Just self -> T.initDnsOnUse $ \resolve -> do
         selfMetadata <- metadataFor allPeers self
         resolved     <- resolvePeers resolve (Y.allStaticallyKnownPeers allPeers)
-        let directory = M.fromList (map (\(a, b) -> (b, a)) (M.elems resolved))
-        routes       <- mkRoutes resolved (Y.nmRoutes selfMetadata)
-        return (selfMetadata, peersFromList directory routes)
+        routes       <- mkRoutes (second addressToNodeId <$> resolved) (Y.nmRoutes selfMetadata)
+        let directory     = M.fromList (map (\(a, b) -> (addressToNodeId b, a)) (M.elems resolved))
+            hasKademlia   = M.filter nmKademlia (Y.allStaticallyKnownPeers allPeers)
+            selfKademlia  = M.member self hasKademlia
+            otherKademlia = M.delete self hasKademlia
+            allKademlia   = M.keys otherKademlia ++ if selfKademlia then [self] else []
+            kademliaPeers = mkKademliaAddress . snd <$> mapMaybe (\name -> M.lookup name resolved) allKademlia
+        return (selfMetadata, peersFromList directory routes, kademliaPeers)
   where
+
+    mkKademliaAddress :: NetworkAddress -> Y.KademliaAddress
+    mkKademliaAddress (addr, port) = Y.KademliaAddress
+        { Y.kaHost = BS.C8.unpack addr
+        , Y.kaPort = port
+        }
 
     -- Use the name/metadata association to come up with types and
     -- addresses for each name.
-    resolvePeers :: T.Resolver -> Map NodeName Y.NodeMetadata -> IO (Map NodeName (T.NodeType, NodeId))
+    resolvePeers :: T.Resolver -> Map NodeName Y.NodeMetadata -> IO (Map NodeName (T.NodeType, NetworkAddress))
     resolvePeers resolve = M.traverseWithKey (resolvePeer resolve)
 
-    resolvePeer :: T.Resolver -> NodeName -> Y.NodeMetadata -> IO (T.NodeType, NodeId)
+    resolvePeer :: T.Resolver -> NodeName -> Y.NodeMetadata -> IO (T.NodeType, NetworkAddress)
     resolvePeer resolve name metadata =
       (typ,) <$> resolveNodeAddr cfg resolve (name, addr)
       where
@@ -343,10 +393,10 @@ fromPovOf cfg@NetworkConfigOpts{..} allPeers =
 resolveNodeAddr :: NetworkConfigOpts
                 -> T.Resolver
                 -> (NodeName, NodeAddr (Maybe DNS.Domain))
-                -> IO NodeId
+                -> IO NetworkAddress
 resolveNodeAddr cfg _ (_, NodeAddrExact addr mPort) = do
     let port = fromMaybe (networkConfigOptsPort cfg) mPort
-    return $ addressToNodeId (addr, port)
+    return (addr, port)
 resolveNodeAddr cfg resolve (name, NodeAddrDNS mHost mPort) = do
     let host = fromMaybe (nameToDomain name)         mHost
         port = fromMaybe (networkConfigOptsPort cfg) mPort
@@ -356,13 +406,13 @@ resolveNodeAddr cfg resolve (name, NodeAddrDNS mHost mPort) = do
       Left err            -> throwM $ NetworkConfigDnsError host err
       Right []            -> throwM $ CannotResolve name
       Right addrs@(_:_:_) -> throwM $ NoUniqueResolution name addrs
-      Right [addr]        -> return $ ipv4ToNodeId addr port
+      Right [addr]        -> return $ ipv4ToNetworkAddress addr port
   where
     nameToDomain :: NodeName -> DNS.Domain
     nameToDomain (NodeName n) = BS.C8.pack (toString n)
 
-ipv4ToNodeId :: IPv4 -> Word16 -> NodeId
-ipv4ToNodeId addr port = addressToNodeId (BS.C8.pack (show addr), port)
+ipv4ToNetworkAddress :: IPv4 -> Word16 -> NetworkAddress
+ipv4ToNetworkAddress addr port = (BS.C8.pack (show addr), port)
 
 metadataFor :: Y.AllStaticallyKnownPeers -> NodeName -> IO Y.NodeMetadata
 metadataFor (Y.AllStaticallyKnownPeers allPeers) node =
@@ -388,7 +438,7 @@ parseKademlia :: FilePath -> IO Y.KademliaParams
 parseKademlia fp = do
     mKademlia <- Yaml.decodeFileEither fp
     case mKademlia of
-      Left  err      -> throwM $ CannotParseKademliaConfig err
+      Left  err      -> throwM $ CannotParseKademliaConfig (Right err)
       Right kademlia -> return kademlia
 
 {-------------------------------------------------------------------------------
@@ -409,7 +459,7 @@ data NetworkConfigException =
   | MissingKademliaConfig
 
     -- | We cannot parse the kademlia .yaml file
-  | CannotParseKademliaConfig Yaml.ParseException
+  | CannotParseKademliaConfig (Either DHT.MalformedDHTKey Yaml.ParseException)
 
     -- | A policy description .yaml was specified but couldn't be parsed.
   | CannotParsePolicies Yaml.ParseException

--- a/infra/Pos/Network/Yaml.hs
+++ b/infra/Pos/Network/Yaml.hs
@@ -111,7 +111,7 @@ data KademliaParams = KademliaParams
       -- ^ Initial Kademlia peers, for joining the network.
     , kpAddress         :: !(Maybe KademliaAddress)
       -- ^ External Kadmelia address.
-    , kpBind            :: !KademliaAddress
+    , kpBind            :: !(Maybe KademliaAddress)
       -- ^ Address at which to bind the Kademlia socket.
       -- Shouldn't be necessary to have a separate bind and public address.
       -- The Kademlia instance in fact shouldn't even need to know its own
@@ -119,7 +119,7 @@ data KademliaParams = KademliaParams
       -- that responses for FIND_NODES are serialized, Kademlia needs to know
       -- its own external address [TW-153]. The mainline 'kademlia' package
       -- doesn't suffer this problem.
-    , kpExplicitInitial :: !Bool
+    , kpExplicitInitial :: !(Maybe Bool)
     , kpDumpFile        :: !(Maybe FilePath)
     }
     deriving (Show)
@@ -129,8 +129,8 @@ instance FromJSON KademliaParams where
         kpId <- obj .:? "identifier"
         kpPeers <- obj .: "peers"
         kpAddress <- obj .:? "externalAddress"
-        kpBind <- obj .: "address"
-        kpExplicitInitial <- obj .:? "explicitInitial" .!= False
+        kpBind <- obj .:? "address"
+        kpExplicitInitial <- obj .:? "explicitInitial"
         kpDumpFile <- obj .:? "dumpFile"
         return KademliaParams {..}
 

--- a/node/src/Pos/Client/CLI/NodeOptions.hs
+++ b/node/src/Pos/Client/CLI/NodeOptions.hs
@@ -53,9 +53,9 @@ data CommonNodeArgs = CommonNodeArgs
     , devVssGenesisI            :: !(Maybe Int)
     , keyfilePath               :: !FilePath
     , backupPhrase              :: !(Maybe BackupPhrase)
-    , externalAddress           :: !NetworkAddress
+    , externalAddress           :: !(Maybe NetworkAddress)
       -- ^ A node must be addressable on the network.
-    , bindAddress               :: !NetworkAddress
+    , bindAddress               :: !(Maybe NetworkAddress)
       -- ^ A node may have a bind address which differs from its external
       -- address.
     , nodeType                  :: !NodeType
@@ -109,9 +109,9 @@ commonNodeArgsParser = do
         help    (show backupPhraseWordsNum ++
                  "-word phrase to recover the wallet. Words should be separated by spaces.")
     externalAddress <-
-        externalNetworkAddressOption (Just ("0.0.0.0", 0))
+        optional $ externalNetworkAddressOption Nothing
     bindAddress <-
-        listenNetworkAddressOption (Just ("0.0.0.0", 0))
+        optional $ listenNetworkAddressOption Nothing
     nodeType <- nodeTypeOption
     peers <- (++) <$> corePeersList <*> relayPeersList
     networkConfigOpts <- networkConfigOption

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -137,8 +137,8 @@ getTransportParams args networkConfig = case ncTopology networkConfig of
     -- confusion: if a user gives a --listen parameter then they probably
     -- think the program will bind a socket.
     TopologyBehindNAT{} -> do
-        _ <- maybe (return ()) (const (throw UnnecessaryAddress)) (bindAddress args)
-        _ <- maybe (return ()) (const (throw UnnecessaryAddress)) (externalAddress args)
+        _ <- whenJust (bindAddress args) (const (throw UnnecessaryAddress))
+        _ <- whenJust (externalAddress args) (const (throw UnnecessaryAddress))
         return $ TransportParams { tpTcpAddr = TCP.Unaddressable }
     _ -> do
         (bindHost, bindPort) <- maybe (throw MissingBindAddress) return (bindAddress args)

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -9,10 +9,11 @@ module Pos.Client.CLI.Params
        , gtSscParams
        ) where
 
-import           Universum
+import           Base                  (Show (..))
+import           Universum             hiding (show)
 
 import qualified Data.ByteString.Char8      as BS8 (unpack)
-import           Mockable                   (Catch, Fork, Mockable)
+import           Mockable                   (Catch, Fork, Mockable, Throw, throw)
 import qualified Network.Transport.TCP      as TCP (TCPAddr (..), TCPAddrInfo (..))
 import           System.Wlog                (LoggerName, WithLogger)
 
@@ -64,8 +65,9 @@ getKeyfilePath CommonNodeArgs {..}
           Just i  -> "node-" ++ show i ++ "." ++ keyfilePath
     | otherwise = keyfilePath
 
+
 getNodeParams ::
-       (MonadIO m, WithLogger m, Mockable Fork m, Mockable Catch m)
+       (MonadIO m, WithLogger m, Mockable Fork m, Mockable Catch m, Mockable Throw m)
     => CommonNodeArgs
     -> NodeArgs
     -> Timestamp
@@ -76,8 +78,8 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
             updateUserSecretVSS cArgs =<<
                 peekUserSecret (getKeyfilePath cArgs)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    let npTransport = getTransportParams cArgs npNetworkConfig
-        devStakeDistr =
+    npTransport <- getTransportParams cArgs npNetworkConfig
+    let devStakeDistr =
             devStakesDistr
                 (flatDistr commonArgs)
                 (richPoorDistr commonArgs)
@@ -110,14 +112,38 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
         , ..
         }
 
-getTransportParams :: CommonNodeArgs -> NetworkConfig kademlia -> TransportParams
-getTransportParams args networkConfig = TransportParams { tpTcpAddr = tcpAddr }
-  where
-    tcpAddr = case ncTopology networkConfig of
-        TopologyBehindNAT{} -> TCP.Unaddressable
-        _ -> let (bindHost, bindPort) = bindAddress args
-                 (externalHost, externalPort) = externalAddress args
-                 tcpHost = BS8.unpack bindHost
-                 tcpPort = show bindPort
-                 tcpMkExternal = const (BS8.unpack externalHost, show externalPort)
-             in  TCP.Addressable $ TCP.TCPAddrInfo tcpHost tcpPort tcpMkExternal
+data NetworkTransportMisconfiguration =
+
+      -- | A bind address was not given.
+      MissingBindAddress
+
+      -- | An external address was not given.
+    | MissingExternalAddress
+
+      -- | An address was given when one was not expected (behind NAT).
+    | UnnecessaryAddress
+
+instance Show NetworkTransportMisconfiguration where
+    show MissingBindAddress     = "No network bind address given. Use the --listen option."
+    show MissingExternalAddress = "No external network address given. Use the --address option."
+    show UnnecessaryAddress     = "Network address given when none was expected. Remove the --listen and --address options."
+
+instance Exception NetworkTransportMisconfiguration
+
+getTransportParams :: ( Mockable Throw m ) => CommonNodeArgs -> NetworkConfig kademlia -> m TransportParams
+getTransportParams args networkConfig = case ncTopology networkConfig of
+    -- Behind-NAT topology claims no address for the transport, and also
+    -- throws an exception if the --listen parameter is given, to avoid
+    -- confusion: if a user gives a --listen parameter then they probably
+    -- think the program will bind a socket.
+    TopologyBehindNAT{} -> do
+        _ <- maybe (return ()) (const (throw UnnecessaryAddress)) (bindAddress args)
+        _ <- maybe (return ()) (const (throw UnnecessaryAddress)) (externalAddress args)
+        return $ TransportParams { tpTcpAddr = TCP.Unaddressable }
+    _ -> do
+        (bindHost, bindPort) <- maybe (throw MissingBindAddress) return (bindAddress args)
+        (externalHost, externalPort) <- maybe (throw MissingExternalAddress) return (externalAddress args)
+        let tcpHost = BS8.unpack bindHost
+            tcpPort = show bindPort
+            tcpMkExternal = const (BS8.unpack externalHost, show externalPort)
+        return $ TransportParams { tpTcpAddr = TCP.Addressable (TCP.TCPAddrInfo tcpHost tcpPort tcpMkExternal) }

--- a/scripts/bench/buildbench.sh
+++ b/scripts/bench/buildbench.sh
@@ -4,4 +4,4 @@
 # CONFIG=.. selects section from config file (core/constants.yaml)
 # dev-custom-config needed to override config file section
 
-stack build --flag cardano-sl-core:dev-mode --flag cardano-sl-core:dev-custom-config --ghc-options=-DCONFIG=benchmark --flag cardano-sl-core:-asserts cardano-sl cardano-sl-lwallet
+stack build --flag cardano-sl-core:dev-mode --flag cardano-sl-core:dev-custom-config --ghc-options=-DCONFIG=benchmark --flag cardano-sl-core:-asserts cardano-sl cardano-sl-lwallet cardano-sl-wallet cardano-sl-explorer

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -119,13 +119,20 @@ function node_cmd {
     rts_opts="+RTS -N -pa -A6G -qg -RTS"
   fi
 
+  local topology_file="$config_dir/topology$i.yaml"
+  local kademlia_file="$config_dir/kademlia$i.yaml"
+
   echo -n "$(find_binary $exec_name) --db-path $run_dir/node-db$i $rts_opts $reb $no_ntp $keys_args"
 
   ekg_server="127.0.0.1:"$((8000+$i))
   statsd_server="127.0.0.1:"$((8125+$i))
 
-  echo -n " --address 127.0.0.1:"`get_port $i`
-  echo -n " --listen 127.0.0.1:"`get_port $i`
+  # A sloppy test but it'll do for now.
+  local topology_first_six_bytes=`cat $topology_file | head -c 6`
+  if [[ "$topology_first_six_bytes" != "wallet" ]]; then
+    echo -n " --address 127.0.0.1:"`get_port $i`
+    echo -n " --listen 127.0.0.1:"`get_port $i`
+  fi
   echo -n " $(logs node$i.log) $time_lord $stats"
   echo -n " $stake_distr $ssc_algo "
   echo -n " $web "
@@ -136,8 +143,8 @@ function node_cmd {
   echo -n " --ekg-server $ekg_server"
   #echo -n " --statsd-server $statsd_server"
   echo -n " --node-id node$i"
-  echo -n " --topology $config_dir/topology$i.yaml"
-  echo -n " --kademlia $config_dir/kademlia$i.yaml"
+  echo -n " --topology $topology_file"
+  echo -n " --kademlia $kademlia_file"
   # Use the policies option if you want to change enqueue/dequeue/failure
   # policies without re-compiling. See example files
   #   run/policy_core.yaml

--- a/wallet/node/Params.hs
+++ b/wallet/node/Params.hs
@@ -6,7 +6,7 @@ module Params
 
 import           Universum
 
-import           Mockable            (Catch, Fork, Mockable)
+import           Mockable            (Catch, Fork, Mockable, Throw)
 import           System.Wlog         (WithLogger)
 
 import           Pos.Client.CLI      (CommonNodeArgs (..))
@@ -28,6 +28,7 @@ getNodeParams ::
        , WithLogger m
        , Mockable Fork m
        , Mockable Catch m
+       , Mockable Throw m
        )
     => CommonNodeArgs
     -> Timestamp
@@ -38,8 +39,8 @@ getNodeParams args@CommonNodeArgs{..} systemStart = do
             CLI.updateUserSecretVSS args =<<
                 peekUserSecret (CLI.getKeyfilePath args)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    let npTransport = CLI.getTransportParams args npNetworkConfig
-        devStakeDistr =
+    npTransport <- CLI.getTransportParams args npNetworkConfig
+    let devStakeDistr =
             devStakesDistr
                 (CLI.flatDistr commonArgs)
                 (CLI.richPoorDistr commonArgs)


### PR DESCRIPTION
If a `--listen` or `--address` command-line argument is given, but the node is in behind-nat mode and therefore won't use these parameters, an exception is thrown.

If a topology file giving a static routing table is given, but no `--kademlia` flag is present, then a sensible default kademlia configuration is derived from the topology: every node which runs kademlia is included as an initial peer, and the bind address is chosen to be `0.0.0.0` on the default port.

~~This has broken the demo script because `--address` and `--listen` are always passed. Will fix this.~~