### PR TITLE
[TW-162] Use latest revision of timewarp-nt

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4826,8 +4826,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "1540fdgp8b61z3ms55iz17bhiw45c0winhijnhzmqmy792wchd91";
-            rev = "fe6403d2e82c13eb7c05cf000d7cae5a5ca76fae";
+            sha256 = "10q90lcqhvrqchrnj3yaidh7p2wvic7v9ggdm57iqvi0dd0xwv08";
+            rev = "9fdc19ff8f4c2630adcf9df01bcfd58c80b85a06";
           };
           isLibrary = true;
           isExecutable = true;

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: fe6403d2e82c13eb7c05cf000d7cae5a5ca76fae # master
+    commit: 9fdc19ff8f4c2630adcf9df01bcfd58c80b85a06 # master
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
This PR simply uses the latest revision of `timewarp-nt` so we can benefit from https://github.com/serokell/time-warp-nt/pull/98