### PR TITLE
[CSL-1559] Refactor locking in delegation

### DIFF
--- a/core/Pos/Util/Concurrent/PriorityLock.hs
+++ b/core/Pos/Util/Concurrent/PriorityLock.hs
@@ -7,23 +7,22 @@ Within each precedence, the lock is taken in FIFO order.
 -}
 
 module Pos.Util.Concurrent.PriorityLock
-    ( PriorityLock
-    , Priority (..)
-    , newPriorityLock
-    , withPriorityLock
-    ) where
+       ( PriorityLock
+       , Priority (..)
+       , newPriorityLock
+       , withPriorityLock
+       ) where
 
-import           Control.Concurrent.STM      (TMVar, newEmptyTMVar
-                                             , putTMVar, takeTMVar)
-import           Control.Monad.Catch         (MonadMask)
+import           Control.Concurrent.STM (TMVar, newEmptyTMVar, putTMVar, takeTMVar)
+import           Control.Monad.Catch    (MonadMask)
 import           Universum
 
-import           Pos.Util.Queue              (Q, queue, enqueue, dequeue)
+import           Pos.Util.Queue         (Q, dequeue, enqueue, queue)
 
 newtype PriorityLock = PriorityLock (TVar PriorityLockState)
 
-data PriorityLockState =
-    Unlocked
+data PriorityLockState
+    = Unlocked
     | Locked (Q (TMVar ())) (Q (TMVar ()))
     -- ^ locked, with a queue of contenders with high precedence, and
     -- a second queuewith contenders of low precedence

--- a/node/src/Pos/Delegation/Class.hs
+++ b/node/src/Pos/Delegation/Class.hs
@@ -11,7 +11,7 @@ module Pos.Delegation.Class
        , dwConfirmationCache
        , dwProxySKPool
        , dwPoolSize
-       , dwEpochId
+       , dwTip
 
        , DelegationVar
        , MonadDelegation
@@ -25,7 +25,7 @@ import qualified Data.Cache.LRU             as LRU
 import           Data.Time.Clock            (UTCTime)
 import           Serokell.Data.Memory.Units (Byte)
 
-import           Pos.Core                   (EpochIndex, ProxySKHeavy, ProxySKLight)
+import           Pos.Core                   (HeaderHash, ProxySKHeavy, ProxySKLight)
 import           Pos.Delegation.Types       (DlgMemPool)
 import           Pos.Util.Util              (HasLens (..))
 
@@ -38,20 +38,20 @@ import           Pos.Util.Util              (HasLens (..))
 -- with LRU.lookup.
 -- | In-memory storage needed for delegation logic.
 data DelegationWrap = DelegationWrap
