### PR TITLE
[CSL-1610] Delete lrcOnNewSlotWorker

### DIFF
--- a/node/src/Pos/Generator/Block/Logic.hs
+++ b/node/src/Pos/Generator/Block/Logic.hs
@@ -28,7 +28,7 @@ import           Pos.Generator.Block.Mode    (BlockGenRandMode, MonadBlockGen,
                                               withCurrentSlot)
 import           Pos.Generator.Block.Param   (BlockGenParams, HasBlockGenParams (..))
 import           Pos.Generator.Block.Payload (genPayload)
-import           Pos.Lrc                     (lrcSingleShotNoLock)
+import           Pos.Lrc                     (lrcSingleShot)
 import           Pos.Lrc.Context             (lrcActionOnEpochReason)
 import qualified Pos.Lrc.DB                  as LrcDB
 import           Pos.Ssc.GodTossing          (SscGodTossing)
@@ -68,7 +68,7 @@ genBlock ::
 genBlock eos = do
     let epoch = eos ^. epochIndexL
     unlessM ((epoch ==) <$> lift LrcDB.getEpoch) $
-        lift $ lrcSingleShotNoLock epoch
+        lift $ lrcSingleShot epoch
     -- We need to know leaders to create any block.
     leaders <- lift $ lrcActionOnEpochReason epoch "genBlock" LrcDB.getLeaders
     case eos of

--- a/node/src/Pos/Lrc/Worker.hs
+++ b/node/src/Pos/Lrc/Worker.hs
@@ -1,88 +1,61 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
 -- | Workers responsible for Leaders and Richmen computation.
+-- This module also contains high-level logic of LRC for historical
+-- reasons.
+-- And actually nowadays there are no workers here.
 
 module Pos.Lrc.Worker
