### PR TITLE
CSE-210 Add help info to executable(s).

### DIFF
--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -233,6 +233,7 @@ executable cardano-explorer-swagger
                      , servant-swagger-ui
                      , text
                      , universum >= 0.1.11
+                     , optparse-applicative
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts
                        -Wall
@@ -260,7 +261,7 @@ executable cardano-explorer-mock
                      , cardano-sl
                      , cardano-sl-explorer
                      , universum
-                     , optparse-simple
+                     , optparse-applicative
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts
                        -Wall

--- a/explorer/src/documentation/Main.hs
+++ b/explorer/src/documentation/Main.hs
@@ -14,7 +14,9 @@
 -- version of wallet web API description at cardanodocs.com website
 -- (please see 'update_explorer_web_api_docs.sh' for technical details).
 
-module Main where
+module Main
+    ( main
+    ) where
 
 import           Universum
 
@@ -28,6 +30,9 @@ import           Data.Swagger                 (Operation, Swagger, ToParamSchema
                                                name, title, version)
 import           Data.Typeable                (Typeable, typeRep)
 import           Data.Version                 (showVersion)
+import           Options.Applicative          (execParser, footer, fullDesc, header, help,
+                                               helper, infoOption, long, progDesc)
+import qualified Options.Applicative          as Opt
 import           Servant                      ((:>))
 import           Servant.Multipart            (MultipartForm)
 import           Servant.Swagger              (HasSwagger (toSwagger), subOperations)
@@ -37,14 +42,32 @@ import qualified Pos.Explorer.Web.Api         as A
 import qualified Pos.Explorer.Web.ClientTypes as C
 import           Pos.Explorer.Web.Error       (ExplorerError)
 
+
+
 import qualified Description                  as D
 
 main :: IO ()
 main = do
+    showProgramInfoIfRequired jsonFile
     BSL8.writeFile jsonFile $ encode swaggerSpecForExplorerApi
     putStrLn $ "Done. See " <> jsonFile <> "."
   where
     jsonFile = "explorer-web-api-swagger.json"
+
+    -- | Showing info for the program.
+    showProgramInfoIfRequired :: FilePath -> IO ()
+    showProgramInfoIfRequired generatedJSON = void $ execParser programInfo
+      where
+        programInfo = Opt.info (helper <*> versionOption) $
+            fullDesc <> progDesc "Generate Swagger specification for Explorer web API."
+                     <> header   "Cardano SL Explorer web API docs generator."
+                     <> footer   ("This program runs during 'cardano-sl' building on Travis CI. " <>
+                                  "Generated file '" <> generatedJSON <> "' will be used to produce HTML documentation. " <>
+                                  "This documentation will be published at cardanodocs.com using 'update-explorer-web-api-docs.sh'.")
+
+        versionOption = infoOption
+            ("cardano-swagger-" <> showVersion CSLE.version)
+            (long "version" <> help "Show version.")
 
 instance HasSwagger api => HasSwagger (MultipartForm a :> api) where
     toSwagger Proxy = toSwagger $ Proxy @api

--- a/explorer/src/mock/Main.hs
+++ b/explorer/src/mock/Main.hs
@@ -1,7 +1,36 @@
-module Main where
+-- | This program runs a simple data mock of the Explorer API.
 
-import Universum
-import Pos.Explorer.Web.TestServer (runMockServer)
+module Main
+    ( main
+    ) where
+
+import           Universum
+
+import           Data.Version                (showVersion)
+import           Options.Applicative         (execParser, footer, fullDesc, header, help,
+                                              helper, info, infoOption, long, progDesc)
+
+import qualified Paths_cardano_sl_explorer   as CSLE
+import           Pos.Explorer.Web.TestServer (runMockServer)
+
+
 
 main :: IO ()
