### PR TITLE
[CSL-1662] Define mempool limit in terms of number of transactions

### DIFF
--- a/core/Pos/Core/Constants/Raw.hs
+++ b/core/Pos/Core/Constants/Raw.hs
@@ -21,7 +21,7 @@ module Pos.Core.Constants.Raw
        , protocolMagic
        , staticSysStartRaw
        , genesisKeysN
-       , memPoolLimitRatio
+       , memPoolLimit
 
        , genesisBinSuffix
 
@@ -86,8 +86,9 @@ data CoreConfig = CoreConfig
       ccGenesisN                     :: !Int
       -- | Size of mem pool will be limited by this value muliplied by block
       -- size limit.
-    , ccMemPoolLimitRatio            :: !Word
-      -- | Suffix for genesis.bin files
+    , ccMemPoolLimit                 :: !Int
+      -- | Limint on the number of transactions that can be stored in
+      -- the mem pool.
     , ccGenesisBinSuffix             :: ![Char]
 
        -- Genesis block version data
@@ -228,8 +229,8 @@ genesisKeysN = fromIntegral . ccGenesisN $ coreConfig
 
 -- | Size of mem pool will be limited by this value muliplied by block
 -- size limit.
-memPoolLimitRatio :: Integral i => i
-memPoolLimitRatio = fromIntegral . ccMemPoolLimitRatio $ coreConfig
+memPoolLimit :: Int
+memPoolLimit = ccMemPoolLimit coreConfig
 
 -- | If chain quality in bootstrap era is less than this value,
 -- non critical misbehavior will be reported.

--- a/core/Pos/Core/Constants/Raw.hs
+++ b/core/Pos/Core/Constants/Raw.hs
@@ -84,11 +84,10 @@ data CoreConfig = CoreConfig
       ccProductionNetworkStartTime   :: !Int
     , -- | Number of pre-generated keys
       ccGenesisN                     :: !Int
-      -- | Size of mem pool will be limited by this value muliplied by block
-      -- size limit.
-    , ccMemPoolLimit                 :: !Int
       -- | Limint on the number of transactions that can be stored in
       -- the mem pool.
+    , ccMemPoolLimit                 :: !Int
+      -- | Suffix for genesis.bin files
     , ccGenesisBinSuffix             :: ![Char]
 
        -- Genesis block version data
@@ -227,8 +226,7 @@ protocolMagic = fromIntegral . ccProtocolMagic $ coreConfig
 genesisKeysN :: Integral i => i
 genesisKeysN = fromIntegral . ccGenesisN $ coreConfig
 
--- | Size of mem pool will be limited by this value muliplied by block
--- size limit.
+-- | Size of mem pool will be limited to this number of transactions.
 memPoolLimit :: Int
 memPoolLimit = ccMemPoolLimit coreConfig
 

--- a/core/constants.yaml
+++ b/core/constants.yaml
@@ -123,8 +123,7 @@ dev: &dev
 
 
   # These constants mostly depend on hardware capabilities
-  memPoolLimitRatio: 2 # mem pool will be limited by this value
-                       # muliplied by block size limit
+  memPoolLimit: 200 # mem pool will be limited to this many transactions
 
   genesisBinSuffix: tn # it is set here arbitrarily, it won't be actually used
 
@@ -266,4 +265,3 @@ devnet_shortep_updated_full: &devnet_shortep_updated_full
 devnet_shortep_updated_wallet: &devnet_shortep_updated_wallet
   <<: *devnet_shortep_updated_full
   applicationName: csl-daedalus
-

--- a/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
+++ b/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
@@ -253,7 +253,8 @@ sscProcessDataDo richmenData bvd gs payload =
         let multiRichmen = HM.fromList [richmenData]
         unless (storedEpoch == givenEpoch) $
             throwError $ DifferentEpoches storedEpoch givenEpoch
-        let maxMemPoolSize = bvdMaxBlockSize bvd
+        -- TODO: This is a rather arbitrary limit, we should revisit it (see CSL-1664)
+        let maxMemPoolSize = bvdMaxBlockSize bvd * 2
         curSize <- use ldSize
         let exhausted = curSize >= maxMemPoolSize
         -- If our mempool is exhausted we drop some data from it.

--- a/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
+++ b/godtossing/Pos/Ssc/GodTossing/LocalData/Logic.hs
@@ -34,7 +34,6 @@ import           Pos.Binary.GodTossing              ()
 import           Pos.Core                           (BlockVersionData (..), EpochIndex,
                                                      HasCoreConstants, SlotId (..),
                                                      StakeholderId)
