### PR TITLE
[CSM-448] Rewrap errors during tx fee calculating

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -69,7 +69,8 @@ getTxFee
 getTxFee srcAccount dstAccount coin = do
     utxo <- getMoneySourceUtxo (AccountMoneySource srcAccount)
     outputs <- coinDistrToOutputs $ one (dstAccount, coin)
-    TxFee fee <- eitherToThrow =<< runTxCreator (computeTxFee utxo outputs)
+    TxFee fee <- rewrapTxError "Cannot compute transaction fee" $
+        eitherToThrow =<< runTxCreator (computeTxFee utxo outputs)
     pure $ mkCCoin fee
 
 data MoneySource


### PR DESCRIPTION
Valid errors while calculating transaction fees (like `NotEnoughMoney`) weren't properly processed in `getTxFee` endpoint. This PR fixes it