### PR TITLE
[CSL-1579] Revise 'reportingFatal'

### DIFF
--- a/explorer/src/Pos/Explorer/Socket/Methods.hs
+++ b/explorer/src/Pos/Explorer/Socket/Methods.hs
@@ -265,7 +265,7 @@ broadcast event args recipients = do
             Nothing   -> logWarning $
                 sformat ("No socket with SocketId="%shown%" registered") sockid
             Just sock -> emitTo sock event args
-                `catchAll` handler sockid
+                `catchAny` handler sockid
   where
     handler sockid = logWarning .
         sformat ("Failed to send to SocketId="%shown%": "%shown) sockid

--- a/explorer/src/Pos/Explorer/Socket/Util.hs
+++ b/explorer/src/Pos/Explorer/Socket/Util.hs
@@ -89,7 +89,7 @@ runPeriodicallyUnless
 runPeriodicallyUnless delay stop initState action =
     let loop st = unlessM stop $ do
             st' <- execStateT action st
-                `catchAll` \e -> handler e $> st
+                `catchAny` \e -> handler e $> st
             threadDelay delay
             loop st'
     in  loop initState

--- a/godtossing/Pos/Ssc/GodTossing/Toss/Trans.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Trans.hs
@@ -33,20 +33,20 @@ import           Pos.Util.Util                 (ether)
 --
 -- [WARNING] This transformer uses StateT and is intended for
 -- single-threaded usage only.
-type TossT = Ether.LazyStateT' TossModifier
+type TossT = Ether.StateT' TossModifier
 
 ----------------------------------------------------------------------------
 -- Runners
 ----------------------------------------------------------------------------
 
 runTossT :: TossModifier -> TossT m a -> m (a, TossModifier)
-runTossT = flip Ether.runLazyStateT
+runTossT = flip Ether.runStateT
 
 evalTossT :: Monad m => TossModifier -> TossT m a -> m a
-evalTossT = flip Ether.evalLazyStateT
+evalTossT = flip Ether.evalStateT
 
 execTossT :: Monad m => TossModifier -> TossT m a -> m TossModifier
-execTossT = flip Ether.execLazyStateT
+execTossT = flip Ether.execStateT
 
 ----------------------------------------------------------------------------
 -- MonadToss

--- a/infra/Pos/Communication/Relay/Logic.hs
+++ b/infra/Pos/Communication/Relay/Logic.hs
@@ -406,6 +406,12 @@ dataFlow what enqueue msg dt = handleAll handleE $ do
             send conv $ DataMsg dt
     void $ waitForConversations its
   where
+    -- TODO: is this function really special that it wants to catch
+    -- all exceptions and log them instead of letting higher-level
+    -- code to do it?
+    -- FIXME: are we sure we don't want to propagate exception to caller???
+    -- Fortunatelly, it's used only in lwallet, so I don't care much.
+    -- @gromak
     handleE e =
         logWarning $
         sformat ("Error sending "%stext%", data = "%build%": "%shown)
@@ -483,6 +489,11 @@ invReqDataFlow what enqueue msg key dt = handleAll handleE $ do
         \addr _ -> pure $ Conversation $ invReqDataFlowDo what key dt addr
     waitForConversations (fmap try its)
   where
+    -- TODO: is this function really special that it wants to catch
+    -- all exceptions and log them instead of letting higher-level
+    -- code to do it?
+    -- Anyway, 'reportOrLog' is not used here, because exception is rethrown.
+    -- @gromak
     handleE e = do
         logWarning $
             sformat ("Error sending "%stext%", key = "%build%": "%shown)

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -33,7 +33,7 @@ import           System.Directory          (doesFileExist)
 import           System.Wlog               (HasLoggerName (modifyLoggerName), WithLogger,
                                             logDebug, logError, logInfo, logWarning,
                                             usingLoggerName)