-       ( LrcModeFullNoSemaphore
-       , LrcModeFull
-       , lrcOnNewSlotWorker
+       ( LrcModeFull
        , lrcSingleShot
-       , lrcSingleShotNoLock
        ) where
 
 import           Universum
 
-import           Control.Lens               (views)
-import           Control.Monad.Catch        (bracketOnError)
-import           Control.Monad.STM          (retry)
-import           Data.Conduit               (runConduitRes, (.|))
-import qualified Data.HashMap.Strict        as HM
-import qualified Data.HashSet               as HS
-import           Ether.Internal             (HasLens (..))
-import           Formatting                 (build, sformat, (%))
-import           Mockable                   (forConcurrently)
-import           Serokell.Util.Exceptions   ()
-import           System.Wlog                (logDebug, logInfo, logWarning)
+import           Control.Lens             (views)
+import           Control.Monad.Catch      (bracketOnError)
+import           Control.Monad.STM        (retry)
+import           Data.Conduit             (runConduitRes, (.|))
+import qualified Data.HashMap.Strict      as HM
+import qualified Data.HashSet             as HS
+import           Ether.Internal           (HasLens (..))
+import           Formatting               (build, sformat, (%))
+import           Mockable                 (forConcurrently)
+import           Serokell.Util.Exceptions ()
+import           System.Wlog              (logDebug, logInfo, logWarning)
 
-import           Pos.Binary.Communication   ()
-import           Pos.Block.Logic.Internal   (BypassSecurityCheck (..), MonadBlockApply,
-                                             applyBlocksUnsafe, rollbackBlocksUnsafe)
-import           Pos.Communication.Protocol (OutSpecs, WorkerSpec, localOnNewSlotWorker)
-import           Pos.Context                (recoveryCommGuard)
-import           Pos.Core                   (Coin, EpochIndex, EpochOrSlot (..),
-                                             EpochOrSlot (..), SharedSeed, SlotId (..),
-                                             StakeholderId, crucialSlot, epochIndexL,
-                                             getEpochOrSlot, getSlotIndex,
-                                             slotSecurityParam)
-import qualified Pos.DB.DB                  as DB
-import qualified Pos.GState                 as GS
-import           Pos.Lrc.Consumer           (LrcConsumer (..))
-import           Pos.Lrc.Consumers          (allLrcConsumers)
-import           Pos.Lrc.Context            (LrcContext (lcLrcSync), LrcSyncData (..))
-import           Pos.Lrc.DB                 (IssuersStakes, getLeaders, getSeed, putEpoch,
-                                             putIssuersStakes, putLeaders, putSeed)
-import           Pos.Lrc.Error              (LrcError (..))
-import           Pos.Lrc.Fts                (followTheSatoshiM)
-import           Pos.Lrc.Logic              (findAllRichmenMaybe)
-import           Pos.Lrc.Mode               (LrcMode)
-import           Pos.Reporting              (reportError, reportMisbehaviour)
-import           Pos.Slotting               (MonadSlots)
-import           Pos.Ssc.Class              (SscHelpersClass, SscWorkersClass)
-import           Pos.Ssc.Extra              (MonadSscMem, sscCalculateSeed)
-import           Pos.StateLock              (Priority (..), StateLock, StateLockMetrics,
-                                             withStateLock)
-import           Pos.Txp.MemState           (MonadTxpMem)
-import           Pos.Update.DB              (getCompetingBVStates)
-import           Pos.Update.Poll.Types      (BlockVersionState (..))
-import           Pos.Util                   (logWarningWaitLinear, maybeThrow)
-import           Pos.Util.Chrono            (NewestFirst (..), toOldestFirst)
-import           Pos.WorkMode.Class         (TxpExtra_TMP, WorkMode)
+import           Pos.Binary.Communication ()
+import           Pos.Block.Logic.Internal (BypassSecurityCheck (..), MonadBlockApply,
+                                           applyBlocksUnsafe, rollbackBlocksUnsafe)
+import           Pos.Core                 (Coin, EpochIndex, EpochOrSlot (..),
+                                           EpochOrSlot (..), SharedSeed, StakeholderId,
+                                           crucialSlot, epochIndexL, getEpochOrSlot)
+import qualified Pos.DB.DB                as DB
+import qualified Pos.GState               as GS
+import           Pos.Lrc.Consumer         (LrcConsumer (..))
+import           Pos.Lrc.Consumers        (allLrcConsumers)
+import           Pos.Lrc.Context          (LrcContext (lcLrcSync), LrcSyncData (..))
+import           Pos.Lrc.DB               (IssuersStakes, getLeaders, getSeed, putEpoch,
+                                           putIssuersStakes, putLeaders, putSeed)
+import           Pos.Lrc.Error            (LrcError (..))
+import           Pos.Lrc.Fts              (followTheSatoshiM)
+import           Pos.Lrc.Logic            (findAllRichmenMaybe)
+import           Pos.Lrc.Mode             (LrcMode)
+import           Pos.Reporting            (reportMisbehaviour)
+import           Pos.Slotting             (MonadSlots)
+import           Pos.Ssc.Class            (SscHelpersClass, SscWorkersClass)
+import           Pos.Ssc.Extra            (MonadSscMem, sscCalculateSeed)
+import           Pos.Update.DB            (getCompetingBVStates)
+import           Pos.Update.Poll.Types    (BlockVersionState (..))
+import           Pos.Util                 (logWarningWaitLinear, maybeThrow)
+import           Pos.Util.Chrono          (NewestFirst (..), toOldestFirst)
 
-lrcOnNewSlotWorker
-    :: forall ssc ctx m.
-       (WorkMode ssc ctx m, SscWorkersClass ssc, MonadTxpMem TxpExtra_TMP ctx m)
-    => (WorkerSpec m, OutSpecs)
-lrcOnNewSlotWorker = localOnNewSlotWorker True $ \SlotId {..} ->
-    recoveryCommGuard $
-        when (getSlotIndex siSlot < fromIntegral slotSecurityParam) $
-            lrcSingleShot @ssc @ctx siEpoch `catch` onLrcError
-  where
-    -- Here we log it as a warning and report an error, even though it
-    -- can happen there we don't know recent blocks. That's because if
-    -- we don't know them, we should be in recovery mode and this
-    -- worker should be turned off.
-    --
-    -- We don't rethrow it though, because probably it can happen in
-    -- some corner cases but it doesn't indicate an error (maybe only
-    -- 'recoveryCommGuard' error).
-    onLrcError e@UnknownBlocksForLrc = reportE e
-    onLrcError e                     = reportE e >> throwM e
+----------------------------------------------------------------------------
+-- Single short
+----------------------------------------------------------------------------
 
-    -- REPORT:ERROR LRC worker failed with some LRC-related error
-    reportE e = reportError $
-        "Lrc worker failed with error: " <> show e
-
-type LrcModeFullNoSemaphore ssc ctx m =
+-- | 'LrcModeFull' contains all constraints necessary to launch LRC.
+type LrcModeFull ssc ctx m =
     ( LrcMode ssc ctx m
     , SscWorkersClass ssc
     , SscHelpersClass ssc
@@ -92,38 +65,17 @@ type LrcModeFullNoSemaphore ssc ctx m =
     , MonadReader ctx m
     )
 
--- | 'LrcModeFull' contains all constraints necessary to launch LRC.
-type LrcModeFull ssc ctx m =
-    ( LrcModeFullNoSemaphore ssc ctx m
-    , HasLens StateLock ctx StateLock
-    , HasLens StateLockMetrics ctx StateLockMetrics
-    , MonadTxpMem TxpExtra_TMP ctx m
-    )
-
-type WithStateLock_ m = m () -> m ()
-
 -- | Run leaders and richmen computation for given epoch. If stable
 -- block for this epoch is not known, LrcError will be thrown.
+-- It assumes that 'StateLock' is taken already.
 lrcSingleShot
     :: forall ssc ctx m. (LrcModeFull ssc ctx m)
     => EpochIndex -> m ()
