### PR TITLE
[CSL-1647] Add canonical JSON instances for GenesisData

### DIFF
--- a/core/Pos/Aeson/Genesis.hs
+++ b/core/Pos/Aeson/Genesis.hs
@@ -8,10 +8,7 @@ import           Universum
 
 import           Data.Aeson             (FromJSON (..), withObject, (.:))
 import           Data.Aeson.TH          (deriveFromJSON)
-import qualified Data.ByteString        as BS
-import qualified Data.Text              as T
 import           Serokell.Aeson.Options (defaultOptions)
-import qualified Serokell.Util.Base64   as B64
 
 import           Pos.Aeson.Core         ()
 import           Pos.Aeson.Crypto       ()
@@ -21,21 +18,7 @@ import           Pos.Core.Genesis.Types (AvvmData, AvvmEntry (..), FakeAvvmOptio
                                          GenesisWStakeholders, ProtocolConstants,
                                          TestnetBalanceOptions, TestnetDistribution,
                                          convertAvvmDataToBalances)
-import           Pos.Crypto             (RedeemPublicKey, redeemPkBuild)
--- | Read the text into a redeeming public key.
---
--- There's also a copy of this function in cardano-addr-convert.
-fromAvvmPk :: (MonadFail m, Monad m) => Text -> m RedeemPublicKey
-fromAvvmPk addrText = do
-    let base64rify = T.replace "-" "+" . T.replace "_" "/"
-    let parsedM = B64.decode $ base64rify addrText
-    addrParsed <-
-        maybe (fail $ "Address " <> toString addrText <> " is not base64(url) format")
-        pure
-        (rightToMaybe parsedM)
-    unless (BS.length addrParsed == 32) $
-        fail "Address' length is not equal to 32, can't be redeeming pk"
-    pure $ redeemPkBuild addrParsed
+import           Pos.Crypto             (fromAvvmPk)
 
 instance FromJSON AvvmEntry where
     parseJSON = withObject "avvmEntry" $ \o -> do

--- a/core/Pos/Core/Address.hs
+++ b/core/Pos/Core/Address.hs
@@ -48,7 +48,6 @@ module Pos.Core.Address
 
 import           Universum
 
