### PR TITLE
[CSL-1618] Run LRC before creating genesis block

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/Workers.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Workers.hs
@@ -54,7 +54,7 @@ import           Pos.Crypto                            (SecretKey, VssKeyPair,
                                                         runSecureRandom, vssKeyGen)
 import           Pos.Crypto.SecretSharing              (toVssPublicKey)
 import           Pos.DB                                (gsAdoptedBVData)
-import           Pos.Lrc.Context                       (lrcActionOnEpochReason, waitLrc)
+import           Pos.Lrc.Context                       (lrcActionOnEpochReason)
 import           Pos.Lrc.Types                         (RichmenStakes)
 import           Pos.Recovery.Info                     (recoveryCommGuard)
 import           Pos.Reporting                         (reportMisbehaviour)
@@ -110,7 +110,6 @@ instance GtMessageConstraints => SscWorkersClass SscGodTossing where
 
 shouldParticipate :: (SscMode SscGodTossing ctx m) => EpochIndex -> m Bool
 shouldParticipate epoch = do
-    waitLrc epoch
     richmen <- lrcActionOnEpochReason epoch
         "couldn't get SSC richmen"
         getRichmenSsc

--- a/node/src/Pos/Block/Logic/VAR.hs
+++ b/node/src/Pos/Block/Logic/VAR.hs
@@ -56,6 +56,8 @@ import           Pos.Util.Chrono          (NE, NewestFirst (..), OldestFirst (..
 -- verification fails. All blocks must be from the same epoch.  This
 -- function checks literally __everything__ from blocks, including
 -- header, body, extra data, etc.
+--
+-- LRC must be already performed for the epoch from which blocks are.
 verifyBlocksPrefix
     :: forall ssc ctx m.
        MonadBlockVerify ssc ctx m


### PR DESCRIPTION
Nobody will run it for us, we should do it by ourselves.

I also removed redundant 'waitLrc' in one place.
'lrcActionOnEpochReason' does 'waitLrc' internally.

We don't need to catch 'UnknownBlocksForLrc' because 'shouldCreate'
guarantees it.