-    { _dwMessageCache      :: LRU.LRU (Either ProxySKLight ProxySKHeavy) UTCTime
+    { _dwMessageCache      :: !(LRU.LRU (Either ProxySKLight ProxySKHeavy) UTCTime)
       -- ^ Message cache to prevent infinite propagation of useless
       -- certs.
-    , _dwConfirmationCache :: LRU.LRU ProxySKLight UTCTime
+    , _dwConfirmationCache :: !(LRU.LRU ProxySKLight UTCTime)
       -- ^ Confirmation cache for lightweight PSKs. Not used in endpoints tho.
-    , _dwProxySKPool       :: DlgMemPool
+    , _dwProxySKPool       :: !DlgMemPool
       -- ^ Memory pool of hardweight proxy secret keys. Keys of this
       -- map are issuer public keys.
     , _dwPoolSize          :: !Byte
       -- ^ Size of '_dwProxySKPool' in bytes.
       -- It's not exact size for a variety of reasons, but it should be
       -- a good approximation.
-    , _dwEpochId           :: EpochIndex
-      -- ^ Epoch index 'DelegationWrap' is correct in relation to.
+    , _dwTip               :: !HeaderHash
+      -- ^ Header tip 'DelegationWrap' is correct in relation to.
     }
 
 makeLenses ''DelegationWrap

--- a/node/src/Pos/Delegation/Class.hs
+++ b/node/src/Pos/Delegation/Class.hs
@@ -27,7 +27,6 @@ import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Core                   (EpochIndex, ProxySKHeavy, ProxySKLight)
 import           Pos.Delegation.Types       (DlgMemPool)
-import           Pos.Util.Concurrent.RWVar  (RWVar)
 import           Pos.Util.Util              (HasLens (..))
 
 ---------------------------------------------------------------------------
@@ -57,7 +56,10 @@ data DelegationWrap = DelegationWrap
 
 makeLenses ''DelegationWrap
 
-type DelegationVar = RWVar DelegationWrap
+-- This variable is not used to actually lock on something. We use
+-- 'StateLock' for thread communication, this is used mostly as
+-- 'IORef' with atomic updates.
+type DelegationVar = TVar DelegationWrap
 
 ----------------------------------------------------------------------------
 -- Class definition

--- a/node/src/Pos/Delegation/Listeners.hs
+++ b/node/src/Pos/Delegation/Listeners.hs
@@ -53,7 +53,7 @@ pskHeavyRelay = Data $ DataParams MsgTransaction $ \_ _ -> handlePsk
         verdict <- processProxySKHeavy @ssc pSk
         logDebug $ sformat ("The verdict for cert "%build%" is: "%shown) pSk verdict
         case verdict of
-            PHIncoherent -> do
+            PHTipMismatch -> do
                 -- We're probably updating state over epoch, so leaders
                 -- can be calculated incorrectly.
                 stateLock <- views (lensOf @StateLock) slTip

--- a/node/src/Pos/Delegation/Logic/Mempool.hs
+++ b/node/src/Pos/Delegation/Logic/Mempool.hs
@@ -14,6 +14,7 @@ module Pos.Delegation.Logic.Mempool
 
        , PskHeavyVerdict (..)
        , processProxySKHeavy
+       , processProxySKHeavyInternal
 
        -- * Lightweight psks handling
        , PskLightVerdict (..)
@@ -28,47 +29,47 @@ module Pos.Delegation.Logic.Mempool
 
 import           Universum
 
-import           Control.Lens                (at, uses, (%=), (+=), (-=), (.=))
-import qualified Data.Cache.LRU              as LRU
-import qualified Data.HashMap.Strict         as HM
-import qualified Data.HashSet                as HS
-import           Ether.Internal              (HasLens (..))
-import           Mockable                    (CurrentTime, Mockable, currentTime)
+import           Control.Lens                     (at, uses, (%=), (+=), (-=), (.=))
+import qualified Data.Cache.LRU                   as LRU
+import qualified Data.HashMap.Strict              as HM
+import qualified Data.HashSet                     as HS
+import           Mockable                         (CurrentTime, Mockable, currentTime)
 
-import           Pos.Binary.Class            (biSize)
-import           Pos.Binary.Communication    ()
-import           Pos.Constants               (memPoolLimitRatio)
-import           Pos.Context                 (lrcActionOnEpochReason)
-import           Pos.Core                    (HasPrimaryKey (..), ProxySKHeavy,
-                                              ProxySKLight, ProxySigLight, addressHash,
-                                              bvdMaxBlockSize, epochIndexL,
-                                              getOurPublicKey)
-import           Pos.Crypto                  (ProxySecretKey (..), PublicKey,
-                                              SignTag (SignProxySK), proxyVerify,
-                                              verifyPsk)
-import           Pos.DB                      (MonadDB, MonadDBRead, MonadGState,
-                                              MonadRealDB)
-import qualified Pos.DB                      as DB
-import           Pos.DB.Block                (MonadBlockDB)
-import qualified Pos.DB.DB                   as DB
-import qualified Pos.DB.Misc                 as Misc
-import           Pos.Delegation.Cede         (detectCycleOnAddition, evalMapCede,
-                                              pskToDlgEdgeAction)
-import           Pos.Delegation.Class        (DlgMemPool, MonadDelegation,
-                                              askDelegationState, dwConfirmationCache,
-                                              dwEpochId, dwMessageCache, dwPoolSize,
-                                              dwProxySKPool)
-import           Pos.Delegation.Helpers      (isRevokePsk)
-import           Pos.Delegation.Logic.Common (DelegationStateAction,
-                                              runDelegationStateAction)
-import           Pos.Delegation.Types        (DlgPayload, mkDlgPayload)
-import qualified Pos.GState                  as GS
-import           Pos.Lrc.Context             (LrcContext)
-import qualified Pos.Lrc.DB                  as LrcDB
-import           Pos.Util                    (leftToPanic, microsecondsToUTC)
-import qualified Pos.Util.Concurrent.RWLock  as RWL
-import qualified Pos.Util.Concurrent.RWVar   as RWV
-
+import           Pos.Binary.Class                 (biSize)
+import           Pos.Binary.Communication         ()
+import           Pos.Constants                    (memPoolLimitRatio)
+import           Pos.Context                      (lrcActionOnEpochReason)
+import           Pos.Core                         (HasPrimaryKey (..), ProxySKHeavy,
+                                                   ProxySKLight, ProxySigLight,
+                                                   addressHash, bvdMaxBlockSize,
+                                                   epochIndexL, getOurPublicKey)
+import           Pos.Crypto                       (ProxySecretKey (..), PublicKey,
+                                                   SignTag (SignProxySK), proxyVerify,
+                                                   verifyPsk)
+import           Pos.DB                           (MonadDB, MonadDBRead, MonadGState,
+                                                   MonadRealDB)
+import qualified Pos.DB                           as DB
+import           Pos.DB.Block                     (MonadBlockDB)
+import qualified Pos.DB.DB                        as DB
+import qualified Pos.DB.Misc                      as Misc
+import           Pos.Delegation.Cede              (detectCycleOnAddition, evalMapCede,
+                                                   pskToDlgEdgeAction)
+import           Pos.Delegation.Class             (DlgMemPool, MonadDelegation,
+                                                   dwConfirmationCache, dwEpochId,
+                                                   dwMessageCache, dwPoolSize,
+                                                   dwProxySKPool)
+import           Pos.Delegation.Helpers           (isRevokePsk)
+import           Pos.Delegation.Logic.Common      (DelegationStateAction,
+                                                   runDelegationStateAction)
+import           Pos.Delegation.Types             (DlgPayload, mkDlgPayload)
+import qualified Pos.GState                       as GS
+import           Pos.Lrc.Context                  (LrcContext)
+import qualified Pos.Lrc.DB                       as LrcDB
+import           Pos.StateLock                    (StateLock, withStateLockNoMetrics)
+import           Pos.Util                         (HasLens', leftToPanic,
+                                                   microsecondsToUTC)
+import           Pos.Util.Concurrent.PriorityLock (Priority (..))
+import qualified Pos.Util.Concurrent.RWLock       as RWL
 
 ----------------------------------------------------------------------------
 -- Delegation mempool
@@ -88,7 +89,7 @@ clearDlgMemPool
     => m ()
 clearDlgMemPool = runDelegationStateAction clearDlgMemPoolAction
 
-clearDlgMemPoolAction :: (Monad m) => DelegationStateAction m ()
+clearDlgMemPoolAction :: DelegationStateAction ()
 clearDlgMemPoolAction = do
     dwProxySKPool .= mempty
     dwPoolSize .= 1
@@ -96,12 +97,12 @@ clearDlgMemPoolAction = do
 -- Put value into Proxy SK Pool. Value must not exist in pool.
 -- Caller must ensure it.
 -- Caller must also ensure that size limit allows to put more data.
-putToDlgMemPool :: (Monad m) => PublicKey -> ProxySKHeavy -> DelegationStateAction m ()
+putToDlgMemPool :: PublicKey -> ProxySKHeavy -> DelegationStateAction ()
 putToDlgMemPool pk psk = do
     dwProxySKPool . at pk .= Just psk
     dwPoolSize += biSize pk + biSize psk
 
-deleteFromDlgMemPool :: (Monad m) => PublicKey -> DelegationStateAction m ()
+deleteFromDlgMemPool :: PublicKey -> DelegationStateAction ()
 deleteFromDlgMemPool pk =
     use (dwProxySKPool . at pk) >>= \case
         Nothing -> pass
@@ -111,7 +112,7 @@ deleteFromDlgMemPool pk =
 
 -- Caller must ensure that there won't be too much data (more than limit) as
 -- a result of transformation.
-modifyDlgMemPool :: (Monad m) => (DlgMemPool -> DlgMemPool) -> DelegationStateAction m ()
+modifyDlgMemPool :: (DlgMemPool -> DlgMemPool) -> DelegationStateAction ()
 modifyDlgMemPool f = do
     memPool <- use dwProxySKPool
     let newPool = f memPool
@@ -147,11 +148,32 @@ processProxySKHeavy
        , MonadGState m
        , MonadDelegation ctx m
        , MonadReader ctx m
-       , HasLens LrcContext ctx LrcContext
+       , HasLens' ctx LrcContext
+       , HasLens' ctx StateLock
        , Mockable CurrentTime m
        )
     => ProxySKHeavy -> m PskHeavyVerdict