-import           Control.Lens            (_Left)
 import           Crypto.Hash             (Blake2b_224, Digest, SHA3_256)
 import qualified Crypto.Hash             as CryptoHash
 import           Data.ByteString.Base58  (Alphabet (..), bitcoinAlphabet, decodeBase58,
@@ -144,13 +143,13 @@ addressF = build
 
 -- | A function which decodes base58-encoded 'Address'.
 decodeTextAddress :: Text -> Either Text Address
-decodeTextAddress = first toText . decodeAddress . encodeUtf8
+decodeTextAddress = decodeAddress . encodeUtf8
   where
-    decodeAddress :: ByteString -> Either String Address
+    decodeAddress :: ByteString -> Either Text Address
     decodeAddress bs = do
         let base58Err = "Invalid base58 representation of address"
         dbs <- maybeToRight base58Err $ decodeBase58 addrAlphabet bs
-        over _Left toString $ Bi.decodeFull dbs
+        Bi.decodeFull dbs
 
 ----------------------------------------------------------------------------
 -- Constructors

--- a/core/Pos/Core/Genesis.hs
+++ b/core/Pos/Core/Genesis.hs
@@ -45,6 +45,7 @@ import           Pos.Crypto.SafeSigning     (EncryptedSecretKey, emptyPassphrase
 import           Pos.Crypto.Signing         (PublicKey, SecretKey, deterministicKeyGen)
 
 -- reexports
+import           Pos.Core.Genesis.Canonical ()
 import           Pos.Core.Genesis.Parser
 import           Pos.Core.Genesis.Types
 

--- a/core/Pos/Core/Genesis/Canonical.hs
+++ b/core/Pos/Core/Genesis/Canonical.hs
@@ -1,0 +1,211 @@
+-- | Canonical encoding of 'GenesisData'.
+
+module Pos.Core.Genesis.Canonical
+       (
+       ) where
+
+import           Universum
+
+import           Data.Fixed                 (Fixed (..))
+import qualified Data.HashMap.Strict        as HM
+import           Data.Time.Units            (Millisecond)
+import           Formatting                 (formatToString)
+import           Serokell.Data.Memory.Units (Byte)
+import           Serokell.Util.Base16       (base16F)
+import           Serokell.Util.Base64       (base64F)
+import           Text.JSON.Canonical        (JSValue (..), ToJSON (..), ToObjectKey (..),
+                                             mkObject)
+
+import           Pos.Binary.Class           (AsBinary (..))
+import           Pos.Core.Address           (addressF)
+import           Pos.Core.Fee               (Coeff (..), TxFeePolicy (..),
+                                             TxSizeLinear (..))
+import           Pos.Core.Genesis.Types     (GenesisAvvmBalances (..), GenesisData (..),
+                                             GenesisDelegation (..),
+                                             GenesisWStakeholders (..),
+                                             ProtocolConstants (..))
+import           Pos.Core.Types             (Address, BlockVersionData (..), Coin,
+                                             CoinPortion, EpochIndex (..),
+                                             SharedSeed (..), SoftforkRule (..),
+                                             StakeholderId, Timestamp (..),
+                                             getCoinPortion, unsafeGetCoin)
+import           Pos.Core.Vss               (VssCertificate (..))
+import           Pos.Crypto                 (ProxyCert, ProxySecretKey (..), PublicKey,
+                                             RedeemPublicKey, Signature,
+                                             fullProxyCertHexF, fullPublicKeyF,
+                                             fullSignatureHexF, hashHexF, redeemPkB64UrlF)
+
+----------------------------------------------------------------------------
+-- Primitive standard/3rdparty types
+----------------------------------------------------------------------------
+
+instance Monad m => ToJSON m Int32 where
+    toJSON = pure . JSNum . fromIntegral
+
+instance Monad m => ToJSON m Word16 where
+    toJSON = pure . JSNum . fromIntegral
+
+instance Monad m => ToJSON m Word32 where
+    toJSON = pure . JSNum . fromIntegral
+
+instance Monad m => ToJSON m Word64 where
+    toJSON = pure . JSString . show
+
+instance Monad m => ToJSON m Integer where
+    toJSON = pure . JSString . show
+
+-- We don't need to sort keys in this instance, because rendering
+-- takes care of it.
+instance (Monad m, ToObjectKey m k, ToJSON m a) => ToJSON m (HashMap k a) where
+    toJSON = fmap JSObject . mapM aux . HM.toList
+      where
+        aux :: (k, a) -> m (String, JSValue)
+        aux (k, a) = (,) <$> toObjectKey k <*> toJSON a
+
+instance Monad m => ToJSON m Byte where
+    toJSON = toJSON . toInteger
+
+instance Monad m => ToJSON m Millisecond where
+    toJSON = toJSON . toInteger
+
+----------------------------------------------------------------------------
+-- Our crypto types
+----------------------------------------------------------------------------
+
+instance Monad m => ToJSON m PublicKey where
+    toJSON = pure . JSString . formatToString fullPublicKeyF
+
+instance Monad m => ToJSON m (ProxyCert w) where
+    toJSON = pure . JSString . formatToString fullProxyCertHexF
+
+instance Monad m => ToJSON m (Signature w) where
+    toJSON = pure . JSString . formatToString fullSignatureHexF
+
+instance Monad m => ToObjectKey m RedeemPublicKey where
+    toObjectKey = pure . formatToString redeemPkB64UrlF
+
+----------------------------------------------------------------------------
+-- Our core types
+----------------------------------------------------------------------------
+
+instance Monad m => ToJSON m (AsBinary smth) where
+    toJSON = pure . JSString . formatToString base64F . getAsBinary
+
+-- Note that it will be encoded as string, because 'EpochIndex'
+-- doesn't necessary fits into JS number.
+instance Monad m => ToJSON m EpochIndex where
+    toJSON = toJSON . getEpochIndex
+
+instance Monad m => ToJSON m VssCertificate where
+    toJSON vc =
+        mkObject
+            [ ("vssKey", toJSON (vcVssKey vc))
+            , ("expiryEpoch", pure (JSNum . fromIntegral $ vcExpiryEpoch vc))
+            , ("signature", toJSON (vcSignature vc))
+            , ("signingKey", toJSON (vcSigningKey vc))
+            ]
+
+instance Monad m => ToObjectKey m StakeholderId where
+    toObjectKey = pure . formatToString hashHexF
+
+instance Monad m => ToJSON m Coin where
+    toJSON = toJSON @_ @Word64 . unsafeGetCoin  -- i. e. String
+
+instance Monad m => ToJSON m CoinPortion where
+    toJSON = toJSON @_ @Word64 . getCoinPortion  -- i. e. String
+
+-- JSNum is ok here, current timestamp is almost 6x less than maximal
+-- bound, so overflow will happen after we die.
+instance Monad m => ToJSON m Timestamp where
+    toJSON = pure . JSNum . fromIntegral
+
+instance Monad m => ToObjectKey m Address where
+    toObjectKey = pure . formatToString addressF
+
+instance Monad m => ToJSON m Address where
+    toJSON = fmap JSString . toObjectKey
+
+instance Monad m => ToJSON m (ProxySecretKey EpochIndex) where
+    toJSON ProxySecretKey {..} =
+        -- omega is encoded as a number, because in genesis we always
+        -- set it to 0.
+        mkObject
+            [ ("omega", pure (JSNum . fromIntegral $ pskOmega))
+            , ("issuerPk", toJSON pskIssuerPk)
+            , ("delegatePk", toJSON pskDelegatePk)
+            , ("cert", toJSON pskCert)
+            ]
+
+instance Monad m => ToJSON m SoftforkRule where
+    toJSON SoftforkRule {..} =
+        mkObject
+            [ ("initThd", toJSON srInitThd)
+            , ("minThd", toJSON srMinThd)
+            , ("thdDecrement", toJSON srThdDecrement)
+            ]
+
+instance Monad m => ToJSON m Coeff where
+    toJSON (Coeff (MkFixed integer)) = toJSON @_ @Integer integer
+
+instance Monad m => ToJSON m TxFeePolicy where
+    toJSON (TxFeePolicyTxSizeLinear (TxSizeLinear summand multiplier)) =
+        mkObject
+            [("summand", toJSON summand), ("multiplier", toJSON multiplier)]
+    toJSON (TxFeePolicyUnknown {}) =
+        error "Having TxFeePolicyUnknown in genesis is likely a bug"
+
+instance Monad m => ToJSON m GenesisWStakeholders where
+    toJSON (GenesisWStakeholders stks) = toJSON stks
+
+instance Monad m => ToJSON m GenesisDelegation where
+    toJSON = toJSON . toList . unGenesisDelegation
+
+instance Monad m => ToJSON m ProtocolConstants where
+    toJSON ProtocolConstants {..} =
+        mkObject
+            -- 'k' definitely won't exceed the limit
+            [ ("k", pure . JSNum . fromIntegral $ pcK)
+            , ("protocolMagic", toJSON pcProtocolMagic)
+            , ("vssMaxTTL", toJSON pcVssMaxTTL)
+            , ("vssMinTTL", toJSON pcVssMinTTL)
+            ]
+
+instance Monad m => ToJSON m GenesisAvvmBalances where
+    toJSON = toJSON . getGenesisAvvmBalances
+
+instance Monad m => ToJSON m SharedSeed where
+    toJSON (SharedSeed seed) = pure . JSString . formatToString base16F $ seed
+
+instance Monad m => ToJSON m BlockVersionData where
+    toJSON (BlockVersionData scriptVersion slotDuration maxBlockSize maxHeaderSize maxTxSize maxProposalSize mpcThd heavyDelThd updateVoteThd updateProposalThd updateImplicit softforkRule txFeePolicy unlockStakeEpoch) =
+        mkObject
+            [ ("scriptVersion", toJSON scriptVersion)
+            , ("slotDuration", toJSON slotDuration)
+            , ("maxBlockSize", toJSON maxBlockSize)
+            , ("maxHeaderSize", toJSON maxHeaderSize)
+            , ("maxTxSize", toJSON maxTxSize)
+            , ("maxProposalSize", toJSON maxProposalSize)
+            , ("mpcThd", toJSON mpcThd)
+            , ("heavyDelThd", toJSON heavyDelThd)
+            , ("updateVoteThd", toJSON updateVoteThd)
+            , ("updateProposalThd", toJSON updateProposalThd)
+            , ("updateImplicit", toJSON updateImplicit)
+            , ("softforkRule", toJSON softforkRule)
+            , ("txFeePolicy", toJSON txFeePolicy)
+            , ("unlockStakeEpoch", toJSON unlockStakeEpoch)
+            ]
+
+instance Monad m => ToJSON m GenesisData where
+    toJSON GenesisData {..} =
+        mkObject
+            [ ("bootStakeholders", toJSON gdBootStakeholders)
+            , ("heavyDelegation", toJSON gdHeavyDelegation)
+            , ("startTime", toJSON gdStartTime)
+            -- no need to encode keys from 'VssCertificatesMap'
+            , ("vssCerts", toJSON $ toList gdVssCerts)
+            , ("nonAvvmBalances", toJSON gdNonAvvmBalances)
+            , ("blockVersionData", toJSON gdBlockVersionData)
+            , ("protocolConsts", toJSON gdProtocolConsts)
+            , ("avvmDistr", toJSON gdAvvmDistr)
+            , ("ftsSeed", toJSON gdFtsSeed)
+            ]

--- a/core/Pos/Core/Genesis/Types.hs
+++ b/core/Pos/Core/Genesis/Types.hs
@@ -228,7 +228,7 @@ data AvvmData = AvvmData
 -- | Predefined balances of avvm entries.
 newtype GenesisAvvmBalances = GenesisAvvmBalances
     { getGenesisAvvmBalances :: HashMap RedeemPublicKey Coin
-    } deriving (Show)
+    } deriving (Show, Eq)
 
 -- | Generate genesis address distribution out of avvm
 -- parameters. Txdistr of the utxo is all empty. Redelegate it in
@@ -257,7 +257,7 @@ data ProtocolConstants = ProtocolConstants
     , pcVssMaxTTL     :: !Word32
       -- | VSS certificates min timeout to live (number of epochs).
     , pcVssMinTTL     :: !Word32
-    } deriving (Show, Generic)
+    } deriving (Show, Eq, Generic)
 
 -- | Specification how to generate full genesis data.
 data GenesisSpec = UnsafeGenesisSpec