-import           Pos.Core.Constants                 (memPoolLimitRatio)
 import           Pos.DB                             (MonadDBRead,
                                                      MonadGState (gsAdoptedBVData))
 import           Pos.Lrc.Types                      (RichmenStakes)
@@ -254,7 +253,7 @@ sscProcessDataDo richmenData bvd gs payload =
         let multiRichmen = HM.fromList [richmenData]
         unless (storedEpoch == givenEpoch) $
             throwError $ DifferentEpoches storedEpoch givenEpoch
-        let maxMemPoolSize = bvdMaxBlockSize bvd * memPoolLimitRatio
+        let maxMemPoolSize = bvdMaxBlockSize bvd
         curSize <- use ldSize
         let exhausted = curSize >= maxMemPoolSize
         -- If our mempool is exhausted we drop some data from it.

--- a/node/src/Pos/Delegation/Logic/Mempool.hs
+++ b/node/src/Pos/Delegation/Logic/Mempool.hs
@@ -227,7 +227,8 @@ processProxySKHeavyInternal psk = do
         coherent <- uses dwTip $ (==) dbTipHash
         dwMessageCache %= LRU.insert msg curTime
         let doublePosted = alreadyPosted && not isRevoke
-            exhausted = memPoolSize >= maxBlockSize
+        -- TODO: This is a rather arbitrary limit, we should revisit it (see CSL-1664)
+            exhausted = memPoolSize >= maxBlockSize * 2
         let res = if | not consistent -> PHBroken
                      | not coherent -> PHTipMismatch
                      | not omegaCorrect -> PHInvalid "PSK epoch is different from current"

