### PR TITLE
[CSL-1598] Fix kademlia/topology/address/listener CLI mess

### DIFF
--- a/explorer/src/explorer/ExplorerOptions.hs
+++ b/explorer/src/explorer/ExplorerOptions.hs
@@ -16,50 +16,32 @@ import           Options.Applicative.Simple (Parser, auto, help, long, metavar, 
                                              showDefault, simpleOptions, strOption,
                                              switch, value)
 import           Prelude                    (show)
-import           Serokell.Util.OptParse     (fromParsec)
 
 import           Paths_cardano_sl_explorer  (version)
 import qualified Pos.Client.CLI             as CLI
-import           Pos.DHT.Model              (DHTKey)
-import           Pos.DHT.Real.CLI           (dhtExplicitInitialOption, dhtKeyOption,
-                                             dhtNetworkAddressOption, dhtPeersFileOption)
 import           Pos.Network.CLI            (NetworkConfigOpts, networkConfigOption)
 import           Pos.Statistics             (EkgParams, StatsdParams, ekgParamsOption,
                                              statsdParamsOption)
 import           Pos.Util.BackupPhrase      (BackupPhrase, backupPhraseWordsNum)
-import           Pos.Util.TimeWarp          (NetworkAddress, addrParser)
 
 data Args = Args
-    { dbPath             :: !FilePath
-    , rebuildDB          :: !Bool
-    , keyfilePath        :: !FilePath
-    , backupPhrase       :: !(Maybe BackupPhrase)
-    , dhtKey             :: !(Maybe DHTKey)
-    , bindAddress        :: !NetworkAddress
-    , externalAddress    :: !NetworkAddress
-      -- ^ A node must be addressable on the network.
-    , dhtNetworkAddress  :: !NetworkAddress
-      -- ^ A node may have a bind address which differs from its external
-      -- address.
-    , dhtPeersList       :: ![NetworkAddress]
-      -- ^ A list of initial Kademlia peers to use.
-    , dhtExplicitInitial :: !Bool
-    , dhtPeersFile       :: !(Maybe FilePath)
-      -- ^ A file containing a list of Kademlia peers to use.
-    , networkConfigOpts  :: !NetworkConfigOpts
+    { dbPath            :: !FilePath
+    , rebuildDB         :: !Bool
+    , keyfilePath       :: !FilePath
+    , backupPhrase      :: !(Maybe BackupPhrase)
+    , networkConfigOpts :: !NetworkConfigOpts
       -- ^ Network configuration
       -- TODO: Does this obsolete 'peers' and 'peersFile'?
-    , timeLord           :: !Bool
-    , jlPath             :: !(Maybe FilePath)
-    , webPort            :: !Word16
-    , commonArgs         :: !CLI.CommonArgs
-    , noSystemStart      :: !Int
-    , noNTP              :: !Bool
-    , enableMetrics      :: !Bool
-    , ekgParams          :: !(Maybe EkgParams)
-    , statsdParams       :: !(Maybe StatsdParams)
-    , notifierPort       :: !Word16
-    , staticPeers        :: !Bool
+    , jlPath            :: !(Maybe FilePath)
+    , webPort           :: !Word16
+    , commonArgs        :: !CLI.CommonArgs
+    , noSystemStart     :: !Int
+    , noNTP             :: !Bool
+    , enableMetrics     :: !Bool
+    , ekgParams         :: !(Maybe EkgParams)
+    , statsdParams      :: !(Maybe StatsdParams)
+    , notifierPort      :: !Word16
+    , staticPeers       :: !Bool
     } deriving Show
 
 argsParser :: Parser Args
@@ -89,16 +71,7 @@ argsParser = do
         help    (show backupPhraseWordsNum ++
                  "-word phrase to recover the wallet. Words should be separated by spaces.")
 
-    externalAddress <- CLI.externalNetworkAddressOption (Just ("0.0.0.0", 0))
-    bindAddress <- CLI.listenNetworkAddressOption (Just ("0.0.0.0", 0))
-    dhtNetworkAddress <- dhtNetworkAddressOption (Just ("0.0.0.0", 0))
-    dhtExplicitInitial <- dhtExplicitInitialOption
-    dhtPeersList <- many addrNodeOption
-    dhtPeersFile <- optional dhtPeersFileOption
     networkConfigOpts <- networkConfigOption
-    dhtKey <- optional dhtKeyOption
-
-    timeLord <- CLI.timeLordOption
 
     jlPath <- CLI.optionalJSONPath
 
@@ -129,13 +102,6 @@ argsParser = do
         help "Don't use Kademlia, use only static peers"
 
     pure Args{..}
-
-addrNodeOption :: Parser NetworkAddress
-addrNodeOption =
-    option (fromParsec addrParser) $
-        long "kademlia-peer" <>
-        metavar "HOST:PORT" <>
-        help "Identifier of a node in a Kademlia network"
 
 getExplorerOptions :: IO Args
 getExplorerOptions = do

--- a/explorer/src/explorer/ExplorerOptions.hs
+++ b/explorer/src/explorer/ExplorerOptions.hs
@@ -20,10 +20,10 @@ import           Serokell.Util.OptParse     (fromParsec)
 
 import           Paths_cardano_sl_explorer  (version)
 import qualified Pos.Client.CLI             as CLI
-import           Pos.Network.CLI            (NetworkConfigOpts, networkConfigOption)
 import           Pos.DHT.Model              (DHTKey)
 import           Pos.DHT.Real.CLI           (dhtExplicitInitialOption, dhtKeyOption,
                                              dhtNetworkAddressOption, dhtPeersFileOption)
+import           Pos.Network.CLI            (NetworkConfigOpts, networkConfigOption)
 import           Pos.Statistics             (EkgParams, StatsdParams, ekgParamsOption,
                                              statsdParamsOption)
 import           Pos.Util.BackupPhrase      (BackupPhrase, backupPhraseWordsNum)
@@ -51,7 +51,6 @@ data Args = Args
       -- TODO: Does this obsolete 'peers' and 'peersFile'?
     , timeLord           :: !Bool
     , jlPath             :: !(Maybe FilePath)
-    , kademliaDumpPath   :: !FilePath
     , webPort            :: !Word16
     , commonArgs         :: !CLI.CommonArgs
     , noSystemStart      :: !Int
@@ -102,13 +101,6 @@ argsParser = do
     timeLord <- CLI.timeLordOption
 
     jlPath <- CLI.optionalJSONPath
-
-    kademliaDumpPath <- strOption $
-        long    "kademlia-dump-path" <>
-        metavar "FILEPATH" <>
-        value   "kademlia.dump" <>
-        help    "Path to Kademlia dump file. If file doesn't exist, it will be created." <>
-        showDefault
 
     webPort <- CLI.webPortOption 8100 "Port for web API."
 

--- a/explorer/src/explorer/Params.hs
+++ b/explorer/src/explorer/Params.hs
@@ -5,35 +5,29 @@ module Params
        , getLoggingParams
        , getNodeParams
        , getBaseParams
-       , getPeersFromArgs
        ) where
 
 import           Universum
 
-import           Data.Default          (def)
-import           Mockable              (Catch, Fork, Mockable, Throw)
-import           System.Wlog           (LoggerName, WithLogger)
+import           Data.Default        (def)
+import           Mockable            (Catch, Fork, Mockable, Throw)
+import           System.Wlog         (LoggerName, WithLogger)
 
-import qualified Data.ByteString.Char8 as BS8 (unpack)
-import qualified Network.Transport.TCP as TCP (TCPAddr (..), TCPAddrInfo (..))
-import qualified Pos.Client.CLI        as CLI
-import           Pos.Constants         (isDevelopment)
-import           Pos.Core.Types        (Timestamp (..))
-import           Pos.Crypto            (VssKeyPair)
-import           Pos.Genesis           (devBalancesDistr, devGenesisContext,
-                                        genesisContextProduction)
-import           Pos.Launcher          (BaseParams (..), LoggingParams (..),
-                                        NodeParams (..), TransportParams (..))
-import           Pos.Network.CLI       (intNetworkConfigOpts)
-import           Pos.Network.Types     (NetworkConfig (..), Topology (..))
-import           Pos.Ssc.GodTossing    (GtParams (..))
-import           Pos.Update.Params     (UpdateParams (..))
-import           Pos.Util.TimeWarp     (NetworkAddress, readAddrFile)
-import           Pos.Util.UserSecret   (peekUserSecret)
+import qualified Pos.Client.CLI      as CLI
+import           Pos.Constants       (isDevelopment)
+import           Pos.Core.Types      (Timestamp (..))
+import           Pos.Crypto          (VssKeyPair)
+import           Pos.Genesis         (devBalancesDistr, devGenesisContext,
+                                      genesisContextProduction)
+import           Pos.Launcher        (BaseParams (..), LoggingParams (..),
+                                      NodeParams (..))
+import           Pos.Network.CLI     (intNetworkConfigOpts)
+import           Pos.Ssc.GodTossing  (GtParams (..))
+import           Pos.Update.Params   (UpdateParams (..))
+import           Pos.Util.UserSecret (peekUserSecret)
 
