### PR TITLE
Adjust the fallback node types to match the policy.

### DIFF
--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -211,12 +211,12 @@ topologyUnknownNodeType :: Topology kademlia -> OQ.UnknownNodeType NodeId
 topologyUnknownNodeType topology = OQ.UnknownNodeType $ go topology
   where
     go :: Topology kademlia -> NodeId -> NodeType
-    go TopologyCore{..}      = const NodeEdge
-    go TopologyRelay{..}     = const NodeEdge
+    go TopologyCore{..}      = const NodeRelay  -- to allow dynamic reconfig
+    go TopologyRelay{..}     = const NodeEdge   -- since we don't trust anyone
     go TopologyTraditional{} = const NodeCore
-    go TopologyP2P{}         = const NodeEdge
-    go TopologyBehindNAT{}   = const NodeEdge
-    go TopologyLightWallet{} = const NodeEdge
+    go TopologyP2P{}         = const NodeRelay  -- a fairly normal expected case
+    go TopologyBehindNAT{}   = const NodeEdge   -- should never happen
+    go TopologyLightWallet{} = const NodeEdge   -- should never happen
 
 data SubscriptionWorker kademlia =
     SubscriptionWorkerBehindNAT (DnsDomains DNS.Domain) Valency Fallbacks


### PR DESCRIPTION
Noticed that when the static routes were mis-configured and nodes did not know about each other, they were falling back to presuming unknown peers were edge nodes, and so were failing to ask for blocks from each other.

The correct policy for fallback in these cases is relay.