### PR TITLE
[CSL-1540] Make Topology Yaml parser less lenient

### DIFF
--- a/infra/Pos/Network/CLI.hs
+++ b/infra/Pos/Network/CLI.hs
@@ -26,8 +26,8 @@ import qualified Data.Map.Strict                 as M
 import           Data.Maybe                      (fromJust, mapMaybe)
 import qualified Data.Yaml                       as Yaml
 import           Formatting                      (sformat, shown, (%))
-import           Mockable                        (Catch, Mockable, fork, try,
-                                                  Throw, throw)
+import           Mockable                        (Catch, Mockable, Throw, fork, throw,
+                                                  try)
 import           Mockable.Concurrent
 import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS                     as DNS
@@ -36,7 +36,7 @@ import qualified Pos.DHT.Real.Param              as DHT (KademliaParams,
                                                          MalformedDHTKey (..),
                                                          fromYamlConfig)
 import           Pos.Network.DnsDomains          (DnsDomains (..), NodeAddr (..))
-import           Pos.Network.Types               (NodeId, NodeName(..))
+import           Pos.Network.Types               (NodeId, NodeName (..))
 import qualified Pos.Network.Types               as T
 import           Pos.Network.Yaml                (NodeMetadata (..))
 import qualified Pos.Network.Yaml                as Y
@@ -400,7 +400,7 @@ resolveNodeAddr :: NetworkConfigOpts
                 -> IO NetworkAddress
 resolveNodeAddr cfg _ (_, NodeAddrExact addr mPort) = do
     let port = fromMaybe (networkConfigOptsPort cfg) mPort
-    return (addr, port)
+    return (encodeUtf8 @String . show $ addr, port)
 resolveNodeAddr cfg resolve (name, NodeAddrDNS mHost mPort) = do
     let host = fromMaybe (nameToDomain name)         mHost
         port = fromMaybe (networkConfigOptsPort cfg) mPort

--- a/infra/Pos/Network/DnsDomains.hs
+++ b/infra/Pos/Network/DnsDomains.hs
@@ -6,7 +6,7 @@ module Pos.Network.DnsDomains (
   ) where
 
 import qualified Data.ByteString.Char8                 as BS.C8
-import           Data.IP                               (IPv4)
+import           Data.IP                               (IP, IPv4)
 import           Network.Broadcast.OutboundQueue.Types (AllOf, Alts)
 import           Universum
 
@@ -29,7 +29,7 @@ data NodeAddr a =
     -- | We specify the exact address of this node
     --
     -- If port unspecified, use the default.
-    NodeAddrExact ByteString (Maybe Word16)
+    NodeAddrExact IP (Maybe Word16)
 
     -- | Do a DNS lookup to find the node's address
     --
@@ -79,4 +79,5 @@ resolveDnsDomains resolve defaultPort (DnsDomains{..}) =
             Right ips -> go (reverse (map toAddr ips) ++ acc) addrs
         go acc (NodeAddrExact ip mPort:addrs) = do
           let port = fromMaybe defaultPort mPort
-          go ((ip, port):acc) addrs
+              ipBS = encodeUtf8 @String . show $ ip
+          go ((ipBS, port):acc) addrs

--- a/infra/Pos/Network/Yaml.hs
+++ b/infra/Pos/Network/Yaml.hs
@@ -23,21 +23,22 @@ module Pos.Network.Yaml (
   , fromStaticPolicies
   ) where
 
-import           Data.Aeson             (FromJSON (..), ToJSON (..), (.!=),
-                                         (.:), (.:?), (.=))
-import qualified Data.Aeson             as A
-import qualified Data.Aeson.Types       as A
-import qualified Data.ByteString.Char8  as BS.C8
-import qualified Data.HashMap.Lazy      as HM
-import qualified Data.Map.Strict        as M
+import           Data.Aeson                            (FromJSON (..), ToJSON (..), (.!=),
+                                                        (.:), (.:?), (.=))
+import qualified Data.Aeson                            as A
+import qualified Data.Aeson.Types                      as A
+import qualified Data.ByteString.Char8                 as BS.C8
+import qualified Data.HashMap.Lazy                     as HM
+import           Data.IP                               (IP)
+import qualified Data.Map.Strict                       as M
+import qualified Network.Broadcast.OutboundQueue       as OQ
 import           Network.Broadcast.OutboundQueue.Types
-import qualified Network.Broadcast.OutboundQueue as OQ
-import qualified Network.DNS            as DNS
-import           Pos.Network.Types      (NodeName(..), Valency, Fallbacks)
+import qualified Network.DNS                           as DNS
+import           Pos.Network.Types                     (Fallbacks, NodeName (..), Valency)
 import           Pos.Util.Config
 import           Universum
 
-import           Pos.Network.DnsDomains (DnsDomains (..), NodeAddr (..))
+import           Pos.Network.DnsDomains                (DnsDomains (..), NodeAddr (..))
 
 -- | Description of the network topology in a Yaml file
 --