-processProxySKHeavy psk = do
+processProxySKHeavy psk =
+    withStateLockNoMetrics LowPriority $ \_stateLockHeader ->
+        processProxySKHeavyInternal @ssc psk
+
+-- | Main logic of heavy psk processing, doesn't have
+-- synchronization. Should be called __only__ if you are sure that
+-- 'StateLock' is taken already.
+processProxySKHeavyInternal
+    :: forall ssc ctx m.
+       ( MonadIO m
+       , MonadMask m
+       , MonadDBRead m
+       , MonadBlockDB ssc m
+       , MonadGState m
+       , MonadDelegation ctx m
+       , MonadReader ctx m
+       , HasLens' ctx LrcContext
+       , Mockable CurrentTime m
+       )
+    => ProxySKHeavy -> m PskHeavyVerdict
+processProxySKHeavyInternal psk = do
     curTime <- microsecondsToUTC <$> currentTime
     headEpoch <- view epochIndexL <$> DB.getTipHeader @ssc
     richmen <-
@@ -167,24 +189,33 @@ processProxySKHeavy psk = do
         -- even if you don't have money anymore.
         enoughStake = isRevokePsk psk || addressHash iPk `HS.member` richmen
         omegaCorrect = headEpoch == pskOmega psk
+
+    -- DB related checks
+    alreadyPosted <- GS.isIssuerPostedThisEpoch $ addressHash iPk
+    hasPskInDB <- isJust <$> GS.getPskByIssuer (Left $ pskIssuerPk psk)
+
+    -- Retrieve psk pool and perform another db check. It's
+    -- guaranteed that pool is not changed when we're under
+    -- 'withStateLock' lock.
+    cyclePool <- runDelegationStateAction $ use dwProxySKPool
+    producesCycle <-
+        -- This is inefficient. Consider supporting this map
+        -- in-memory or changing mempool key to stakeholderId.
+        let cedeModifier =
+                HM.fromList $
+                map (bimap addressHash pskToDlgEdgeAction) $
+                HM.toList cyclePool
+        in evalMapCede cedeModifier $ detectCycleOnAddition psk
+
+    -- Here the memory state is the same.
     runDelegationStateAction $ do
         memPoolSize <- use dwPoolSize
         posted <- uses dwProxySKPool (\m -> isJust $ HM.lookup iPk m)
         existsSame <- uses dwProxySKPool (\m -> HM.lookup iPk m == Just psk)
         cached <- isJust . snd . LRU.lookup msg <$> use dwMessageCache
