### PR TITLE
Fix benchmark constants

### DIFF
--- a/core/constants.yaml
+++ b/core/constants.yaml
@@ -222,11 +222,16 @@ benchmark: &benchmark
   <<: *testnet_public_full
 
   genesisN: 50000
-  k: 2
+  k: 6
 
   genesisUnlockStakeEpoch: 0 # it effectively disables bootstrap era in
                              # benchmarks because we don't need it there
+  genesisTxFeePolicy:
+    # We do not want minimal fees in the benchmarks, since the transactions
+    # from the generator have zero fees.
+    txSizeLinear:
+      a: 0 # absolute minimal fees per transaction
+      b: 0 # additional minimal fees per byte of transaction size
 
   protocolMagic: 55550007
   genesisBinSuffix: tn # it is set here arbitrarily, it won't be actually used
-


### PR DESCRIPTION
- minimal fees are set to zero, since otherwise the transactions from
  the generator will be invalid (they are balanced)
- increased k to 6 -- with k=2, it was too easy to go into recovery
  mode, or to end up with an unacceptable chain quality end stop the
  system.