### PR TITLE
[CSL-1637] Initialize StateLock in creation

### DIFF
--- a/infra/Pos/StateLock.hs
+++ b/infra/Pos/StateLock.hs
@@ -12,6 +12,7 @@ how long the action takes.
 module Pos.StateLock
        ( Priority (..)
        , StateLock (..)
+       , newEmptyStateLock
        , newStateLock
 
        , StateLockMetrics (..)
@@ -45,8 +46,13 @@ data StateLock = StateLock
     , slLock :: !PriorityLock
     }
 
-newStateLock :: MonadIO m => m StateLock
-newStateLock = StateLock <$> newEmptyMVar <*> newPriorityLock
+-- | Create empty (i. e. locked) 'StateLock'.
+newEmptyStateLock :: MonadIO m => m StateLock
+newEmptyStateLock = StateLock <$> newEmptyMVar <*> newPriorityLock
+
+-- | Create a 'StateLock' with given tip.
+newStateLock :: MonadIO m => HeaderHash -> m StateLock
+newStateLock tip = StateLock <$> newMVar tip <*> newPriorityLock
 
 -- | Effectful getters and setters for metrics related to the actions
 -- which use 'StateLock'.

--- a/node/src/Pos/Launcher/Resource.hs
+++ b/node/src/Pos/Launcher/Resource.hs
@@ -20,7 +20,7 @@ module Pos.Launcher.Resource
        , bracketTransport
        ) where
 
-import           Universum                  hiding (bracket, finally)
+import           Universum                  hiding (bracket)
 
 import           Control.Concurrent.STM     (newEmptyTMVarIO, newTBQueueIO)
 import           Data.Tagged                (untag)
@@ -54,6 +54,7 @@ import           Pos.DB.Rocks               (closeNodeDBs, openNodeDBs)
 import           Pos.Delegation             (DelegationVar, mkDelegationVar)
 import           Pos.DHT.Real               (KademliaDHTInstance, KademliaParams (..),
                                              startDHTInstance, stopDHTInstance)
+import qualified Pos.GState                 as GS
 import           Pos.Launcher.Param         (BaseParams (..), LoggingParams (..),
                                              NodeParams (..))
 import           Pos.Lrc.Context            (LrcContext (..), mkLrcSyncData)
@@ -255,7 +256,7 @@ allocateNodeContext ancd = do
                                 , ancdTxpMemState = TxpLocalData {..}
                                 } = ancd
     ncLoggerConfig <- getRealLoggerConfig $ bpLoggingParams npBaseParams
-    ncStateLock <- newStateLock
+    ncStateLock <- newStateLock =<< GS.getTip
     ncStateLockMetrics <- liftIO $ recordTxpMetrics store txpMemPool
     lcLrcSync <- mkLrcSyncData >>= newTVarIO
     ncSlottingVar <- (npSystemStart,) <$> mkSlottingVar

--- a/node/src/Pos/Launcher/Scenario.hs
+++ b/node/src/Pos/Launcher/Scenario.hs
@@ -5,22 +5,19 @@
 
 module Pos.Launcher.Scenario
        ( runNode
-       , initSemaphore
        , runNode'
        , nodeStartMsg
        ) where
 
 import           Universum
 
-import           Control.Lens          (views)
 import           Data.Time.Units       (Second)
 import           Ether.Internal        (HasLens (..))
 import           Formatting            (build, int, sformat, shown, (%))
 import           Mockable              (mapConcurrently, race)
 import           Serokell.Util.Text    (listJson)
 import           System.Exit           (ExitCode (..))
-import           System.Wlog           (WithLogger, getLoggerName, logError, logInfo,
-                                        logWarning)
+import           System.Wlog           (WithLogger, getLoggerName, logInfo, logWarning)
 
 import           Pos.Communication     (ActionSpec (..), OutSpecs, WorkerSpec,
                                         wrapActionSpec)
@@ -40,7 +37,6 @@ import           Pos.Reporting         (reportError)
 import           Pos.Shutdown          (waitForShutdown)
 import           Pos.Slotting          (waitSystemStart)
 import           Pos.Ssc.Class         (SscConstraint)
-import           Pos.StateLock         (StateLock (..))
 import           Pos.Util              (inAssertMode)
 import           Pos.Util.Config       (configName)
 import           Pos.Util.LogSafe      (logInfoS)
@@ -107,7 +103,6 @@ runNode' NodeResources {..} workers' plugins' = ActionSpec $ \vI sendActions -> 
     tipHeader <- DB.getTipHeader @ssc
     logInfo $ sformat ("Current tip header: "%build) tipHeader
 
-    initSemaphore
     waitSystemStart
     let unpackPlugin (ActionSpec action) =
             action vI sendActions `catch` reportHandler
@@ -183,11 +178,3 @@ nodeStartMsg = logInfo msg
 --             flip (createPsk secretKey) eternity . encToPublic
 --         ownPSKs = uSecret ^.. usKeys . _tail . each . to makeOwnPSK
 --     for_ ownPSKs addProxySecretKey
-
-initSemaphore :: (WorkMode ssc ctx m) => m ()
-initSemaphore = do
-    semaphore <- views (lensOf @StateLock) slTip
-    whenJustM (tryReadMVar semaphore) $ const $
-        logError "ncStateLock is not empty at the very beginning"
-    tip <- GS.getTip
-    putMVar semaphore tip


### PR DESCRIPTION
`StateLock` is now filled in `newStateLock`, not in `initSemaphore`, so it' properly initialized in auxx.