### PR TITLE
[CSL-1619] Add MsgNo{Block,Headers} and related logic

### DIFF
--- a/node/src/Pos/Binary/Communication.hs
+++ b/node/src/Pos/Binary/Communication.hs
@@ -40,37 +40,55 @@ deriveSimpleBi ''MsgGetBlocks [
     ]]
 
 instance (HasCoreConstants, SscHelpersClass ssc) => Bi (MsgHeaders ssc) where
-  encode (MsgHeaders b) = encode b
-  decode = MsgHeaders <$> decode
+    encode = \case
+        (MsgHeaders b) -> encodeListLen 2 <> encode (0 :: Word8) <> encode b
+        (MsgNoHeaders t) -> encodeListLen 2 <> encode (1 :: Word8) <> encode t
+    decode = do
+        enforceSize "MsgHeaders" 2
+        tag <- decode @Word8
+        case tag of
+            0 -> MsgHeaders <$> decode
+            1 -> MsgNoHeaders <$> decode
+            t -> fail $ "MsgHeaders wrong tag: " <> show t
 
 instance (HasCoreConstants, SscHelpersClass ssc) => Bi (MsgBlock ssc) where
-  encode (MsgBlock b) = encode b
-  decode = MsgBlock <$> decode
+    encode = \case
+        (MsgBlock b) -> encodeListLen 2 <> encode (0 :: Word8) <> encode b
+        (MsgNoBlock t) -> encodeListLen 2 <> encode (1 :: Word8) <> encode t
+    decode = do
+        enforceSize "MsgBlock" 2
+        tag <- decode @Word8
+        case tag of
+            0 -> MsgBlock <$> decode
+            1 -> MsgNoBlock <$> decode
+            t -> fail $ "MsgBlock wrong tag: " <> show t
 
 -- deriveSimpleBi is not happy with constructors without arguments
 -- "fake" deriving as per `MempoolMsg`.
 -- TODO: Shall we encode this as `CBOR` TkNull?
 instance Bi MsgSubscribe where
-  encode MsgSubscribe = encode (42 :: Word8)
-  decode = do
-    x <- decode @Word8
-    when (x /= 42) $ fail "wrong byte"
-    pure MsgSubscribe
+    encode MsgSubscribe = encode (42 :: Word8)
+    decode = do
+        x <- decode @Word8
+        when (x /= 42) $ fail "wrong byte"
+        pure MsgSubscribe
 
 ----------------------------------------------------------------------------
 -- Protocol version info and related
 ----------------------------------------------------------------------------
 
 instance Bi HandlerSpec where
-  encode input = case input of
-    ConvHandler mname        -> encodeListLen 2 <> encode (0 :: Word8) <> encodeKnownCborDataItem mname
-    UnknownHandler word8 bs  -> encodeListLen 2 <> encode word8 <> encodeUnknownCborDataItem bs
-  decode = do
-    enforceSize "HandlerSpec" 2
-    tag <- decode @Word8
-    case tag of
-      0 -> ConvHandler        <$> decodeKnownCborDataItem
-      _ -> UnknownHandler tag <$> decodeUnknownCborDataItem
+    encode input = case input of
+        ConvHandler mname        ->
+            encodeListLen 2 <> encode (0 :: Word8) <> encodeKnownCborDataItem mname
+        UnknownHandler word8 bs  ->
+            encodeListLen 2 <> encode word8 <> encodeUnknownCborDataItem bs
+    decode = do
+        enforceSize "HandlerSpec" 2
+        tag <- decode @Word8
+        case tag of
+            0 -> ConvHandler        <$> decodeKnownCborDataItem
+            _ -> UnknownHandler tag <$> decodeUnknownCborDataItem
 
 deriveSimpleBi ''VerInfo [
     Cons 'VerInfo [

--- a/node/src/Pos/Block/Network/Announce.hs
+++ b/node/src/Pos/Block/Network/Announce.hs
@@ -91,12 +91,12 @@ handleHeadersCommunication conv = do
             Right _ -> pure tipHeader
     handleSuccess h = do
         send conv (MsgHeaders h)
-        onSuccess
-        handleHeadersCommunication conv
-    onSuccess =
         logDebug "handleGetHeaders: responded successfully"
-    onRecovery =
+        handleHeadersCommunication conv
+    onNoHeaders reason = do
+        let err = "getheadersFromManyTo returned Nothing, reason: " <> reason
+        logDebug err
+        send conv (MsgNoHeaders err)
+    onRecovery = do
         logDebug "handleGetHeaders: not responding, we're in recovery mode"
-    onNoHeaders reason =
-        logDebug $ "getheadersFromManyTo returned Nothing, " <>
-                   "not replying to node, reason: " <> reason
+        send conv (MsgNoHeaders "server node is in recovery mode")

--- a/node/src/Pos/Block/Network/Announce.hs
+++ b/node/src/Pos/Block/Network/Announce.hs
@@ -14,7 +14,7 @@ import           Control.Monad.Except       (runExceptT)
 import           Ether.Internal             (HasLens (..))
 import           Formatting                 (build, sformat, (%))
 import           Mockable                   (throw)
-import           System.Wlog                (logDebug)
+import           System.Wlog                (logDebug, logWarning)
 
 import           Pos.Block.Core             (Block, BlockHeader, MainBlockHeader,
                                              blockHeader)
@@ -72,12 +72,13 @@ handleHeadersCommunication conv = do
         logDebug $ sformat ("Got request on handleGetHeaders: "%build) mgh
         ifM recoveryInProgress onRecovery $ do
             headers <- case (mghFrom,mghTo) of
-                ([], Nothing) -> Right . one <$> getLastMainHeader
+                ([], Nothing) ->
+                    Right . one <$> getLastMainHeader
                 ([], Just h)  ->
                     maybeToRight "getBlockHeader returned Nothing" . fmap one <$>
                     DB.blkGetHeader @ssc h
-                (c1:cxs, _)   -> runExceptT
-                    (getHeadersFromManyTo (c1:|cxs) mghTo)
+                (c1:cxs, _)   ->
+                    runExceptT (getHeadersFromManyTo (c1:|cxs) mghTo)
             either onNoHeaders handleSuccess headers
   where
     -- retrieves header of the newest main block if there's any,
@@ -95,7 +96,7 @@ handleHeadersCommunication conv = do
         handleHeadersCommunication conv
     onNoHeaders reason = do
         let err = "getheadersFromManyTo returned Nothing, reason: " <> reason
-        logDebug err
+        logWarning err
         send conv (MsgNoHeaders err)
     onRecovery = do
         logDebug "handleGetHeaders: not responding, we're in recovery mode"

--- a/node/src/Pos/Block/Network/Listeners.hs
+++ b/node/src/Pos/Block/Network/Listeners.hs
@@ -69,7 +69,7 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
             Just hashes -> do
                 logDebug $ sformat
                     ("handleGetBlocks: started sending "%int%
-                     "blocks to "%build%" one-by-one: "%listJson)
+                     " blocks to "%build%" one-by-one: "%listJson)
                     (length hashes) nodeId hashes
                 for_ hashes $ \hHash ->
                     DB.blkGetBlock @ssc hHash >>= \case