-main = runMockServer
+main = do
+    showProgramInfoIfRequired
+    runMockServer
+  where
+    -- | Showing info for the program.
+    showProgramInfoIfRequired :: IO ()
+    showProgramInfoIfRequired = void $ execParser programInfo
+      where
+        programInfo = info (helper <*> versionOption) $
+            fullDesc <> progDesc "Run mock for Explorer web API."
+                     <> header   "Cardano SL Explorer web mock."
+                     <> footer   ("This program returns just the mocked data. " <>
+                                  "It doesn't call any CSL functions and doesn't interact with it. " <>
+                                  "It just implements the API and returns simeple test data.")
+
+        versionOption = infoOption
+            ("cardano-mock-" <> showVersion CSLE.version)
+            (long "version" <> help "Show version.")

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1396,7 +1396,7 @@ self: {
           description = "Cardano SL - basic DB interfaces";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-explorer = callPackage ({ MonadRandom, QuickCheck, aeson, base, base16-bytestring, binary, bytestring, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-ssc, cardano-sl-update, cborg, cereal, containers, cpphs, cryptonite, data-default, either, engine-io, engine-io-wai, ether, exceptions, formatting, generic-arbitrary, hspec, http-types, kademlia, lens, lifted-base, log-warper, memory, mkDerivation, mmorph, monad-control, monad-loops, mtl, network-transport-tcp, node-sketch, optparse-simple, purescript-bridge, pvss, quickcheck-instances, random, reflection, regex-tdfa, regex-tdfa-text, safecopy, serokell-util, servant, servant-multipart, servant-server, servant-swagger, servant-swagger-ui, socket-io, stdenv, stm, swagger2, tagged, text, text-format, time, time-units, transformers, transformers-base, universum, unordered-containers, vector, wai, wai-cors, warp }:
+      cardano-sl-explorer = callPackage ({ MonadRandom, QuickCheck, aeson, base, base16-bytestring, binary, bytestring, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-ssc, cardano-sl-update, cborg, cereal, containers, cpphs, cryptonite, data-default, either, engine-io, engine-io-wai, ether, exceptions, formatting, generic-arbitrary, hspec, http-types, kademlia, lens, lifted-base, log-warper, memory, mkDerivation, mmorph, monad-control, monad-loops, mtl, network-transport-tcp, node-sketch, optparse-applicative, optparse-simple, purescript-bridge, pvss, quickcheck-instances, random, reflection, regex-tdfa, regex-tdfa-text, safecopy, serokell-util, servant, servant-multipart, servant-server, servant-swagger, servant-swagger-ui, socket-io, stdenv, stm, swagger2, tagged, text, text-format, time, time-units, transformers, transformers-base, universum, unordered-containers, vector, wai, wai-cors, warp }:
       mkDerivation {
           pname = "cardano-sl-explorer";
           version = "0.2.0";
@@ -1466,6 +1466,7 @@ self: {
             mtl
             network-transport-tcp
             node-sketch
+            optparse-applicative
             optparse-simple
             purescript-bridge
             serokell-util
@@ -3616,8 +3617,8 @@ self: {
       happy = callPackage ({ Cabal, array, base, containers, directory, filepath, mkDerivation, mtl, stdenv }:
       mkDerivation {
           pname = "happy";
-          version = "1.19.6";
-          sha256 = "1hqg42cmaa5zc499sank10r8qyqkgwlv5sr17b748kz5j3n2nivw";
+          version = "1.19.7";
+          sha256 = "16vg292pp12wnkny7znsv7bichh9ghny7swl7v55qafmcfg2lcdv";
           isLibrary = false;
           isExecutable = true;
           setupHaskellDepends = [


### PR DESCRIPTION
https://issues.serokell.io/issue/CSE-210

Fixed as @denisshevchenko proposed.

Tested with:
`cardano-explorer-swagger`:
```
$ stack exec -- cardano-explorer-swagger -h    
Cardano SL Explorer web API docs generator.

Usage: cardano-explorer-swagger [--version]
  Generate Swagger specification for Explorer web API.

Available options:
  -h,--help                Show this help text
  --version                Show version.

This program runs during 'cardano-sl' building on Travis CI. Generated file
'explorer-web-api-swagger.json' will be used to produce HTML documentation. This
documentation will be published at cardanodocs.com using
'update-explorer-web-api-docs.sh'.

$ stack exec -- cardano-explorer-swagger --version
cardano-swagger-0.2.0
```

`cardano-explorer-mock`:
```
$ stack exec -- cardano-explorer-mock --help   
Cardano SL Explorer web mock.

Usage: cardano-explorer-mock [--version]
  Run mock for Explorer web API.

Available options:
  -h,--help                Show this help text
  --version                Show version.

This program returns just the mocked data. It doesn't call any CSL functions and
doesn't interact with it. It just implements the API and returns simeple test
data.

$ stack exec -- cardano-explorer-mock --version
cardano-mock-0.2.0
```