-        alreadyPosted <- GS.isIssuerPostedThisEpoch $ addressHash iPk
         epochMatches <- (headEpoch ==) <$> use dwEpochId
-        hasPskInDB <- isJust <$> GS.getPskByIssuer (Left $ pskIssuerPk psk)
         let isRevoke = isRevokePsk psk
         let rerevoke = isRevoke && not hasPskInDB
-        producesCycle <- use dwProxySKPool >>= \pool ->
-            -- This is inefficient. Consider supporting this map
-            -- in-memory or changing mempool key to stakeholderId.
-            let cedeModifier =
-                    HM.fromList $
-                    map (bimap addressHash pskToDlgEdgeAction) $
-                    HM.toList pool
-            in lift $ evalMapCede cedeModifier $ detectCycleOnAddition psk
         dwMessageCache %= LRU.insert msg curTime
         let maxMemPoolSize = memPoolLimitRatio * maxBlockSize
             -- Here it would be good to add size of data we want to insert
@@ -195,7 +226,8 @@ processProxySKHeavy psk = do
                      | not omegaCorrect -> PHInvalid "PSK epoch is different from current"
                      | alreadyPosted -> PHInvalid "issuer has already posted PSK this epoch"
                      | rerevoke ->
-                         PHInvalid "can't accept revoke cert, user doesn't have any psk in db"
+                         PHInvalid $ "can't accept revoke cert, user doesn't " <>
+                                     "have any psk in db"
                      | isJust producesCycle ->
                          PHInvalid $ "adding psk causes cycle at: " <> pretty producesCycle
                      | not enoughStake -> PHInvalid "issuer doesn't have enough stake"
