### PR TITLE
[CSL-1585] Namespace cardano EKG metrics

### DIFF
--- a/core/Pos/System/Metrics/Constants.hs
+++ b/core/Pos/System/Metrics/Constants.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Pos.System.Metrics.Constants (
-    withCardanoNamespace
+      cardanoNamespace
+    , withCardanoNamespace
                                         ) where
 
 import           Universum

--- a/core/Pos/System/Metrics/Constants.hs
+++ b/core/Pos/System/Metrics/Constants.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Pos.System.Metrics.Constants (
       cardanoNamespace
     , withCardanoNamespace

--- a/core/Pos/System/Metrics/Constants.hs
+++ b/core/Pos/System/Metrics/Constants.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Pos.System.Metrics.Constants (
+    withCardanoNamespace
+                                        ) where
+
+import           Universum
+
+cardanoNamespace :: Text
+cardanoNamespace = "cardano"
+
+withCardanoNamespace :: Text -> Text
+withCardanoNamespace label = cardanoNamespace <> "." <> label

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -98,6 +98,8 @@ library
                        Pos.Binary.Core.Version
                        Pos.Binary.Core.Genesis
 
+                       Pos.System.Metrics.Constants
+
                        Pos.Util.Arbitrary
                        Pos.Util.Concurrent
                        Pos.Util.Concurrent.LockedTVar

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -1,5 +1,6 @@
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings         #-}
 
 #if !defined(mingw32_HOST_OS)
 #define POSIX
@@ -57,13 +58,14 @@ import           Node.Internal                         (NodeId (..))
 import           Pos.Network.DnsDomains                (DnsDomains (..))
 import qualified Pos.Network.DnsDomains                as DnsDomains
 import qualified Pos.Network.Policy                    as Policy
+import           Pos.System.Metrics.Constants          (cardanoNamespace)
 import           Pos.Util.TimeWarp                     (addressToNodeId)
 import qualified System.Metrics                        as Monitoring
 import           System.Wlog.CanLog                    (WithLogger)
 import           Universum                             hiding (show)
 
 #if !defined(POSIX)
-import qualified Pos.Network.Windows.DnsDomains as Win
+import qualified Pos.Network.Windows.DnsDomains        as Win
 #endif
 
 {-------------------------------------------------------------------------------
@@ -290,7 +292,7 @@ topologyMaxBucketSize topology bucket =
       BucketSubscriptionListener ->
         case topologySubscribers topology of
           Just (_subscriberType, maxBucketSize) -> maxBucketSize
-          Nothing -> OQ.BucketSizeMax 0 -- subscription not allowed
+          Nothing                               -> OQ.BucketSizeMax 0 -- subscription not allowed
       _otherBucket ->
         OQ.BucketSizeUnlimited
 
@@ -339,7 +341,7 @@ initQueue NetworkConfig{..} mStore = do
 
     case mStore of
       Nothing    -> return () -- EKG store not used
-      Just store -> liftIO $ OQ.registerQueueMetrics oq store
+      Just store -> liftIO $ OQ.registerQueueMetrics (Just (toString cardanoNamespace)) oq store
 
     case ncTopology of
       TopologyLightWallet peers -> do

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE OverloadedStrings         #-}
 
 #if !defined(mingw32_HOST_OS)
 #define POSIX

--- a/node/cardano-sl.cabal
+++ b/node/cardano-sl.cabal
@@ -113,6 +113,7 @@ library
                         -- Utilities/helpers
                         Pos.Util
                         Pos.Util.LoggerName
+                        Pos.Util.Monitor
                         Pos.Util.Undefined
                         Pos.Util.BackupPhrase
                         Pos.Util.JsonLog
@@ -358,7 +359,7 @@ library
                       , dlist
                       , dns
                       , ed25519
-                      , ekg
+                      , ekg-wai
                       , ekg-core
                       , ekg-statsd
                       , ether >= 0.5

--- a/node/src/Pos/Launcher/Runner.hs
+++ b/node/src/Pos/Launcher/Runner.hs
@@ -124,13 +124,12 @@ runRealModeDo NodeResources {..} outSpecs action =
         case npEnableMetrics of
             False -> return Nothing
             True  -> Just <$> do
-                let ekgStore' = nrEkgStore
-                registerMetrics (Just cardanoNamespace) (runProduction . runToProd JsonLogDisabled oq) node' ekgStore'
-                liftIO $ Metrics.registerGcMetrics ekgStore'
+                registerMetrics (Just cardanoNamespace) (runProduction . runToProd JsonLogDisabled oq) node' nrEkgStore
+                liftIO $ Metrics.registerGcMetrics nrEkgStore
                 mEkgServer <- case npEkgParams of
                     Nothing -> return Nothing
                     Just (EkgParams {..}) -> Just <$> do
-                        liftIO $ Monitoring.forkServerWith ekgStore' ekgHost ekgPort
+                        liftIO $ Monitoring.forkServerWith nrEkgStore ekgHost ekgPort
                 mStatsdServer <- case npStatsdParams of
                     Nothing -> return Nothing
                     Just (StatsdParams {..}) -> Just <$> do
@@ -142,7 +141,7 @@ runRealModeDo NodeResources {..} outSpecs action =
                                 , Monitoring.prefix = statsdPrefix
                                 , Monitoring.suffix = statsdSuffix
                                 }
-                        liftIO $ Monitoring.forkStatsd statsdOptions ekgStore'
+                        liftIO $ Monitoring.forkStatsd statsdOptions nrEkgStore
                 return (mEkgServer, mStatsdServer)
 
     stopMonitoring Nothing = return ()

--- a/node/src/Pos/Launcher/Runner.hs
+++ b/node/src/Pos/Launcher/Runner.hs
@@ -32,11 +32,11 @@ import           Node                            (Node, NodeAction (..), NodeEnd
                                                   node, simpleNodeEndPoint)
 import qualified Node.Conversation               as N (Conversation, Converse,
                                                        converseWith)
-import           Node.Util.Monitor               (setupMonitor, stopMonitor)
+import           Pos.Util.Monitor                (setupMonitor, stopMonitor)
 import qualified System.Metrics                  as Metrics
 import           System.Random                   (newStdGen)
-import qualified System.Remote.Monitoring        as Monitoring
 import qualified System.Remote.Monitoring.Statsd as Monitoring
+import qualified System.Remote.Monitoring.Wai    as Monitoring
 import           System.Wlog                     (WithLogger, logInfo)
 
 import           Pos.Binary                      ()

--- a/node/src/Pos/Launcher/Runner.hs
+++ b/node/src/Pos/Launcher/Runner.hs
@@ -32,7 +32,9 @@ import           Node                            (Node, NodeAction (..), NodeEnd
                                                   node, simpleNodeEndPoint)
 import qualified Node.Conversation               as N (Conversation, Converse,
                                                        converseWith)
-import           Pos.Util.Monitor                (setupMonitor, stopMonitor)
+import           Node.Util.Monitor               (registerMetrics)
+import           Pos.System.Metrics.Constants    (cardanoNamespace)
+import           Pos.Util.Monitor                (stopMonitor)
 import qualified System.Metrics                  as Metrics
 import           System.Random                   (newStdGen)
 import qualified System.Remote.Monitoring.Statsd as Monitoring
@@ -122,8 +124,8 @@ runRealModeDo NodeResources {..} outSpecs action =
         case npEnableMetrics of
             False -> return Nothing
             True  -> Just <$> do
-                ekgStore' <- setupMonitor
-                    (runProduction . runToProd JsonLogDisabled oq) node' nrEkgStore
+                let ekgStore' = nrEkgStore
+                registerMetrics (Just cardanoNamespace) (runProduction . runToProd JsonLogDisabled oq) node' ekgStore'
                 liftIO $ Metrics.registerGcMetrics ekgStore'
                 mEkgServer <- case npEkgParams of
                     Nothing -> return Nothing

--- a/node/src/Pos/Util/Monitor.hs
+++ b/node/src/Pos/Util/Monitor.hs
@@ -5,8 +5,7 @@
 
 module Pos.Util.Monitor (
 
-      setupMonitor
-    , startMonitor
+      startMonitor
     , stopMonitor
 
     ) where
@@ -16,39 +15,13 @@ import           Control.Monad.IO.Class
 import           Mockable.Class
 import qualified Mockable.Metrics             as Metrics
 import           Node
-import           Pos.System.Metrics.Constants (withCardanoNamespace)
+import           Node.Util.Monitor            (registerMetrics)
+import           Pos.System.Metrics.Constants (cardanoNamespace)
 import qualified System.Metrics               as Monitoring
 import qualified System.Metrics.Distribution  as Monitoring.Distribution
 import qualified System.Remote.Monitoring.Wai as Monitoring
 
 import           Universum
-
--- | Put time-warp related metrics into an EKG store.
---   You must indicate how to run the monad into IO, so that EKG can produce
---   the metrics (it works in IO).
-setupMonitor
-    :: ( Mockable Metrics.Metrics m
-       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
-       , MonadIO m
-       )
-    => (forall t . m t -> IO t)
-    -> Node m
-    -> Monitoring.Store
-    -> m Monitoring.Store
-setupMonitor lowerIO node store = do
-    liftIO $ flip (Monitoring.registerGauge (withCardanoNamespace "handlers.initiated_remotely")) store $ lowerIO $ do
-        stats <- nodeStatistics node
-        Metrics.readGauge (stRunningHandlersRemote stats)
-    liftIO $ flip (Monitoring.registerGauge (withCardanoNamespace "handlers.initiated_locally")) store $ lowerIO $ do
-        stats <- nodeStatistics node
-        Metrics.readGauge (stRunningHandlersLocal stats)
-    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_normally.elapsed_time_microseconds")) store $ lowerIO $ do
-        stats <- nodeStatistics node
-        liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
-    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_exceptionally.elapsed_time_microseconds")) store $ lowerIO $ do
-        stats <- nodeStatistics node
-        liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
-    return store
 
 startMonitor
     :: ( Mockable Metrics.Metrics m
@@ -61,8 +34,8 @@ startMonitor
     -> m Monitoring.Server
 startMonitor port lowerIO node = do
     store <- liftIO Monitoring.newStore
-    store' <- setupMonitor lowerIO node store
-    liftIO $ Monitoring.registerGcMetrics store'
+    registerMetrics (Just cardanoNamespace) lowerIO node store
+    liftIO $ Monitoring.registerGcMetrics store
     server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" port
     liftIO . putStrLn $ "Forked EKG server on port " ++ show port
     return server

--- a/node/src/Pos/Util/Monitor.hs
+++ b/node/src/Pos/Util/Monitor.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}
 {-# LANGUAGE RankNTypes       #-}
@@ -11,10 +10,10 @@ module Pos.Util.Monitor (
     ) where
 
 import           Control.Concurrent           (killThread)
-import           Control.Monad.IO.Class
-import           Mockable.Class
+import           Control.Monad.IO.Class       (MonadIO)
+import           Mockable.Class               (Mockable)
 import qualified Mockable.Metrics             as Metrics
-import           Node
+import           Node                         (Node)
 import           Node.Util.Monitor            (registerMetrics)
 import           Pos.System.Metrics.Constants (cardanoNamespace)
 import qualified System.Metrics               as Monitoring

--- a/node/src/Pos/Util/Monitor.hs
+++ b/node/src/Pos/Util/Monitor.hs
@@ -1,0 +1,74 @@
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE RankNTypes       #-}
+
+module Pos.Util.Monitor (
+
+      setupMonitor
+    , startMonitor
+    , stopMonitor
+
+    ) where
+
+import           Control.Concurrent           (killThread)
+import           Control.Monad.IO.Class
+import           Mockable.Class
+import qualified Mockable.Metrics             as Metrics
+import           Node
+import           Pos.System.Metrics.Constants (withCardanoNamespace)
+import qualified System.Metrics               as Monitoring
+import qualified System.Metrics.Distribution  as Monitoring.Distribution
+import qualified System.Remote.Monitoring.Wai as Monitoring
+
+import           Universum
+
+-- | Put time-warp related metrics into an EKG store.
+--   You must indicate how to run the monad into IO, so that EKG can produce
+--   the metrics (it works in IO).
+setupMonitor
+    :: ( Mockable Metrics.Metrics m
+       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
+       , MonadIO m
+       )
+    => (forall t . m t -> IO t)
+    -> Node m
+    -> Monitoring.Store
+    -> m Monitoring.Store
+setupMonitor lowerIO node store = do
+    liftIO $ flip (Monitoring.registerGauge (withCardanoNamespace "handlers.initiated_remotely")) store $ lowerIO $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersRemote stats)
+    liftIO $ flip (Monitoring.registerGauge (withCardanoNamespace "handlers.initiated_locally")) store $ lowerIO $ do
+        stats <- nodeStatistics node
+        Metrics.readGauge (stRunningHandlersLocal stats)
+    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_normally.elapsed_time_μs")) store $ lowerIO $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
+    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_exceptionally.elapsed_time_μs")) store $ lowerIO $ do
+        stats <- nodeStatistics node
+        liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
+    return store
+
+startMonitor
+    :: ( Mockable Metrics.Metrics m
+       , Metrics.Distribution m ~ Monitoring.Distribution.Distribution
+       , MonadIO m
+       )
+    => Int
+    -> (forall t . m t -> IO t)
+    -> Node m
+    -> m Monitoring.Server
+startMonitor port lowerIO node = do
+    store <- liftIO Monitoring.newStore
+    store' <- setupMonitor lowerIO node store
+    liftIO $ Monitoring.registerGcMetrics store'
+    server <- liftIO $ Monitoring.forkServerWith store "127.0.0.1" port
+    liftIO . putStrLn $ "Forked EKG server on port " ++ show port
+    return server
+
+stopMonitor
+    :: ( MonadIO m )
+    => Monitoring.Server
+    -> m ()
+stopMonitor server = liftIO $ killThread (Monitoring.serverThreadId server)

--- a/node/src/Pos/Util/Monitor.hs
+++ b/node/src/Pos/Util/Monitor.hs
@@ -42,10 +42,10 @@ setupMonitor lowerIO node store = do
     liftIO $ flip (Monitoring.registerGauge (withCardanoNamespace "handlers.initiated_locally")) store $ lowerIO $ do
         stats <- nodeStatistics node
         Metrics.readGauge (stRunningHandlersLocal stats)
-    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_normally.elapsed_time_μs")) store $ lowerIO $ do
+    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_normally.elapsed_time_microseconds")) store $ lowerIO $ do
         stats <- nodeStatistics node
         liftIO $ Monitoring.Distribution.read (stHandlersFinishedNormally stats)
-    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_exceptionally.elapsed_time_μs")) store $ lowerIO $ do
+    liftIO $ flip (Monitoring.registerDistribution (withCardanoNamespace "handlers.finished_exceptionally.elapsed_time_microseconds")) store $ lowerIO $ do
         stats <- nodeStatistics node
         liftIO $ Monitoring.Distribution.read (stHandlersFinishedExceptionally stats)
     return store

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1086,7 +1086,7 @@ self: {
           description = "Reporting server for CSL";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      cardano-sl = callPackage ({ MonadRandom, QuickCheck, acid-state, aeson, ansi-terminal, ansi-wl-pprint, async, base, base58-bytestring, base64-bytestring, binary, bytestring, cardano-crypto, cardano-report-server, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cborg, cereal, conduit, containers, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, dlist, dns, ed25519, ekg, ekg-core, ekg-statsd, ether, exceptions, file-embed, filelock, filepath, focus, formatting, generic-arbitrary, hashable, hspec, http-client, http-client-tls, http-conduit, http-types, iproute, kademlia, lens, list-t, log-warper, lrucache, memory, mkDerivation, mmorph, monad-control, monad-loops, mono-traversable, mtl, neat-interpolation, network-info, network-transport, network-transport-tcp, network-uri, node-sketch, optparse-applicative, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, regex-tdfa, regex-tdfa-text, resourcet, rocksdb-haskell, safecopy, serokell-util, servant, servant-multipart, servant-server, stdenv, stm, stm-containers, string-qq, systemd, tagged, template-haskell, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers, vector, wai, wai-extra, warp, warp-tls, yaml }:
+      cardano-sl = callPackage ({ MonadRandom, QuickCheck, acid-state, aeson, ansi-terminal, ansi-wl-pprint, async, base, base58-bytestring, base64-bytestring, binary, bytestring, cardano-crypto, cardano-report-server, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cborg, cereal, conduit, containers, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, dlist, dns, ed25519, ekg-core, ekg-statsd, ekg-wai, ether, exceptions, file-embed, filelock, filepath, focus, formatting, generic-arbitrary, hashable, hspec, http-client, http-client-tls, http-conduit, http-types, iproute, kademlia, lens, list-t, log-warper, lrucache, memory, mkDerivation, mmorph, monad-control, monad-loops, mono-traversable, mtl, neat-interpolation, network-info, network-transport, network-transport-tcp, network-uri, node-sketch, optparse-applicative, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, regex-tdfa, regex-tdfa-text, resourcet, rocksdb-haskell, safecopy, serokell-util, servant, servant-multipart, servant-server, stdenv, stm, stm-containers, string-qq, systemd, tagged, template-haskell, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers, vector, wai, wai-extra, warp, warp-tls, yaml }:
       mkDerivation {
           pname = "cardano-sl";
           version = "0.5.1";
@@ -1128,9 +1128,9 @@ self: {
             dlist
             dns
             ed25519
-            ekg
             ekg-core
             ekg-statsd
+            ekg-wai
             ether
             exceptions
             file-embed
@@ -2949,34 +2949,6 @@ self: {
           description = "An either monad transformer";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      ekg = callPackage ({ aeson, base, bytestring, ekg-core, ekg-json, filepath, mkDerivation, network, snap-core, snap-server, stdenv, text, time, transformers, unordered-containers }:
-      mkDerivation {
-          pname = "ekg";
-          version = "0.4.0.14";
-          sha256 = "1n0l5lpkgkln9jmwwx2p2m2mbm7pr66w7lggj0yw4ay7ipjxjrrd";
-          revision = "1";
-          editedCabalFile = "152b4w3qld6jmwir3a06h6sc1girahla8cc1y2g23bwv6nnhxapp";
-          libraryHaskellDepends = [
-            aeson
-            base
-            bytestring
-            ekg-core
-            ekg-json
-            filepath
-            network
-            snap-core
-            snap-server
-            text
-            time
-            transformers
-            unordered-containers
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "https://github.com/tibbe/ekg";
-          description = "Remote monitoring of processes";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
       ekg-core = callPackage ({ base, containers, ghc-prim, mkDerivation, stdenv, text, unordered-containers }:
       mkDerivation {
           pname = "ekg-core";
@@ -3031,6 +3003,34 @@ self: {
           doCheck = false;
           homepage = "https://github.com/tibbe/ekg-statsd";
           description = "Push metrics to statsd";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
+      ekg-wai = callPackage ({ aeson, base, bytestring, ekg-core, ekg-json, filepath, http-types, mkDerivation, network, stdenv, text, time, transformers, unordered-containers, wai, wai-app-static, warp }:
+      mkDerivation {
+          pname = "ekg-wai";
+          version = "0.1.0.2";
+          sha256 = "1ridcn930lf8gjj7lqdbhzzmz0i6r668bhid72anbq3v1h6fnhnw";
+          libraryHaskellDepends = [
+            aeson
+            base
+            bytestring
+            ekg-core
+            ekg-json
+            filepath
+            http-types
+            network
+            text
+            time
+            transformers
+            unordered-containers
+            wai
+            wai-app-static
+            warp
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/tvh/ekg-wai";
+          description = "Remote monitoring of processes";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       engine-io = callPackage ({ aeson, async, attoparsec, base, base64-bytestring, bytestring, either, fetchgit, free, mkDerivation, monad-loops, mwc-random, stdenv, stm, stm-delay, text, transformers, unordered-containers, vector, websockets }:
@@ -4120,51 +4120,6 @@ self: {
           description = "Interval Arithmetic";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      io-streams = callPackage ({ attoparsec, base, bytestring, bytestring-builder, mkDerivation, network, primitive, process, stdenv, text, time, transformers, vector, zlib-bindings }:
-      mkDerivation {
-          pname = "io-streams";
-          version = "1.4.1.0";
-          sha256 = "0d6m7hq6l3zabqm2kga9qs1742vh5rnhfsa76svpkyn32z8n1i1w";
-          libraryHaskellDepends = [
-            attoparsec
-            base
-            bytestring
-            bytestring-builder
-            network
-            primitive
-            process
-            text
-            time
-            transformers
-            vector
-            zlib-bindings
-          ];
-          doHaddock = false;
-          doCheck = false;
-          description = "Simple, composable, and easy-to-use stream I/O";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
-      io-streams-haproxy = callPackage ({ attoparsec, base, bytestring, io-streams, mkDerivation, network, stdenv, transformers }:
-      mkDerivation {
-          pname = "io-streams-haproxy";
-          version = "1.0.0.1";
-          sha256 = "0zwjdsg1pcxzd8s0d308q4jhx0pfrk2aq8q039gs8k9y8h9cbh64";
-          revision = "2";
-          editedCabalFile = "1zm580jcncmh667k51k47xwwhd171r3f0h00d25hi6isq812ia40";
-          libraryHaskellDepends = [
-            attoparsec
-            base
-            bytestring
-            io-streams
-            network
-            transformers
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "http://snapframework.com/";
-          description = "HAProxy protocol 1.5 support for io-streams";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
       iproute = callPackage ({ appar, base, byteorder, containers, mkDerivation, network, stdenv }:
       mkDerivation {
           pname = "iproute";
@@ -4867,14 +4822,14 @@ self: {
           description = "A typeclass and set of functions for working with newtypes, with generics support";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      node-sketch = callPackage ({ aeson, async, attoparsec, base, binary, bytestring, containers, cryptonite, data-default, deepseq, ekg, ekg-core, exceptions, fetchgit, formatting, hashable, kademlia, lens, lifted-base, log-warper, mkDerivation, mmorph, monad-control, mtl, mwc-random, network, network-transport, network-transport-tcp, random, resourcet, semigroups, serokell-util, statistics, stdenv, stm, tagged, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
+      node-sketch = callPackage ({ aeson, async, attoparsec, base, binary, bytestring, containers, cryptonite, data-default, deepseq, ekg-core, exceptions, fetchgit, formatting, hashable, kademlia, lens, lifted-base, log-warper, mkDerivation, mmorph, monad-control, mtl, mwc-random, network, network-transport, network-transport-tcp, random, resourcet, semigroups, serokell-util, statistics, stdenv, stm, tagged, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "node-sketch";
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "0gwr1n6mp6n70mwgczf8pblq1l2085nmyll5wl19dg1ic0dnmbh2";
-            rev = "40f4235cda65c746c6edc2a3455242d96d7175bf";
+            sha256 = "1b74lvdc5a5yyyiylkzasbr6xxd2ww2gjh90q66bv8s1m0hfhli6";
+            rev = "51ce7d0f54c6232fb0c27f2edbe25a338535d02d";
           };
           isLibrary = true;
           isExecutable = true;
@@ -4889,7 +4844,6 @@ self: {
             cryptonite
             data-default
             deepseq
-            ekg
             ekg-core
             exceptions
             formatting
@@ -5459,22 +5413,6 @@ self: {
           description = "Random shuffle implementation";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      readable = callPackage ({ base, bytestring, mkDerivation, stdenv, text }:
-      mkDerivation {
-          pname = "readable";
-          version = "0.3.1";
-          sha256 = "1ja39cg26wy2fs00gi12x7iq5k8i366pbqi3p916skfa5jnkfc3h";
-          libraryHaskellDepends = [
-            base
-            bytestring
-            text
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "https://github.com/mightybyte/readable";
-          description = "Reading from Text and ByteString";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
       reflection = callPackage ({ base, mkDerivation, stdenv, template-haskell }:
       mkDerivation {
           pname = "reflection";
@@ -5501,24 +5439,6 @@ self: {
             bytestring
             containers
             mtl
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "http://sourceforge.net/projects/lazy-regex";
-          description = "Replaces/Enhances Text.Regex";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
-      regex-posix = callPackage ({ array, base, bytestring, containers, mkDerivation, regex-base, stdenv }:
-      mkDerivation {
-          pname = "regex-posix";
-          version = "0.95.2";
-          sha256 = "0gkhzhj8nvfn1ija31c7xnl6p0gadwii9ihyp219ck2arlhrj0an";
-          libraryHaskellDepends = [
-            array
-            base
-            bytestring
-            containers
-            regex-base
           ];
           doHaddock = false;
           doCheck = false;
@@ -6031,82 +5951,6 @@ self: {
           doHaddock = false;
           doCheck = false;
           description = "Cross platform library for the sendfile system call";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
-      snap-core = callPackage ({ HUnit, attoparsec, base, bytestring, bytestring-builder, case-insensitive, containers, directory, filepath, hashable, io-streams, lifted-base, mkDerivation, monad-control, mtl, network, network-uri, old-locale, random, readable, regex-posix, stdenv, text, time, transformers, transformers-base, unix-compat, unordered-containers, vector }:
-      mkDerivation {
-          pname = "snap-core";
-          version = "1.0.3.0";
-          sha256 = "0vkla7rfrwyhk31nign8ccjfhp7f0nqjhmg6hb7rq7ggblgwgnr4";
-          libraryHaskellDepends = [
-            attoparsec
-            base
-            bytestring
-            bytestring-builder
-            case-insensitive
-            containers
-            directory
-            filepath
-            hashable
-            HUnit
-            io-streams
-            lifted-base
-            monad-control
-            mtl
-            network
-            network-uri
-            old-locale
-            random
-            readable
-            regex-posix
-            text
-            time
-            transformers
-            transformers-base
-            unix-compat
-            unordered-containers
-            vector
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "http://snapframework.com/";
-          description = "Snap: A Haskell Web Framework (core interfaces and types)";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
-      snap-server = callPackage ({ attoparsec, base, blaze-builder, bytestring, bytestring-builder, case-insensitive, clock, containers, filepath, io-streams, io-streams-haproxy, lifted-base, mkDerivation, mtl, network, old-locale, snap-core, stdenv, text, time, unix, unix-compat, vector }:
-      mkDerivation {
-          pname = "snap-server";
-          version = "1.0.3.0";
-          sha256 = "1lvwfrirf6gq6nr6ias0i0xynq62s9myrj4203wdwq0y4c40nhqc";
-          isLibrary = true;
-          isExecutable = true;
-          libraryHaskellDepends = [
-            attoparsec
-            base
-            blaze-builder
-            bytestring
-            bytestring-builder
-            case-insensitive
-            clock
-            containers
-            filepath
-            io-streams
-            io-streams-haproxy
-            lifted-base
-            mtl
-            network
-            old-locale
-            snap-core
-            text
-            time
-            unix
-            unix-compat
-            vector
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "http://snapframework.com/";
-          description = "A web server for the Snap Framework";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       socket-io = callPackage ({ aeson, attoparsec, base, bytestring, engine-io, fetchgit, mkDerivation, mtl, stdenv, stm, text, transformers, unordered-containers, vector }:
@@ -7749,24 +7593,6 @@ self: {
           description = "Compression and decompression in the gzip and zlib formats";
           license = stdenv.lib.licenses.bsd3;
         }) { zlib = pkgs.zlib; };
-      zlib-bindings = callPackage ({ base, bytestring, mkDerivation, stdenv, zlib }:
-      mkDerivation {
-          pname = "zlib-bindings";
-          version = "0.1.1.5";
-          sha256 = "02ciywlz4wdlymgc3jsnicz9kzvymjw1www2163gxidnz4wb8fy8";
-          revision = "2";
-          editedCabalFile = "0fq49694gqkab8m0vq4i879blswczwd66n7xh4r4gwiahf0ryvqc";
-          libraryHaskellDepends = [
-            base
-            bytestring
-            zlib
-          ];
-          doHaddock = false;
-          doCheck = false;
-          homepage = "http://github.com/snapframework/zlib-bindings";
-          description = "Low-level bindings to the zlib package";
-          license = stdenv.lib.licenses.bsd3;
-        }) {};
     };
 in
 compiler.override {

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,8 +47,8 @@ packages:
     commit: c2af07ab7d627556ed3f6185b062e4cd1fb5ad26 #master
   extra-dep: true
 - location:
-    git: https://github.com/adinapoli-iohk/time-warp-nt.git
-    commit: be51e525ba7d52d246ccffe285c709b01dc316d0 #master
+    git: https://github.com/serokell/time-warp-nt.git
+    commit: 51ce7d0f54c6232fb0c27f2edbe25a338535d02d #master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,8 +47,8 @@ packages:
     commit: c2af07ab7d627556ed3f6185b062e4cd1fb5ad26 #master
   extra-dep: true
 - location:
-    git: https://github.com/serokell/time-warp-nt.git
-    commit: 40f4235cda65c746c6edc2a3455242d96d7175bf #master
+    git: https://github.com/adinapoli-iohk/time-warp-nt.git
+    commit: be51e525ba7d52d246ccffe285c709b01dc316d0 #master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/txp/Pos/Txp/MemState/Metrics.hs
+++ b/txp/Pos/Txp/MemState/Metrics.hs
@@ -3,13 +3,14 @@ module Pos.Txp.MemState.Metrics
     , recordTxpMetrics
     ) where
 
-import           Formatting             (sformat, shown, (%))
-import qualified System.Metrics         as Metrics
-import qualified System.Metrics.Gauge   as Metrics.Gauge
-import           System.Wlog            (logDebug)
+import           Formatting                   (sformat, shown, (%))
+import qualified System.Metrics               as Metrics
+import qualified System.Metrics.Gauge         as Metrics.Gauge
+import           System.Wlog                  (logDebug)
 import           Universum
 
-import           Pos.Txp.MemState.Types (TxpMetrics (..))
+import           Pos.System.Metrics.Constants (withCardanoNamespace)
+import           Pos.Txp.MemState.Types       (TxpMetrics (..))
 
 -- | A TxpMetrics that never does any writes. Use it if you don't care about
 -- metrics.
@@ -23,10 +24,10 @@ ignoreTxpMetrics = TxpMetrics
 -- | Record MemPool metrics.
 recordTxpMetrics :: Metrics.Store -> IO TxpMetrics
 recordTxpMetrics ekgStore = do
-    ekgMemPoolSize        <- Metrics.createGauge "MemPoolSize" ekgStore
-    ekgMemPoolWaitTime    <- Metrics.createGauge "MemPoolWaitTime" ekgStore
-    ekgMemPoolModifyTime  <- Metrics.createGauge "MemPoolModifyTime" ekgStore
-    ekgMemPoolQueueLength <- Metrics.createGauge "MemPoolQueueLength" ekgStore
+    ekgMemPoolSize        <- Metrics.createGauge (withCardanoNamespace "MemPoolSize") ekgStore
+    ekgMemPoolWaitTime    <- Metrics.createGauge (withCardanoNamespace "MemPoolWaitTime_μs") ekgStore
+    ekgMemPoolModifyTime  <- Metrics.createGauge (withCardanoNamespace "MemPoolModifyTime_μs") ekgStore
+    ekgMemPoolQueueLength <- Metrics.createGauge (withCardanoNamespace "MemPoolQueueLength") ekgStore
 
     -- An exponential moving average is used for the time gauges (wait
     -- and modify durations). The parameter alpha is chosen somewhat

--- a/txp/Pos/Txp/MemState/Metrics.hs
+++ b/txp/Pos/Txp/MemState/Metrics.hs
@@ -25,8 +25,8 @@ ignoreTxpMetrics = TxpMetrics
 recordTxpMetrics :: Metrics.Store -> IO TxpMetrics
 recordTxpMetrics ekgStore = do
     ekgMemPoolSize        <- Metrics.createGauge (withCardanoNamespace "MemPoolSize") ekgStore
-    ekgMemPoolWaitTime    <- Metrics.createGauge (withCardanoNamespace "MemPoolWaitTime_μs") ekgStore
-    ekgMemPoolModifyTime  <- Metrics.createGauge (withCardanoNamespace "MemPoolModifyTime_μs") ekgStore
+    ekgMemPoolWaitTime    <- Metrics.createGauge (withCardanoNamespace "MemPoolWaitTime_microseconds") ekgStore
+    ekgMemPoolModifyTime  <- Metrics.createGauge (withCardanoNamespace "MemPoolModifyTime_microseconds") ekgStore
     ekgMemPoolQueueLength <- Metrics.createGauge (withCardanoNamespace "MemPoolQueueLength") ekgStore
 
     -- An exponential moving average is used for the time gauges (wait


### PR DESCRIPTION
This PR correctly namespace IOHK's metrics by the "cardano" namespace, for which I have added a smart "constructor" inside a new module called `Pos.System.Metrics.Constants` within `core`.

Note this PR is not complete as we need to modify `timewarp-nt` so that `registerQueueMetrics` can take an optional namespace (will do this in parallel):

https://github.com/serokell/time-warp-nt/blob/40f4235cda65c746c6edc2a3455242d96d7175bf/src/Network/Broadcast/OutboundQueue.hs#L607

Last but not least, now the time-based queues are parametrised by their unit of measures, microseconds in `txp` case. (maybe one of the devops like @deepfire or @domenkozar  could tell us if `statsd` will choke if non-ASCII chars are passed to it). This is the result so far:

![screen shot 2017-08-31 at 12 42 10](https://user-images.githubusercontent.com/29383371/29919611-4e068fa0-8e4a-11e7-8f21-616e4430f416.png)