@@ -310,4 +310,4 @@ data GenesisData = GenesisData
     , gdProtocolConsts   :: !ProtocolConstants
     , gdAvvmDistr        :: !GenesisAvvmBalances
     , gdFtsSeed          :: !SharedSeed
-    }
+    } deriving (Show, Eq)

--- a/core/Pos/Crypto/RedeemSigning.hs
+++ b/core/Pos/Crypto/RedeemSigning.hs
@@ -6,11 +6,14 @@ module Pos.Crypto.RedeemSigning
        , redeemToPublic
        , redeemPkBuild
        , redeemPkB64F
+       , redeemPkB64UrlF
        , redeemPkB64ShortF
        , RedeemSignature (..)
        , redeemSign
        , redeemCheckSig
        ) where
+
+import           Universum
 
 import           Crypto.Random        (MonadRandom, getRandomBytes)
 import qualified Data.ByteString      as BS
@@ -19,7 +22,7 @@ import           Data.Hashable        (Hashable)
 import qualified Data.Text.Buildable  as B
 import           Formatting           (Format, bprint, fitLeft, later, (%), (%.))
 import           Serokell.Util.Base64 (formatBase64)
-import           Universum
+import qualified Serokell.Util.Base64 as B64
 
 import qualified Crypto.Sign.Ed25519  as Ed25519
 import           Pos.Binary.Class     (Bi, Raw)
