### PR TITLE
[DEVOPS-302] release.nix: simplify and allow setting the platform

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -5,28 +5,28 @@ in
   , scrubJobs ? false
   , dconfigs ? [ "testnet_staging_full" "testnet_staging_wallet" ]
   , cardano ? { outPath = ./.; rev = "abcdef"; }
-}:
-with import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") { inherit supportedSystems scrubJobs; packageSet = import ./.; };
-with builtins;
+  }:
+
 let
-  rlib = import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") { inherit supportedSystems scrubJobs; };
   lib = import ./lib.nix;
-  pkgs = import lib.fetchNixPkgs { config={}; };
-  mkJob = dconfig: system: let
-    jobs = import ./. { inherit system dconfig; gitrev = cardano.rev; };
-  in {
-    name = system;
-    value = {
-      inherit (jobs) cardano-sl cardano-sl-static cardano-sl-tools cardano-sl-explorer-static stack2nix cardano-report-server-static;
+  mergeAttrsMap = f: attrs: lib.foldl (x: y: x // (f y)) {} attrs;
+  rlib = import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") { inherit supportedSystems scrubJobs; };
+  withDconfig = dconfig: import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") { 
+    inherit supportedSystems scrubJobs; 
+    packageSet = import ./.;
+    nixpkgsArgs = { 
+      inherit dconfig; 
+      gitrev = cardano.rev;
+      config = { allowUnfree = false; inHydra = true; };
     };
   };
-  mkJobs = dconfig: systems: listToAttrs (map (mkJob dconfig) systems);
-  mkDconfigs = dconfig: let
-    cardano = import ./. { inherit pkgs dconfig; gitrev = cardano.rev; };
-    jobs = mkJobs dconfig supportedSystems;
-  in {
-    name = dconfig;
-    value = jobs;
+  platforms = {
+    cardano-sl = supportedSystems;
+    cardano-sl-static = supportedSystems;
+    cardano-sl-tools = supportedSystems;
+    cardano-sl-explorer-static = [ "x86_64-linux" ];
+    cardano-report-server-static = [ "x86_64-linux" ];
   };
-in (listToAttrs (map mkDconfigs dconfigs))
+in (mergeAttrsMap (dconfig: { ${dconfig } = (withDconfig dconfig).mapTestOn platforms; }) dconfigs)
+   // ((withDconfig null).mapTestOn { stack2nix = supportedSystems; })
    // (rlib.mapTestOn { purescript = supportedSystems; })

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -35,7 +35,12 @@ if [[ "$with_haddock" == "true" ]]; then
   find core/ -name '*.hs' -exec sed -i 's/QUOTED(CONFIG)/"'$DCONFIG'"/g' {} +
 fi
 
-targets="cardano-sl cardano-sl-lwallet cardano-sl-tools cardano-sl-wallet cardano-sl-explorer-static"
+targets="cardano-sl cardano-sl-lwallet cardano-sl-tools cardano-sl-wallet"
+
+# There are no macOS explorer devs atm and it's only deployed on linux
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+   targets="$targets cardano-sl-explorer-static"
+fi
 
 # TODO: CSL-1133: Add test coverage to CI. To be reenabled when build times
 # become smaller and allow coverage report to be built.


### PR DESCRIPTION
- platform is now an attribute suffix
- explorer and report server are now built only for linux