-
-import           ExplorerOptions       (Args (..))
-import           Secrets               (updateUserSecretVSS, userSecretWithGenesisKey)
+import           ExplorerOptions     (Args (..))
+import           Secrets             (updateUserSecretVSS, userSecretWithGenesisKey)
 
 
 
@@ -57,23 +51,6 @@ getLoggingParams tag Args{..} =
     , lpRunnerTag = tag
     }
 
-getPeersFromArgs :: Args -> IO [NetworkAddress]
-getPeersFromArgs Args {..} = do
-    filePeers <- maybe (pure []) readAddrFile dhtPeersFile
-    pure $ dhtPeersList ++ filePeers
-
-getTransportParams :: Args -> NetworkConfig kademlia -> TransportParams
-getTransportParams args networkConfig = TransportParams { tpTcpAddr = tcpAddr }
-  where
-    tcpAddr = case ncTopology networkConfig of
-        TopologyBehindNAT{} -> TCP.Unaddressable
-        _ -> let (bindHost, bindPort) = bindAddress args
-                 (externalHost, externalPort) = externalAddress args
-                 tcpHost = BS8.unpack bindHost
-                 tcpPort = show bindPort
-                 tcpMkExternal = const (BS8.unpack externalHost, show externalPort)
-             in  TCP.Addressable $ TCP.TCPAddrInfo tcpHost tcpPort tcpMkExternal
-
 getNodeParams
     :: ( MonadIO        m
        , MonadFail      m
@@ -91,7 +68,6 @@ getNodeParams args@Args {..} systemStart = do
         peekUserSecret keyfilePath
 
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    let npTransport = getTransportParams args npNetworkConfig
 
     let devBalanceDistr =
             devBalancesDistr

--- a/infra/Pos/DHT/Real/Param.hs
+++ b/infra/Pos/DHT/Real/Param.hs
@@ -1,4 +1,3 @@
-
 module Pos.DHT.Real.Param
        ( KademliaParams (..)
        , fromYamlConfig
@@ -42,7 +41,8 @@ fromYamlConfig yamlParams = do
         }
 
 kademliaAddressToNetworkAddress :: Y.KademliaAddress -> NetworkAddress
-kademliaAddressToNetworkAddress yamlAddr = (B8.pack $ Y.kaHost yamlAddr, Y.kaPort yamlAddr)
+kademliaAddressToNetworkAddress yamlAddr =
+    (B8.pack $ Y.kaHost yamlAddr, Y.kaPort yamlAddr)
 
 kademliaIdToDHTKey :: Y.KademliaId -> Either String DHTKey
 kademliaIdToDHTKey (Y.KademliaId txt) = do

--- a/infra/Pos/Network/CLI.hs
+++ b/infra/Pos/Network/CLI.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP           #-}
 
 -- following Pos.Util.UserSecret
 #if !defined(mingw32_HOST_OS)
@@ -11,6 +12,8 @@ module Pos.Network.CLI
          NetworkConfigOpts(..)
        , NetworkConfigException(..)
        , networkConfigOption
+       , externalNetworkAddressOption
+       , listenNetworkAddressOption
        , ipv4ToNetworkAddress
        , intNetworkConfigOpts
          -- * Exported primilary for testing
@@ -19,6 +22,8 @@ module Pos.Network.CLI
        , fromPovOf
        ) where
 
+import           Universum
+
 import           Control.Concurrent
 import           Control.Exception               (Exception (..))
 import qualified Data.ByteString.Char8           as BS.C8
@@ -26,14 +31,18 @@ import           Data.IP                         (IPv4)
 import qualified Data.Map.Strict                 as M
 import           Data.Maybe                      (fromJust, mapMaybe)
 import qualified Data.Yaml                       as Yaml
-import           Formatting                      (sformat, shown, (%))
+import           Formatting                      (build, sformat, shown, (%))
 import           Mockable                        (Catch, Mockable, Throw, fork, throw,
                                                   try)
 import           Mockable.Concurrent
 import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS                     as DNS
+import qualified Network.Transport.TCP           as TCP
 import qualified Options.Applicative             as Opt
