### PR TITLE
[CSL-1549] policy update, time-warp-nt revision bump

### DIFF
--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -23,9 +23,13 @@ defaultEnqueuePolicyCore = go
         EnqueueAll NodeCore  (MaxAhead 0) PHighest
       , EnqueueAll NodeRelay (MaxAhead 0) PHigh
       ]
-    go (MsgRequestBlockHeaders _) = [
+    go (MsgRequestBlockHeaders Nothing) = [
         EnqueueAll NodeCore  (MaxAhead 2) PHigh
       , EnqueueAll NodeRelay (MaxAhead 2) PHigh
+      ]
+    go (MsgRequestBlockHeaders (Just _)) = [
+        -- We never ask for data from edge nodes
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 3) PHigh
       ]
     go (MsgRequestBlocks _) = [
         -- We never ask for data from edge nodes
@@ -51,9 +55,13 @@ defaultEnqueuePolicyRelay = go
       , EnqueueAll NodeCore  (MaxAhead 0) PHigh
       , EnqueueAll NodeEdge  (MaxAhead 0) PMedium
       ]
-    go (MsgRequestBlockHeaders _) = [
+    go (MsgRequestBlockHeaders Nothing) = [
         EnqueueAll NodeCore  (MaxAhead 2) PHigh
       , EnqueueAll NodeRelay (MaxAhead 2) PHigh
+      ]
+    go (MsgRequestBlockHeaders (Just _)) = [
+        -- We never ask for data from edge nodes
+        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 3) PHigh
       ]
     go (MsgRequestBlocks _) = [
         -- We never ask for blocks from edge nodes
@@ -83,8 +91,11 @@ defaultEnqueuePolicyEdgeBehindNat = go
     go (MsgAnnounceBlockHeader _) = [
         -- not forwarded
       ]
-    go (MsgRequestBlockHeaders _) = [
+    go (MsgRequestBlockHeaders Nothing) = [
         EnqueueAll NodeRelay (MaxAhead 1) PHigh
+      ]
+    go (MsgRequestBlockHeaders (Just _)) = [
+        EnqueueOne [NodeRelay] (MaxAhead 2) PHigh
       ]
     go (MsgRequestBlocks _) = [
         -- Edge nodes can only talk to relay nodes

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4811,8 +4811,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "09sqk5vdv3fkn2r48kcvw77vwsbslfnijcnm3ssfqapmnvw1d2id";
-            rev = "39fd29a944efdfd19270a5866ec4ee81ac80fe01";
+            sha256 = "18bs4k4zspzivmgqikq7hv6qqv57l7j703qr99d8fz4nlp49nxl7";
+            rev = "18e60874e5725a1e5abf4f19957542bdd342a0a3";
           };
           isLibrary = true;
           isExecutable = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4811,8 +4811,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "18bs4k4zspzivmgqikq7hv6qqv57l7j703qr99d8fz4nlp49nxl7";
-            rev = "18e60874e5725a1e5abf4f19957542bdd342a0a3";
+            sha256 = "0gwr1n6mp6n70mwgczf8pblq1l2085nmyll5wl19dg1ic0dnmbh2";
+            rev = "40f4235cda65c746c6edc2a3455242d96d7175bf";
           };
           isLibrary = true;
           isExecutable = true;

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 39fd29a944efdfd19270a5866ec4ee81ac80fe01 # master
+    commit: 18e60874e5725a1e5abf4f19957542bdd342a0a3
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 18e60874e5725a1e5abf4f19957542bdd342a0a3
+    commit: 40f4235cda65c746c6edc2a3455242d96d7175bf #master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
This is to use time-warp-nt at https://github.com/serokell/time-warp-nt/pull/96

CI on that pull request keeps timing out. Will go to a master revision as soon as that's sorted.