@@ -54,6 +57,12 @@ newtype RedeemSecretKey = RedeemSecretKey Ed25519.SecretKey
 redeemPkB64F :: Format r (RedeemPublicKey -> r)
 redeemPkB64F =
     later $ \(RedeemPublicKey pk) -> formatBase64 $ Ed25519.openPublicKey pk
+
+-- | Base64url Format for 'RedeemPublicKey'.
+redeemPkB64UrlF :: Format r (RedeemPublicKey -> r)
+redeemPkB64UrlF =
+    later $ \(RedeemPublicKey pk) ->
+        B.build $ B64.encodeUrl $ Ed25519.openPublicKey pk
 
 redeemPkB64ShortF :: Format r (RedeemPublicKey -> r)
 redeemPkB64ShortF = fitLeft 8 %. redeemPkB64F

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -59,6 +59,7 @@ library
                        Pos.Core.Vss
 
                        Pos.Core.Genesis
+                       Pos.Core.Genesis.Canonical
                        Pos.Core.Genesis.Parser
                        Pos.Core.Genesis.Types
 
@@ -127,6 +128,7 @@ library
                      , base58-bytestring
                      , binary
                      , bytestring
+                     , canonical-json
                      , cardano-crypto
                      , cborg
                      , cereal

--- a/node/cardano-sl.cabal
+++ b/node/cardano-sl.cabal
@@ -589,6 +589,7 @@ test-suite cardano-test
                        Test.Pos.DHT.Identity.BinarySpec
                        Test.Pos.Explorer.Identity.BinarySpec
                        Test.Pos.Genesis.Identity.BinarySpec