-import qualified Pos.DHT.Real.Param              as DHT (KademliaParams,
+import           Serokell.Util.OptParse          (fromParsec)
+import           System.Wlog.CanLog              (WithLogger, logError, logNotice)
+
+import qualified Pos.DHT.Real.Param              as DHT (KademliaParams (..),
                                                          MalformedDHTKey (..),
                                                          fromYamlConfig)
 import           Pos.Network.DnsDomains          (DnsDomains (..), NodeAddr (..))
@@ -41,9 +50,8 @@ import           Pos.Network.Types               (NodeId, NodeName (..))
 import qualified Pos.Network.Types               as T
 import           Pos.Network.Yaml                (NodeMetadata (..))
 import qualified Pos.Network.Yaml                as Y
-import           Pos.Util.TimeWarp               (NetworkAddress, addressToNodeId)
-import           System.Wlog.CanLog              (WithLogger, logError, logNotice)
-import           Universum
+import           Pos.Util.TimeWarp               (NetworkAddress, addrParser,
+                                                  addrParserNoWildcard, addressToNodeId)
 
 #ifdef POSIX
 import           Pos.Util.SigHandler             (Signal (..), installHandler)
@@ -54,16 +62,21 @@ import           Pos.Util.SigHandler             (Signal (..), installHandler)
 ----------------------------------------------------------------------------
 
 data NetworkConfigOpts = NetworkConfigOpts
-    { networkConfigOptsTopology :: Maybe FilePath
+    { ncoTopology        :: !(Maybe FilePath)
       -- ^ Filepath to .yaml file with the network topology
-    , networkConfigOptsKademlia :: Maybe FilePath
+    , ncoKademlia        :: !(Maybe FilePath)
       -- ^ Filepath to .yaml config of kademlia
-    , networkConfigOptsSelf     :: Maybe NodeName
+    , ncoSelf            :: !(Maybe NodeName)
       -- ^ Name of the current node
-    , networkConfigOptsPort     :: Word16
+    , ncoPort            :: !Word16
       -- ^ Port number to use when translating IP addresses to NodeIds
-    , networkConfigOptsPolicies :: Maybe FilePath
+    , ncoPolicies        :: !(Maybe FilePath)
       -- DOCUMENT THIS FIELD
+    , ncoBindAddress     :: !(Maybe NetworkAddress)
+      -- ^ A node may have a bind address which differs from its external
+      -- address.
+    , ncoExternalAddress :: !(Maybe NetworkAddress)
+      -- ^ A node must be addressable on the network.
     } deriving (Show)
 
 ----------------------------------------------------------------------------
@@ -71,33 +84,73 @@ data NetworkConfigOpts = NetworkConfigOpts
 ----------------------------------------------------------------------------
 
 networkConfigOption :: Opt.Parser NetworkConfigOpts
-networkConfigOption = NetworkConfigOpts
-    <$> (optional . Opt.strOption $ mconcat [
-            Opt.long "topology"
-          , Opt.metavar "FILEPATH"
-          , Opt.help "Path to a YAML file containing the network topology"
-          ])
-    <*> (optional . Opt.strOption $ mconcat [
-            Opt.long "kademlia"
-          , Opt.metavar "FILEPATH"
-          , Opt.help "Path to a YAML file containing the kademlia configuration"
-          ])
-    <*> (optional . Opt.option (fromString <$> Opt.str) $ mconcat [
-            Opt.long "node-id"
-          , Opt.metavar "NODE_ID"
-          , Opt.help "Identifier for this node within the network"
-          ])
-    <*> (Opt.option Opt.auto $ mconcat [
-            Opt.long "default-port"
-          , Opt.metavar "PORT"
-          , Opt.help "Port number for IP address to node ID translation"
-          , Opt.value 3000
-          ])
-    <*> (Opt.optional . Opt.strOption $ mconcat [
-            Opt.long "policies"
-          , Opt.metavar "FILEPATH"
-          , Opt.help "Path to a YAML file containing the network policies"
-          ])
+networkConfigOption = do
+    ncoTopology <-
+        optional $ Opt.strOption $
+        mconcat
+            [ Opt.long "topology"
+            , Opt.metavar "FILEPATH"
+            , Opt.help "Path to a YAML file containing the network topology"
+            ]
+    ncoKademlia <-
+        optional $ Opt.strOption $
+        mconcat
+            [ Opt.long "kademlia"
+            , Opt.metavar "FILEPATH"
+            , Opt.help
+                  "Path to a YAML file containing the kademlia configuration"
+            ]
+    ncoSelf <-
+        optional $ Opt.option (fromString <$> Opt.str) $
+        mconcat
+            [ Opt.long "node-id"
+            , Opt.metavar "NODE_ID"
+            , Opt.help "Identifier for this node within the network"
+            ]
+    ncoPort <-
+        Opt.option Opt.auto $
+        mconcat
+            [ Opt.long "default-port"
+            , Opt.metavar "PORT"
+            , Opt.help "Port number for IP address to node ID translation"
+            , Opt.value 3000
+            ]
+    ncoPolicies <-
+        Opt.optional $ Opt.strOption $
+        mconcat
+            [ Opt.long "policies"
+            , Opt.metavar "FILEPATH"
+            , Opt.help "Path to a YAML file containing the network policies"
+            ]
+    ncoExternalAddress <- optional $ externalNetworkAddressOption Nothing
+    ncoBindAddress <- optional $ listenNetworkAddressOption Nothing
+    pure $ NetworkConfigOpts {..}
+
+externalNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
+externalNetworkAddressOption na =
+    Opt.option (fromParsec addrParserNoWildcard) $
+            Opt.long "address"
+         <> Opt.metavar "IP:PORT"
+         <> Opt.help helpMsg
+         <> Opt.showDefault
+         <> maybe mempty Opt.value na
+  where
+    helpMsg = "IP and port of external address. "
+        <> "Please make sure these IP and port (on which node is running) are accessible "
+        <> "otherwise proper work of CSL isn't guaranteed. "
+        <> "0.0.0.0 is not accepted as a valid host."
+
+listenNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
+listenNetworkAddressOption na =
+    Opt.option (fromParsec addrParser) $
+            Opt.long "listen"
+         <> Opt.metavar "IP:PORT"
+         <> Opt.help helpMsg
+         <> Opt.showDefault
+         <> maybe mempty Opt.value na
+  where
+    helpMsg = "IP and port on which to bind and listen. Please make sure these IP "
+        <> "and port are accessible, otherwise proper work of CSL isn't guaranteed."
 
 ----------------------------------------------------------------------------
 -- Defaults
@@ -105,9 +158,10 @@ networkConfigOption = NetworkConfigOpts
 
 -- | The topology we assume when no topology file is specified
 defaultTopology :: Y.Topology
-defaultTopology = Y.TopologyBehindNAT {
-      topologyValency    = 1
-    , topologyFallbacks  = 1
+defaultTopology =
+    Y.TopologyBehindNAT
+    { topologyValency = 1
+    , topologyFallbacks = 1
     , topologyDnsDomains = defaultDnsDomains
     }
 
@@ -159,7 +213,7 @@ monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
             runHandler peers handler -- Call new handler with current value
             loop events peers (handler:handlers)
         MonitorSIGHUP -> do
-            let fp = fromJust networkConfigOptsTopology
+            let fp = fromJust ncoTopology
             mParsedTopology <- try $ liftIO $ readTopology fp
             case mParsedTopology of
               Right (Y.TopologyStatic allPeers) -> do
@@ -220,10 +274,10 @@ intNetworkConfigOpts ::
     -> m (T.NetworkConfig DHT.KademliaParams)
 intNetworkConfigOpts cfg@NetworkConfigOpts{..} = do
     parsedTopology <-
-        case networkConfigOptsTopology of
+        case ncoTopology of
             Nothing -> pure defaultTopology
             Just fp -> liftIO $ readTopology fp
-    ourTopology <- case parsedTopology of
+    (ourTopology, tcpAddr) <- case parsedTopology of
         Y.TopologyStatic{..} -> do
             (md@NodeMetadata{..}, initPeers, kademliaPeers) <-
                 liftIO $ fromPovOf cfg topologyAllPeers
@@ -232,33 +286,51 @@ intNetworkConfigOpts cfg@NetworkConfigOpts{..} = do
             -- file. However it's not necessary that the file exists. If it doesn't,
             -- we can fill in some sensible defaults using the static routing and
             -- kademlia flags for other nodes.
-            topologyOptKademlia <- if nmKademlia
-                then do
-                    ekparams <- liftIO $ getKademliaParamsFromFile cfg
-                    case ekparams of
-                        Right kparams -> return $ Just kparams
-                        Left MissingKademliaConfig ->
-                            let ekparams' = getKademliaParamsFromStatic kademliaPeers
-                            in  either (throw . CannotParseKademliaConfig . Left)
-                                       (return . Just)
-                                       ekparams'
-                        Left err -> throw err
-                else return Nothing
-            case nmType of
-                T.NodeCore  -> return $ T.TopologyCore{..}
-                T.NodeRelay -> return $ T.TopologyRelay{topologyMaxSubscrs = nmMaxSubscrs, ..}
+            topologyOptKademlia <-
+                if nmKademlia
+                then liftIO getKademliaParamsFromFile >>= \case
+                    Right kparams -> return $ Just kparams
+                    Left MissingKademliaConfig ->
+                        let ekparams' = getKademliaParamsFromStatic kademliaPeers
+                        in  either (throw . CannotParseKademliaConfig . Left)
+                                   (return . Just)
+                                   ekparams'
+                    Left err -> throw err
+                else do when (isJust ncoKademlia) $
+                            throw $ RedundantCliParameter $
+                            "TopologyStatic doesn't require kademlia, but it was passed"
+                        pure Nothing
+            topology <- case nmType of
+                T.NodeCore  -> pure $ T.TopologyCore{..}
+                T.NodeRelay -> pure $ T.TopologyRelay{topologyMaxSubscrs = nmMaxSubscrs, ..}
                 T.NodeEdge  -> throw NetworkConfigSelfEdge
+            tcpAddr <- createTcpAddr topologyOptKademlia
+            pure (topology, tcpAddr)
         Y.TopologyBehindNAT{..} -> do
-            whenJust networkConfigOptsKademlia $ const $ throw RedundantKademliaConfig
-            return T.TopologyBehindNAT{..}
+            -- Behind-NAT topology claims no address for the transport, and also
+            -- throws an exception if the --listen parameter is given, to avoid
+            -- confusion: if a user gives a --listen parameter then they probably
+            -- think the program will bind a socket.
+            whenJust ncoKademlia $ const $ throw $
+                RedundantCliParameter
+                "BehindNAT topology is used, so no kademlia config is expected"
+            when (isJust ncoBindAddress) $ throw $ RedundantCliParameter $
+                "BehindNAT topology is used, no bind address is expected"
+            when (isJust ncoExternalAddress) $ throw $ RedundantCliParameter $
+                "BehindNAT topology is used, no external address is expected"
+            pure (T.TopologyBehindNAT{..}, TCP.Unaddressable)
         Y.TopologyP2P{..} -> do
-            kparams <- either throw return =<< liftIO (getKademliaParamsFromFile cfg)
-            return T.TopologyP2P{topologyKademlia = kparams, ..}
+            kparams <- either throw return =<< liftIO getKademliaParamsFromFile
+            tcpAddr <- createTcpAddr (Just kparams)
+            pure ( T.TopologyP2P{topologyKademlia = kparams, ..}
+                 , tcpAddr )
         Y.TopologyTraditional{..} -> do
-            kparams <- either throw return =<< liftIO (getKademliaParamsFromFile cfg)
-            return T.TopologyTraditional{topologyKademlia = kparams, ..}
+            kparams <- either throw return =<< liftIO getKademliaParamsFromFile
+            tcpAddr <- createTcpAddr (Just kparams)
+            pure ( T.TopologyTraditional{topologyKademlia = kparams, ..}
+                 , tcpAddr )
 
-    (enqueuePolicy, dequeuePolicy, failurePolicy) <- case networkConfigOptsPolicies of
+    (enqueuePolicy, dequeuePolicy, failurePolicy) <- case ncoPolicies of
         -- If no policy file is given we just use the default derived from the
         -- topology.
         Nothing -> return
@@ -270,43 +342,69 @@ intNetworkConfigOpts cfg@NetworkConfigOpts{..} = do
         -- and we take the complete policy description from the file.
         Just fp -> liftIO $ Y.fromStaticPolicies <$> readPolicies fp
 
-    return T.NetworkConfig
-        { ncTopology      = ourTopology
-        , ncDefaultPort   = networkConfigOptsPort
-        , ncSelfName      = networkConfigOptsSelf
-        , ncEnqueuePolicy = enqueuePolicy
-        , ncDequeuePolicy = dequeuePolicy
-        , ncFailurePolicy = failurePolicy
-        }
+    let networkConfig = T.NetworkConfig
+            { ncTopology      = ourTopology
+            , ncDefaultPort   = ncoPort
+            , ncSelfName      = ncoSelf
+            , ncEnqueuePolicy = enqueuePolicy
+            , ncDequeuePolicy = dequeuePolicy
+            , ncFailurePolicy = failurePolicy
+            , ncTcpAddr       = tcpAddr
+            }
 
--- | Come up with kademlia parameters, possibly giving 'Left' in case
--- there's no configuration file path given, or if it couldn't be parsed.
-getKademliaParamsFromFile :: NetworkConfigOpts
-                          -> IO (Either NetworkConfigException DHT.KademliaParams)
-getKademliaParamsFromFile cfg = case networkConfigOptsKademlia cfg of
-    Nothing -> return $ Left MissingKademliaConfig
-    Just fp -> do
-      kconf <- parseKademlia fp
-      either (return . Left . CannotParseKademliaConfig . Left . DHT.MalformedDHTKey)
-             (return . Right)
-             (DHT.fromYamlConfig kconf)
-
--- | Derive kademlia parameters from the set of kademlia-enabled peers. They
--- are used as the initial peers, and everything else is unspecified, and will
--- be defaulted.
-getKademliaParamsFromStatic :: [Y.KademliaAddress]
-                            -> Either DHT.MalformedDHTKey DHT.KademliaParams
--- Since 'Nothing' is given for the kpId, it's impossible to get a 'Left'
-getKademliaParamsFromStatic kpeers = either (Left . DHT.MalformedDHTKey) Right kparams
+    pure networkConfig
   where
-    kparams = DHT.fromYamlConfig $ Y.KademliaParams
-        { Y.kpId              = Nothing
-        , Y.kpPeers           = kpeers
-        , Y.kpAddress         = Nothing
-        , Y.kpBind            = Nothing
-        , Y.kpExplicitInitial = Nothing
-        , Y.kpDumpFile        = Nothing
-        }
+    -- Creates transport params out of config. If kademlia config is
+    -- specified, kademlia external address should match external
+    -- address of transport (which will be checked in this function).
+    createTcpAddr :: Maybe DHT.KademliaParams -> m TCP.TCPAddr
+    createTcpAddr kademliaBind = do
+        let kademliaExternal :: Maybe NetworkAddress
+            kademliaExternal = join $ DHT.kpExternalAddress <$> kademliaBind
+        bindAddr@(bindHost, bindPort) <-
+            maybe (throw MissingBindAddress) pure ncoBindAddress
+        whenJust ((,) <$> kademliaExternal <*> ncoExternalAddress) $ \(kademliaEx::NetworkAddress,paramEx::NetworkAddress) ->
+            when (kademliaEx /= paramEx) $
+            throw $ InconsistentParameters $
+            sformat ("Kademlia network address is "%build%
+                     " but external address passed in cli is "%build%
+                     ". They must be the same")
+                    kademliaEx
+                    paramEx
+        let (externalHost, externalPort) = fromMaybe bindAddr ncoExternalAddress
+        let tcpHost = BS.C8.unpack bindHost
+            tcpPort = show bindPort
+            tcpMkExternal = const (BS.C8.unpack externalHost, show externalPort)
+        pure $ TCP.Addressable $ TCP.TCPAddrInfo tcpHost tcpPort tcpMkExternal
+
+    -- Come up with kademlia parameters, possibly giving 'Left' in case
+    -- there's no configuration file path given, or if it couldn't be parsed.
+    getKademliaParamsFromFile
+        :: IO (Either NetworkConfigException DHT.KademliaParams)
+    getKademliaParamsFromFile = case ncoKademlia of
+        Nothing -> pure $ Left MissingKademliaConfig
+        Just fp -> do
+            kconf <- parseKademlia fp
+            pure $ first (CannotParseKademliaConfig . Left . DHT.MalformedDHTKey)
+                         (DHT.fromYamlConfig kconf)
+
+    -- Derive kademlia parameters from the set of kademlia-enabled peers. They
+    -- are used as the initial peers, and everything else is unspecified, and will
+    -- be defaulted.
+    getKademliaParamsFromStatic
+        :: [Y.KademliaAddress]
+        -> Either DHT.MalformedDHTKey DHT.KademliaParams
+    -- Since 'Nothing' is given for the kpId, it's impossible to get a 'Left'
+    getKademliaParamsFromStatic kpeers =
+        first DHT.MalformedDHTKey $
+        DHT.fromYamlConfig $ Y.KademliaParams
+            { Y.kpId              = Nothing
+            , Y.kpPeers           = kpeers
+            , Y.kpAddress         = Nothing
+            , Y.kpBind            = Nothing
+            , Y.kpExplicitInitial = Nothing
+            , Y.kpDumpFile        = Nothing
+            }
 
 -- | Perspective on 'AllStaticallyKnownPeers' from the point of view of
 -- a single node.
@@ -319,7 +417,7 @@ getKademliaParamsFromStatic kpeers = either (Left . DHT.MalformedDHTKey) Right k
 fromPovOf :: NetworkConfigOpts
           -> Y.AllStaticallyKnownPeers
           -> IO (NodeMetadata, Peers NodeId, [Y.KademliaAddress])
-fromPovOf cfg@NetworkConfigOpts{..} allPeers = case networkConfigOptsSelf of
+fromPovOf cfg@NetworkConfigOpts{..} allPeers = case ncoSelf of
     Nothing   -> throwM NetworkConfigSelfUnknown
     Just self -> T.initDnsOnUse $ \resolve -> do
         selfMetadata <- metadataFor allPeers self
@@ -369,7 +467,7 @@ fromPovOf cfg@NetworkConfigOpts{..} allPeers = case networkConfigOptsSelf of
     mkRoutes directory (Y.NodeRoutes routes) = mapM (mkAlts directory) routes
 
     mkAlts :: Map NodeName (T.NodeType, NodeId) -> Alts NodeName -> IO (T.NodeType, Alts NodeId)
-    mkAlts _ [] = throwM $ EmptyListOfAltsFor (fromJust networkConfigOptsSelf)
+    mkAlts _ [] = throwM $ EmptyListOfAltsFor (fromJust ncoSelf)
     mkAlts directory names@(name:_) = do
       -- Use the type associated to the first name, and assume all alts have
       -- same type.
@@ -386,6 +484,7 @@ fromPovOf cfg@NetworkConfigOpts{..} allPeers = case networkConfigOptsSelf of
     resolveName directory name = case M.lookup name directory of
       Nothing -> throwM $ UndefinedNodeName name
       Just t  -> return t
+
 
 -- | Resolve node name to IP address
 --
@@ -406,11 +505,11 @@ resolveNodeAddr :: NetworkConfigOpts
                 -> (NodeName, NodeAddr (Maybe DNS.Domain))
                 -> IO NetworkAddress
 resolveNodeAddr cfg _ (_, NodeAddrExact addr mPort) = do
-    let port = fromMaybe (networkConfigOptsPort cfg) mPort
+    let port = fromMaybe (ncoPort cfg) mPort
     return (encodeUtf8 @String . show $ addr, port)
 resolveNodeAddr cfg resolve (name, NodeAddrDNS mHost mPort) = do
     let host = fromMaybe (nameToDomain name)         mHost
-        port = fromMaybe (networkConfigOptsPort cfg) mPort
+        port = fromMaybe (ncoPort cfg) mPort
 
     mAddrs <- resolve host
     case mAddrs of
@@ -463,8 +562,14 @@ data NetworkConfigException =
     -- | A Kademlia configuration file is expected but was not specified.
   | MissingKademliaConfig
 
-    -- | A Kademlia configuration file is provided, but not needed.
-  | RedundantKademliaConfig
+    -- | Address to bind on is missing in CLI.
+  | MissingBindAddress
+
+    -- | Some passed parameters can't be used together.
+  | InconsistentParameters Text
+
+    -- | Some CLI parameter is redundant.
+  | RedundantCliParameter Text
 
     -- | We cannot parse the kademlia .yaml file
   | CannotParseKademliaConfig (Either DHT.MalformedDHTKey Yaml.ParseException)
@@ -496,6 +601,7 @@ data NetworkConfigException =
     --
     -- This is no good because we need canonical node IDs.
   | NoUniqueResolution NodeName [IPv4]
+
   deriving (Show)
 
 instance Exception NetworkConfigException

--- a/infra/Pos/Network/DnsDomains.hs
+++ b/infra/Pos/Network/DnsDomains.hs
@@ -1,14 +1,15 @@
+module Pos.Network.DnsDomains
+       ( DnsDomains(..)
+       , NodeAddr(..)
+       , resolveDnsDomains
+       ) where
 
-module Pos.Network.DnsDomains (
-    DnsDomains(..)
-  , NodeAddr(..)
-  , resolveDnsDomains
-  ) where
+
+import           Universum
 
 import qualified Data.ByteString.Char8                 as BS.C8
 import           Data.IP                               (IP, IPv4)
 import           Network.Broadcast.OutboundQueue.Types (AllOf, Alts)
-import           Universum
 
 -- | DNS domains for relay discovery
 --

--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -1,18 +1,20 @@
 module Pos.Network.Policy
-    ( defaultEnqueuePolicyCore
-    , defaultEnqueuePolicyRelay
-    , defaultEnqueuePolicyEdgeBehindNat
-    , defaultEnqueuePolicyEdgeP2P
-    , defaultDequeuePolicyCore
-    , defaultDequeuePolicyRelay
-    , defaultDequeuePolicyEdgeBehindNat
-    , defaultDequeuePolicyEdgeP2P
-    , defaultFailurePolicy
-    ) where
+       ( defaultEnqueuePolicyCore
+       , defaultEnqueuePolicyRelay
+       , defaultEnqueuePolicyEdgeBehindNat
+       , defaultEnqueuePolicyEdgeP2P
+       , defaultDequeuePolicyCore
+       , defaultDequeuePolicyRelay
+       , defaultDequeuePolicyEdgeBehindNat
+       , defaultDequeuePolicyEdgeP2P
+       , defaultFailurePolicy
+       ) where
+
 
 import           Universum
-import           Network.Broadcast.OutboundQueue.Types
+
 import           Network.Broadcast.OutboundQueue
+import           Network.Broadcast.OutboundQueue.Types
 
 -- | Default enqueue policy for core nodes
 defaultEnqueuePolicyCore :: EnqueuePolicy nid

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -6,45 +6,45 @@
 #endif
 
 module Pos.Network.Types
-    ( -- * Network configuration
-      NetworkConfig (..)
-    , NodeName (..)
-    , defaultNetworkConfig
-      -- * Topology
-    , StaticPeers(..)
-    , Topology(..)
-      -- ** Derived information
-    , SubscriptionWorker(..)
-    , topologyNodeType
-    , topologySubscribers
-    , topologyUnknownNodeType
-    , topologySubscriptionWorker
-    , topologyRunKademlia
-    , topologyEnqueuePolicy
-    , topologyDequeuePolicy
-    , topologyFailurePolicy
-    , topologyMaxBucketSize
-      -- * Queue initialization
-    , Bucket(..)
-    , initQueue
-      -- * Constructing peers
-    , Valency
-    , Fallbacks
-    , choosePeers
-      -- * DNS support
-    , Resolver
-    , resolveDnsDomains
-    , initDnsOnUse
-      -- * Re-exports
-      -- ** from .DnsDomains
-    , DnsDomains(..)
-      -- ** from time-warp
-    , NodeType (..)
-    , MsgType (..)
-    , Origin (..)
-      -- ** other
-    , NodeId (..)
-    ) where
+       ( -- * Network configuration
+         NetworkConfig (..)
+       , NodeName (..)
+       , defaultNetworkConfig
+         -- * Topology
+       , StaticPeers(..)
+       , Topology(..)
+         -- ** Derived information
+       , SubscriptionWorker(..)
+       , topologyNodeType
+       , topologySubscribers
+       , topologyUnknownNodeType
+       , topologySubscriptionWorker
+       , topologyRunKademlia
+       , topologyEnqueuePolicy
+       , topologyDequeuePolicy
+       , topologyFailurePolicy
+       , topologyMaxBucketSize
+         -- * Queue initialization
+       , Bucket(..)
+       , initQueue
+         -- * Constructing peers
+       , Valency
+       , Fallbacks
+       , choosePeers
+         -- * DNS support
+       , Resolver
+       , resolveDnsDomains
+       , initDnsOnUse
+         -- * Re-exports
+         -- ** from .DnsDomains
+       , DnsDomains(..)
+         -- ** from time-warp
+       , NodeType (..)
+       , MsgType (..)
+       , Origin (..)
+         -- ** other
+       , NodeId (..)
+       ) where
 
 import           Data.IP                               (IPv4)
 import           GHC.Show                              (Show (..))
@@ -67,9 +67,9 @@ import           Universum                             hiding (show)
 import qualified Pos.Network.Windows.DnsDomains        as Win
 #endif
 
-{-------------------------------------------------------------------------------
-  Network configuration
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Network configuration
+----------------------------------------------------------------------------
 
 newtype NodeName = NodeName Text
     deriving (Show, Ord, Eq, IsString)
@@ -117,9 +117,9 @@ defaultNetworkConfig ncTopology = NetworkConfig {
     , ..
     }
 
-{-------------------------------------------------------------------------------
-  Topology (from the pov of a single node)
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Topology
+----------------------------------------------------------------------------
 
 -- | Statically configured peers
 --
@@ -134,7 +134,7 @@ data StaticPeers = forall m. (MonadIO m, WithLogger m) => StaticPeers {
     }
 
 instance Show StaticPeers where
-  show _ = "<<StaticPeers>>"
+    show _ = "<<StaticPeers>>"
 
 -- | Topology of the network, from the point of view of the current node
 data Topology kademlia =
@@ -185,9 +185,9 @@ data Topology kademlia =
       }
   deriving (Show)
 
-{-------------------------------------------------------------------------------
-  Information derived from the topology
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Information derived from the topology
+----------------------------------------------------------------------------
 
 -- | Derive node type from its topology
 topologyNodeType :: Topology kademlia -> NodeType
@@ -295,9 +295,9 @@ topologyMaxBucketSize topology bucket =
       _otherBucket ->
         OQ.BucketSizeUnlimited
 
-{-------------------------------------------------------------------------------
-  Queue initialization
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Queue initialization
+----------------------------------------------------------------------------
 
 -- | The various buckets we use for the outbound queue
 data Bucket =
@@ -366,9 +366,9 @@ initQueue NetworkConfig{..} mStore = do
 
     return oq
 
-{-------------------------------------------------------------------------------
-  Constructing peers
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Constructing peers
+----------------------------------------------------------------------------
 
 -- | The number of peers we want to send to
 --
@@ -396,9 +396,9 @@ choosePeers valency fallbacks peerType =
     mkGroupsOf n lst = case splitAt n lst of
                          (these, those) -> these : mkGroupsOf n those
 
-{-------------------------------------------------------------------------------
-  DNS support
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- DNS support
+----------------------------------------------------------------------------
 
 type Resolver = DNS.Domain -> IO (Either DNSError [IPv4])
 

--- a/infra/Pos/Network/Windows/DnsDomains.hs
+++ b/infra/Pos/Network/Windows/DnsDomains.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Pos.Network.Windows.DnsDomains (
-    getWindowsDefaultDnsServer
-    ) where
+module Pos.Network.Windows.DnsDomains
+       ( getWindowsDefaultDnsServer
+       ) where
 
 import           Universum
 

--- a/infra/Pos/Network/Yaml.hs
+++ b/infra/Pos/Network/Yaml.hs
@@ -2,26 +2,30 @@
 
 {-# LANGUAGE RankNTypes #-}
 
-module Pos.Network.Yaml (
-    Topology(..)
-  , AllStaticallyKnownPeers(..)
-  , DnsDomains(..)
-  , KademliaParams(..)
-  , KademliaId(..)
-  , KademliaAddress(..)
-  , NodeRegion(..)
-  , NodeRoutes(..)
-  , NodeMetadata(..)
-  , RunKademlia
-  , Valency
-  , Fallbacks
+module Pos.Network.Yaml
+       (
+         Topology(..)
+       , AllStaticallyKnownPeers(..)
+       , DnsDomains(..)
+       , KademliaParams(..)
+       , KademliaId(..)
+       , KademliaAddress(..)
+       , NodeRegion(..)
+       , NodeRoutes(..)
+       , NodeMetadata(..)
+       , RunKademlia
+       , Valency
+       , Fallbacks
 
-  , StaticPolicies(..)
-  , StaticEnqueuePolicy -- opaque
-  , StaticDequeuePolicy -- opaque
-  , StaticFailurePolicy -- opaque
-  , fromStaticPolicies
-  ) where
+       , StaticPolicies(..)
+       , StaticEnqueuePolicy -- opaque
+       , StaticDequeuePolicy -- opaque
+       , StaticFailurePolicy -- opaque
+       , fromStaticPolicies
+       ) where
+
+
+import           Universum
 
 import           Data.Aeson                            (FromJSON (..), ToJSON (..), (.!=),
                                                         (.:), (.:?), (.=))
@@ -34,11 +38,10 @@ import qualified Data.Map.Strict                       as M
 import qualified Network.Broadcast.OutboundQueue       as OQ
 import           Network.Broadcast.OutboundQueue.Types
 import qualified Network.DNS                           as DNS
-import           Pos.Network.Types                     (Fallbacks, NodeName (..), Valency)
-import           Pos.Util.Config
-import           Universum
 
 import           Pos.Network.DnsDomains                (DnsDomains (..), NodeAddr (..))
+import           Pos.Network.Types                     (Fallbacks, NodeName (..), Valency)
+import           Pos.Util.Config
 
 -- | Description of the network topology in a Yaml file
 --
@@ -70,10 +73,9 @@ data Topology =
   deriving (Show)
 
 -- | All statically known peers in the newtork
-data AllStaticallyKnownPeers = AllStaticallyKnownPeers {
-    allStaticallyKnownPeers :: !(Map NodeName NodeMetadata)
-  }
-  deriving (Show)
+data AllStaticallyKnownPeers = AllStaticallyKnownPeers
+    { allStaticallyKnownPeers :: !(Map NodeName NodeMetadata)
+    } deriving (Show)
 
 newtype NodeRegion = NodeRegion Text
     deriving (Show, Ord, Eq, IsString)
@@ -158,8 +160,7 @@ instance ToJSON KademliaId where
 data KademliaAddress = KademliaAddress
     { kaHost :: !String
     , kaPort :: !Word16
-    }
-    deriving (Show)
+    } deriving (Show)
 
 instance FromJSON KademliaAddress where
     parseJSON = A.withObject "KademliaAddress " $ \obj ->
@@ -171,9 +172,9 @@ instance ToJSON KademliaAddress where
         , "port" .= kaPort
         ]
 
-{-------------------------------------------------------------------------------
-  FromJSON instances
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- FromJSON instances
+----------------------------------------------------------------------------
 
 instance FromJSON NodeRegion where
   parseJSON = fmap NodeRegion . parseJSON
@@ -297,29 +298,29 @@ maybeBucketSize (Just n) = OQ.BucketSizeMax n
 instance IsConfig Topology where
   configPrefix = return Nothing
 
-{-------------------------------------------------------------------------------
-  Policies described in JSON/YAML.
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Policies described in JSON/YAML.
+----------------------------------------------------------------------------
 
 -- | Policies described by a JSON/YAML.
-data StaticPolicies = StaticPolicies {
-      staticEnqueuePolicy :: StaticEnqueuePolicy
+data StaticPolicies = StaticPolicies
+    { staticEnqueuePolicy :: StaticEnqueuePolicy
     , staticDequeuePolicy :: StaticDequeuePolicy
     , staticFailurePolicy :: StaticFailurePolicy
     }
 
 -- | An enqueue policy which can be described by JSON/YAML.
-newtype StaticEnqueuePolicy = StaticEnqueuePolicy {
-      getStaticEnqueuePolicy :: forall nid . MsgType nid -> [OQ.Enqueue]
+newtype StaticEnqueuePolicy = StaticEnqueuePolicy
+    { getStaticEnqueuePolicy :: forall nid. MsgType nid -> [OQ.Enqueue]
     }
 
 -- | A dequeue policy which can be described by JSON/YAML.
-newtype StaticDequeuePolicy = StaticDequeuePolicy {
-      getStaticDequeuePolicy :: NodeType -> OQ.Dequeue
+newtype StaticDequeuePolicy = StaticDequeuePolicy
+    { getStaticDequeuePolicy :: NodeType -> OQ.Dequeue
     }
 
-newtype StaticFailurePolicy = StaticFailurePolicy {
-      getStaticFailurePolicy :: forall nid. NodeType -> MsgType nid -> OQ.ReconsiderAfter
+newtype StaticFailurePolicy = StaticFailurePolicy
+    { getStaticFailurePolicy :: forall nid. NodeType -> MsgType nid -> OQ.ReconsiderAfter
     }
 
 fromStaticPolicies :: StaticPolicies
@@ -327,8 +328,8 @@ fromStaticPolicies :: StaticPolicies
                       , OQ.DequeuePolicy
                       , OQ.FailurePolicy nid
                       )
-fromStaticPolicies StaticPolicies{..} = (
-      fromStaticEnqueuePolicy staticEnqueuePolicy
+fromStaticPolicies StaticPolicies {..} =
+    ( fromStaticEnqueuePolicy staticEnqueuePolicy
     , fromStaticDequeuePolicy staticDequeuePolicy
     , fromStaticFailurePolicy staticFailurePolicy
     )
@@ -346,17 +347,17 @@ fromStaticFailurePolicy p nodeType = const . getStaticFailurePolicy p nodeType
   Common patterns in the .yaml file
 -------------------------------------------------------------------------------}
 
-data SendOrForward t = SendOrForward {
-      send    :: !t
+data SendOrForward t = SendOrForward
+    { send    :: !t
     , forward :: !t
     }
 
-newtype ByMsgType t = ByMsgType {
-      byMsgType :: forall nid. MsgType nid -> t
+newtype ByMsgType t = ByMsgType
+    { byMsgType :: forall nid. MsgType nid -> t
     }
 
-newtype ByNodeType t = ByNodeType {
-      byNodeType :: NodeType -> t
+newtype ByNodeType t = ByNodeType
+    { byNodeType :: NodeType -> t
     }
 
 instance FromJSON t => FromJSON (SendOrForward t) where
@@ -391,9 +392,9 @@ instance FromJSON t => FromJSON (ByNodeType t) where
             NodeRelay -> relay
             NodeEdge  -> edge
 
-{-------------------------------------------------------------------------------
-  FromJSON instances
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- FromJSON instances
+----------------------------------------------------------------------------
 
 instance FromJSON StaticPolicies where
     parseJSON = A.withObject "StaticPolicies" $ \obj -> do
@@ -420,9 +421,9 @@ instance FromJSON StaticFailurePolicy where
         aux :: ByNodeType (ByMsgType OQ.ReconsiderAfter) -> StaticFailurePolicy
         aux f = StaticFailurePolicy (byMsgType . byNodeType f)
 
-{-------------------------------------------------------------------------------
-  Orphans
--------------------------------------------------------------------------------}
+----------------------------------------------------------------------------
+-- Orphans
+----------------------------------------------------------------------------
 
 instance FromJSON OQ.Enqueue where
     parseJSON = A.withObject "Enqueue" $ \obj -> do

--- a/node/src/Pos/Client/CLI/NodeOptions.hs
+++ b/node/src/Pos/Client/CLI/NodeOptions.hs
@@ -20,8 +20,7 @@ import           NeatInterpolation            (text)
 import           Options.Applicative          (Parser, auto, execParser, footerDoc,
                                                fullDesc, header, help, helper, info,
                                                infoOption, long, metavar, option,
-                                               progDesc, showDefault, strOption, switch,
-                                               value)
+                                               progDesc, strOption, switch, value)
 import           Prelude                      (show)
 import           Serokell.Util.OptParse       (fromParsec)
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
@@ -29,8 +28,6 @@ import           Text.PrettyPrint.ANSI.Leijen (Doc)
 import           Paths_cardano_sl             (version)
 
 import           Pos.Client.CLI.Options       (CommonArgs (..), commonArgsParser,
-                                               externalNetworkAddressOption,
-                                               listenNetworkAddressOption,
                                                optionalJSONPath, sscAlgoOption)
 import           Pos.Constants                (isDevelopment)
 import           Pos.Network.CLI              (NetworkConfigOpts, networkConfigOption)
@@ -50,11 +47,6 @@ data CommonNodeArgs = CommonNodeArgs
     , devVssGenesisI      :: !(Maybe Int)
     , keyfilePath         :: !FilePath
     , backupPhrase        :: !(Maybe BackupPhrase)
-    , externalAddress     :: !(Maybe NetworkAddress)
-      -- ^ A node must be addressable on the network.
-    , bindAddress         :: !(Maybe NetworkAddress)
-      -- ^ A node may have a bind address which differs from its external
-      -- address.
     , networkConfigOpts   :: !NetworkConfigOpts
       -- ^ Network configuration
     , peers               :: ![(NodeId, NodeType)]
@@ -104,10 +96,6 @@ commonNodeArgsParser = do
         metavar "PHRASE" <>
         help    (show backupPhraseWordsNum ++
                  "-word phrase to recover the wallet. Words should be separated by spaces.")
-    externalAddress <-
-        optional $ externalNetworkAddressOption Nothing
-    bindAddress <-
-        optional $ listenNetworkAddressOption Nothing
     peers <- (++) <$> corePeersList <*> relayPeersList
     networkConfigOpts <- networkConfigOption
     jlPath <-

--- a/node/src/Pos/Client/CLI/NodeOptions.hs
+++ b/node/src/Pos/Client/CLI/NodeOptions.hs
@@ -59,8 +59,8 @@ data CommonNodeArgs = CommonNodeArgs
       -- ^ Network configuration
     , peers               :: ![(NodeId, NodeType)]
       -- ^ Known peers (addresses with classification).
+
     , jlPath              :: !(Maybe FilePath)
-    , kademliaDumpPath    :: !FilePath
     , commonArgs          :: !CommonArgs
     , updateLatestPath    :: !FilePath
     , updateWithPackage   :: !Bool
@@ -112,12 +112,6 @@ commonNodeArgsParser = do
     networkConfigOpts <- networkConfigOption
     jlPath <-
         optionalJSONPath
-    kademliaDumpPath <- strOption $
-        long    "kademlia-dump-path" <>
-        metavar "FILEPATH" <>
-        value   "kademlia.dump" <>
-        help    "Path to Kademlia dump file. If file doesn't exist, it will be created." <>
-        showDefault
     commonArgs <- commonArgsParser
     updateLatestPath <- strOption $
         long    "update-latest-path" <>

--- a/node/src/Pos/Client/CLI/NodeOptions.hs
+++ b/node/src/Pos/Client/CLI/NodeOptions.hs
@@ -55,10 +55,10 @@ data CommonNodeArgs = CommonNodeArgs
     , bindAddress         :: !(Maybe NetworkAddress)
       -- ^ A node may have a bind address which differs from its external
       -- address.
-    , peers               :: ![(NodeId, NodeType)]
-      -- ^ Known peers (addresses with classification).
     , networkConfigOpts   :: !NetworkConfigOpts
       -- ^ Network configuration
+    , peers               :: ![(NodeId, NodeType)]
+      -- ^ Known peers (addresses with classification).
     , jlPath              :: !(Maybe FilePath)
     , kademliaDumpPath    :: !FilePath
     , commonArgs          :: !CommonArgs

--- a/node/src/Pos/Client/CLI/Options.hs
+++ b/node/src/Pos/Client/CLI/Options.hs
@@ -9,12 +9,9 @@ module Pos.Client.CLI.Options
        , optionalJSONPath
        , optionalLogPrefix
        , portOption
-       , timeLordOption
        , webPortOption
        , walletPortOption
        , networkAddressOption
-       , externalNetworkAddressOption
-       , listenNetworkAddressOption
        , templateParser
        , sscAlgoOption
 
@@ -30,6 +27,7 @@ import           Serokell.Util                        (sec)
 import           Serokell.Util.OptParse               (fromParsec)
 
 import           Pos.Binary.Core                      ()
+import           Pos.Client.CLI.Util                  (sscAlgoParser)
 import           Pos.Communication                    (NodeId)
 import           Pos.Constants                        (isDevelopment, staticSysStart)
 import           Pos.Core                             (Timestamp (..))
@@ -37,7 +35,6 @@ import           Pos.Ssc.SscAlgo                      (SscAlgo (..))
 import           Pos.Util.TimeWarp                    (NetworkAddress, addrParser,
                                                        addrParserNoWildcard,
                                                        addressToNodeId)
-import           Pos.Client.CLI.Util                   (sscAlgoParser)
 
 data CommonArgs = CommonArgs
     { logConfig     :: !(Maybe FilePath)
@@ -174,13 +171,6 @@ expDistrOption =
                 "INT"
                 "Use exponential distribution with given amount of nodes."
 
-timeLordOption :: Opt.Parser Bool
-timeLordOption =
-    Opt.switch
-        (Opt.long "time-lord" <>
-         Opt.help "Peer is time lord, i.e. one responsible for system start time decision\
-                  \ and propagation (used only in development mode).")
-
 webPortOption :: Word16 -> String -> Opt.Parser Word16
 webPortOption portNum help =
     Opt.option Opt.auto $
@@ -194,32 +184,6 @@ walletPortOption portNum help =
         templateParser "wallet-port" "PORT" help -- "Port for wallet"
         <> Opt.value portNum
         <> Opt.showDefault
-
-externalNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
-externalNetworkAddressOption na =
-    Opt.option (fromParsec addrParserNoWildcard) $
-            Opt.long "address"
-         <> Opt.metavar "IP:PORT"
-         <> Opt.help helpMsg
-         <> Opt.showDefault
-         <> maybe mempty Opt.value na
-  where
-    helpMsg = "IP and port of external address. "
-        <> "Please make sure these IP and port (on which node is running) are accessible "
-        <> "otherwise proper work of CSL isn't guaranteed. "
-        <> "0.0.0.0 is not accepted as a valid host."
-
-listenNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
-listenNetworkAddressOption na =
-    Opt.option (fromParsec addrParser) $
-            Opt.long "listen"
-         <> Opt.metavar "IP:PORT"
-         <> Opt.help helpMsg
-         <> Opt.showDefault
-         <> maybe mempty Opt.value na
-  where
-    helpMsg = "IP and port on which to bind and listen. Please make sure these IP "
-        <> "and port are accessible, otherwise proper work of CSL isn't guaranteed."
 
 sysStartOption :: Opt.Parser Timestamp
 sysStartOption = Opt.option (Timestamp . sec <$> Opt.auto) $

--- a/node/src/Pos/Client/CLI/Params.hs
+++ b/node/src/Pos/Client/CLI/Params.hs
@@ -5,18 +5,14 @@ module Pos.Client.CLI.Params
        , getBaseParams
        , getKeyfilePath
        , getNodeParams
-       , getTransportParams
        , gtSscParams
        ) where
 
 import           Universum
 
-import qualified Data.ByteString.Char8      as BS8 (unpack)
 import           Data.Default               (def)
 import qualified Data.Yaml                  as Yaml
 import           Mockable                   (Catch, Fork, Mockable, Throw, throw)
-import qualified Network.Transport.TCP      as TCP (TCPAddr (..), TCPAddrInfo (..))
-import qualified Prelude
 import           System.Wlog                (LoggerName, WithLogger)
 
 import           Pos.Behavior               (BehaviorConfig (..))
@@ -30,9 +26,8 @@ import           Pos.Crypto                 (VssKeyPair)
 import           Pos.Genesis                (devBalancesDistr, devGenesisContext,
                                              genesisContextProduction)
 import           Pos.Launcher               (BaseParams (..), LoggingParams (..),
-                                             NodeParams (..), TransportParams (..))
+                                             NodeParams (..))
 import           Pos.Network.CLI            (intNetworkConfigOpts)
-import           Pos.Network.Types          (NetworkConfig (..), Topology (..))
 import           Pos.Ssc.GodTossing         (GtParams (..))
 import           Pos.Update.Params          (UpdateParams (..))
 import           Pos.Util.UserSecret        (peekUserSecret)
@@ -77,7 +72,6 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
             updateUserSecretVSS cArgs =<<
                 peekUserSecret (getKeyfilePath cArgs)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    npTransport <- getTransportParams cArgs npNetworkConfig
     npBehaviorConfig <- case behaviorConfigPath of
         Nothing -> pure def
         Just fp -> either throw pure =<< liftIO (Yaml.decodeFileEither fp)
@@ -109,47 +103,3 @@ getNodeParams cArgs@CommonNodeArgs{..} NodeArgs{..} systemStart = do
         , npStatsdParams = statsdParams
         , ..
         }
-
-data NetworkTransportMisconfiguration =
-      -- | A bind address was not given.
-      MissingBindAddress
-      -- | An external address was not given.
-    | MissingExternalAddress
-      -- | An address was given when one was not expected (behind NAT).
-    | UnnecessaryAddress
-
-instance Show NetworkTransportMisconfiguration where
-    show MissingBindAddress =
-        "No network bind address given. Use the --listen option."
-    show MissingExternalAddress =
-        "No external network address given. Use the --address option."
-    show UnnecessaryAddress =
-        "Network address given when none was expected. " <>
-        "Remove the --listen and --address options."
-
-instance Exception NetworkTransportMisconfiguration
-
-getTransportParams ::
-       (Mockable Throw m)
-    => CommonNodeArgs
-    -> NetworkConfig kademlia
-    -> m TransportParams
-getTransportParams args networkConfig = case ncTopology networkConfig of
-    -- Behind-NAT topology claims no address for the transport, and also
-    -- throws an exception if the --listen parameter is given, to avoid
-    -- confusion: if a user gives a --listen parameter then they probably
-    -- think the program will bind a socket.
-    TopologyBehindNAT{} -> do
-        _ <- whenJust (bindAddress args) (const (throw UnnecessaryAddress))
-        _ <- whenJust (externalAddress args) (const (throw UnnecessaryAddress))
-        return $ TransportParams { tpTcpAddr = TCP.Unaddressable }
-    _ -> do
-        (bindHost, bindPort) <-
-            maybe (throw MissingBindAddress) return (bindAddress args)
-        (externalHost, externalPort) <-
-            maybe (throw MissingExternalAddress) return (externalAddress args)
-        let tcpHost = BS8.unpack bindHost
-            tcpPort = show bindPort
-            tcpMkExternal = const (BS8.unpack externalHost, show externalPort)
-            addr = TCP.Addressable (TCP.TCPAddrInfo tcpHost tcpPort tcpMkExternal)
-        pure $ TransportParams { tpTcpAddr = addr }

--- a/node/src/Pos/Launcher/Param.hs
+++ b/node/src/Pos/Launcher/Param.hs
@@ -6,7 +6,6 @@
 module Pos.Launcher.Param
        ( LoggingParams (..)
        , BaseParams (..)
-       , TransportParams (..)
        , NodeParams (..)
        ) where
 
@@ -14,7 +13,6 @@ import           Universum
 
 import           Control.Lens                (makeLensesWith)
 import           Ether.Internal              (HasLens (..))
-import qualified Network.Transport.TCP       as TCP
 import           System.Wlog                 (LoggerName)
 
 import           Pos.Behavior                (BehaviorConfig (..))
@@ -45,13 +43,6 @@ data BaseParams = BaseParams
     { bpLoggingParams   :: !LoggingParams  -- ^ Logger parameters
     } deriving (Show)
 
--- | Network parameters.
-data TransportParams = TransportParams
-    { tpTcpAddr   :: !TCP.TCPAddr
-    -- ^ External TCP address of the node.
-    -- It encapsulates bind address and address visible to other nodes.
-    }
-
 -- | This data type contains all data necessary to launch node and
 -- known in advance (from CLI, configs, etc.)
 data NodeParams = NodeParams
@@ -66,7 +57,6 @@ data NodeParams = NodeParams
     , npReportServers  :: ![Text]               -- ^ List of report server URLs
     , npUpdateParams   :: !UpdateParams         -- ^ Params for update system
     , npUseNTP         :: !Bool                 -- ^ Whether to use synchronisation with NTP servers.
-    , npTransport      :: !TransportParams      -- ^ (TCP) transport parameters.
     , npEnableMetrics  :: !Bool                 -- ^ Gather runtime statistics.
     , npEkgParams      :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
     , npStatsdParams   :: !(Maybe StatsdParams) -- ^ statsd statistics backend.

--- a/node/src/Pos/Launcher/Resource.hs
+++ b/node/src/Pos/Launcher/Resource.hs
@@ -55,7 +55,7 @@ import           Pos.Delegation             (DelegationVar, mkDelegationVar)
 import           Pos.DHT.Real               (KademliaDHTInstance, KademliaParams (..),
                                              startDHTInstance, stopDHTInstance)
 import           Pos.Launcher.Param         (BaseParams (..), LoggingParams (..),
-                                             NodeParams (..), TransportParams (..))
+                                             NodeParams (..))
 import           Pos.Lrc.Context            (LrcContext (..), mkLrcSyncData)
 import           Pos.Network.Types          (NetworkConfig (..), Topology (..))
 import           Pos.Shutdown.Types         (ShutdownContext (..))
@@ -200,14 +200,14 @@ bracketNodeResources :: forall ssc m a.
     -> SscParams ssc
     -> (HasCoreConstants => NodeResources ssc m -> Production a)
     -> Production a
-bracketNodeResources np sp k = bracketTransport tcpAddr $ \transport ->
-    bracketKademlia (npBaseParams np) (npNetworkConfig np) $ \networkConfig ->
-        bracket (allocateNodeResources transport networkConfig np sp) releaseNodeResources $ \nodeRes ->do
-            -- Notify systemd we are fully operative
-            notifyReady
-            k nodeRes
-  where
-    tcpAddr = tpTcpAddr (npTransport np)
+bracketNodeResources np sp k =
+    bracketTransport (ncTcpAddr (npNetworkConfig np)) $ \transport ->
+        bracketKademlia (npBaseParams np) (npNetworkConfig np) $ \networkConfig ->
+            bracket (allocateNodeResources transport networkConfig np sp)
+                    releaseNodeResources $ \nodeRes ->do
+                -- Notify systemd we are fully operative
+                notifyReady
+                k nodeRes
 
 ----------------------------------------------------------------------------
 -- Logging

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -201,7 +201,7 @@ function node_cmd {
   fi
 
   local topology_file="$config_dir/topology$i.yaml"
-  local kademlia_file="$config_dir/kademlia$i.yaml"
+  #local kademlia_file="$config_dir/kademlia$i.yaml"
 
   echo -n "$(find_binary $exec_name) --db-path $run_dir/node-db$i $rts_opts $reb $no_ntp $keys_args"
 
@@ -211,7 +211,7 @@ function node_cmd {
   # A sloppy test but it'll do for now.
   local topology_first_six_bytes=`cat $topology_file | head -c 6`
   if [[ "$topology_first_six_bytes" != "wallet" ]]; then
-    echo -n " --address 127.0.0.1:"`get_port $i`
+    #echo -n " --address 127.0.0.1:"`get_port $i`
     echo -n " --listen 127.0.0.1:"`get_port $i`
   fi
   echo -n " $(logs node$i.log) $time_lord $stats"
@@ -225,7 +225,7 @@ function node_cmd {
   #echo -n " --statsd-server $statsd_server"
   echo -n " --node-id node$i"
   echo -n " --topology $topology_file"
-  echo -n " --kademlia $kademlia_file"
+  #echo -n " --kademlia $kademlia_file"
   # Use the policies option if you want to change enqueue/dequeue/failure
   # policies without re-compiling. See example files
   #   scripts/policies/policy_core.yaml

--- a/scripts/launch/explorer.sh
+++ b/scripts/launch/explorer.sh
@@ -27,8 +27,8 @@ cmd="stack exec cardano-explorer --
       --system-start $system_start \
       --log-config explorer/log-config.yaml \
       --topology ./run/topology0.yaml \
-      --kademlia ./run/kademlia_explorer.yaml \
       --no-ntp"
+#      --kademlia ./run/kademlia_explorer.yaml \ # topology is not kademlia-suitable
 echo "$cmd"
 $cmd
 #tmux select-pane -t 3

--- a/wallet/node/Params.hs
+++ b/wallet/node/Params.hs
@@ -39,7 +39,6 @@ getNodeParams args@CommonNodeArgs{..} systemStart = do
             CLI.updateUserSecretVSS args =<<
                 peekUserSecret (CLI.getKeyfilePath args)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    npTransport <- CLI.getTransportParams args npNetworkConfig
     let devBalanceDistr =
             devBalancesDistr
                 (CLI.flatDistr commonArgs)


### PR DESCRIPTION
* Moved `tcpAddr` to `NetworkConfig`.
* Removed `TransportConfig` as it was holding `tcpAddr` only.
* Changed binding CLI logic:
   * Bind address is unchanged
   * External address is taken from cli or taken as bind address if absent (no need to specify same address twice explicitly)
   * If kademlia external address is not equal to CLI external address, exception is thrown
* Removed a bunch of useless parameters in explorer.
* Formatted `Pos.Network` according to the style guide.