@@ -295,6 +327,6 @@ processConfirmProxySk psk proof = do
 isProxySKConfirmed
     :: (MonadIO m, MonadMask m, MonadDelegation ctx m)
     => ProxySKLight -> m Bool
-isProxySKConfirmed psk = do
-    var <- askDelegationState
-    RWV.with var $ \v -> pure $ isJust $ snd $ LRU.lookup psk (v ^. dwConfirmationCache)
+isProxySKConfirmed psk =
+    runDelegationStateAction $
+        uses dwConfirmationCache $ isJust . snd . LRU.lookup psk

--- a/txp/Pos/StateLock.hs
+++ b/txp/Pos/StateLock.hs
@@ -20,20 +20,19 @@ module Pos.StateLock
 
 import           Universum
 
-import           Control.Monad.Catch    (MonadMask)
-import           Mockable               (CurrentTime, Mockable, currentTime)
-import           System.Wlog            (WithLogger, getLoggerName, usingLoggerName
-                                        )
+import           Control.Monad.Catch              (MonadMask)
+import           Mockable                         (CurrentTime, Mockable, currentTime)
+import           System.Wlog                      (WithLogger, getLoggerName,
+                                                   usingLoggerName)
 
-import           Pos.Core               (HeaderHash)
-import           Pos.Util.Concurrent.PriorityLock
-                                        (PriorityLock, Priority (..)
-                                        , newPriorityLock, withPriorityLock)
-import           Pos.Txp.MemState       (GenericTxpLocalData (..), MonadTxpMem
-                                        , TxpMetrics (..), askTxpMemAndMetrics)
-import           Pos.Txp.Toil.Types     (MemPool (..))
-import           Pos.Util.Concurrent    (modifyMVar, withMVar)
-import           Pos.Util.Util          (HasLens', lensOf)
+import           Pos.Core                         (HeaderHash)
+import           Pos.Txp.MemState                 (GenericTxpLocalData (..), MonadTxpMem,
+                                                   TxpMetrics (..), askTxpMemAndMetrics)
+import           Pos.Txp.Toil.Types               (MemPool (..))
+import           Pos.Util.Concurrent              (modifyMVar, withMVar)
+import           Pos.Util.Concurrent.PriorityLock (Priority (..), PriorityLock,
+                                                   newPriorityLock, withPriorityLock)
+import           Pos.Util.Util                    (HasLens', lensOf)
 
 
 -- | A simple wrapper over 'MVar' which stores 'HeaderHash' (our


### PR DESCRIPTION
This uses newly introduced global `StateLock` instead of old (dlg-specific) synchronization mechanism.