-import           Universum                 hiding (bracket, catch, catchAll)
+import           Universum                 hiding (bracket, catch)
 
 import           Pos.Binary.Class          (Bi (..), decodeFull)
 import           Pos.Binary.Infra.DHTModel ()

--- a/infra/Pos/Reporting/Methods.hs
+++ b/infra/Pos/Reporting/Methods.hs
@@ -171,17 +171,14 @@ extendRTDesc text (RMisbehavior isCritical reason) = RMisbehavior isCritical $ r
 extendRTDesc text' (RInfo text) = RInfo $ text <> text'
 extendRTDesc _ x = x
 
--- FIXME catch and squelch *all* exceptions? Probably a bad idea.
--- georgeee: I don't think it's a bad idea, reporting shouldn't be
---           an operation, exceptions of which we would like to consider
--- gromak: it should use `catchAny` fron `safe-exceptions`. I will fix it.
--- I made a PR to 'universum'. If it's merged soon, I will use 'Universum'
--- version, otherwise will use 'safe-exceptions' one.
+-- Note that we are catching all synchronous exceptions, but don't
+-- catch async ones. If reporting is broken, we don't want it to
+-- affect anything else.
 reportNode
     :: forall ctx m . (MonadReporting ctx m)
     => Bool -> Bool -> ReportType -> m ()
 reportNode sendLogs extendWithNodeInfo reportType =
-    reportNodeDo `catch` handler
+    reportNodeDo `catchAny` handler
   where
     send' = if sendLogs then sendReportNode else sendReportNodeNologs
     reportNodeDo = do

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -118,7 +118,7 @@ library
                       , bytestring
                       , cardano-sl-core
                       , cardano-sl-db
-                      , cardano-report-server >= 0.2.1
+                      , cardano-report-server >= 0.3.0
                       , containers
                       , data-default
                       , directory

