### PR TITLE
Enable disabled tests in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,6 @@ test_script:
       --extra-lib-dirs="C:\OpenSSL-Win64-v102"
       --extra-include-dirs="%WORK_DIR%\rocksdb\include"
       --extra-lib-dirs="%WORK_DIR%"
-      --test-arguments "--skip Block.Logic.Var --skip Lrc.Worker"
   - scripts\ci\appveyor-retry call stack install cardano-sl-tools
       -j 2
       --no-terminal


### PR DESCRIPTION
They were temporarily disabled when they were kinda broken. Now they should be ok.