--- a/node/src/Pos/Delegation/Logic/Mempool.hs
+++ b/node/src/Pos/Delegation/Logic/Mempool.hs
@@ -37,7 +37,6 @@ import           Mockable                         (CurrentTime, Mockable, curren
 
 import           Pos.Binary.Class                 (biSize)
 import           Pos.Binary.Communication         ()
-import           Pos.Constants                    (memPoolLimitRatio)
 import           Pos.Context                      (lrcActionOnEpochReason)
 import           Pos.Core                         (HasCoreConstants, HasPrimaryKey (..),
                                                    ProxySKHeavy, ProxySKLight,
@@ -228,10 +227,7 @@ processProxySKHeavyInternal psk = do
         coherent <- uses dwTip $ (==) dbTipHash
         dwMessageCache %= LRU.insert msg curTime
         let doublePosted = alreadyPosted && not isRevoke
-        let maxMemPoolSize = memPoolLimitRatio * maxBlockSize
-            -- Here it would be good to add size of data we want to insert
-            -- but it's negligible.
-            exhausted = memPoolSize >= maxMemPoolSize
+            exhausted = memPoolSize >= maxBlockSize
         let res = if | not consistent -> PHBroken
                      | not coherent -> PHTipMismatch
                      | not omegaCorrect -> PHInvalid "PSK epoch is different from current"

--- a/txp/Pos/Txp/MemState/Metrics.hs
+++ b/txp/Pos/Txp/MemState/Metrics.hs
@@ -7,7 +7,6 @@ module Pos.Txp.MemState.Metrics
 import           Universum
 
 import           Formatting                   (sformat, shown, (%))
-import           Serokell.Data.Memory.Units   (memory)
 import qualified System.Metrics               as Metrics
 import qualified System.Metrics.Gauge         as Metrics.Gauge
 import           System.Wlog                  (logDebug)
@@ -61,6 +60,6 @@ recordTxpMetrics ekgStore memPoolVar = do
                         then fromIntegral timeElapsed
                         else round $ alpha * fromIntegral timeElapsed + (1 - alpha) * fromIntegral timeElapsed'
               liftIO $ Metrics.Gauge.set ekgMemPoolModifyTime new_
-              logDebug $ sformat ("MemPool metrics release: modify time was "%shown%" size is "%memory)
+              logDebug $ sformat ("MemPool metrics release: modify time was "%shown%" size is "%shown)
                          timeElapsed newMemPoolSize
         }

--- a/txp/Pos/Txp/Toil/Class.hs
+++ b/txp/Pos/Txp/Toil/Class.hs
@@ -19,7 +19,6 @@ import           Universum
 import           Control.Lens               (at, (.=))
 import           Control.Monad.Trans.Class  (MonadTrans)
 import qualified Ether
-import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Core                   (Coin, StakeholderId)
 import           Pos.Txp.Core.Types         (TxAux, TxId, TxIn, TxOutAux, TxUndo)
@@ -97,8 +96,8 @@ instance {-# OVERLAPPABLE #-}
 class Monad m => MonadTxPool m where
     -- | Check whether Tx with given identifier is stored in the pool.
     hasTx :: TxId -> m Bool
-    -- | Return size of the pool's binary representation (approximate).
-    poolSize :: m Byte
+    -- | Return the number of transactions contained in the pool.
+    poolSize :: m Int
     -- | Put a transaction with corresponding Undo into MemPool.
     -- Transaction must not be in MemPool.
     putTxWithUndo :: TxId -> TxAux -> TxUndo -> m ()
@@ -108,7 +107,7 @@ class Monad m => MonadTxPool m where
     hasTx = lift . hasTx
 
     default poolSize
-        :: (MonadTrans t, MonadTxPool m', t m' ~ m) => m Byte
+        :: (MonadTrans t, MonadTxPool m', t m' ~ m) => m Int
     poolSize = lift poolSize
 
     default putTxWithUndo

--- a/txp/Pos/Txp/Toil/Failure.hs
+++ b/txp/Pos/Txp/Toil/Failure.hs
@@ -31,7 +31,7 @@ data ToilVerFailure
     | ToilTipsMismatch { ttmOldTip :: !HeaderHash
                        , ttmNewTip :: !HeaderHash}
     | ToilSlotUnknown
-    | ToilOverwhelmed !Byte -- ^ Local transaction storage is full --
+    | ToilOverwhelmed !Int -- ^ Local transaction storage is full --
                             -- can't accept more txs. Current limit is attached.
     | ToilNotUnspent !TxIn -- ^ Tx input is not a known unspent input.
     | ToilOutGTIn { tInputSum  :: !Integer
@@ -82,7 +82,7 @@ instance Buildable ToilVerFailure where
     build ToilSlotUnknown =
         "can't process, current slot is unknown"
     build (ToilOverwhelmed limit) =
-        bprint ("max size of the mem pool is reached which is "%memory) limit
+        bprint ("max size of the mem pool is reached which is "%shown) limit
     build (ToilNotUnspent txId) =
         bprint ("input is not a known unspent input: "%build) txId
     build (ToilOutGTIn {..}) =

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -31,7 +31,7 @@ import           Pos.Core                   (AddrAttributes (..),
                                              BlockVersionData (..), EpochIndex,
                                              addrAttributesUnwrapped, isRedeemAddress)
 import           Pos.Core.Coin              (integerToCoin)
-import           Pos.Core.Constants         (memPoolLimitRatio)
+import           Pos.Core.Constants         (memPoolLimit)
 import qualified Pos.Core.Fee               as Fee
 import           Pos.Core.Genesis           (GenesisWStakeholders (..))
 import           Pos.Crypto                 (WithHash (..), hash)
@@ -121,10 +121,8 @@ processTx
     => EpochIndex -> (TxId, TxAux) -> m TxUndo
 processTx curEpoch tx@(id, aux) = do
     whenM (hasTx id) $ throwError ToilKnown
-    maxBlockSize <- bvdMaxBlockSize <$> gsAdoptedBVData
-    let maxPoolSize = memPoolLimitRatio * maxBlockSize
-    whenM ((>= maxPoolSize) <$> poolSize) $
-        throwError (ToilOverwhelmed maxPoolSize)
+    whenM ((>= memPoolLimit) <$> (poolSize)) $
+        throwError (ToilOverwhelmed memPoolLimit)
     undo <- verifyAndApplyTx @ctx curEpoch True tx
     undo <$ putTxWithUndo id aux undo
 

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -121,7 +121,7 @@ processTx
     => EpochIndex -> (TxId, TxAux) -> m TxUndo
 processTx curEpoch tx@(id, aux) = do
     whenM (hasTx id) $ throwError ToilKnown
-    whenM ((>= memPoolLimit) <$> (poolSize)) $
+    whenM ((>= memPoolLimit) <$> poolSize) $
         throwError (ToilOverwhelmed memPoolLimit)
     undo <- verifyAndApplyTx @ctx curEpoch True tx
     undo <$ putTxWithUndo id aux undo

--- a/txp/Pos/Txp/Toil/Trans.hs
+++ b/txp/Pos/Txp/Toil/Trans.hs
@@ -15,7 +15,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Ether
 import           Universum
 
-import           Pos.Binary.Class    (biSize)
 import           Pos.Txp.Toil.Class  (MonadStakes (..), MonadStakesRead (..),
                                       MonadTxPool (..), MonadUtxo (..),
                                       MonadUtxoRead (..))
@@ -62,7 +61,7 @@ instance Monad m => MonadTxPool (ToilT __ m) where
         has <- use $ tmMemPool . mpLocalTxs . to (HM.member id)
         unless has $ do
             tmMemPool . mpLocalTxs . at id .= Just tx
-            tmMemPool . mpSize += biSize tx + biSize id
+            tmMemPool . mpSize += 1
             tmUndos . at id .= Just undo
 
     poolSize = ether $ use $ tmMemPool . mpSize

--- a/txp/Pos/Txp/Toil/Types.hs
+++ b/txp/Pos/Txp/Toil/Types.hs
@@ -39,7 +39,6 @@ import qualified Data.HashMap.Strict        as HM
 import qualified Data.Map                   as M (toList)
 import           Data.Text.Lazy.Builder     (Builder)
 import           Formatting                 (Format, later)
-import           Serokell.Data.Memory.Units (Byte)
 import           Serokell.Util.Text         (mapBuilderJson)
 
 import           Pos.Core                   (Coin, GenesisWStakeholders, StakeholderId,
@@ -111,8 +110,8 @@ type TxMap = HashMap TxId TxAux
 
 data MemPool = MemPool
     { _mpLocalTxs :: !TxMap
-      -- | Approximate size of encoded memory pool.
-    , _mpSize     :: !Byte
+      -- | Number of transactions in the memory pool.
+    , _mpSize     :: !Int
     }
 
 makeLenses ''MemPool
@@ -121,7 +120,7 @@ instance Default MemPool where
     def =
         MemPool
         { _mpLocalTxs = mempty
-        , _mpSize     = 1
+        , _mpSize     = 0
         }
 
 ----------------------------------------------------------------------------

--- a/update/Pos/Update/Logic/Local.hs
+++ b/update/Pos/Update/Logic/Local.hs
@@ -36,7 +36,6 @@ import           Pos.Binary.Class       (biSize)
 import           Pos.Core               (BlockVersionData (bvdMaxBlockSize),
                                          HasCoreConstants, HeaderHash, SlotId (..),
                                          slotIdF)
-import           Pos.Core.Constants     (memPoolLimitRatio)
 import           Pos.Crypto             (PublicKey, shortHashF)
 import           Pos.DB.Class           (MonadDBRead)
 import qualified Pos.DB.GState.Common   as DB
@@ -145,9 +144,8 @@ processSkeleton payload =
             let err = PollTipMismatch {ptmTipMemory = msTip, ptmTipDB = dbTip}
             throwError err
         maxBlockSize <- bvdMaxBlockSize <$> DB.getAdoptedBVData
-        let maxMemPoolSize = maxBlockSize * memPoolLimitRatio
         msIntermediate <-
-            if | maxMemPoolSize <= mpSize msPool -> refreshMemPool ms
+            if | maxBlockSize <= mpSize msPool -> refreshMemPool ms
                | otherwise -> pure ms
         processSkeletonDo msIntermediate
   where

--- a/update/Pos/Update/Logic/Local.hs
+++ b/update/Pos/Update/Logic/Local.hs
@@ -145,7 +145,8 @@ processSkeleton payload =
             throwError err
         maxBlockSize <- bvdMaxBlockSize <$> DB.getAdoptedBVData
         msIntermediate <-
-            if | maxBlockSize <= mpSize msPool -> refreshMemPool ms
+            -- TODO: This is a rather arbitrary limit, we should revisit it (see CSL-1664)
+            if | maxBlockSize * 2 <= mpSize msPool -> refreshMemPool ms
                | otherwise -> pure ms
         processSkeletonDo msIntermediate
   where


### PR DESCRIPTION
It's what's relevant for processing time, and directly limiting the
number of transactions in the mempool is more predictable.  Also, this
removes a lot of unnecessary work serialising transactions over and
over again to get their serialised size.

Set the limit of transactions in the mempool to 200.  This ensures
fast block application, while still allowing transaction rates of up
to 10 Hz.  We will want to relax this bound in the future, but for
Byron I suggest erring on the side of caution.

The Godtossing and Deletion pools were also limited to the size of the
transaction mempool, which seems rather arbitrary. I've set the limit
to the block limit.  We might want to revisit the limits on those
pools at some point.