-lrcSingleShot epoch =
-    lrcSingleShotImpl @ssc ((withStateLock HighPriority "lrcSingleShot") . const) epoch (allLrcConsumers @ssc)
-
--- | Same, but doesn't take lock on the semaphore.
-lrcSingleShotNoLock
-    :: forall ssc ctx m. (LrcModeFullNoSemaphore ssc ctx m)
-    => EpochIndex -> m ()
-lrcSingleShotNoLock epoch =
-    lrcSingleShotImpl @ssc identity epoch (allLrcConsumers @ssc)
-
-lrcSingleShotImpl
-    :: forall ssc ctx m. (LrcModeFullNoSemaphore ssc ctx m)
-    => WithStateLock_ m -> EpochIndex -> [LrcConsumer m] -> m ()
-lrcSingleShotImpl withSemaphore epoch consumers = do
+lrcSingleShot epoch = do
     lock <- views (lensOf @LrcContext) lcLrcSync
     tryAcquireExclusiveLock epoch lock onAcquiredLock
   where
+    consumers = allLrcConsumers @ssc
     onAcquiredLock = do
         (need, filteredConsumers) <-
             logWarningWaitLinear 5 "determining whether LRC is needed" $ do
@@ -138,7 +90,7 @@ lrcSingleShotImpl withSemaphore epoch consumers = do
                     , expectedRichmenComp)
         when need $ do
             logInfo "LRC is starting"
-            withSemaphore $ lrcDo @ssc epoch filteredConsumers
+            lrcDo @ssc epoch filteredConsumers
             logInfo "LRC has finished"
         putEpoch epoch
         logInfo "LRC has updated LRC DB"
@@ -163,7 +115,7 @@ tryAcquireExclusiveLock epoch lock action =
 
 lrcDo
     :: forall ssc ctx m.
-       LrcModeFullNoSemaphore ssc ctx m
+       LrcModeFull ssc ctx m
     => EpochIndex -> [LrcConsumer m] -> m ()
 lrcDo epoch consumers = do
     blundsUpToGenesis <- DB.loadBlundsFromTipWhile @ssc upToGenesis
@@ -266,3 +218,24 @@ richmenComputationDo epochIdx consumers = unless (null consumers) $ do
     safeMinimum a
         | null a = Nothing
         | otherwise = Just $ minimum a
+
+----------------------------------------------------------------------------
+-- Worker
+----------------------------------------------------------------------------
+
+-- TODO CSL-359
+--
+-- This worker no longer exists. It was added as the first step
+-- towards CSL-359. The idea is that we can start LRC before the end
+-- of an epoch. We just need to check that rollback deeper than
+-- 'crucialSlot' didn't happen. It's only an optimization which can be
+-- quite crucial when there are many stakeholders.
+--
+-- It was deleted because of possible deadlock. This worker may start
+-- doing LRC and try to acquire 'StateLock' while another thread may
+-- hold 'StateLock' for block processing and try to start LRC.  So if
+-- you are going to uncomment it at some point, please take it into
+-- account.  One way to avoid locking here is to do CSL-360, i. e. use
+-- snapshot instead of locking.
+--
+-- You can find it in git history if you want to.

--- a/node/src/Pos/Worker.hs
+++ b/node/src/Pos/Worker.hs
@@ -18,7 +18,6 @@ import           Pos.Context             (NodeContext (..), recoveryCommGuard)
 import           Pos.Delegation          (delegationRelays, dlgWorkers)
 import           Pos.DHT.Workers         (dhtWorkers)
 import           Pos.Launcher.Resource   (NodeResources (..))
-import           Pos.Lrc.Worker          (lrcOnNewSlotWorker)
 import           Pos.Network.Types       (NetworkConfig (..), SubscriptionWorker (..),
                                           topologyRunKademlia, topologySubscriptionWorker)
 import           Pos.Security.Workers    (securityWorkers)
@@ -48,7 +47,6 @@ allWorkers NodeResources {..} = mconcatPair
 
       wrap' "ssc"        $ sscWorkers
     , wrap' "security"   $ securityWorkers
-    , wrap' "lrc"        $ first one lrcOnNewSlotWorker
     , wrap' "us"         $ usWorkers
 
       -- Have custom loggers

--- a/node/test/Test/Pos/Lrc/WorkerSpec.hs
+++ b/node/test/Test/Pos/Lrc/WorkerSpec.hs
@@ -178,7 +178,7 @@ lrcCorrectnessProp = do
     -- already applied 1 blocks, hence 'pred'.
     blkCount1 <- pred <$> pick (choose (k, 2 * k))
     () <$ bpGenBlocks (Just blkCount1) (EnableTxPayload False) (InplaceDB True)
-    lift $ Lrc.lrcSingleShotNoLock 1
+    lift $ Lrc.lrcSingleShot 1
     leaders1 <-
         maybeStopProperty "No leaders for epoch#1!" =<< lift (Lrc.getLeaders 1)
     gws <- view (lensOf @GenesisWStakeholders)


### PR DESCRIPTION
This worker made deadlock possible. It was decided to delete it completely
because it wasn't useful anyway.
For more details see comments I left in Pos.Lrc.Worker module.