### PR TITLE
[CSL-1152] verifyHeaders check more predicates

### DIFF
--- a/node/src/Pos/Block/Logic/Header.hs
+++ b/node/src/Pos/Block/Logic/Header.hs
@@ -199,6 +199,11 @@ classifyHeaders inRecovery headers = do
                  ("Newest header is from slot "%build%", but current slot"%
                   " is "%build%" (and we're not in recovery mode)")
                  (newestHeader ^. epochOrSlotG) currentSlot
+         -- This check doesn't normally fail. RetrievalWorker
+         -- calculates lrc every time before calling this function so
+         -- it only fails when oldest header is from the next epoch e'
+         -- and somehow lrc didn't calculate data for e' knowing the
+         -- last header from e.
        | isNothing leaders ->
              pure $ CHsUseless $
              "Don't know leaders for oldest header epoch " <> pretty headersValid

--- a/node/src/Pos/Block/Logic/VAR.hs
+++ b/node/src/Pos/Block/Logic/VAR.hs
@@ -81,7 +81,7 @@ verifyBlocksPrefix blocks = runExceptT $ do
     TxpGlobalSettings {..} <- view (lensOf @TxpGlobalSettings)
     txUndo <- withExceptT (VerifyBlocksError . pretty) $
         tgsVerifyBlocks dataMustBeKnown $ map toTxpBlock blocks
-    pskUndo <- withExceptT VerifyBlocksError . ExceptT $ dlgVerifyBlocks blocks
+    pskUndo <- withExceptT VerifyBlocksError $ dlgVerifyBlocks blocks
     (pModifier, usUndos) <- withExceptT (VerifyBlocksError . pretty) $
         ExceptT $ usVerifyBlocks dataMustBeKnown (map toUpdateBlock blocks)
 

--- a/node/src/Pos/Block/Network/Logic.hs
+++ b/node/src/Pos/Block/Network/Logic.hs
@@ -320,7 +320,6 @@ handleRequestedHeaders cont inRecovery headers = do
     -- be automatically calculated as all workers are locked in
     -- recovery mode. So we should try to do it manually.
     logDebug "handleREquesteHeaders: LRC started"
-    -- TODO EXCEPTION HANDLING HERE
     void $ tryAny $ withStateLockNoMetrics LowPriority $ const $ lrcSingleShot oldestEpoch
     logDebug "handleRequesteHeaders: LRC ended"
     classificationRes <- classifyHeaders inRecovery headers

--- a/node/src/Pos/Block/Network/Logic.hs
+++ b/node/src/Pos/Block/Network/Logic.hs
@@ -25,7 +25,6 @@ import           Universum
 import           Control.Concurrent.STM     (isFullTBQueue, readTVar, writeTBQueue,
                                              writeTVar)
 import           Control.Exception          (Exception (..))
-import           Control.Exception.Safe     (tryAny)
 import           Control.Lens               (to)
 import qualified Data.List.NonEmpty         as NE
 import qualified Data.Text.Buildable        as B
