### PR TITLE
CSL-1529  Change the way data is updated in SlottingVar 

### DIFF
--- a/core/Pos/Util/Concurrent/LockedTVar.hs
+++ b/core/Pos/Util/Concurrent/LockedTVar.hs
@@ -1,0 +1,53 @@
+-- | Locked 'TVar' which can be used to synchronize in-memory data
+-- with outside world.
+
+module Pos.Util.Concurrent.LockedTVar
+       ( LockedTVar
+       , newLockedTVar
+       , writeLockedTVar
+       ) where
+
+import           Universum
+
+import           Pos.Util.Concurrent (withMVar)
+
+-- | 'LockedTVar' is a mutable variable which can store a value
+-- inside. It can be used to store a value from the outside world in
+-- memory.
+--
+-- The problem is that we want to avoid situation when only one value
+-- is updated and other code doesn't notice it. 'MVar' is taken when
+-- we want to update this value. Before we update external value, we
+-- put 'Nothing' into this variable, which means that in-memory value
+-- is not available. Then we update external value, put it into this
+-- variable and release 'MVar'.
+--
+-- So there are 3 possible states.
+-- • Value is present, 'MVar' is not taken, we can just use the stored
+-- value, it's synchronized with external value.
+-- • 'MVar' is taken, it means that the value is being updated, we
+-- should wait until update finishes.
+-- • 'MVar' is not taken, but the value is absent. It means that the
+-- value should be read from external source.
+newtype LockedTVar a = LockedTVar (MVar (TVar (Maybe a)))
+
+-- | Create a new 'LockedTVar' which is corresponds to the third state
+-- from its description, i. e. external value is not known and should
+-- be fetched directly from the outside.
+newLockedTVar :: MonadIO m => m (LockedTVar a)
+newLockedTVar = do
+    tVar <- newTVarIO Nothing
+    LockedTVar <$> newMVar tVar
+
+-- | This function takes a 'LockedTVar' and an action. This action
+-- writes a value to external storage and returns it. Then this value
+-- is put into 'LockedTVar'.
+writeLockedTVar :: (MonadIO m, MonadMask m) => LockedTVar a -> m a -> m a
+writeLockedTVar (LockedTVar mvar) writeVal =
+    withMVar mvar impl
+  where
+    impl tvar = do
+      atomically $ writeTVar tvar Nothing
+      newVal <- writeVal
+      atomically $ writeTVar tvar (Just newVal)
+      return newVal

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -100,6 +100,7 @@ library
 
                        Pos.Util.Arbitrary
                        Pos.Util.Concurrent
+                       Pos.Util.Concurrent.LockedTVar
                        Pos.Util.Concurrent.RWLock
                        Pos.Util.Concurrent.RWVar
                        Pos.Util.Chrono

--- a/node/src/Pos/Block/Slog/Logic.hs
+++ b/node/src/Pos/Block/Slog/Logic.hs
@@ -25,7 +25,6 @@ import           Universum
 import           Control.Lens           (_Wrapped)
 import           Control.Monad.Except   (MonadError (throwError))
 import qualified Data.List.NonEmpty     as NE
-import qualified Data.Map.Strict        as M
 import           Formatting             (build, sformat, (%))
 import           Serokell.Util          (Color (Red), colorize)
 import           Serokell.Util.Verify   (formatAllErrors, verResToMonadError)
@@ -52,8 +51,7 @@ import           Pos.Exception          (assertionFailed, reportFatalError)
 import qualified Pos.GState             as GS
 import           Pos.Lrc.Context        (LrcContext)
 import qualified Pos.Lrc.DB             as LrcDB
-import           Pos.Slotting           (MonadSlots (getCurrentSlot), getSlottingDataMap,
-                                         putEpochSlottingDataM)
+import           Pos.Slotting           (MonadSlots (getCurrentSlot))
 import           Pos.Ssc.Class.Helpers  (SscHelpersClass (..))
 import           Pos.Util               (HasLens (..), HasLens', inAssertMode, _neHead,
                                          _neLast)
@@ -328,9 +326,3 @@ slogCommon
     -> m ()
 slogCommon newLastSlots = do
     slogPutLastSlots newLastSlots
-    -- We read from the database and write in the memory.
-    -- TODO(ks): This is unsafe! We don't have control over sequentiality and
-    -- use explicit indexing. It would be better if we have sorted EpochSlotData and
-    -- pass it without the index.
-    slotData <- M.toList . getSlottingDataMap <$> GS.getSlottingData
-    forM_ slotData (uncurry putEpochSlottingDataM)


### PR DESCRIPTION
This PR does two things:
1. It introduces `LockedTVar` type which can be used to synchronize in-memory data and data stored in DB. For more context this issue description and CSL-1560. However, it's currently not used, because I decided to leave its usages for CSL-1560 and because it's not really necessary for CSL-1529.
2. It moves slotting data update from Slog to Update and changes the way it's done. I left a comment which explains why desynchronization of in-memory data and data from DB is ok. Apart from desynchronization problem (which would be substantial if we updated memory state after updating DB), it solves two other problems:
• previously data was read from DB and put into memory state before it was written to DB. It somehow worked because we apply genesis block separately and update slotting data only when apply genesis block.
• In rollback we were using `putEpochSlottingDataM` despite the fact that it can delete some slotting data, not add it.