--- a/node/src/Pos/Block/Network/Listeners.hs
+++ b/node/src/Pos/Block/Network/Listeners.hs
@@ -71,9 +71,13 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
                     ("handleGetBlocks: started sending "%int%
                      "blocks to "%build%" one-by-one: "%listJson)
                     (length hashes) nodeId hashes
-                for_ hashes $ \hHash -> do
-                    block <- maybe failMalformed pure =<< DB.blkGetBlock @ssc hHash
-                    send conv (MsgBlock block)
+                for_ hashes $ \hHash ->
+                    DB.blkGetBlock @ssc hHash >>= \case
+                        Nothing -> do
+                            send conv (MsgNoBlock $
+                                       "Couldn't retrieve block with hash " <> pretty hHash)
+                            failMalformed
+                        Just b -> send conv (MsgBlock b)
                 logDebug "handleGetBlocks: blocks sending done"
             _ -> logWarning $ "getBlocksByHeaders@retrieveHeaders returned Nothing"
   where
@@ -98,5 +102,7 @@ handleBlockHeaders oq = listenerConv @MsgGetHeaders oq $ \__ourVerInfo nodeId co
     -- we don't really send any messages.
     logDebug "handleBlockHeaders: got some unsolicited block header(s)"
     mHeaders <- recvLimited conv
-    whenJust mHeaders $ \(MsgHeaders headers) ->
-        handleUnsolicitedHeaders (getNewestFirst headers) nodeId
+    whenJust mHeaders $ \case
+        (MsgHeaders headers) ->
+            handleUnsolicitedHeaders (getNewestFirst headers) nodeId
+        _ -> pass -- Why would somebody propagate 'MsgNoHeaders'? We don't care.

--- a/node/src/Pos/Block/Network/Retrieval.hs
+++ b/node/src/Pos/Block/Network/Retrieval.hs
@@ -352,7 +352,10 @@ retrieveBlocks'
     -> HeaderHash -- ^ Block at which to stop
     -> ExceptT Text m (OldestFirst NE (Block ssc))
 retrieveBlocks' i conv prevH endH = lift (recvLimited conv) >>= \case
-    Nothing -> throwError $ sformat ("Failed to receive block #"%int) i
+    Nothing ->
+        throwError $ sformat ("Failed to receive block #"%int) i
+    Just (MsgNoBlock t) ->
+        throwError $ sformat ("Server failed to return block #"%int%": "%stext) i t
     Just (MsgBlock block) -> do
         let prevH' = block ^. prevBlockL
             curH = headerHash block

--- a/node/src/Pos/Block/Network/Types.hs
+++ b/node/src/Pos/Block/Network/Types.hs
@@ -62,13 +62,15 @@ instance Buildable MsgGetBlocks where
                mgbFrom mgbTo
 
 -- | 'Headers' message (see protocol specification).
-newtype MsgHeaders ssc =
-    MsgHeaders (NewestFirst NE (BlockHeader ssc))
+data MsgHeaders ssc
+    = MsgHeaders (NewestFirst NE (BlockHeader ssc))
+    | MsgNoHeaders Text
     deriving (Generic, Show, Eq)
 
 -- | 'Block' message (see protocol specification).
-newtype MsgBlock ssc =
-    MsgBlock (Block ssc)
+data MsgBlock ssc
+    = MsgBlock (Block ssc)
+    | MsgNoBlock Text
     deriving (Generic, Show)
 
 deriving instance (Ssc ssc, Eq (SscPayload ssc)) => Eq (MsgBlock ssc)


### PR DESCRIPTION
> What does this PR introduce?

Headers/block communication didn't have the response option for fail case. Instead, server node just didn't reply. As a result, calling party couldn't distinguish between timeout and negative response which lead to ambiguity. Now server party replies with exact error if it occurs. 

> Did the protocol change

Yes. Old clients won't manage to deserialize the message (binary format changed). But from the logic standpoint changes are minor. 

> Why is it needed in the mainnet.

1. We will later may want to introduce node web interface for querying blocks and headers separately and unability to understand whether node didn't reply or failed is very important to the client.
2. Similarly, we may have problems with debugging network timeouts because in order to confirm it is a timeout we need to check server node's logs. 