### PR TITLE
[DEVOPS-278] Fix daedalus bridge generation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,19 +14,9 @@ let
   addConfigureFlags = flags: drv: overrideCabal drv (drv: {
     configureFlags = flags;
   });
-  cleanSource2 = builtins.filterSource (name: type: let
-      f1 = cleanSourceFilter name type;
-      baseName = baseNameOf (toString name);
-      f2 = ! (type == "symlink" && hasSuffix ".root" baseName);
-      f3 = ! (hasSuffix ".root" baseName);
-      f4 = ! (baseName == ".stack-work");
-      f5 = ! (hasSuffix ".nix" baseName);
-      f6 = ! (hasSuffix ".swp" baseName);
-    in f1 && f2 && f3 && f4 && f5 && f6);
 in ((import ./pkgs { inherit pkgs; }).override {
   overrides = self: super: {
     cardano-sl = overrideCabal super.cardano-sl (drv: {
-      src = cleanSource2 drv.src;
       patchPhase = ''
        export CSL_SYSTEM_TAG=${if pkgs.stdenv.isDarwin then "macos" else "linux64"}
       '';
@@ -40,7 +30,6 @@ in ((import ./pkgs { inherit pkgs; }).override {
       doCheck = ! pkgs.stdenv.isDarwin;
     });
     cardano-sl-core = overrideCabal super.cardano-sl-core (drv: {
-      src = cleanSource2 drv.src;
       configureFlags = [
         "-f-embed-config"
         "-f-asserts"
@@ -49,20 +38,12 @@ in ((import ./pkgs { inherit pkgs; }).override {
         "--ghc-options=-DGITREV=${gitrev}"
       ];
     });
-    cardano-sl-tools = overrideCabal super.cardano-sl-tools (drv: {
-      src = cleanSource2 drv.src;
+    cardano-sl-wallet = justStaticExecutables super.cardano-sl-wallet;
+    cardano-sl-tools = justStaticExecutables (overrideCabal super.cardano-sl-tools (drv: {
       # waiting on load-command size fix in dyld
       doCheck = ! pkgs.stdenv.isDarwin;
-    });
+    }));
     # TODO: patch cabal2nix to allow this
-    cardano-sl-db = overrideCabal super.cardano-sl-db (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-infra = overrideCabal super.cardano-sl-infra (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-lrc = overrideCabal super.cardano-sl-lrc (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-ssc = overrideCabal super.cardano-sl-ssc (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-txp = overrideCabal super.cardano-sl-txp (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-update = overrideCabal super.cardano-sl-update (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-godtossing = overrideCabal super.cardano-sl-godtossing (drv: { src = cleanSource2 drv.src; });
-    cardano-sl-lwallet = overrideCabal super.cardano-sl-lwallet (drv: { src = cleanSource2 drv.src; });
 
     cardano-sl-static = justStaticExecutables self.cardano-sl;
     cardano-sl-explorer-static = justStaticExecutables self.cardano-sl-explorer;

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -72,6 +72,11 @@ pushd daedalus
   nix-shell --run "npm install && npm run build:prod"
   echo $TRAVIS_BUILD_NUMBER > build-id
   cp ../log-config-prod.yaml .
+  cp ../cardano-sl-tools.root/bin/cardano-launcher .
+  cp ../cardano-sl-wallet.root/bin/cardano-node .
+  # check that binaries exit with 0
+  ./cardano-node --help > /dev/null
+  ./cardano-launcher --help > /dev/null
 popd
 
 # Replace TRAVIS_BRANCH slash not to fail on subdirectory missing


### PR DESCRIPTION
- remove filterSource2 as it's not needed anymore
- compile cardano-node and cardano-launcher statically
- check that executables are self contained and pass --help