### PR TITLE
[CSL-619] Delete broken 'MVar' functions

### DIFF
--- a/core/Pos/Util/Concurrent.hs
+++ b/core/Pos/Util/Concurrent.hs
@@ -2,9 +2,6 @@
 
 module Pos.Util.Concurrent
        ( clearMVar
-       , forcePutMVar
-       , readMVarConditional
-       , readUntilEqualMVar
        , readTVarConditional
        , readUntilEqualTVar
 
@@ -21,32 +18,6 @@ import           Control.Monad.STM   (retry)
 
 clearMVar :: MonadIO m => MVar a -> m ()
 clearMVar = void . tryTakeMVar
-
-forcePutMVar :: MonadIO m => MVar a -> a -> m ()
-forcePutMVar mvar val = do
-    unlessM (tryPutMVar mvar val) $ do
-        _ <- tryTakeMVar mvar
-        forcePutMVar mvar val
-
--- | Block until value in MVar satisfies given predicate. When value
--- satisfies, it is returned.
-readMVarConditional :: (MonadIO m) => (x -> Bool) -> MVar x -> m x
-readMVarConditional predicate mvar = do
-    rData <- readMVar mvar -- first we try to read for optimization only
-    if predicate rData then pure rData
-    else do
-        tData <- takeMVar mvar         -- now take data
-        if predicate tData then do     -- check again
-            _ <- tryPutMVar mvar tData -- try to put taken value
-            pure tData
-        else
-            readMVarConditional predicate mvar
-
--- | Read until value is equal to stored value comparing by some function.
-readUntilEqualMVar
-    :: (Eq a, MonadIO m)
-    => (x -> a) -> MVar x -> a -> m x
-readUntilEqualMVar f mvar expVal = readMVarConditional ((expVal ==) . f) mvar
 
 -- | Block until value in TVar satisfies given predicate. When value
 -- satisfies, it is returned.


### PR DESCRIPTION
These functions are bad, because they don't take asynchronous exceptions
into account. Read carefully and you'll see it.
Also they are not used at all.
If someone wants these functions, it's usually better to use STM instead.