@@ -58,14 +57,17 @@ import           Pos.Communication.Protocol (Conversation (..), ConversationActi
 import qualified Pos.Constants              as Constants
 import           Pos.Context                (BlockRetrievalQueueTag, LastKnownHeaderTag,
                                              recoveryInProgress)
-import           Pos.Core                   (HasCoreConstants, HasHeaderHash (..),
-                                             HeaderHash, epochIndexL, gbHeader,
-                                             headerHashG, isMoreDifficult, prevBlockL)
+import           Pos.Core                   (EpochOrSlot (..), HasCoreConstants,
+                                             HasHeaderHash (..), HeaderHash, SlotId (..),
+                                             crucialSlot, epochIndexL, epochOrSlotG,
+                                             gbHeader, headerHashG, isMoreDifficult,
+                                             prevBlockL)
 import           Pos.Crypto                 (shortHashF)
 import           Pos.DB.Block               (blkGetHeader)
 import qualified Pos.DB.DB                  as DB
 import           Pos.Exception              (cardanoExceptionFromException,
                                              cardanoExceptionToException)
+import           Pos.Lrc.Error              (LrcError (UnknownBlocksForLrc))
 import           Pos.Lrc.Worker             (lrcSingleShot)
 import           Pos.Reporting.Methods      (reportMisbehaviour)
 import           Pos.Ssc.Class              (SscHelpersClass, SscWorkersClass)
@@ -310,18 +312,12 @@ handleRequestedHeaders
     -> NewestFirst NE (BlockHeader ssc)
     -> m (Maybe t)
 handleRequestedHeaders cont inRecovery headers = do
-    let newestHeader = headers ^. _NewestFirst . _neHead
-        oldestHeader = headers ^. _NewestFirst . _neLast
-        newestHash = headerHash newestHeader
-        oldestHash = headerHash oldestHeader
-        oldestEpoch = oldestHeader ^. epochIndexL
     -- Try to calculate LRC for the oldest header epoch. If we're in
     -- recovery and oldest header is from the next epoch, no lrc will
     -- be automatically calculated as all workers are locked in
     -- recovery mode. So we should try to do it manually.
-    logDebug "handleREquesteHeaders: LRC started"
-    void $ tryAny $ withStateLockNoMetrics LowPriority $ const $ lrcSingleShot oldestEpoch
-    logDebug "handleRequesteHeaders: LRC ended"
+    tryCalculateLrc
+
     classificationRes <- classifyHeaders inRecovery headers
     case classificationRes of
         CHsValid lcaChild -> do
@@ -348,6 +344,41 @@ handleRequestedHeaders cont inRecovery headers = do
             logDebug msg
             throwM $ DialogUnexpected msg
   where
+    newestHeader = headers ^. _NewestFirst . _neHead
+    oldestHeader = headers ^. _NewestFirst . _neLast
+    newestHash = headerHash newestHeader
+    oldestHash = headerHash oldestHeader
+    oldestEpoch = oldestHeader ^. epochIndexL
+
+    tryCalculateLrc = do
+        tip <- DB.getTipHeader @ssc
+        let tipEpochOrSlot = tip ^. epochOrSlotG
+        let tipEpoch = tip ^. epochIndexL
+        let differentEpochs = oldestEpoch == tipEpoch + 1
+        -- CSL-1660 We should also check that there's k blocks after
+        -- crucial slot.
+        let tipAfterCrucial = case unEpochOrSlot tipEpochOrSlot of
+                -- we assume differentEpochs is true, so this is
+                -- before zero's slot of epoch e, while new header has
+                -- epoch e+1.
+                Left _   -> False
+                Right si -> siSlot si > siSlot (crucialSlot $ siEpoch si)
+        let shouldExecute = differentEpochs && tipAfterCrucial
+
+        if shouldExecute then do
+            logDebug "handleRequesteHeaders: LRC started"
+            let handler UnknownBlocksForLrc =
+                    logWarning $
+                    "handleRequestedHeaders: tried lrcSingleShot, " <>
+                    "got UnknownBlocksForLrc"
+                handler e                   = throwM e
+            withStateLockNoMetrics HighPriority $ const $
+                lrcSingleShot oldestEpoch `catch` handler
+            logDebug "handleRequesteHeaders: LRC ended"
+        else logDebug $ sformat ("handleRequestHeaders: not calculating LRC: "%
+                                 "oldest header epoch "%build%", tip epoch "%build)
+                                oldestEpoch tipEpoch
+
     validFormat =
         "Received valid headers, can request blocks from " %shortHashF % " to " %shortHashF
     genericFormat what =
@@ -367,7 +398,7 @@ addHeaderToBlockRequestQueue
        (WorkMode ssc ctx m)
     => NodeId
     -> BlockHeader ssc
-    -> Bool -- Continues?
+    -> Bool -- brtContinues flag
     -> m ()
 addHeaderToBlockRequestQueue nodeId header continues = do
     logDebug $ sformat ("addToBlockRequestQueue, : "%build) header

--- a/node/src/Pos/Block/Pure.hs
+++ b/node/src/Pos/Block/Pure.hs
@@ -3,8 +3,7 @@
 -- | Pure functions related to blocks and headers.
 
 module Pos.Block.Pure
-       ( headerDifficultyIncrement
-
+       (
        -- * Header
        , VerifyHeaderParams (..)
        , verifyHeader
@@ -47,7 +46,7 @@ import           Pos.Util.Chrono            (NewestFirst (..), OldestFirst)
 -- Header
 ----------------------------------------------------------------------------
 
--- | Difficulty of the BlockHeader. 0 for genesis block, 1 for main block.
+-- Difficulty of the BlockHeader. 0 for genesis block, 1 for main block.
 headerDifficultyIncrement :: BlockHeader ssc -> ChainDifficulty
 headerDifficultyIncrement (Left _)  = 0
 headerDifficultyIncrement (Right _) = 1

--- a/node/src/Pos/Block/Pure.hs
+++ b/node/src/Pos/Block/Pure.hs
@@ -4,12 +4,12 @@
 
 module Pos.Block.Pure
        (
-       -- * Header
-       , VerifyHeaderParams (..)
+         -- * Header
+         VerifyHeaderParams (..)
        , verifyHeader
        , verifyHeaders
 
-       -- * Block
+         -- * Block
        , VerifyBlockParams (..)
        , verifyBlocks
        ) where

--- a/node/src/Pos/Block/Slog/Logic.hs
+++ b/node/src/Pos/Block/Slog/Logic.hs
@@ -53,8 +53,7 @@ import           Pos.Lrc.Context        (LrcContext)
 import qualified Pos.Lrc.DB             as LrcDB
 import           Pos.Slotting           (MonadSlots (getCurrentSlot))
 import           Pos.Ssc.Class.Helpers  (SscHelpersClass (..))
-import           Pos.Util               (HasLens (..), HasLens', inAssertMode, _neHead,
-                                         _neLast)
+import           Pos.Util               (HasLens', inAssertMode, _neHead, _neLast)
 import           Pos.Util.Chrono        (NE, NewestFirst (getNewestFirst),
                                          OldestFirst (..), toOldestFirst)
 
@@ -114,7 +113,7 @@ type MonadSlogBase ssc ctx m =
 type MonadSlogVerify ssc ctx m =
     ( MonadSlogBase ssc ctx m
     , MonadReader ctx m
-    , HasLens LrcContext ctx LrcContext
+    , HasLens' ctx LrcContext
     )
 
 -- | Verify everything from block that is not checked by other components.

--- a/node/src/Pos/Delegation/Cede/Class.hs
+++ b/node/src/Pos/Delegation/Cede/Class.hs
@@ -30,6 +30,9 @@ class MonadThrow m => MonadCedeRead m where
     -- certificate this epoch.
     hasPostedThisEpoch :: StakeholderId -> m Bool
 
+    -- | Get all stakeholders that have posted cert this epoch.
+    getAllPostedThisEpoch :: m (HashSet StakeholderId)
+
     default getPsk :: (MonadTrans t, MonadCedeRead n, t n ~ m) =>
         StakeholderId -> m (Maybe ProxySKHeavy)
     getPsk = lift . getPsk
@@ -37,6 +40,11 @@ class MonadThrow m => MonadCedeRead m where
     default hasPostedThisEpoch :: (MonadTrans t, MonadCedeRead n, t n ~ m) =>
         StakeholderId -> m Bool
     hasPostedThisEpoch = lift . hasPostedThisEpoch
+
+    default getAllPostedThisEpoch :: (MonadTrans t, MonadCedeRead n, t n ~ m) =>
+        m (HashSet StakeholderId)
+    getAllPostedThisEpoch = lift getAllPostedThisEpoch
+
 
 -- | Resolve by public key. Equialent to @getPsk . addressHash@.
 getPskPk :: (MonadCedeRead m) => PublicKey -> m (Maybe ProxySKHeavy)

--- a/node/src/Pos/Delegation/Cede/Class.hs
+++ b/node/src/Pos/Delegation/Cede/Class.hs
@@ -19,15 +19,24 @@ import           Pos.Delegation.Cede.Types (DlgEdgeAction (..))
 import           Pos.Types                 (ProxySKHeavy, StakeholderId, addressHash)
 
 
--- | This monad includes psk reading capabilities.
+-- | This monad abstracts data needed for verifying headers/blocks
+-- from the standpoint of delegatino component.
 class MonadThrow m => MonadCedeRead m where
     -- | Resolve public key of issuer (hashed) to the psk. This method
     -- never returns a revoke psk.
     getPsk :: StakeholderId -> m (Maybe ProxySKHeavy)
 
+    -- | Returns 'True' if given stakeholder has already posted
+    -- certificate this epoch.
+    hasPostedThisEpoch :: StakeholderId -> m Bool
+
     default getPsk :: (MonadTrans t, MonadCedeRead n, t n ~ m) =>
         StakeholderId -> m (Maybe ProxySKHeavy)
     getPsk = lift . getPsk
+
+    default hasPostedThisEpoch :: (MonadTrans t, MonadCedeRead n, t n ~ m) =>
+        StakeholderId -> m Bool
+    hasPostedThisEpoch = lift . hasPostedThisEpoch
 
 -- | Resolve by public key. Equialent to @getPsk . addressHash@.
 getPskPk :: (MonadCedeRead m) => PublicKey -> m (Maybe ProxySKHeavy)
@@ -38,15 +47,26 @@ instance MonadCedeRead m => MonadCedeRead (StateT s m)
 instance MonadCedeRead m => MonadCedeRead (ExceptT s m)
 
 
--- | Monad that can modify PSK contents inside.
+-- | 'MonadCedeRead' extension with write capabilities.
 class MonadCedeRead m => MonadCede m where
     -- | Modify the content of PSK holder using the edge delegation
     -- action (change/removal).
     modPsk :: DlgEdgeAction -> m ()
 
-    default modPsk :: (MonadTrans t, MonadCede n, t n ~ m) =>
-        DlgEdgeAction -> m ()
+    -- | Adds stakeholder to "this epoch posted set".
+    addThisEpochPosted :: StakeholderId -> m ()
+
+    -- | Removes stakeholder from "this epoch posted" set.
+    delThisEpochPosted :: StakeholderId -> m ()
+
+    default modPsk :: (MonadTrans t, MonadCede n, t n ~ m) => DlgEdgeAction -> m ()
     modPsk = lift . modPsk
+
+    default addThisEpochPosted :: (MonadTrans t, MonadCede n, t n ~ m) => StakeholderId -> m ()
+    addThisEpochPosted = lift . addThisEpochPosted
+
+    default delThisEpochPosted :: (MonadTrans t, MonadCede n, t n ~ m) => StakeholderId -> m ()
+    delThisEpochPosted = lift . delThisEpochPosted
 
 instance MonadCede m => MonadCede (ReaderT s m)
 instance MonadCede m => MonadCede (StateT s m)

--- a/node/src/Pos/Delegation/Cede/Holders.hs
+++ b/node/src/Pos/Delegation/Cede/Holders.hs
@@ -21,9 +21,9 @@ import qualified Ether
 import           Pos.DB.Class                 (MonadDBRead)
 import           Pos.Delegation.Cede.Class    (MonadCede (..), MonadCedeRead (..))
 import           Pos.Delegation.Cede.Types    (CedeModifier, DlgEdgeAction (..),
+                                               cmHasPostedThisEpoch, cmPskMods,
                                                dlgEdgeActionIssuer)
 import qualified Pos.Delegation.DB            as DB
-import           Pos.Types                    (ProxySKHeavy, StakeholderId)
 import           Pos.Util.Util                (ether)
 
 ----------------------------------------------------------------------------
@@ -37,11 +37,12 @@ type DBCede = Ether.TaggedTrans DBCedeTag IdentityT
 runDBCede :: DBCede m a -> m a
 runDBCede = coerce
 
-getPskDB :: MonadDBRead m => StakeholderId -> m (Maybe ProxySKHeavy)
-getPskDB = DB.getPskByIssuer . Right
-
 instance MonadDBRead m => MonadCedeRead (DBCede m) where
-    getPsk = getPskDB
+    getPsk = DB.getPskByIssuer . Right
+    hasPostedThisEpoch = DB.isIssuerPostedThisEpoch
+
+-- We don't provide 'MonadCede' instance as writing into database is
+-- performed in batches on block application only.
 
 ----------------------------------------------------------------------------
 -- DB + CedeModifier resolving
@@ -59,12 +60,18 @@ evalMapCede = flip Ether.evalLazyStateT
 
 instance MonadDBRead m => MonadCedeRead (MapCede m) where
     getPsk iPk =
-        ether $ use (at iPk) >>= \case
+        ether $ use (cmPskMods . at iPk) >>= \case
             Nothing                -> lift $ DB.getPskByIssuer $ Right iPk
             Just (DlgEdgeDel _)    -> pure Nothing
             Just (DlgEdgeAdd psk ) -> pure (Just psk)
+    hasPostedThisEpoch sId =
+        ether $ use (cmHasPostedThisEpoch . at sId) >>= \case
+            Nothing                -> lift $ DB.isIssuerPostedThisEpoch sId
+            Just v                 -> pure v
 
 instance MonadDBRead m => MonadCede (MapCede m) where
     modPsk eAction = do
         let issuer = dlgEdgeActionIssuer eAction
-        ether $ identity %= HM.insert issuer eAction
+        ether $ cmPskMods %= HM.insert issuer eAction
+    addThisEpochPosted sId = ether $ cmHasPostedThisEpoch %= HM.insert sId True
+    delThisEpochPosted sId = ether $ cmHasPostedThisEpoch %= HM.insert sId False

--- a/node/src/Pos/Delegation/Cede/Logic.hs
+++ b/node/src/Pos/Delegation/Cede/Logic.hs
@@ -8,18 +8,26 @@ module Pos.Delegation.Cede.Logic
        , getPskChainInternal
        , detectCycleOnAddition
        , dlgReachesIssuance
+       , dlgVerifyHeader
+       , CheckForCycle(..)
+       , dlgVerifyPskHeavy
        ) where
 
 import           Universum
 
 import           Control.Lens              (uses, (%=))
+import           Control.Monad.Except      (throwError)
 import qualified Data.HashMap.Strict       as HM
 import qualified Data.HashSet              as HS
+import           Formatting                (build, sformat, (%))
 
-import           Pos.Core                  (ProxySKHeavy, StakeholderId, addressHash)
-import           Pos.Crypto                (ProxySecretKey (..), PublicKey)
+import           Pos.Block.Core            (BlockSignature (..), MainBlockHeader,
+                                            mainHeaderLeaderKey, mcdSignature)
+import           Pos.Core                  (EpochIndex, ProxySKHeavy, StakeholderId,
+                                            addressHash, gbhConsensus)
+import           Pos.Crypto                (ProxySecretKey (..), PublicKey, psigPsk)
 import           Pos.DB                    (DBError (DBMalformed))
-import           Pos.Delegation.Cede.Class (MonadCedeRead (..))
+import           Pos.Delegation.Cede.Class (MonadCedeRead (..), getPskPk)
 import           Pos.Delegation.Helpers    (isRevokePsk)
 import           Pos.Delegation.Types      (DlgMemPool)
 
@@ -103,3 +111,115 @@ dlgReachesIssuance i d psk = reach i
         Just psk'@ProxySecretKey{..}
             | pskDelegatePk == d -> pure $ psk' == psk
             | otherwise          -> reach pskDelegatePk
+
+
+-- | Verifies a header from delegation perspective (signature checks).
+dlgVerifyHeader ::
+       (MonadCedeRead m)
+    => MainBlockHeader ssc
+    -> ExceptT Text m ()
+dlgVerifyHeader h = do
+    -- Issuer didn't delegate the right to issue to elseone.
+    let issuer = h ^. mainHeaderLeaderKey
+    let sig = h ^. gbhConsensus ^. mcdSignature
+    issuerPsk <- getPskPk issuer
+    whenJust issuerPsk $ \psk -> case sig of
+        (BlockSignature _) ->
+            throwError $
+            sformat ("issuer "%build%" has delegated issuance right, "%
+                     "so he can't issue the block, psk: "%build%", sig: "%build)
+                issuer psk sig
+        _ -> pass
+
+    -- Check that if proxy sig is used, delegate indeed has right to
+    -- issue the block. Signatures themselves are checked in the
+    -- constructor, here we only verify they are related to slot
+    -- leader. Self-signed proxySigs are forbidden on block
+    -- construction level.
+    case h ^. gbhConsensus ^. mcdSignature of
+        (BlockPSignatureHeavy pSig) -> do
+            let psk = psigPsk pSig
+            let delegate = pskDelegatePk psk
+            canIssue <- dlgReachesIssuance issuer delegate psk
+            unless canIssue $ throwError $
+                sformat ("heavy proxy signature's "%build%" "%
+                         "related proxy cert can't be found/doesn't "%
+                         "match the one in current allowed heavy psks set")
+                        pSig
+        (BlockPSignatureLight pSig) -> do
+            let pskIPk = pskIssuerPk (psigPsk pSig)
+            unless (pskIPk == issuer) $ throwError $
+                sformat ("light proxy signature's "%build%" issuer "%
+                         build%" doesn't match block slot leader "%build)
+                        pSig pskIPk issuer
+        _ -> pass
+
+-- | Wrapper that turns on/off check of cycle creation in psk
+-- verification.
+newtype CheckForCycle = CheckForCycle Bool
+
+-- | Verify consistent heavy PSK.
+dlgVerifyPskHeavy ::
+       (MonadCedeRead m)
+    => HashSet StakeholderId
+    -> CheckForCycle
+    -> EpochIndex
+    -> ProxySKHeavy
+    -> ExceptT Text m ()
+dlgVerifyPskHeavy richmen (CheckForCycle checkCycle) tipEpoch psk = do
+    let iPk = pskIssuerPk psk
+    let dPk = pskDelegatePk psk
+    let stakeholderId = addressHash iPk
+
+    -- Issuers have enough money (though it's free to revoke).
+    when (not (isRevokePsk psk) &&
+          not (stakeholderId `HS.member` richmen)) $
+        throwError $ sformat
+            ("PSK can't be accepted: issuer doesn't have enough stake: "%build)
+            psk
+
+    -- There are no psks that are isomorphic to ones from
+    -- db. That is, if i delegated to d using psk1, we forbid
+    -- using psk2 (in the next epoch) if psk2 delegates i → d
+    -- as well.
+    prevPsk <- getPsk stakeholderId
+    let duplicate = do
+            psk2@ProxySecretKey{..} <- prevPsk
+            guard $ pskIssuerPk == iPk && pskDelegatePk == dPk
+            pure psk2
+    whenJust duplicate $ \psk2 ->
+        throwError $ sformat
+            ("User effectively duplicates his previous PSK: "%
+             build%" with new one "%build)
+            psk2 psk
+
+    -- No issuer has posted psk this epoch before (unless
+    -- processed psk is a revocation).
+    alreadyPostedThisEpoch <- hasPostedThisEpoch stakeholderId
+    when (not (isRevokePsk psk) && alreadyPostedThisEpoch) $
+        throwError $ sformat
+            ("PSK "%build%" is not a revocation and his issuer "%
+             " has already published psk this epoch")
+            psk
+
+    -- Every revoking psk indeed revokes previous non-revoking
+    -- psk.
+    when (isRevokePsk psk && isNothing prevPsk) $
+        throwError $ sformat
+            ("Revoke PSK "%build%" doesn't revoke anything")
+            psk
+
+    -- Internal PSK epoch should match current tip epoch.
+    unless (tipEpoch == pskOmega psk) $
+        throwError $ sformat
+            ("PSK "%build%" has epoch which is different from tip epoch "%build)
+            psk tipEpoch
+
+    -- No cycle is created. This check is optional because when
+    -- applying blocks we want to check for cycles after bulk
+    -- application.
+    when checkCycle $
+        whenJustM (detectCycleOnAddition psk) $ \cyclePoint ->
+            throwError $ sformat
+                ("Adding PSK "%build%" leads to cycle at point "%build)
+                psk cyclePoint

--- a/node/src/Pos/Delegation/Cede/Logic.hs
+++ b/node/src/Pos/Delegation/Cede/Logic.hs
@@ -30,6 +30,7 @@ import           Pos.DB                    (DBError (DBMalformed))
 import           Pos.Delegation.Cede.Class (MonadCedeRead (..), getPskPk)
 import           Pos.Delegation.Helpers    (isRevokePsk)
 import           Pos.Delegation.Types      (DlgMemPool)
+import           Pos.Lrc.Types             (RichmenSet)
 
 -- | Given an issuer, retrieves all certificate chains starting in
 -- issuer. This function performs a series of sequential db reads so
@@ -121,7 +122,7 @@ dlgVerifyHeader ::
 dlgVerifyHeader h = do
     -- Issuer didn't delegate the right to issue to elseone.
     let issuer = h ^. mainHeaderLeaderKey
-    let sig = h ^. gbhConsensus ^. mcdSignature
+    let sig = h ^. gbhConsensus . mcdSignature
     issuerPsk <- getPskPk issuer
     whenJust issuerPsk $ \psk -> case sig of
         (BlockSignature _) ->
@@ -161,7 +162,7 @@ newtype CheckForCycle = CheckForCycle Bool
 -- | Verify consistent heavy PSK.
 dlgVerifyPskHeavy ::
        (MonadCedeRead m)
-    => HashSet StakeholderId
+    => RichmenSet
     -> CheckForCycle
     -> EpochIndex
     -> ProxySKHeavy

--- a/node/src/Pos/Delegation/Logic/Mempool.hs
+++ b/node/src/Pos/Delegation/Logic/Mempool.hs
@@ -52,7 +52,8 @@ import qualified Pos.DB                           as DB
 import           Pos.DB.Block                     (MonadBlockDB)
 import qualified Pos.DB.DB                        as DB
 import qualified Pos.DB.Misc                      as Misc
-import           Pos.Delegation.Cede              (detectCycleOnAddition, evalMapCede,
+import           Pos.Delegation.Cede              (CedeModifier (..),
+                                                   detectCycleOnAddition, evalMapCede,
                                                    pskToDlgEdgeAction)
 import           Pos.Delegation.Class             (DlgMemPool, MonadDelegation,
                                                    dwConfirmationCache, dwMessageCache,
@@ -206,10 +207,11 @@ processProxySKHeavyInternal psk = do
     producesCycle <-
         -- This is inefficient. Consider supporting this map
         -- in-memory or changing mempool key to stakeholderId.
-        let cedeModifier =
-                HM.fromList $
+        let _cmPskMods = HM.fromList $
                 map (bimap addressHash pskToDlgEdgeAction) $
                 HM.toList cyclePool
+            _cmHasPostedThisEpoch = mempty -- not used
+            cedeModifier = CedeModifier {..}
         in evalMapCede cedeModifier $ detectCycleOnAddition psk
 
     -- Here the memory state is the same.

--- a/node/src/Pos/Delegation/Logic/Mempool.hs
+++ b/node/src/Pos/Delegation/Logic/Mempool.hs
@@ -32,7 +32,6 @@ import           Universum
 import           Control.Lens                     (at, uses, (%=), (+=), (-=), (.=))
 import qualified Data.Cache.LRU                   as LRU
 import qualified Data.HashMap.Strict              as HM
-import qualified Data.HashSet                     as HS
 import           Mockable                         (CurrentTime, Mockable, currentTime)
 
 import           Pos.Binary.Class                 (biSize)
@@ -52,8 +51,8 @@ import qualified Pos.DB                           as DB
 import           Pos.DB.Block                     (MonadBlockDB)
 import qualified Pos.DB.DB                        as DB
 import qualified Pos.DB.Misc                      as Misc
-import           Pos.Delegation.Cede              (CedeModifier (..),
-                                                   detectCycleOnAddition, evalMapCede,
+import           Pos.Delegation.Cede              (CedeModifier (..), CheckForCycle (..),
+                                                   dlgVerifyPskHeavy, evalMapCede,
                                                    pskToDlgEdgeAction)
 import           Pos.Delegation.Class             (DlgMemPool, MonadDelegation,
                                                    dwConfirmationCache, dwMessageCache,
@@ -62,7 +61,6 @@ import           Pos.Delegation.Helpers           (isRevokePsk)
 import           Pos.Delegation.Logic.Common      (DelegationStateAction,
                                                    runDelegationStateAction)
 import           Pos.Delegation.Types             (DlgPayload, mkDlgPayload)
-import qualified Pos.GState                       as GS
 import           Pos.Lrc.Context                  (LrcContext)
 import qualified Pos.Lrc.DB                       as LrcDB
 import           Pos.StateLock                    (StateLock, withStateLockNoMetrics)
@@ -189,63 +187,48 @@ processProxySKHeavyInternal psk = do
     let msg = Right psk
         consistent = verifyPsk psk
         iPk = pskIssuerPk psk
-        dPk = pskDelegatePk psk
-        -- We don't check stake for revoking certs. You can revoke
-        -- even if you don't have money anymore.
-        enoughStake = isRevokePsk psk || addressHash iPk `HS.member` richmen
-        omegaCorrect = headEpoch == pskOmega psk
-
-    -- DB related checks
-    alreadyPosted <- GS.isIssuerPostedThisEpoch $ addressHash iPk
-    pskFromDB <- GS.getPskByIssuer (Left $ pskIssuerPk psk)
-    let hasPskInDB = isJust pskFromDB
 
     -- Retrieve psk pool and perform another db check. It's
     -- guaranteed that pool is not changed when we're under
     -- 'withStateLock' lock.
     cyclePool <- runDelegationStateAction $ use dwProxySKPool
-    producesCycle <-
-        -- This is inefficient. Consider supporting this map
-        -- in-memory or changing mempool key to stakeholderId.
-        let _cmPskMods = HM.fromList $
-                map (bimap addressHash pskToDlgEdgeAction) $
-                HM.toList cyclePool
-            _cmHasPostedThisEpoch = mempty -- not used
-            cedeModifier = CedeModifier {..}
-        in evalMapCede cedeModifier $ detectCycleOnAddition psk
+
+    -- This is inefficient. Consider supporting this map
+    -- in-memory or changing mempool key to stakeholderId.
+    let _cmPskMods = HM.fromList $
+            map (bimap addressHash pskToDlgEdgeAction) $
+            HM.toList cyclePool
+        -- Not used since we can't have more than one psk per issuer
+        -- in mempool and "has posted this epoch" is fully backed up
+        -- by the database.
+    let _cmHasPostedThisEpoch = mempty
+    let cedeModifier = CedeModifier {..}
+    (verificationError, pskValid) <-
+        fmap (either (,False)
+                     (const (error "processProxySKHeavyInternal:can't happen",True))) $
+        evalMapCede cedeModifier $
+        runExceptT $
+        dlgVerifyPskHeavy richmen (CheckForCycle True) headEpoch psk
 
     -- Here the memory state is the same.
     runDelegationStateAction $ do
         memPoolSize <- use dwPoolSize
         posted <- uses dwProxySKPool (\m -> isJust $ HM.lookup iPk m)
         existsSameMempool <- uses dwProxySKPool $ \m -> HM.lookup iPk m == Just psk
-        let existsIsoDB =
-                fromMaybe False $ do
-                    ProxySecretKey{..} <- pskFromDB
-                    pure $ pskIssuerPk == iPk && pskDelegatePk == dPk
         cached <- isJust . snd . LRU.lookup msg <$> use dwMessageCache
         let isRevoke = isRevokePsk psk
-        let rerevoke = isRevoke && not hasPskInDB
         coherent <- uses dwTip $ (==) dbTipHash
         dwMessageCache %= LRU.insert msg curTime
-        let doublePosted = alreadyPosted && not isRevoke
-        -- TODO: This is a rather arbitrary limit, we should revisit it (see CSL-1664)
+
+        let -- TODO: This is a rather arbitrary limit, we should
+            -- revisit it (see CSL-1664)
             exhausted = memPoolSize >= maxBlockSize * 2
-        let res = if | not consistent -> PHBroken
+
+        let res = if | cached -> PHCached
                      | not coherent -> PHTipMismatch
-                     | not omegaCorrect -> PHInvalid "PSK epoch is different from current"
-                     | existsIsoDB ->
-                         PHInvalid $ "isomorphic proxy sk already exists in db: " <>
-                                     pretty pskFromDB
-                     | doublePosted -> PHInvalid "issuer has already posted PSK this epoch"
-                     | rerevoke ->
-                         PHInvalid $ "can't accept revoke cert, user doesn't " <>
-                                     "have any psk in db"
-                     | isJust producesCycle ->
-                         PHInvalid $ "adding psk causes cycle at: " <> pretty producesCycle
-                     | not enoughStake -> PHInvalid "issuer doesn't have enough stake"
-                     | cached -> PHCached
+                     | not consistent -> PHBroken
                      | existsSameMempool -> PHExists
+                     | not pskValid -> PHInvalid verificationError
                      | exhausted -> PHExhausted
                      | posted && isRevoke -> PHRemoved
                      | otherwise -> PHAdded

--- a/node/src/Pos/Delegation/Logic/VAR.hs
+++ b/node/src/Pos/Delegation/Logic/VAR.hs
@@ -55,6 +55,7 @@ import           Pos.Delegation.Types         (DlgPayload (getDlgPayload), DlgUn
 import qualified Pos.GState                   as GS
 import           Pos.Lrc.Context              (LrcContext)
 import qualified Pos.Lrc.DB                   as LrcDB
+import           Pos.Lrc.Types                (RichmenSet)
 import           Pos.Ssc.Class.Helpers        (SscHelpersClass)
 import           Pos.Util                     (HasLens', getKeys, _neHead)
 import           Pos.Util.Chrono              (NE, NewestFirst (..), OldestFirst (..))
@@ -334,7 +335,7 @@ dlgVerifyBlocks ::
     => OldestFirst NE (Block ssc)
     -> ExceptT Text m (OldestFirst NE DlgUndo)
 dlgVerifyBlocks blocks = do
-    (richmen :: HashSet StakeholderId) <-
+    (richmen :: RichmenSet) <-
         lrcActionOnEpochReason
         headEpoch
         "Delegation.Logic#delegationVerifyBlocks: there are no richmen for current epoch"
@@ -344,7 +345,7 @@ dlgVerifyBlocks blocks = do
     headEpoch = blocks ^. _Wrapped . _neHead . epochIndexL
 
     verifyBlock ::
-        HashSet StakeholderId ->
+        RichmenSet ->
         Block ssc ->
         ExceptT Text (MapCede m) DlgUndo
     verifyBlock _ (Left genesisBlk) = do

--- a/node/src/Pos/Delegation/Logic/VAR.hs
+++ b/node/src/Pos/Delegation/Logic/VAR.hs
@@ -41,8 +41,8 @@ import           Pos.DB                       (DBError (DBMalformed), MonadDBRea
 import qualified Pos.DB                       as DB
 import qualified Pos.DB.Block                 as DB
 import qualified Pos.DB.DB                    as DB
-import           Pos.Delegation.Cede          (CedeModifier, DlgEdgeAction (..), MapCede,
-                                               MonadCedeRead (getPsk),
+import           Pos.Delegation.Cede          (CedeModifier (..), DlgEdgeAction (..),
+                                               MapCede, MonadCedeRead (getPsk),
                                                detectCycleOnAddition, dlgEdgeActionIssuer,
                                                dlgReachesIssuance, evalMapCede,
                                                getPskChain, getPskPk, modPsk,
@@ -268,8 +268,10 @@ calculateTransCorrections eActions = do
 
             eActionsHM :: CedeModifier
             eActionsHM =
-                HM.fromList $ map (\x -> (dlgEdgeActionIssuer x, x)) $
-                HS.toList eActions
+                CedeModifier
+                    (HM.fromList $ map (\x -> (dlgEdgeActionIssuer x, x)) $
+                                      HS.toList eActions)
+                    mempty
 
         in void $ evalMapCede eActionsHM $ loop iSId
 

--- a/node/src/Pos/Delegation/Logic/VAR.hs
+++ b/node/src/Pos/Delegation/Logic/VAR.hs
@@ -312,7 +312,6 @@ getNoLongerRichmen newEpoch =
         lrcActionOnEpochReason e "getNoLongerRichmen" LrcDB.getRichmenDlg
 
 
-
 -- | Verifies if blocks are correct relatively to the delegation logic
 -- and returns a non-empty list of proxySKs needed for undoing
 -- them. Predicate for correctness here is:

--- a/node/test/Test/Pos/Types/BlockSpec.hs
+++ b/node/test/Test/Pos/Types/BlockSpec.hs
@@ -57,7 +57,7 @@ spec = giveStaticConsts $ describe "Block properties" $ do
     verifyHeadersDesc = "Successfully verifies a correct chain of block headers"
     verifyEmptyHsDesc = "Successfully validates an empty header chain"
     emptyHeaderChain l = giveStaticConsts $ -- WHAT THE HECK? WHY IS IT NEEDED?
-        it verifyEmptyHsDesc $ isVerSuccess $ T.verifyHeaders l
+        it verifyEmptyHsDesc $ isVerSuccess $ T.verifyHeaders Nothing l
 
 -- | Both of the following tests are boilerplate - they use `mkGenericHeader` to create
 -- headers and then compare these with manually built headers.
@@ -159,4 +159,4 @@ validateGoodHeaderChain
     :: forall ssc . (HasCoreConstants, SscHelpersClass ssc)
     => T.BlockHeaderList ssc -> Bool
 validateGoodHeaderChain (T.BHL (l, _)) =
-    isVerSuccess $ T.verifyHeaders (NewestFirst l)
+    isVerSuccess $ T.verifyHeaders Nothing (NewestFirst l)


### PR DESCRIPTION
Pre-story. Say you have headers `[h1,h2]` (`h2` is more difficult than `h1`) and you want to verify their signatures. Let `h1` be signed with `BlockSignature`: we match stakeholder id with related field in the header and check signature. And we're done. Then assume that `h2` is signed with `BlockPSignatureHeavy`, and `d` has the right to issue block according to `psk`. But then also assume that `psk` got into blockchain in block having header `h1`. So it is literally impossible to verify block signature of more than one header at once given using current delegation scheme.

What this PR does is:
* Delegation logic got abstracted (added some methods to `Cede`, removed duplicated code).
* As a result, found one missing check in the old mempool checker.
* `classifyNewHeader` now checks proxy signatures when header is a direct continuation of our chain
* `verifyHeaders` now accepts `Maybe Stakeholders` as a parameter so stakeholder field in headers can be (and is now) matched against data derived from fts.