### PR TITLE
[CSL-1592] First step towards reworking software update downloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
 
 before_install:
 - echo $TRAVIS_OS_NAME
-- export CSL_SYSTEM_TAG=$TRAVIS_OS_NAME
 - mkdir -p s3
 - export DCONFIG=testnet_staging_wallet
 - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/default.nix
+++ b/default.nix
@@ -17,9 +17,6 @@ let
   cardanoPkgs = ((import ./pkgs { inherit pkgs; }).override {
     overrides = self: super: {
       cardano-sl = overrideCabal super.cardano-sl (drv: {
-        patchPhase = ''
-          export CSL_SYSTEM_TAG=${if pkgs.stdenv.isDarwin then "macos" else "linux64"}
-        '';
         # production full nodes shouldn't use wallet as it means different constants
         configureFlags = [
           "-f-asserts"
@@ -49,6 +46,12 @@ let
           "--ghc-options=-DGITREV=${gitrev}"
         ];
       });
+      cardano-sl-update = overrideCabal super.cardano-sl-update (drv: {
+        patchPhase = ''
+          export CSL_SYSTEM_TAG=${if pkgs.stdenv.isDarwin then "macos64" else "linux64"}
+        '';
+      });
+
       cardano-sl-wallet = justStaticExecutables super.cardano-sl-wallet;
       cardano-sl-tools = justStaticExecutables (overrideCabal super.cardano-sl-tools (drv: {
         # waiting on load-command size fix in dyld

--- a/explorer/src/explorer/Main.hs
+++ b/explorer/src/explorer/Main.hs
@@ -8,16 +8,14 @@ module Main where
 
 import           Universum
 
-import           Control.Lens        (views)
 import           Data.Maybe          (fromJust)
-import           Ether.Internal      (HasLens (..))
 import           Formatting          (sformat, shown, (%))
 import           Mockable            (Production, currentTime, runProduction)
 import           System.Wlog         (logInfo)
 
 import           Pos.Binary          ()
 import qualified Pos.Client.CLI      as CLI
-import           Pos.Communication   (OutSpecs, WorkerSpec, worker)
+import           Pos.Communication   (OutSpecs, WorkerSpec)
 import           Pos.Constants       (isDevelopment)
 import           Pos.Core            (HasCoreConstants, giveStaticConsts)
 import           Pos.Explorer        (runExplorerBListener)
@@ -26,21 +24,14 @@ import           Pos.Explorer.Web    (ExplorerProd, explorerPlugin, notifierPlug
 import           Pos.Launcher        (NodeParams (..), NodeResources (..),
                                       bracketNodeResources, hoistNodeResources, runNode,
                                       runRealBasedMode)
-import           Pos.Shutdown        (triggerShutdown)
 import           Pos.Ssc.GodTossing  (SscGodTossing)
 import           Pos.Types           (Timestamp (Timestamp))
-import           Pos.Update.Context  (UpdateContext, ucUpdateSemaphore)
+import           Pos.Update          (updateTriggerWorker)
 import           Pos.Util            (inAssertMode, mconcatPair)
 import           Pos.Util.UserSecret (usVss)
 
 import           ExplorerOptions     (Args (..), getExplorerOptions)
 import           Params              (getNodeParams, gtSscParams)
-
-updateTriggerWorker :: ([WorkerSpec ExplorerProd], OutSpecs)
-updateTriggerWorker = first pure $ worker mempty $ \_ -> do
-    logInfo "Update trigger worker is locked"
-    void $ takeMVar =<< views (lensOf @UpdateContext) ucUpdateSemaphore
-    triggerShutdown
 
 printFlags :: IO ()
 printFlags = do

--- a/node/src/Pos/Constants.hs
+++ b/node/src/Pos/Constants.hs
@@ -33,23 +33,17 @@ module Pos.Constants
        -- * Malicious activity detection constants
        , mdNoBlocksSlotThreshold
 
-       -- * Update system constants
-       , appSystemTag
-
        -- * Transaction resubmition constants
        , pendingTxResubmitionPeriod
        ) where
 
-import           Universum                    hiding (lift)
+import           Universum
 
 import           Data.Time.Units              (Microsecond, Second)
-import           Language.Haskell.TH.Syntax   (lift, runIO)
 import           Serokell.Util                (ms, sec)
-import           System.Environment           (lookupEnv)
 import qualified Text.Parsec                  as P
 
 import           Pos.CompileConfig            (CompileConfig (..), compileConfig)
-import           Pos.Update.Core              (SystemTag, mkSystemTag)
 import           Pos.Util                     ()
 import           Pos.Util.TimeWarp            (NetworkAddress, addrParser)
 
@@ -127,24 +121,6 @@ dlgCacheParam = fromIntegral . ccDlgCacheParam $ compileConfig
 -- we are not receiving generated blocks.
 mdNoBlocksSlotThreshold :: Integral i => i
 mdNoBlocksSlotThreshold = fromIntegral . ccMdNoBlocksSlotThreshold $ compileConfig
-
-----------------------------------------------------------------------------
--- Update system
-----------------------------------------------------------------------------
-
-appSystemTag :: SystemTag
-appSystemTag = $(do
-    mbTag <- runIO (lookupEnv "CSL_SYSTEM_TAG")
-    case mbTag of
-        Just tag -> lift =<< mkSystemTag (toText tag)
-        Nothing
-            | isDevelopment ->
-                  [|error "'appSystemTag' can't be used if \
-                          \env var \"CSL_SYSTEM_TAG\" wasn't set \
-                          \during compilation" |]
-            | otherwise ->
-                  fail "Failed to init appSystemTag: \
-                       \couldn't find env var \"CSL_SYSTEM_TAG\"")
 
 ----------------------------------------------------------------------------
 -- Transactions resubmition

--- a/node/src/Pos/Update/Download.hs
+++ b/node/src/Pos/Update/Download.hs
@@ -4,16 +4,15 @@
 
 module Pos.Update.Download
        ( downloadUpdate
-       , downloadHash
        ) where
 
-import           Control.Concurrent.STM  (modifyTVar')
+import           Universum
+
 import           Control.Lens            (views)
 import           Control.Monad.Except    (ExceptT (..), throwError)
 import qualified Data.ByteArray          as BA
 import qualified Data.ByteString.Lazy    as BSL
 import qualified Data.HashMap.Strict     as HM
-import qualified Data.HashSet            as HS
 import           Ether.Internal          (HasLens (..))
 import           Formatting              (build, sformat, stext, (%))
 import           Network.HTTP.Client     (Manager, newManager)
@@ -22,80 +21,85 @@ import           Network.HTTP.Simple     (getResponseBody, getResponseStatus,
                                           getResponseStatusCode, httpLBS, parseRequest,
                                           setRequestManager)
 import qualified Serokell.Util.Base16    as B16
-import           Serokell.Util.Text      (listJson, listJsonIndent)
+import           Serokell.Util.Text      (listJsonIndent)
 import           System.Directory        (doesFileExist)
-import           System.Wlog             (logDebug, logInfo, logWarning)
-import           Universum
+import           System.Wlog             (logInfo, logWarning)
 
 import           Pos.Binary.Update       ()
-import           Pos.Constants           (appSystemTag, curSoftwareVersion)
+import           Pos.Constants           (curSoftwareVersion, ourSystemTag)
 import           Pos.Core.Types          (SoftwareVersion (..))
 import           Pos.Crypto              (Hash, castHash, hash)
+import           Pos.Exception           (reportFatalError)
 import           Pos.Update.Context      (UpdateContext (..))
 import           Pos.Update.Core.Types   (UpdateData (..), UpdateProposal (..))
 import           Pos.Update.Mode         (UpdateMode)
 import           Pos.Update.Params       (UpdateParams (..))
 import           Pos.Update.Poll.Types   (ConfirmedProposalState (..))
 import           Pos.Util                ((<//>))
+import           Pos.Util.Concurrent     (withMVar)
 
-showHash :: Hash a -> FilePath
-showHash = toString . B16.encode . BA.convert
-
--- CSL-887: if we're downloading update not for `cardano-sl`,
--- but e. g. for `daedalus`, how do we check that version is new?
-versionIsNew :: SoftwareVersion -> Bool
-versionIsNew ver = svAppName ver /= svAppName curSoftwareVersion
-    || svNumber ver > svNumber curSoftwareVersion
-
--- TODO Now we suppose there is no more than one update at every moment.
--- | Determine whether to download update and download it if needed.
+-- | Download a software update for given 'ConfirmedProposalState' and
+-- put it into a variable which holds 'ConfirmedProposalState' of
+-- downloaded update.
+-- Parallel downloads aren't supported, so this function may blocks.
+-- If we have already downloaded an update successfully, this function won't
+-- download new updates.
+--
+-- The caller must ensure that:
+-- 1. This update is for our software.
+-- 2. This update is for our system (according to system tag).
+-- 3. This update brings newer software version than our current version.
 downloadUpdate :: forall ctx m . UpdateMode ctx m => ConfirmedProposalState -> m ()
-downloadUpdate cst@ConfirmedProposalState {..} = do
-    unlessM (liftIO . doesFileExist =<< views (lensOf @UpdateParams) upUpdatePath) $ do
-        downSetVar <- views (lensOf @UpdateContext) ucDownloadingUpdates
-        (forDownload, downSet) <- tryPutToSet downSetVar cpsUpdateProposal
-        if forDownload
-           then do
-              logDebug $ sformat ("Update downloading triggered, download state: "%listJson)
-                                 downSet
-              downloadUpdateDo cst
-                `finally` clear downSetVar cpsUpdateProposal
-           else
-              logDebug $ sformat ("Update downloading already in progress, download state: "%listJson)
-                                 downSet
-
+downloadUpdate cps = do
+    downloadLock <- ucDownloadLock <$> view (lensOf @UpdateContext)
+    withMVar downloadLock $ \() -> do
+        downloadedUpdateMVar <-
+            ucDownloadedUpdate <$> view (lensOf @UpdateContext)
+        tryReadMVar downloadedUpdateMVar >>= \case
+            Nothing -> downloadUpdateDo cps
+            Just existingCPS -> onAlreadyDownloaded existingCPS
   where
-    clear downSetVar up = do
-        downSet <- atomically $ do
-            modifyTVar' downSetVar (HS.delete cpsUpdateProposal)
-            readTVar downSetVar
-        logDebug $ sformat ("Update "%build%" downloaded, download state: "%listJson)
-                           up downSet
-    -- Whether to start downloading?
-    tryPutToSet downSetVar up = atomically $ do
-        downSet <- readTVar downSetVar
-        if HS.member up downSet then pure (False, downSet)
-        else let downSet' = HS.insert up downSet
-              in (True, downSet') <$ writeTVar downSetVar downSet'
+    proposalToDL = cpsUpdateProposal cps
+    onAlreadyDownloaded ConfirmedProposalState {..} =
+        logInfo $
+        sformat
+            ("We won't download an update for proposal "%build%
+             ", because we have already downloaded another update: "%build%
+             " and we are waiting for it to be applied")
+            proposalToDL
+            cpsUpdateProposal
 
--- | Download and save archive update by given `ConfirmedProposalState`
+-- Download and save archive update by given `ConfirmedProposalState`
 downloadUpdateDo :: UpdateMode ctx m => ConfirmedProposalState -> m ()
-downloadUpdateDo cst@ConfirmedProposalState {..} = do
+downloadUpdateDo cps@ConfirmedProposalState {..} = do
     useInstaller <- views (lensOf @UpdateParams) upUpdateWithPkg
     updateServers <- views (lensOf @UpdateParams) upUpdateServers
 
     let dataHash = if useInstaller then udPkgHash else udAppDiffHash
         mupdHash = castHash . dataHash <$>
-                   HM.lookup appSystemTag (upData cpsUpdateProposal)
+                   HM.lookup ourSystemTag (upData cpsUpdateProposal)
 
+    logInfo $ sformat ("We are going to start downloading an update for "%build)
+              cpsUpdateProposal
     res <- runExceptT $ do
-        updHash <- maybe (throwError "This update is not for our system")
-                   pure mupdHash
+        -- It must be enforced by the caller.
+        updHash <- maybe (reportFatalError $ sformat
+                            ("We are trying to download an update not for our "%
+                            "system, update proposal is: "%build)
+                            cpsUpdateProposal)
+                          pure
+                   mupdHash
         let updateVersion = upSoftwareVersion cpsUpdateProposal
-        unless (versionIsNew updateVersion) $
-            throwError $ sformat ("Update #"%build%" hasn't been downloaded: \
-                                  \current software version is newer than \
-                                  \update version") updHash
+        -- It's just a sanity check which must always pass due to the
+        -- outside logic. We take only updates for our software and
+        -- explicitly request only new updates. This invariant must be
+        -- ensure by the caller of 'downloadUpdate'.
+        unless (isVersionAppropriate updateVersion) $
+            reportFatalError $
+            sformat ("Update #"%build%" hasn't been downloaded: "%
+                    "its version is not newer than current software "%
+                    "software version or it's not for our "%
+                    "software at all") updHash
 
         updPath <- views (lensOf @UpdateParams) upUpdatePath
         whenM (liftIO $ doesFileExist updPath) $
@@ -108,13 +112,20 @@ downloadUpdateDo cst@ConfirmedProposalState {..} = do
 
         liftIO $ BSL.writeFile updPath file
         logInfo "Update was downloaded"
-        sm <- views (lensOf @UpdateContext) ucUpdateSemaphore
-        putMVar sm cst
+        downloadedMVar <- views (lensOf @UpdateContext) ucDownloadedUpdate
+        putMVar downloadedMVar cps
         logInfo "Update MVar filled, wallet is notified"
 
     whenLeft res logWarning
+  where
+    -- Check that we really should download an update with given
+    -- 'SoftwareVersion'.
+    isVersionAppropriate :: SoftwareVersion -> Bool
+    isVersionAppropriate ver = svAppName ver == svAppName curSoftwareVersion
+        && svNumber ver > svNumber curSoftwareVersion
 
--- | Download a file by its hash.
+
+-- Download a file by its hash.
 --
 -- Tries all servers in turn, fails if none of them work.
 downloadHash :: [Text] -> Hash LByteString -> IO (Either Text LByteString)
@@ -137,6 +148,9 @@ downloadHash updateServers h = do
                     (reverse errs)
 
     go [] updateServers
+  where
+    showHash :: Hash a -> FilePath
+    showHash = toString . B16.encode . BA.convert
 
 -- Download a file and check its hash.
 downloadUri :: Manager

--- a/node/src/Pos/Update/Worker.hs
+++ b/node/src/Pos/Update/Worker.hs
@@ -2,22 +2,29 @@
 
 module Pos.Update.Worker
        ( usWorkers
+
+       , updateTriggerWorker
        ) where
 
 import           Universum
 
-import           Formatting                 (sformat, (%))
-import           Serokell.Util.Text         (listJson)
-import           System.Wlog                (logDebug)
+import           Formatting                 (build, sformat, (%))
+import           Serokell.Util.Text         (listJsonIndent)
+import           System.Wlog                (logDebug, logInfo)
 
-import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
+import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker,
+                                             worker)
 import           Pos.Constants              (curSoftwareVersion)
 import           Pos.Context                (recoveryCommGuard)
 import           Pos.Core                   (SoftwareVersion (..))
+import           Pos.Shutdown               (triggerShutdown)
+import           Pos.Update.Context         (UpdateContext (..))
+import           Pos.Update.Core            (UpdateProposal (..))
 import           Pos.Update.DB              (getConfirmedProposals)
 import           Pos.Update.Download        (downloadUpdate)
 import           Pos.Update.Logic.Local     (processNewSlot)
 import           Pos.Update.Poll            (ConfirmedProposalState (..))
+import           Pos.Util.Util              (lensOf)
 import           Pos.WorkMode.Class         (WorkMode)
 
 -- | Update System related workers.
@@ -30,10 +37,40 @@ usWorkers =
             processNewSlot s
             checkForUpdate
 
-checkForUpdate :: WorkMode ssc ctx m => m ()
+checkForUpdate ::
+       forall ssc ctx m. WorkMode ssc ctx m
+    => m ()
 checkForUpdate = do
     logDebug "Checking for update..."
-    proposals <- getConfirmedProposals (Just $ svNumber curSoftwareVersion)
-    logDebug $ sformat ("Potentially relevant proposals: "%listJson)
-                    (cpsUpdateProposal <$> proposals)
-    mapM_ downloadUpdate proposals
+    confirmedProposals <-
+        getConfirmedProposals (Just $ svNumber curSoftwareVersion)
+    case nonEmpty confirmedProposals of
+        Nothing ->
+            logDebug
+                "There are no new confirmed update proposals for our application"
+        Just confirmedProposalsNE -> processProposals confirmedProposalsNE
+  where
+    processProposals :: NonEmpty ConfirmedProposalState -> m ()
+    processProposals confirmedProposals = do
+        let cpsToNumericVersion =
+                svNumber . upSoftwareVersion . cpsUpdateProposal
+        let newestCPS =
+                maximumBy (comparing cpsToNumericVersion) confirmedProposals
+        logInfo $
+            sformat
+                ("There are new confirmed update proposals for our application: "
+                 %listJsonIndent 2%
+                 "\n The newest one is: "%build%" and we want to download it")
+                (cpsUpdateProposal <$> confirmedProposals)
+                (cpsUpdateProposal newestCPS)
+        downloadUpdate newestCPS
+
+-- | This worker is just waiting until we download an update for our
+-- application. When an update is downloaded, it shuts the system
+-- down. It should be used in there is no high-level code which shuts
+-- down the system (e. g. in regular node w/o wallet or in explorer).
+updateTriggerWorker :: WorkMode ssc ctx m => ([WorkerSpec m], OutSpecs)
+updateTriggerWorker = first pure $ worker mempty $ \_ -> do
+    logInfo "Update trigger worker is locked"
+    void $ takeMVar . ucDownloadedUpdate =<< view (lensOf @UpdateContext)
+    triggerShutdown

--- a/node/src/Pos/Update/Worker.hs
+++ b/node/src/Pos/Update/Worker.hs
@@ -4,16 +4,16 @@ module Pos.Update.Worker
        ( usWorkers
        ) where
 
+import           Universum
+
 import           Formatting                 (sformat, (%))
-import           Mockable                   (fork)
 import           Serokell.Util.Text         (listJson)
 import           System.Wlog                (logDebug)
-import           Universum
 
 import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
 import           Pos.Constants              (curSoftwareVersion)
 import           Pos.Context                (recoveryCommGuard)
-import           Pos.Types                  (SoftwareVersion (..))
+import           Pos.Core                   (SoftwareVersion (..))
 import           Pos.Update.DB              (getConfirmedProposals)
 import           Pos.Update.Download        (downloadUpdate)
 import           Pos.Update.Logic.Local     (processNewSlot)
@@ -28,7 +28,7 @@ usWorkers =
         recoveryCommGuard $ do
             logDebug "Updating slot for US..."
             processNewSlot s
-            void (fork checkForUpdate)
+            checkForUpdate
 
 checkForUpdate :: WorkMode ssc ctx m => m ()
 checkForUpdate = do

--- a/node/src/node/Main.hs
+++ b/node/src/node/Main.hs
@@ -8,11 +8,9 @@ module Main
        ( main
        ) where
 
-import           Universum           hiding (over)
+import           Universum
 
-import           Control.Lens        (views)
 import           Data.Maybe          (fromJust)
-import           Ether.Internal      (HasLens (..))
 import           Formatting          (sformat, shown, (%))
 import           Mockable            (Production, currentTime, runProduction)
 import           System.Wlog         (logInfo)
@@ -21,15 +19,14 @@ import           Pos.Binary          ()
 import           Pos.Client.CLI      (CommonNodeArgs (..), NodeArgs (..),
                                       SimpleNodeArgs (..))
 import qualified Pos.Client.CLI      as CLI
-import           Pos.Communication   (OutSpecs, WorkerSpec, worker)
+import           Pos.Communication   (OutSpecs, WorkerSpec)
 import           Pos.Core            (HasCoreConstants, Timestamp (..), giveStaticConsts)
 import           Pos.Launcher        (NodeParams (..), runNodeReal)
-import           Pos.Shutdown        (triggerShutdown)
 import           Pos.Ssc.Class       (SscConstraint, SscParams)
 import           Pos.Ssc.GodTossing  (SscGodTossing)
 import           Pos.Ssc.NistBeacon  (SscNistBeacon)
 import           Pos.Ssc.SscAlgo     (SscAlgo (..))
-import           Pos.Update.Context  (UpdateContext, ucUpdateSemaphore)
+import           Pos.Update          (updateTriggerWorker)
 import           Pos.Util.UserSecret (usVss)
 import           Pos.WorkMode        (RealMode)
 
@@ -45,13 +42,6 @@ actionWithoutWallet sscParams nodeParams =
   where
     plugins :: ([WorkerSpec (RealMode ssc)], OutSpecs)
     plugins = updateTriggerWorker
-
-updateTriggerWorker
-    :: ([WorkerSpec (RealMode ssc)], OutSpecs)
-updateTriggerWorker = first pure $ worker mempty $ \_ -> do
-    logInfo "Update trigger worker is locked"
-    void $ takeMVar =<< views (lensOf @UpdateContext) ucUpdateSemaphore
-    triggerShutdown
 
 action :: SimpleNodeArgs -> Production ()
 action (SimpleNodeArgs (cArgs@CommonNodeArgs {..}) (nArgs@NodeArgs {..})) = giveStaticConsts $ do

--- a/wallet/src/Pos/Wallet/Redirect.hs
+++ b/wallet/src/Pos/Wallet/Redirect.hs
@@ -33,7 +33,7 @@ import           Pos.DB.Block              (MonadBlockDB)
 import           Pos.DB.DB                 (getTipHeader)
 import           Pos.Shutdown              (HasShutdownContext, triggerShutdown)
 import           Pos.Slotting              (MonadSlots (..), getNextEpochSlotDuration)
-import           Pos.Update.Context        (UpdateContext (ucUpdateSemaphore))
+import           Pos.Update.Context        (UpdateContext (ucDownloadedUpdate))
 import           Pos.Update.Poll.Types     (ConfirmedProposalState)
 import           Pos.Wallet.WalletMode     (MonadBlockchainInfo (..), MonadUpdates (..))
 
@@ -105,7 +105,8 @@ type UpdatesEnv ctx m =
     )
 
 waitForUpdateWebWallet :: UpdatesEnv ctx m => m ConfirmedProposalState
-waitForUpdateWebWallet = takeMVar =<< views (lensOf @UpdateContext) ucUpdateSemaphore
+waitForUpdateWebWallet =
+    takeMVar =<< views (lensOf @UpdateContext) ucDownloadedUpdate
 
 applyLastUpdateWebWallet :: UpdatesEnv ctx m => m ()
 applyLastUpdateWebWallet = triggerShutdown


### PR DESCRIPTION
    1. Previously 'checkForUpdate' was downloading all new updates for our
    application one-by-one. It was useless because we only need to the latest one.
    It's also useless because after we download one update, we won't download
    anymore until the application is restarted.
    Now 'checkForUpdate' downloads only the newest update.
    
    2. It's no longer possible to download multiple updates concurrently.
    Previously it was possible, but it didn't make any sense. After one
    download is started, another one will not start at all (if the first one
    has already created a file) or will do some stuff and fail slightly later
    (again, due to check that the file with an update doesn't exist) or in the
    case there will be a race condition between two downloads with unpredictable
    results.
    
    3. If we have already downloaded an update, we won't download anymore.
    Previously the logic was similar, but the check was done using 'doesFileExist'
    which was probably less reliable.
    
    4. Copy-pasted 'updateTriggerWorker' was moved into 'Pos.Update.Worker'.
    
    There are few more things to improve, see CSL-1602.