--- a/node/src/Pos/Block/Logic/Creation.hs
+++ b/node/src/Pos/Block/Logic/Creation.hs
@@ -51,7 +51,7 @@ import           Pos.Delegation             (DelegationVar, DlgPayload (getDlgPa
 import           Pos.Exception              (assertionFailed, reportFatalError)
 import           Pos.Lrc                    (LrcContext, LrcError (..))
 import qualified Pos.Lrc.DB                 as LrcDB
-import           Pos.Reporting              (reportError, reportingFatal)
+import           Pos.Reporting              (reportError)
 import           Pos.Ssc.Class              (Ssc (..), SscHelpersClass (sscDefaultPayload, sscStripPayload),
                                              SscLocalDataClass)
 import           Pos.Ssc.Extra              (MonadSscMem, sscGetLocalPayload,
@@ -118,7 +118,6 @@ createGenesisBlockAndApply ::
 -- Genesis block for 0-th epoch is hardcoded.
 createGenesisBlockAndApply 0 = pure Nothing
 createGenesisBlockAndApply epoch =
-    reportingFatal $
     try (lrcActionOnEpochReason epoch "there are no leaders" LrcDB.getLeaders) >>= \case
         Left UnknownBlocksForLrc ->
             Nothing <$ logInfo "createGenesisBlock: not enough blocks for LRC"
@@ -193,7 +192,7 @@ createMainBlockAndApply ::
     -> ProxySKBlockInfo
     -> m (Either Text (MainBlock ssc))
 createMainBlockAndApply sId pske =
-    reportingFatal $ modifyStateLock HighPriority "createMainBlockAndApply" createAndApply
+    modifyStateLock HighPriority "createMainBlockAndApply" createAndApply
   where
     createAndApply tip =
         createMainBlockInternal sId pske >>= \case

--- a/node/src/Pos/Block/Logic/Internal.hs
+++ b/node/src/Pos/Block/Logic/Internal.hs
@@ -51,7 +51,7 @@ import           Pos.Delegation.Logic    (dlgApplyBlocks, dlgNormalizeOnRollback
 import           Pos.Exception           (assertionFailed)
 import qualified Pos.GState              as GS
 import           Pos.Lrc.Context         (LrcContext)
-import           Pos.Reporting           (MonadReporting, reportingFatal)
+import           Pos.Reporting           (MonadReporting)
 import           Pos.Ssc.Class.Helpers   (SscHelpersClass)
 import           Pos.Ssc.Class.LocalData (SscLocalDataClass)
 import           Pos.Ssc.Class.Storage   (SscGStateClass)
@@ -137,7 +137,7 @@ type MonadMempoolNormalization ssc ctx m
 normalizeMempool
     :: forall ssc ctx m . (MonadMempoolNormalization ssc ctx m)
     => m ()
-normalizeMempool = reportingFatal $ do
+normalizeMempool = do
     -- We normalize all mempools except the delegation one.
     -- That's because delegation mempool normalization is harder and is done
     -- within block application.
@@ -157,7 +157,7 @@ normalizeMempool = reportingFatal $ do
 applyBlocksUnsafe
     :: forall ssc ctx m . MonadBlockApply ssc ctx m
     => OldestFirst NE (Blund ssc) -> Maybe PollModifier -> m ()
-applyBlocksUnsafe blunds pModifier = reportingFatal $ do
+applyBlocksUnsafe blunds pModifier = do
     -- Check that all blunds have the same epoch.
     unless (null nextEpoch) $ assertionFailed $
         sformat ("applyBlocksUnsafe: tried to apply more than we should"%
@@ -213,7 +213,7 @@ rollbackBlocksUnsafe
     => BypassSecurityCheck -- ^ is rollback for more than k blocks allowed?
     -> NewestFirst NE (Blund ssc)
     -> m ()
-rollbackBlocksUnsafe bsc toRollback = reportingFatal $ do
+rollbackBlocksUnsafe bsc toRollback = do
     slogRoll <- slogRollbackBlocks bsc toRollback
     dlgRoll <- SomeBatchOp <$> dlgRollbackBlocks toRollback
     usRoll <- SomeBatchOp <$> usRollbackBlocks

--- a/node/src/Pos/Block/Logic/VAR.hs
+++ b/node/src/Pos/Block/Logic/VAR.hs
@@ -38,7 +38,6 @@ import           Pos.Core                 (HeaderHash, epochIndexL, headerHashG,
 import           Pos.Delegation.Logic     (dlgVerifyBlocks)
 import qualified Pos.GState               as GS
 import           Pos.Lrc.Worker           (LrcModeFullNoSemaphore, lrcSingleShotNoLock)
-import           Pos.Reporting            (reportingFatal)
 import           Pos.Ssc.Extra            (sscVerifyBlocks)
 import           Pos.Ssc.Util             (toSscBlock)
 import           Pos.Txp.Settings         (TxpGlobalSettings (..))
@@ -106,7 +105,7 @@ type BlockLrcMode ssc ctx m = (MonadBlockApply ssc ctx m, LrcModeFullNoSemaphore
 verifyAndApplyBlocks
     :: forall ssc ctx m. (BlockLrcMode ssc ctx m, MonadMempoolNormalization ssc ctx m)
     => Bool -> OldestFirst NE (Block ssc) -> m (Either ApplyBlocksException HeaderHash)
-verifyAndApplyBlocks rollback blocks = reportingFatal . runExceptT $ do
+verifyAndApplyBlocks rollback blocks = runExceptT $ do
     tip <- GS.getTip
     let assumedTip = blocks ^. _Wrapped . _neHead . prevBlockL
     when (tip /= assumedTip) $
@@ -226,7 +225,7 @@ applyWithRollback
     => NewestFirst NE (Blund ssc)  -- ^ Blocks to rollbck
     -> OldestFirst NE (Block ssc)  -- ^ Blocks to apply
     -> m (Either ApplyBlocksException HeaderHash)
-applyWithRollback toRollback toApply = reportingFatal $ runExceptT $ do
+applyWithRollback toRollback toApply = runExceptT $ do
     tip <- GS.getTip
     when (tip /= newestToRollback) $
         throwError $ ApplyBlocksTipMismatch "applyWithRollback/rollback" tip newestToRollback

--- a/node/src/Pos/Block/Network/Retrieval.hs
+++ b/node/src/Pos/Block/Network/Retrieval.hs
@@ -17,7 +17,7 @@ import qualified Data.Set                   as S
 import           Ether.Internal             (HasLens (..))
 import           Formatting                 (build, builder, int, sformat, shown, stext,
                                              (%))
-import           Mockable                   (delay, handleAll, throw)
+import           Mockable                   (delay, handleAll)
 import           Serokell.Data.Memory.Units (unitBuilder)
 import           Serokell.Util              (listJson, sec)
 import           System.Wlog                (logDebug, logError, logInfo, logWarning)
@@ -101,7 +101,8 @@ retrievalWorkerImpl SendActions {..} =
         mainLoop
     mainLoopE e = do
         logError $ sformat ("retrievalWorker: error caught "%shown) e
-        throw e
+        delay (30 & sec)
+        mainLoop
     --
     handleBlockRetrieval nodeId BlockRetrievalTask{..} =
         handleAll (handleBlockRetrievalE nodeId brtHeader) $

--- a/node/src/Pos/Block/Network/Retrieval.hs
+++ b/node/src/Pos/Block/Network/Retrieval.hs
@@ -21,7 +21,7 @@ import           Formatting                 (build, builder, int, sformat, stext
 import           Mockable                   (delay, handleAll)
 import           Serokell.Data.Memory.Units (unitBuilder)
 import           Serokell.Util              (listJson, sec)
-import           System.Wlog                (logDebug, logError, logInfo, logWarning)
+import           System.Wlog                (logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Class           (biSize)
 import           Pos.Binary.Communication   ()
@@ -254,9 +254,10 @@ dropRecoveryHeaderAndRepeat enqueue nodeId = do
         delay $ sec 2
         handleAll handleRecoveryTriggerE $ triggerRecovery enqueue
         logDebug "Attempting to restart recovery over"
-    handleRecoveryTriggerE e =
-        logError $ "Exception happened while trying to trigger " <>
-                   "recovery inside recoveryWorker: " <> show e
+    handleRecoveryTriggerE =
+        -- REPORT:ERROR 'reportOrLogE' somewhere in block retrieval.
+        reportOrLogE $ "Exception happened while trying to trigger " <>
+                       "recovery inside recoveryWorker: "
 
 -- | Process header that was thought to be continuation. If it's not
 -- now, it is discarded.

--- a/node/src/Pos/Client/Txp/Util.hs
+++ b/node/src/Pos/Client/Txp/Util.hs
@@ -30,7 +30,6 @@ import           Universum
 
 import           Control.Lens             (makeLenses, (%=), (.=))
 import           Control.Monad.Except     (ExceptT, MonadError (throwError), runExceptT)
-import           Control.Monad.State      (StateT (..), evalStateT)
 import qualified Data.HashMap.Strict      as HM
 import           Data.List                (tail)
 import qualified Data.List.NonEmpty       as NE

--- a/node/src/Pos/Delegation/Worker.hs
+++ b/node/src/Pos/Delegation/Worker.hs
@@ -38,7 +38,7 @@ dlgInvalidateCaches
     => m ()
 dlgInvalidateCaches = runIfNotShutdown $ do
     -- REPORT:ERROR 'reportOrLogE' in delegation worker.
-    invalidate `catchAll` reportOrLogE "Delegation worker, error occurred: "
+    invalidate `catchAny` reportOrLogE "Delegation worker, error occurred: "
     delay (sec 1)
     dlgInvalidateCaches
   where

--- a/node/src/Pos/Generator/Block/Mode.hs
+++ b/node/src/Pos/Generator/Block/Mode.hs
@@ -21,6 +21,7 @@ module Pos.Generator.Block.Mode
 import           Universum
 
 import           Control.Lens.TH             (makeLensesWith)
+import qualified Control.Monad.Catch
 import           Control.Monad.Random.Strict (RandT)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Crypto.Random               as Rand

--- a/node/src/Pos/Security/Workers.hs
+++ b/node/src/Pos/Security/Workers.hs
@@ -106,7 +106,7 @@ checkForReceivedBlocksWorkerImpl SendActions {..} = afterDelay $ do
         reportEclipse
     repeatOnInterval delF action = runIfNotShutdown $ do
         -- REPORT:ERROR 'reportOrLogE' in block retrieval worker.
-        () <$ action `catchAll` \e -> reportOrLogE "Security worker" e >> throwM e
+        () <$ action `catchAll` \e -> reportOrLogE "Security worker" e
         getNextEpochSlotDuration >>= delay . delF
         repeatOnInterval delF action
     reportEclipse = do

--- a/node/src/Pos/Security/Workers.hs
+++ b/node/src/Pos/Security/Workers.hs
@@ -106,7 +106,7 @@ checkForReceivedBlocksWorkerImpl SendActions {..} = afterDelay $ do
         reportEclipse
     repeatOnInterval delF action = runIfNotShutdown $ do
         -- REPORT:ERROR 'reportOrLogE' in block retrieval worker.
-        () <$ action `catchAll` \e -> reportOrLogE "Security worker" e
+        () <$ action `catchAny` \e -> reportOrLogE "Security worker" e
         getNextEpochSlotDuration >>= delay . delF
         repeatOnInterval delF action
     reportEclipse = do

--- a/node/test/Test/Pos/Block/Logic/Event.hs
+++ b/node/test/Test/Pos/Block/Logic/Event.hs
@@ -14,7 +14,7 @@ module Test.Pos.Block.Logic.Event
 
 import           Universum
 
-import           Control.Monad.Catch       (catch, fromException)
+import           Control.Monad.Catch       (fromException)
 import qualified Data.Map                  as Map
 import qualified Data.Text                 as T
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1027,11 +1027,11 @@ self: {
       cardano-report-server = callPackage ({ aeson, aeson-pretty, base, bytestring, case-insensitive, directory, exceptions, fetchgit, filelock, filepath, formatting, http-types, lens, lifted-base, log-warper, mkDerivation, monad-control, mtl, network, optparse-applicative, parsec, random, stdenv, text, time, transformers, universum, vector, wai, wai-extra, warp }:
       mkDerivation {
           pname = "cardano-report-server";
-          version = "0.2.1";
+          version = "0.3.0";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-report-server.git";
-            sha256 = "02mf9nw5n0lcq9p6j33lsn0vbab4ai4z3j2099qlzcaqf3kq1987";
-            rev = "c2af07ab7d627556ed3f6185b062e4cd1fb5ad26";
+            sha256 = "0kysicb6ij4mwkg8dx222hn1lxzalmzb79z1f9bpm6dfjhs7m0sf";
+            rev = "69583b607dd841b0de1ef660388172a94c660c84";
           };
           isLibrary = true;
           isExecutable = true;
@@ -4359,8 +4359,8 @@ self: {
       log-warper = callPackage ({ aeson, ansi-terminal, base, containers, directory, dlist, errors, exceptions, extra, filepath, formatting, hashable, lens, mkDerivation, mmorph, monad-control, monad-loops, mtl, network, safecopy, stdenv, text, text-format, time, transformers, transformers-base, universum, unix, unordered-containers, yaml }:
       mkDerivation {
           pname = "log-warper";
-          version = "1.1.2";
-          sha256 = "0j17ylwga4vw0f0hahpmvm3nhk6s274m0msjv0r9jx6a6jx1wsmn";
+          version = "1.2.0";
+          sha256 = "0y02wlfw12x2y6hgq9878ynnghyg4xvai806fbapz3vi9xypd5jv";
           isLibrary = true;
           isExecutable = true;
           libraryHaskellDepends = [
@@ -4826,8 +4826,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "1b74lvdc5a5yyyiylkzasbr6xxd2ww2gjh90q66bv8s1m0hfhli6";
-            rev = "51ce7d0f54c6232fb0c27f2edbe25a338535d02d";
+            sha256 = "1540fdgp8b61z3ms55iz17bhiw45c0winhijnhzmqmy792wchd91";
+            rev = "fe6403d2e82c13eb7c05cf000d7cae5a5ca76fae";
           };
           isLibrary = true;
           isExecutable = true;
@@ -5542,6 +5542,23 @@ self: {
           description = "Library of safe (exception free) functions";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      safe-exceptions = callPackage ({ base, deepseq, exceptions, mkDerivation, stdenv, transformers }:
+      mkDerivation {
+          pname = "safe-exceptions";
+          version = "0.1.6.0";
+          sha256 = "074dy2f9fbhnh59clpz8c1ljplm1wwqjj7r3i4nv0rcl0khprm3i";
+          libraryHaskellDepends = [
+            base
+            deepseq
+            exceptions
+            transformers
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/fpco/safe-exceptions#readme";
+          description = "Safe, consistent, and easy exception handling";
+          license = stdenv.lib.licenses.mit;
+        }) {};
       safecopy = callPackage ({ array, base, bytestring, cereal, containers, mkDerivation, old-time, semigroups, stdenv, template-haskell, text, time, vector }:
       mkDerivation {
           pname = "safecopy";
@@ -5657,8 +5674,8 @@ self: {
       serokell-util = callPackage ({ QuickCheck, acid-state, aeson, ansi-terminal, base, base16-bytestring, base64-bytestring, bytestring, clock, containers, deepseq, directory, exceptions, extra, filepath, formatting, hashable, lens, log-warper, mkDerivation, monad-control, mtl, optparse-applicative, parsec, quickcheck-instances, safecopy, scientific, semigroups, stdenv, stm, template-haskell, text, text-format, time-units, transformers, universum, unordered-containers, vector, yaml }:
       mkDerivation {
           pname = "serokell-util";
-          version = "0.4.0";
-          sha256 = "1hql9cmw43cq9dsrkd0qwy1ycj6srsc2sr32grcfvh2j350k2m0p";
+          version = "0.5.0";
+          sha256 = "0z460j5k1h74y1v0b7lwdw08qdp5c8ayvsvfa17xdhpb0p8dzriw";
           libraryHaskellDepends = [
             acid-state
             aeson
@@ -6784,11 +6801,11 @@ self: {
           description = "IO without any non-error, synchronous exceptions";
           license = "unknown";
         }) {};
-      universum = callPackage ({ base, bytestring, containers, deepseq, exceptions, ghc-prim, hashable, microlens, microlens-mtl, mkDerivation, mtl, safe, stdenv, stm, text, text-format, transformers, type-operators, unordered-containers, utf8-string, vector }:
+      universum = callPackage ({ base, bytestring, containers, deepseq, exceptions, ghc-prim, hashable, microlens, microlens-mtl, mkDerivation, mtl, safe, safe-exceptions, stdenv, stm, text, text-format, transformers, type-operators, unordered-containers, utf8-string, vector }:
       mkDerivation {
           pname = "universum";
-          version = "0.4.3";
-          sha256 = "17rrikfid54z8h95qns5q7bdxadnnggv1pl2d9ilz9pz9hi7a9g6";
+          version = "0.6.1";
+          sha256 = "18q4kydcx273brx24y30i1kqb12h1p20ynvwrl18kfhgprjgz2sk";
           libraryHaskellDepends = [
             base
             bytestring
@@ -6801,6 +6818,7 @@ self: {
             microlens-mtl
             mtl
             safe
+            safe-exceptions
             stm
             text
             text-format

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,11 +44,11 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/input-output-hk/cardano-report-server.git
-    commit: c2af07ab7d627556ed3f6185b062e4cd1fb5ad26 #master
+    commit: 69583b607dd841b0de1ef660388172a94c660c84 # master
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 51ce7d0f54c6232fb0c27f2edbe25a338535d02d #master
+    commit: fe6403d2e82c13eb7c05cf000d7cae5a5ca76fae # master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:
@@ -91,11 +91,11 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
-- universum-0.4.3
-- serokell-util-0.4.1
+- universum-0.6.1
+- serokell-util-0.5.0
 - pvss-0.2.0
 - base58-bytestring-0.1.0
-- log-warper-1.1.2
+- log-warper-1.2.0
 - concurrent-extra-0.7.0.10       # not yet on Stackage
 # - purescript-bridge-0.8.0.1
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8

--- a/stack.yaml
+++ b/stack.yaml
@@ -92,7 +92,7 @@ nix:
 
 extra-deps:
 - universum-0.4.3
-- serokell-util-0.4.0
+- serokell-util-0.4.1
 - pvss-0.2.0
 - base58-bytestring-0.1.0
 - log-warper-1.1.2

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -292,7 +292,7 @@ genGenesisFiles GenesisGenOptions{..} = do
 main :: IO ()
 main = do
     KeygenOptions{..} <- getKeygenOptions
-    setupLogging $ consoleOutB True & lcTermSeverity ?~ Debug
+    setupLogging $ consoleOutB & lcTermSeverity ?~ Debug
     usingLoggerName "keygen" $ do
         logInfo "Processing command"
         case koCommand of

--- a/wallet/src/Pos/Wallet/Web/Sockets/Notifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Sockets/Notifier.hs
@@ -11,7 +11,6 @@ import           Universum
 
 import           Control.Concurrent                (forkFinally)
 import           Control.Lens                      ((.=))
-import           Control.Monad.State               (runStateT)
 import           Data.Default                      (Default (def))
 import           Data.Time.Units                   (Microsecond, Second)
 import           Serokell.Util                     (threadDelay)
@@ -91,4 +90,3 @@ launchNotifier nat =
     --         newHistoryLength <- length <$> getHistory cAddress
     --         when (oldHistoryLength /= newHistoryLength) .
     --             notifyAll $ NewWalletTransaction cAddress
-

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -183,7 +183,7 @@ catchInSync
     :: (MonadReporting ctx m)
     => Text -> (CId Wal -> m ()) -> CId Wal -> m ()
 catchInSync desc syncWallet wId =
-    syncWallet wId `catchAll` reportOrLogW prefix
+    syncWallet wId `catchAny` reportOrLogW prefix
   where
     -- REPORT:ERROR 'reportOrLogW' in wallet sync.
     fmt = "Failed to sync wallet "%build%" in BListener ("%build%"): "


### PR DESCRIPTION
The idea behind `reportingFatal` is that we want to catch some types of exceptions every time they happen and send to report server. I did few changes:
1. I removed `reportingFatal` from functions like block creation which don't have any forking or exception handling inside and aren't special at all with respect to thread management and exception handling. Having this logic there isn't useful at all, it doesn't help us to achieve the main goal: catch fatal errors everywhere.
2. After (1) all usages of `reportingFatal` started having the following pattern:
```
reportingFatal action `catchAll` handler
```
So we have a handler inside `reportingFatal` which rethrows an exception and this exception is then caught by `handler` (which catches everything).
I find it more reasonable to have one exception handler and use `reportOrLog` helper there. That's what I did.
3. I also fixed two workers which didn't restart themselves on failure. It's subjective whether they had to, but I guess they did. There is a delay before they are restarted, because restarting right after an exception is probably useless.
4. I updated `universum` version, so now most of the code which catches `SomeException` doesn't catch asynchronous exceptions, so `catchAll` is quite safe.
There is a caveat though: `Production` from `node-sketch` uses implementation from `base`, so it catches async exceptions as well.

P. S. I haven't yet dealt with listeners and I decided not to do it in this PR. Will do in subsequent one.