@@ -82,19 +83,19 @@ newtype NodeRoutes = NodeRoutes [[NodeName]]
 
 data NodeMetadata = NodeMetadata
     { -- | Node type
-      nmType    :: !NodeType
+      nmType       :: !NodeType
 
       -- | Region
-    , nmRegion  :: !NodeRegion
+    , nmRegion     :: !NodeRegion
 
       -- | Static peers of this node
-    , nmRoutes  :: !NodeRoutes
+    , nmRoutes     :: !NodeRoutes
 
       -- | Address for this node
-    , nmAddress :: !(NodeAddr (Maybe DNS.Domain))
+    , nmAddress    :: !(NodeAddr (Maybe DNS.Domain))
 
       -- | Should the node register itself with the Kademlia network?
-    , nmKademlia :: !RunKademlia
+    , nmKademlia   :: !RunKademlia
 
       -- | Maximum number of subscribers (only relevant for relays)
     , nmMaxSubscrs :: !OQ.MaxBucketSize
@@ -194,11 +195,11 @@ instance FromJSON NodeType where
 instance FromJSON OQ.Precedence where
   parseJSON = A.withText "Precedence" $ \typ -> do
       case toString typ of
-        "lowest"  -> return OQ.PLowest
-        "low"     -> return OQ.PLow
-        "medium"  -> return OQ.PMedium
-        "high"    -> return OQ.PHigh
-        "highest" -> return OQ.PHighest
+        "lowest"   -> return OQ.PLowest
+        "low"      -> return OQ.PLow
+        "medium"   -> return OQ.PMedium
+        "high"     -> return OQ.PHigh
+        "highest"  -> return OQ.PHighest
         _otherwise -> fail $ "Invalid Precedence" ++ show typ
 
 instance FromJSON (DnsDomains DNS.Domain) where
@@ -212,7 +213,7 @@ instance FromJSON (NodeAddr DNS.Domain) where
       aux (Just dom) = return dom
 
 -- Useful when we have a 'NodeAddr' as part of a larger object
-extractNodeAddr :: (Maybe DNS.Domain -> A.Parser a)
+extractNodeAddr :: forall a. (Maybe DNS.Domain -> A.Parser a)
                 -> A.Object
                 -> A.Parser (NodeAddr a)
 extractNodeAddr mkA obj = do
@@ -220,13 +221,27 @@ extractNodeAddr mkA obj = do
     mHost <- obj .:? "host"
     mPort <- obj .:? "port"
     case (mAddr, mHost) of
-      (Just addr, Nothing) -> return $ NodeAddrExact (aux addr) mPort
-      (Nothing,  _)        -> do a <- mkA (aux <$> mHost)
-                                 return $ NodeAddrDNS a mPort
-      (Just _, Just _)     -> fail "Cannot use both 'addr' and 'host'"
+      (Just ipAddr, Nothing) -> do
+          -- Make sure `addr` is a proper IP address
+          case readMaybe ipAddr of
+              Nothing   -> fail "The value specified in 'addr' is not a valid IP address."
+              Just addr -> return $ NodeAddrExact addr mPort
+      (Nothing,  _)        -> do
+          -- Make sure 'host' is not a valid IP address (which is disallowed)
+          case mHost of
+              Nothing  -> mkNodeAddrDNS mHost mPort -- User didn't specify a 'host', proceed normally.
+              Just mbH -> case readMaybe @IP mbH of
+                  Nothing -> mkNodeAddrDNS mHost mPort -- mHost is not an IP, allow it.
+                  Just _  -> fail "The value specified in 'host' is not a valid hostname, but an IP."
+      (Just _, Just _)    -> fail "Cannot use both 'addr' and 'host'"
   where
     aux :: String -> DNS.Domain
     aux = BS.C8.pack
+
+    mkNodeAddrDNS :: Maybe String -> Maybe Word16 -> A.Parser (NodeAddr a)
+    mkNodeAddrDNS mHost mPort = do
+          a <- mkA (aux <$> mHost)
+          return $ NodeAddrDNS a mPort
 
 instance FromJSON NodeMetadata where
   parseJSON = A.withObject "NodeMetadata" $ \obj -> do


### PR DESCRIPTION
See here for the full context: https://issues.serokell.io/issue/CSL-1540

With the new code, now trying to use a hostname instead of an IP address in the `addr` field would result in:

![screen shot 2017-08-25 at 14 39 21](https://user-images.githubusercontent.com/29383371/29714438-867eaaee-89a3-11e7-92bc-2a1336d79299.png)

Conversely, trying to use an IP address in the `host` field...

![screen shot 2017-08-25 at 14 39 37](https://user-images.githubusercontent.com/29383371/29714447-90d7c322-89a3-11e7-8a1d-96b48c0eb01c.png)
