### PR TITLE
[CSL-1568] Improve Address serialisation

### DIFF
--- a/core/Pos/Binary/Class/Primitive.hs
+++ b/core/Pos/Binary/Class/Primitive.hs
@@ -50,7 +50,7 @@ import qualified Data.Serialize                as Cereal (Get, Put)
 import           Data.Typeable                 (typeOf)
 
 import           Data.Digest.CRC32             (CRC32 (..))
-import           Formatting                    (format, shown, (%))
+import           Formatting                    (formatToString, shown, (%))
 import           Pos.Binary.Class.Core         (Bi (..), enforceSize)
 import           Serokell.Data.Memory.Units    (Byte)
 import           Universum
@@ -261,10 +261,8 @@ decodeCrcProtected = do
     body <- decodeUnknownCborDataItem
     expectedCrc  <- decode
     let actualCrc = crc32 body
-    let crcError = format ("decodeCrcProtected, expected CRC " % shown % " was not the computed one, which was " % shown)
-                          expectedCrc
-                          actualCrc
-    when (actualCrc /= expectedCrc) $ fail (toString crcError)
+    let crcErrorFmt = "decodeCrcProtected, expected CRC " % shown % " was not the computed one, which was " % shown
+    when (actualCrc /= expectedCrc) $ fail (formatToString crcErrorFmt expectedCrc actualCrc)
     case decodeFull body of
       Left e  -> fail (toString e)
       Right x -> pure x

--- a/core/Pos/Binary/Class/Primitive.hs
+++ b/core/Pos/Binary/Class/Primitive.hs
@@ -260,7 +260,8 @@ decodeCrcProtected = do
     enforceSize ("decodeCrcProtected: " <> show (typeOf (Proxy @a))) 2
     body <- decodeUnknownCborDataItem
     expectedCrc  <- decode
-    let actualCrc = crc32 body
+    let actualCrc :: Word32
+        actualCrc = crc32 body
     let crcErrorFmt = "decodeCrcProtected, expected CRC " % shown % " was not the computed one, which was " % shown
     when (actualCrc /= expectedCrc) $ fail (formatToString crcErrorFmt expectedCrc actualCrc)
     case decodeFull body of

--- a/core/Pos/Binary/Class/Primitive.hs
+++ b/core/Pos/Binary/Class/Primitive.hs
@@ -30,6 +30,9 @@ module Pos.Binary.Class.Primitive
        , encodeUnknownCborDataItem
        , decodeKnownCborDataItem
        , decodeUnknownCborDataItem
+       -- * Cyclic redundancy check
+       , encodeCrcProtected
+       , decodeCrcProtected
        ) where
 
 import qualified Codec.CBOR.Decoding           as D
@@ -44,8 +47,11 @@ import qualified Data.ByteString.Lazy.Internal as BSL
 import           Data.SafeCopy                 (Contained, SafeCopy (..), contain,
                                                 safeGet, safePut)
 import qualified Data.Serialize                as Cereal (Get, Put)
+import           Data.Typeable                 (typeOf)
 
-import           Pos.Binary.Class.Core         (Bi (..))
+import           Data.Digest.CRC32             (CRC32 (..))
+import           Formatting                    (format, shown, (%))
+import           Pos.Binary.Class.Core         (Bi (..), enforceSize)
 import           Serokell.Data.Memory.Units    (Byte)
 import           Universum
 
@@ -240,3 +246,25 @@ decodeUnknownCborDataItem :: D.Decoder s ByteString
 decodeUnknownCborDataItem = do
     decodeCborDataItemTag
     D.decodeBytes
+
+-- | Encodes a type `a` , protecting it from tampering/network-transport-alteration by
+-- protecting it with a CRC.
+encodeCrcProtected :: Bi a => a -> E.Encoding
+encodeCrcProtected x = E.encodeListLen 2 <> encodeUnknownCborDataItem body <> encode (crc32 body)
+  where
+    body = serialize' x
+
+-- | Decodes a CBOR blob into a type `a`, checking the serialised CRC corresponds to the computed one.
+decodeCrcProtected :: forall s a. Bi a => D.Decoder s a
+decodeCrcProtected = do
+    enforceSize ("decodeCrcProtected: " <> show (typeOf (Proxy @a))) 2
+    body <- decodeUnknownCborDataItem
+    expectedCrc  <- decode
+    let actualCrc = crc32 body
+    let crcError = format ("decodeCrcProtected, expected CRC " % shown % " was not the computed one, which was " % shown)
+                          expectedCrc
+                          actualCrc
+    when (actualCrc /= expectedCrc) $ fail (toString crcError)
+    case decodeFull body of
+      Left e  -> fail (toString e)
+      Right x -> pure x

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5616,8 +5616,8 @@ self: {
           pname = "semigroupoids";
           version = "5.2.1";
           sha256 = "006jys6kvckkmbnhf4jc51sh64hamkz464mr8ciiakybrfvixr3r";
-          revision = "1";
-          editedCabalFile = "1lb59k2hdz9kbhmpw7bzc0n9pb5x3b9ysglp69dn4yf5xxjw03wx";
+          revision = "2";
+          editedCabalFile = "049j2jl6f5mxqnavi1aadx37j4bk5xksvkxsl43hp4rg7n53p11z";
           setupHaskellDepends = [
             base
             Cabal


### PR DESCRIPTION
This PR correctly computes & store CRC for the `Address` type, as well as adding the usual "tag 24" encoding to `AddrSpendingData`.

Reviewed and mostly live-coded with @dcoutts 

Ps. small rant, I really liked having one single file (which was `CborSpec`) to be able to thoroughly test out the serialisation layer without running `stack test` in full (`ghci` worked wonderfully). Hehe. /endOfRant.