### PR TITLE
[CSM-422] Store wallet backup with unencrypted secret key

### DIFF
--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -9,6 +9,7 @@ module Pos.Crypto.SafeSigning
        , noPassEncrypt
        , checkPassMatches
        , changeEncPassphrase
+       , removeEncPassphrase
        , encToPublic
        , safeSign
        , safeToPublic
@@ -99,6 +100,14 @@ changeEncPassphrase
 changeEncPassphrase oldPass newPass esk@(EncryptedSecretKey sk _) = do
     checkPassMatches oldPass esk
     return $ mkEncSecret newPass $ CC.xPrvChangePass oldPass newPass sk
+
+removeEncPassphrase
+    :: Bi PassPhrase
+    => PassPhrase
+    -> EncryptedSecretKey
+    -> Maybe SecretKey
+removeEncPassphrase curPass esk =
+    SecretKey . eskPayload <$> changeEncPassphrase curPass emptyPassphrase esk
 
 signRaw' :: Maybe SignTag
          -> PassPhrase

--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -243,8 +243,9 @@ syncProgress tls = getR tls $ noQueryParam ["settings", "sync", "progress"]
 
 --------------------------------------------------------------------------------
 -- JSON BACKUP -----------------------------------------------------------------
-importBackupJSON :: forall eff. TLSOptions -> String -> Aff (http :: HTTP, exception :: EXCEPTION | eff) CWallet
-importBackupJSON tls = postRBody tls $ noQueryParam ["backup", "import"]
+importBackupJSON :: forall eff. TLSOptions -> Maybe CPassPhrase -> String -> Aff (http :: HTTP, exception :: EXCEPTION | eff) CWallet
+importBackupJSON tls pass = postRBody tls $ queryParams ["backup", "import"] [qParam "passphrase" $ _passPhrase <$> pass]
 
-exportBackupJSON :: forall eff. TLSOptions -> CId Wal -> String -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
-exportBackupJSON tls addr = postRBody tls $ noQueryParam ["backup", "export", _address addr]
+exportBackupJSON :: forall eff. TLSOptions -> Maybe CPassPhrase -> CId Wal -> String -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
+exportBackupJSON tls pass addr = postRBody tls $ queryParams ["backup", "export", _address addr] [qParam "passphrase" $ _passPhrase <$> pass]
+

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -889,11 +889,15 @@ syncProgress = mkEffFn1 $ fromAff <<< map encodeJson <<< B.syncProgress
 
 --------------------------------------------------------------------------------
 -- JSON backup -----------------------------------------------------------------
-importBackupJSON :: forall eff. EffFn2 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions String (Promise Json)
-importBackupJSON = mkEffFn2 $ \tls -> fromAff <<< map encodeJson <<< B.importBackupJSON tls
+importBackupJSON :: forall eff. EffFn3 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions String Foreign (Promise Json)
+importBackupJSON = mkEffFn3 \tls wid pass -> do
+    pass' <- mkCPassPhrase pass
+    fromAff $ map encodeJson $ B.importBackupJSON tls pass' wid
 
-exportBackupJSON :: forall eff. EffFn3 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions String String (Promise Unit)
-exportBackupJSON = mkEffFn3 $ \tls wId -> fromAff <<< B.exportBackupJSON tls (mkCId wId)
+exportBackupJSON :: forall eff. EffFn4 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions String String Foreign (Promise Unit)
+exportBackupJSON = mkEffFn4 $ \tls wId file pass -> do
+    pass' <- mkCPassPhrase pass
+    fromAff $ B.exportBackupJSON tls pass' (mkCId wId) file
 
 --------------------------------------------------------------------------------
 -- Mnemonics ---------------------------------------------------------------------

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -339,12 +339,14 @@ type GetSyncProgress =
 type ImportBackupJSON =
        "backup"
     :> "import"
+    :> DCQueryParam "passphrase" CPassPhrase
     :> ReqBody '[JSON] Text
     :> WRes Post CWallet
 
 type ExportBackupJSON =
        "backup"
     :> "export"
+    :> DCQueryParam "passphrase" CPassPhrase
     :> Capture "walletId" (CId Wal)
     :> ReqBody '[JSON] Text
     :> WRes Post ()


### PR DESCRIPTION
`exportBackup` endpoint now accepts password to decode encrypted secret key. `importBackup` endpoint accepts password as well - one which is assigned to wallet on import.

Tested with postman and daedalus-bridge, including cases with passphrases.