+                       Test.Pos.Genesis.CanonicalSpec
                        Test.Pos.MerkleSpec
                        Test.Pos.Network.Windows.DnsDomainsSpec
                        Test.Pos.Slotting.TypesSpec
@@ -623,6 +624,7 @@ test-suite cardano-test
                      , QuickCheck
                      , base
                      , bytestring
+                     , canonical-json
                      , cardano-sl-core
                      , cardano-sl-db
                      , cardano-sl-godtossing

--- a/node/test/Test/Pos/Genesis/CanonicalSpec.hs
+++ b/node/test/Test/Pos/Genesis/CanonicalSpec.hs
@@ -1,0 +1,27 @@
+-- | Tests for canonical serialization of genesis data.
+
+module Test.Pos.Genesis.CanonicalSpec
+       ( spec
+       ) where
+
+import           Universum
+
+import           Test.Hspec                 (Spec, describe)
+import           Test.Hspec.QuickCheck      (modifyMaxSuccess)
+
+import           Pos.Arbitrary.Core         ()
+import           Pos.Core.Genesis           (GenesisAvvmBalances, GenesisData,
+                                             GenesisDelegation, GenesisWStakeholders,
+                                             ProtocolConstants)
+import           Pos.Core.Genesis.Canonical ()
+
+import           Test.Pos.Util              (canonicalJsonTest)
+
+spec :: Spec
+spec = describe "Genesis" $ modifyMaxSuccess (const 10) $ do
+    describe "Canonical encoding" $ do
+        canonicalJsonTest @ProtocolConstants
+        canonicalJsonTest @GenesisAvvmBalances
+        canonicalJsonTest @GenesisWStakeholders
+        canonicalJsonTest @GenesisDelegation
+        canonicalJsonTest @GenesisData

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,6 +87,11 @@ packages:
     commit: 6da3cd051bd6f6415c8ec3b53f1c0372a80a4376
   extra-dep: true
 
+- location:
+    git: https://github.com/well-typed/canonical-json.git
+    commit: 2d261bb971bada1893753b503452d9e6e217bc4a
+  extra-dep: true
+
 nix:
   shell-file: shell.nix
 


### PR DESCRIPTION
I added ToJSON and FromJSON instances for GenesisData (and all subtypes).
There is a test for their correctness.
They all have been written manually. Format should be reasonable, but maybe someone will tell me something should be changed there. For now I was focused only on implementing correct instances, not necessary the most reasonable.
I think this PR should be open until CSL-1617 is finished.