### PR TITLE
Tweak network policy slightly for MsgAnnounceBlockHeader

### DIFF
--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -21,7 +21,7 @@ defaultEnqueuePolicyCore = go
     go :: EnqueuePolicy nid
     go (MsgAnnounceBlockHeader _) = [
         EnqueueAll NodeCore  (MaxAhead 0) PHighest
-      , EnqueueAll NodeRelay (MaxAhead 0) PHigh
+      , EnqueueAll NodeRelay (MaxAhead 0) PHighest
       ]
     go (MsgRequestBlockHeaders Nothing) = [
         EnqueueAll NodeCore  (MaxAhead 2) PHigh
@@ -52,7 +52,7 @@ defaultEnqueuePolicyRelay = go
     go :: EnqueuePolicy nid
     go (MsgAnnounceBlockHeader _) = [
         EnqueueAll NodeRelay (MaxAhead 0) PHighest
-      , EnqueueAll NodeCore  (MaxAhead 0) PHigh
+      , EnqueueAll NodeCore  (MaxAhead 0) PHighest
       , EnqueueAll NodeEdge  (MaxAhead 0) PMedium
       ]
     go (MsgRequestBlockHeaders Nothing) = [


### PR DESCRIPTION
We were observing errors in the logs of the form

    Rejected alternative as it has 0 messages ahead and 1 messages in
    flight, which total more than the maximum 0` for
    `MsgAnnounceBlockHeader`, from core to relay.

This is due to the fact that block requests and header announcements had the same precedence. So this change bumps the precedence of header announcements up to highest.

We originally had them at different levels because we want to start sending headers to other core nodes before sending them to relay nodes but this is not a big deal since they can all happen concurrently and there is a low limit on concurrency.