### PR TITLE
Update nix expression output by stack2nix

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6296,6 +6296,8 @@ self: {
           pname = "svg-builder";
           version = "0.1.0.2";
           sha256 = "0m7fpxh2viafcfm04xzy64jakx5c0p5wcam3bdwxgmj3r3q0qjc1";
+          revision = "1";
+          editedCabalFile = "1h3bzkimiydj5j2rh7cyp5bhphvy6hglpkidhlfwy520sqsw3zvx";
           libraryHaskellDepends = [
             base
             blaze-builder


### PR DESCRIPTION
Due to a cabal file revision in hackage, stack2nix output was invalidated. Builds on master will fail until this is updated.