### PR TITLE
[CSM-451] Safe servant logging

### DIFF
--- a/core/Pos/Core/Constants/Raw.hs
+++ b/core/Pos/Core/Constants/Raw.hs
@@ -32,8 +32,6 @@ module Pos.Core.Constants.Raw
        , criticalForkThreshold
        , fixedTimeCQ
        , fixedTimeCQSec
-
-       , webLoggingEnabled
        ) where
 
 import           Universum
@@ -145,12 +143,6 @@ data CoreConfig = CoreConfig
     , ccCriticalForkThreshold        :: !Int
       -- | Chain quality will be also calculated for this amount of seconds.
     , ccFixedTimeCQ                  :: !Int
-
-       -- Web settings
-
-      -- | Whether incoming requests logging should be performed by web
-      -- part
-    , ccWebLoggingEnabled            :: !Bool
     }
     deriving (Show, Generic)
 
@@ -263,7 +255,3 @@ fixedTimeCQ = sec . ccFixedTimeCQ $ coreConfig
 -- | 'fixedTimeCQ' expressed as seconds.
 fixedTimeCQSec :: Second
 fixedTimeCQSec = convertUnit fixedTimeCQ
-
--- | Web logging might be disabled for security concerns.
-webLoggingEnabled :: Bool
-webLoggingEnabled = ccWebLoggingEnabled coreConfig

--- a/core/Pos/Util/Util.hs
+++ b/core/Pos/Util/Util.hs
@@ -59,6 +59,9 @@ module Pos.Util.Util
        , withTempFile
        , withSystemTempFile
 
+       -- * Coloring
+       , colorizeDull
+
        -- * Aeson
        , parseJSONWithRead
 
@@ -130,6 +133,7 @@ import           Mockable                       (ChannelT, Counter, Distribution
                                                  ThreadId)
 import qualified Prelude
 import           Serokell.Data.Memory.Units     (Byte, fromBytes, toBytes)
+import qualified System.Console.ANSI            as ANSI
 import           System.Directory               (canonicalizePath, createDirectory,
                                                  doesDirectoryExist,
                                                  getTemporaryDirectory, listDirectory,
@@ -581,6 +585,18 @@ withTempFile tmpDir template action =
   where
      ignoringIOErrors :: MC.MonadCatch m => m () -> m ()
      ignoringIOErrors ioe = ioe `MC.catch` (\e -> const (return ()) (e :: Prelude.IOError))
+
+----------------------------------------------------------------------------
+-- Coloring
+----------------------------------------------------------------------------
+
+-- | Colorize text using 'ANSI.Dull' palete
+-- (in contrast to 'Serokell.Util.colorize' which uses 'ANSI.Vivid' palete)
+colorizeDull :: ANSI.Color -> Text -> Text
+colorizeDull color msg =
+    toText (ANSI.setSGRCode [ANSI.SetColor ANSI.Foreground ANSI.Dull color]) <>
+    msg <>
+    toText (ANSI.setSGRCode [ANSI.Reset])
 
 ----------------------------------------------------------------------------
 -- Aeson

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -119,6 +119,7 @@ library
 
   build-depends:       QuickCheck
                      , aeson
+                     , ansi-terminal
                      , autoexporter
                      , base
                      , base58-bytestring

--- a/core/constants.yaml
+++ b/core/constants.yaml
@@ -128,9 +128,6 @@ dev: &dev
 
   genesisBinSuffix: tn # it is set here arbitrarily, it won't be actually used
 
-  # Mode-sensitive logging options
-  webLoggingEnabled: true
-
 
 ##############################################################################
 ##                                                                          ##

--- a/node/src/Pos/Util/BackupPhrase.hs
+++ b/node/src/Pos/Util/BackupPhrase.hs
@@ -55,10 +55,10 @@ mkBackupPhrase9 ls
     | otherwise = error "Invalid number of words in backup phrase! Expected 9 words."
 
 instance Show BackupPhrase where
-    show = toString . unwords . bpToList
+    show _ = "<backup phrase>"
 
 instance Buildable BackupPhrase where
-    build = build . unwords . bpToList
+    build _ = "<backup phrase>"
 
 instance Read BackupPhrase where
     readsPrec _ str = either fail (pure . (, mempty) .BackupPhrase . words) $ toMnemonic =<< fromMnemonic (toText str)

--- a/node/src/Pos/Util/Servant.hs
+++ b/node/src/Pos/Util/Servant.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE Rank2Types          #-}
@@ -19,53 +20,89 @@ module Pos.Util.Servant
 
     , WithDefaultApiArg
 
+    , HasLoggingServer (..)
+    , ApiLoggingConfig
+    , LoggingApi
+    , LoggingApiRec
+
     , CQueryParam
     , CCapture
     , CReqBody
     , DCQueryParam
+
+    , serverHandlerL
+    , serverHandlerL'
+    , inRouteServer
+
+    , applyLoggingToVerb
     ) where
 
-import           Control.Monad.Except (ExceptT (..))
-import           Data.Default         (Default (..))
-import           Formatting           (formatToString, sformat, shown, stext, string, (%))
-import           Servant.API          ((:>), Capture, QueryParam, ReqBody, Verb)
-import           Servant.Server       (Handler (..), HasServer (..), ServantErr, Server)
 import           Universum
 
+import           Control.Lens            (Iso, iso, makePrisms)
+import           Control.Monad.Catch     (handleAll)
+import           Control.Monad.Except    (ExceptT (..), MonadError (..))
+import           Data.Default            (Default (..))
+import           Data.Reflection         (Reifies (..), reflect)
+import           Formatting              (bprint, build, formatToString, sformat, shown,
+                                          stext, string, (%))
+import           Serokell.Util.ANSI      (Color (..))
+import           Servant.API             ((:<|>) (..), (:>), Capture, QueryParam,
+                                          ReflectMethod (..), ReqBody, Verb)
+import           Servant.Server          (Handler (..), HasServer (..), ServantErr,
+                                          Server)
+import qualified Servant.Server.Internal as SI
+import           System.Wlog             (LoggerName, logInfo, usingLoggerName)
+
+import           Pos.Util.Util           (colorizeDull)
 
 -------------------------------------------------------------------------
 -- Utility functions
 -------------------------------------------------------------------------
 
-mapHandler :: (IO (Either ServantErr a) -> IO (Either ServantErr b))
-           -> Handler a
-           -> Handler b
-mapHandler f = Handler . ExceptT . f . runExceptT . runHandler'
+serverHandlerL :: Iso (Handler a) (Handler b) (ExceptT ServantErr IO a) (ExceptT ServantErr IO b)
+serverHandlerL = iso runHandler' Handler
+
+serverHandlerL' :: Iso (Handler a) (Handler b) (IO $ Either ServantErr a) (IO $ Either ServantErr b)
+serverHandlerL' = serverHandlerL . iso runExceptT ExceptT
+
+inRouteServer
+    :: forall api api' ctx env.
+       (Proxy api -> SI.Context ctx -> SI.Delayed env (Server api) -> SI.Router env)
+    -> (Server api' -> Server api)
+    -> (Proxy api' -> SI.Context ctx -> SI.Delayed env (Server api') -> SI.Router env)
+inRouteServer routing f = \_ ctx delayed -> routing Proxy ctx (fmap f delayed)
 
 -------------------------------------------------------------------------
 -- General useful families
 -------------------------------------------------------------------------
 
 -- | Proves info about argument specifier of servant API.
-class ApiHasArg apiType where
+class ApiHasArgClass apiType a where
     -- | For arguments-specifiers of API, get argument type.
     type ApiArg (apiType :: * -> *) a :: *
     type ApiArg apiType a = a
 
     -- | Name of argument.
     -- E.g. name of argument specified by @Capture "nyan"@ is /nyan/.
-    apiArgName :: Proxy apiType -> String
+    apiArgName :: Proxy (apiType a) -> String
     default apiArgName
         :: forall n someApiType. (KnownSymbol n, someApiType n ~ apiType)
-        => Proxy (someApiType n) -> String
-    apiArgName _ = formatToString (shown%" field") $ symbolVal (Proxy @n)
+        => Proxy (someApiType n a) -> String
+    apiArgName _ = formatToString ("'"%string%"' field") $ symbolVal (Proxy @n)
 
-instance KnownSymbol s => ApiHasArg (Capture s) where
+type ApiHasArgInvariant apiType a res =
+    Server (apiType a :> res) ~ (ApiArg apiType a -> Server res)
 
-instance KnownSymbol s => ApiHasArg (QueryParam s) where
+type ApiHasArg apiType a res =
+    ( ApiHasArgClass apiType a
+    , ApiHasArgInvariant apiType a res
+    )
+
+instance KnownSymbol s => ApiHasArgClass (Capture s) a
+instance KnownSymbol s => ApiHasArgClass (QueryParam s) a where
     type ApiArg (QueryParam s) a = Maybe a
-
-instance ApiHasArg (ReqBody ct) where
+instance ApiHasArgClass (ReqBody ct) a where
     apiArgName _ = "request body"
 
 -------------------------------------------------------------------------
@@ -91,10 +128,8 @@ instance (HasServer (Verb mt st ct $ ApiModifiedRes mod a) ctx,
     type ServerT (VerbMod mod $ Verb mt st ct a) m =
          ServerT (Verb mt st ct a) m
 
-    route _ ctx del = route verbProxy ctx (handlerCatch <$> del)
-      where
-        verbProxy = Proxy @(Verb mt st ct $ ApiModifiedRes mod a)
-        handlerCatch = mapHandler $ modifyApiResult (Proxy @mod)
+    route = inRouteServer @(Verb mt st ct $ ApiModifiedRes mod a) route $
+            serverHandlerL' %~ modifyApiResult (Proxy @mod)
 
 -------------------------------------------------------------------------
 -- Mapping API arguments: client types decoding
@@ -127,7 +162,7 @@ class ReportDecodeError api where
     reportDecodeError :: Proxy api -> Text -> Server api
 
 instance ( ReportDecodeError res
-         , Server (argType a :> res) ~ (ApiArg argType a -> Server res)
+         , ApiHasArg argType a res
          ) =>
          ReportDecodeError (argType a :> res) where
     reportDecodeError _ err = \_ -> reportDecodeError (Proxy @res) err
@@ -137,27 +172,27 @@ instance ( ReportDecodeError res
 -- with 'decodeCType'.
 data CDecodeApiArg (argType :: * -> *) a
 
-instance ApiHasArg apiType => ApiHasArg (CDecodeApiArg apiType) where
+instance ApiHasArgClass apiType a =>
+         ApiHasArgClass (CDecodeApiArg apiType) a where
     type ApiArg (CDecodeApiArg apiType) a = OriginType (ApiArg apiType a)
-    apiArgName _ = apiArgName (Proxy @apiType)
+    apiArgName _ = apiArgName (Proxy @(apiType a))
 
 instance ( HasServer (apiType a :> res) ctx
-         , ApiHasArg apiType
-         , Server (apiType a :> res) ~ (ApiArg apiType a -> Server res)
+         , ApiHasArg apiType a res
          , FromCType (ApiArg apiType a)
          , ReportDecodeError res
          ) =>
          HasServer (CDecodeApiArg apiType a :> res) ctx where
     type ServerT (CDecodeApiArg apiType a :> res) m =
          OriginType (ApiArg apiType a) -> ServerT res m
-    route _ ctx del =
-        route (Proxy @(apiType a :> res)) ctx $
-        del <&> \f a -> decodeCType a & either reportE f
+    route =
+        inRouteServer @(apiType a :> res) route $
+        \f a -> either reportE f $ decodeCType a
       where
         reportE err =
             reportDecodeError (Proxy @res) $
             sformat ("(in "%string%") "%stext)
-                (apiArgName $ Proxy @apiType)
+                (apiArgName $ Proxy @(apiType a))
                 err
 
 -------------------------------------------------------------------------
@@ -172,11 +207,10 @@ type family Unmaybe a where
 
 data WithDefaultApiArg (argType :: * -> *) a
 
--- TODO: why is it needed at all? 'DefaultApiArg' is used only at top
--- layer for given argument
-instance ApiHasArg apiType => ApiHasArg (WithDefaultApiArg apiType) where
+instance (ApiHasArgClass apiType a, ApiArg apiType a ~ Maybe b) =>
+         ApiHasArgClass (WithDefaultApiArg apiType) a where
     type ApiArg (WithDefaultApiArg apiType) a = Unmaybe (ApiArg apiType a)
-    apiArgName _ = apiArgName (Proxy @apiType)
+    apiArgName _ = apiArgName (Proxy @(apiType a))
 
 instance ( HasServer (apiType a :> res) ctx
          , Server (apiType a :> res) ~ (Maybe c -> d)
@@ -185,9 +219,192 @@ instance ( HasServer (apiType a :> res) ctx
          HasServer (WithDefaultApiArg apiType a :> res) ctx where
     type ServerT (WithDefaultApiArg apiType a :> res) m =
          UnmaybeArg (ServerT (apiType a :> res) m)
-    route _ ctx del =
-        route (Proxy @(apiType a :> res)) ctx $
-        del <&> \f a -> f $ fromMaybe def a
+    route =
+        inRouteServer @(apiType a :> res) route $
+        \f a -> f $ fromMaybe def a
+
+-------------------------------------------------------------------------
+-- Logging
+-------------------------------------------------------------------------
+
+data LoggingApi config api
+data LoggingApiRec config api
+type ApiLoggingConfig = LoggerName
+data ApiParamsLogInfo
+    = ApiParamsLogInfo [Text]  -- ^ Parameters gathered at current stage
+    | ApiNoParamsLogInfo Text  -- ^ Parameters collection failed with reason
+                               --   (e.g. decoding error)
+
+makePrisms ''ApiParamsLogInfo
+
+instance Default ApiParamsLogInfo where
+    def = ApiParamsLogInfo mempty
+
+instance HasServer (LoggingApiRec config api) ctx =>
+         HasServer (LoggingApi config api) ctx where
+    type ServerT (LoggingApi config api) m = ServerT api m
+    route = inRouteServer @(LoggingApiRec config api) route
+            (def, )
+
+class HasLoggingServer config api ctx where
+    routeWithLog
+        :: Proxy (LoggingApiRec config api)
+        -> SI.Context ctx
+        -> SI.Delayed env (Server (LoggingApiRec config api))
+        -> SI.Router env
+
+instance HasLoggingServer config api ctx =>
+         HasServer (LoggingApiRec config api) ctx where
+    type ServerT (LoggingApiRec config api) m =
+         (ApiParamsLogInfo, ServerT api m)
+    route = routeWithLog
+
+instance ( HasLoggingServer config api1 ctx
+         , HasLoggingServer config api2 ctx
+         ) =>
+         HasLoggingServer config (api1 :<|> api2) ctx where
+    routeWithLog =
+        inRouteServer
+            @(LoggingApiRec config api1 :<|> LoggingApiRec config api2)
+            route $
+            \(paramsInfo, f1 :<|> f2) -> (paramsInfo, f1) :<|> (paramsInfo, f2)
+
+instance ( KnownSymbol path
+         , HasLoggingServer config res ctx
+         ) =>
+         HasLoggingServer config (path :> res) ctx where
+    routeWithLog =
+        inRouteServer @(path :> LoggingApiRec config res) route $
+        \(paramsInfo, f) -> (updateParamsInfo paramsInfo, f)
+      where
+        updateParamsInfo = do
+            let path = toText . symbolVal $ Proxy @path
+            _ApiParamsLogInfo %~ (path :)
+
+class ApiHasArgClass apiType a =>
+      ApiCanLogArg apiType a where
+    type ApiArgToLog (apiType :: * -> *) a :: *
+    type ApiArgToLog apiType a = a
+
+    toLogParamInfo
+        :: Show (ApiArgToLog apiType a)
+        => Proxy (apiType a) -> ApiArg apiType a -> Text
+    default toLogParamInfo
+        :: (Show a, ApiArgToLog apiType a ~ a)
+        => Proxy (apiType a) -> a -> Text
+    toLogParamInfo _ = show
+
+instance KnownSymbol s => ApiCanLogArg (Capture s) a
+instance ApiCanLogArg (ReqBody ct) a
+instance KnownSymbol cs => ApiCanLogArg (QueryParam cs) a where
+    toLogParamInfo _ = maybe noEntry show
+      where
+        noEntry = colorizeDull White "-"
+
+instance ( ApiHasArgClass apiType a
+         , ApiArg apiType a ~ Maybe b
+         , ApiCanLogArg apiType a
+         , Show (ApiArgToLog apiType a)
+         ) =>
+         ApiCanLogArg (WithDefaultApiArg apiType) a where
+    type ApiArgToLog (WithDefaultApiArg apiType) a = Unmaybe (ApiArg apiType a)
+    toLogParamInfo _ = show
+
+instance ( ApiCanLogArg apiType a
+         , Show (ApiArgToLog apiType a)
+         ) =>
+         ApiCanLogArg (CDecodeApiArg apiType) a where
+    type ApiArgToLog (CDecodeApiArg apiType) a = OriginType (ApiArg apiType a)
+    toLogParamInfo _ = show
+
+instance ( HasServer (apiType a :> LoggingApiRec config res) ctx
+         , ApiHasArg apiType a res
+         , ApiHasArg apiType a (LoggingApiRec config res)
+         , ApiCanLogArg apiType a
+         , Show (ApiArgToLog apiType a)
+         ) =>
+         HasLoggingServer config (apiType a :> res) ctx where
+    routeWithLog =
+        inRouteServer @(apiType a :> LoggingApiRec config res) route $
+        \(paramsInfo, f) a -> (a `updateParamsInfo` paramsInfo, f a)
+      where
+        updateParamsInfo a = do
+            let paramName = apiArgName $ Proxy @(apiType a)
+                paramVal  = toLogParamInfo (Proxy @(apiType a)) a
+                paramInfo = sformat (string%": "%stext) paramName paramVal
+            _ApiParamsLogInfo %~ (paramInfo :)
+
+applyLoggingToVerb
+    :: ( MonadIO m
+       , MonadCatch m
+       , MonadError ServantErr m
+       , Reifies config ApiLoggingConfig
+       )
+    => Proxy config -> Text -> ApiParamsLogInfo -> (a -> Text) -> m a -> m a
+applyLoggingToVerb configP method paramsInfo showResponse action =
+    catchErrors $ do
+        res <- action
+        reportResponse res
+        return res
+  where
+    doLog msg = do
+        let loggerName = reflect configP
+        liftIO . usingLoggerName loggerName $ logInfo msg
+    mkParamLogs = case paramsInfo of
+        (ApiParamsLogInfo info) -> do
+            let params = mconcat $ reverse info <&>
+                  bprint ("    "%stext%" "%stext%"\n") (colorizeDull White ":>")
+            Right $ sformat ("\n"%stext%"\n"%build) cmethod params
+        ApiNoParamsLogInfo why -> Left why
+    logWithParamInfo msg =
+        case mkParamLogs of
+            Left e ->
+                doLog $ sformat ("\n"%stext%" "%stext)
+                        (colorizeDull Red "Unexecuted request due to error") e
+            Right paramLogs ->
+                doLog (paramLogs <> msg)
+    reportResponse resp =
+        logWithParamInfo $
+            sformat (stext%" "%stext%"\n"%stext)
+                (colorizeDull White "Status")
+                (colorizeDull Green "OK")
+                (showResponse resp)
+    catchErrors =
+        flip catchError servantErrHandler .
+        handleAll totalHandler
+    servantErrHandler (e :: ServantErr) = do
+        logWithParamInfo $
+            sformat ("Status: "%stext%"\n") (colorizeDull Red $ show e)
+        throwError e
+    totalHandler (e :: SomeException) = do
+        logWithParamInfo $
+            sformat (stext%" "%shown%"\n") (colorizeDull Red "Exception") e
+        throwM e
+    cmethod = flip colorizeDull method $ case method of
+        "GET"    -> Cyan
+        "POST"   -> Yellow
+        "PUT"    -> Blue
+        "DELETE" -> Red
+        _        -> Magenta
+
+instance ( HasServer (Verb mt st ct a) ctx
+         , Reifies config ApiLoggingConfig
+         , ReflectMethod mt
+         , Show a
+         ) =>
+         HasLoggingServer config (Verb (mt :: k1) (st :: Nat) (ct :: [*]) a) ctx where
+    routeWithLog =
+        inRouteServer @(Verb mt st ct a) route $
+        \(paramsInfo, handler) ->
+            handler & serverHandlerL %~ withLogging paramsInfo
+      where
+        method = decodeUtf8 $ reflectMethod (Proxy @mt)
+        withLogging params = applyLoggingToVerb (Proxy @config) method params show
+
+instance ReportDecodeError api =>
+         ReportDecodeError (LoggingApiRec config api) where
+    reportDecodeError _ msg =
+        (ApiNoParamsLogInfo msg, reportDecodeError (Proxy @api) msg)
 
 -------------------------------------------------------------------------
 -- API construction Helpers

--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -8,8 +8,12 @@ import           Universum
 
 import qualified Data.ByteArray                       as ByteArray
 import qualified Data.ByteString                      as BS
+import           Data.List                            (partition)
 import           Data.Text                            (splitOn)
-import           Formatting                           (build, int, sformat, (%))
+import qualified Data.Text.Buildable
+import           Formatting                           (bprint, build, int, sformat, shown,
+                                                       (%))
+import           Serokell.Util                        (listJson, listJsonIndent)
 import qualified Serokell.Util.Base16                 as Base16
 import           Servant.API                          (FromHttpApiData (..))
 import           Servant.Multipart                    (FromMultipart (..), lookupFile,
@@ -19,20 +23,174 @@ import           Pos.Core                             (Address, Coin, decodeText
                                                        mkCoin)
 import           Pos.Crypto                           (PassPhrase, passphraseLength)
 import           Pos.Txp.Core.Types                   (TxId)
-import           Pos.Util.Servant                     (FromCType (..), OriginType,
-                                                       ToCType (..))
+import           Pos.Util.Servant                     (FromCType (..),
+                                                       HasTruncateLogPolicy (..),
+                                                       OriginType, ToCType (..),
+                                                       WithTruncatedLog (..))
 import           Pos.Wallet.Web.ClientTypes.Functions (addressToCId, cIdToAddress,
                                                        mkCCoin, mkCTxId,
                                                        ptxCondToCPtxCond, txIdToCTxId)
-import           Pos.Wallet.Web.ClientTypes.Types     (AccountId (..), CAccountId (..),
+import           Pos.Wallet.Web.ClientTypes.Types     (AccountId (..), CAccount (..),
+                                                       CAccountId (..), CAccountInit (..),
+                                                       CAccountMeta (..), CAddress (..),
                                                        CCoin (..),
                                                        CElectronCrashReport (..),
-                                                       CId (..), CPassPhrase (..),
-                                                       CPtxCondition, CTxId)
+                                                       CId (..), CInitialized (..),
+                                                       CPaperVendWalletRedeem (..),
+                                                       CPassPhrase (..), CProfile (..),
+                                                       CPtxCondition, CTx (..),
+                                                       CTxId (..), CTxId, CTxMeta (..),
+                                                       CUpdateInfo (..), CWallet (..),
+                                                       CWallet, CWalletAssurance,
+                                                       CWalletInit (..), CWalletMeta (..),
+                                                       CWalletRedeem (..),
+                                                       SyncProgress (..))
 import           Pos.Wallet.Web.Pending.Types         (PtxCondition)
 
 -- TODO [CSM-407] Maybe revert dependency between Functions and Instances modules?
 -- This would allow to get tid of functions like 'ptxCondToCPtxCond' :/
+
+----------------------------------------------------------------------------
+-- Buildable
+----------------------------------------------------------------------------
+
+-- TODO [CSM-407] Move these instances to Types.hs module.
+-- I don't want to do it now because we have pending refactoring which reordered
+-- everything where
+
+instance Buildable CWalletAssurance where
+    build = bprint shown
+
+instance Buildable CWalletMeta where
+    build CWalletMeta{..} =
+        bprint ("'"%build%"' ("%build%"/"%build%")")
+               cwName cwAssurance cwUnit
+
+instance Buildable CWalletInit where
+    build CWalletInit{..} =
+        bprint (build%" / "%build)
+               cwBackupPhrase cwInitMeta
+
+instance Buildable CWallet where
+    build CWallet{..} =
+        bprint ("{ id="%build
+                %" meta="%build
+                %" accs="%build
+                %" amount="%build
+                %" pass="%build
+                %" passlu="%build
+                %" }")
+        cwId
+        cwMeta
+        cwAccountsNumber
+        cwAmount
+        cwHasPassphrase
+        cwPassphraseLU
+
+instance Buildable CAccountMeta where
+    build CAccountMeta{..} =
+        bprint ("'"%build%"'") caName
+
+instance Buildable CAccountInit where
+    build CAccountInit{..} =
+        bprint (build%" / "%build)
+               caInitWId caInitMeta
+
+instance Buildable CAccount where
+    build CAccount{..} =
+        bprint ("{ id="%build
+                %" meta="%build
+                %" amount="%build%"\n"
+                %" addrs="%listJsonIndent 4
+                %" }")
+        caId
+        caMeta
+        caAmount
+        caAddresses
+
+instance Buildable CAddress where
+    build CAddress{..} =
+        bprint ("{ id="%build%"\n"
+                %" amount="%build
+                %" used="%build
+                %" change="%build
+                %" }")
+        cadId
+        cadAmount
+        cadIsUsed
+        cadIsChange
+
+instance Buildable CTxMeta where
+    build CTxMeta{..} = bprint ("{ date="%build%" }") ctmDate
+
+instance Buildable CPtxCondition where
+    build = bprint shown
+
+instance Buildable CTx where
+    build CTx{..} =
+        bprint ("{ id="%build
+                %" amount="%build
+                %" confirms="%build
+                %" meta="%build%"\n"
+                %" inputs="%listJson%"\n"
+                %" outputs="%listJson%"\n"
+                %" local="%build
+                %" outgoing="%build
+                %" condition="%build
+                %" }")
+        ctId
+        ctAmount
+        ctConfirmations
+        ctMeta
+        ctInputAddrs
+        ctOutputAddrs
+        ctIsLocal
+        ctIsOutgoing
+        ctCondition
+
+instance Buildable CProfile where
+    build CProfile{..} =
+        bprint ("{ cpLocale="%build%" }") cpLocale
+
+instance Buildable CUpdateInfo where
+    build CUpdateInfo{..} =
+        bprint ("{ softver="%build
+                %" blockver="%build
+                %" scriptver="%build
+                %" implicit="%build
+                %" for="%build
+                %" against="%build
+                %" pos stake="%build
+                %" neg stake="%build
+                %" }")
+        cuiSoftwareVersion
+        cuiBlockVesion  -- TODO [CSM-407] lol what is it?
+        cuiScriptVersion
+        cuiImplicit
+        cuiVotesFor
+        cuiVotesAgainst
+        cuiPositiveStake
+        cuiNegativeStake
+
+instance Buildable SyncProgress where
+    build SyncProgress{..} =
+        bprint ("progress="%build%"/"%build%" peers="%build)
+               _spLocalCD _spNetworkCD _spPeers
+
+instance Buildable CWalletRedeem where
+    build CWalletRedeem{..} =
+        bprint (build%" <- "%build)
+               crWalletId crSeed
+
+instance Buildable CPaperVendWalletRedeem where
+    build CPaperVendWalletRedeem{..} =
+        bprint (build%" <- "%build%" / "%build)
+               pvWalletId pvSeed pvBackupPhrase
+
+instance Buildable CInitialized where
+    build CInitialized{..} =
+        bprint (build%"/"%build)
+               cPreInit cTotalTime
 
 ----------------------------------------------------------------------------
 -- Convertions
@@ -143,3 +301,49 @@ instance FromMultipart CElectronCrashReport where
           <*> look "prod"
           <*> look "_companyName"
           <*> lookupFile "upload_file_minidump" form
+
+----------------------------------------------------------------------------
+-- Truncated Buildable
+----------------------------------------------------------------------------
+
+instance HasTruncateLogPolicy CTx where
+    -- Related logs are printed often.
+    -- Tx history changes increamentally, order is newest first
+    truncateLogPolicy = take 5
+
+instance HasTruncateLogPolicy CWallet where
+    -- Related logs are printed seldom.
+    -- Contains constantly chaning info (balance)
+    truncateLogPolicy = identity
+
+instance HasTruncateLogPolicy CAccount where
+    -- Currently each wallet has single account, so same logic as for 'CWallet'
+    -- instance.
+    truncateLogPolicy = identity
+
+instance HasTruncateLogPolicy CAddress where
+    -- Their number has the same order as number of transactions made from
+    -- parent account. However, addresses with no money consistute the majority
+    -- and are not very interesting.
+    truncateLogPolicy addrs =
+        let (withoutMoney, withMoney) = partition ((== zeroMoney) . cadAmount) addrs
+        in take 5 (withMoney <> withoutMoney)
+      where
+        zeroMoney = encodeCType minBound
+
+instance Buildable (WithTruncatedLog CAccount) where
+    build (WithTruncatedLog CAccount{..}) =
+        bprint ("{ id="%build
+                %" meta="%build
+                %" amount="%build%"\n"
+                %" addrs="%build
+                %" }")
+        caId
+        caMeta
+        caAmount
+        (WithTruncatedLog caAddresses)
+
+instance Buildable (WithTruncatedLog ([CTx], Word)) where
+    build (WithTruncatedLog (ctxs, size)) =
+        bprint ("Num: "%build%", entries: \n"%build)
+            size (WithTruncatedLog ctxs)

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -92,7 +92,7 @@ data Addr = Addr
 
 -- | Client transaction id
 newtype CTxId = CTxId CHash
-    deriving (Show, Eq, Generic, Hashable)
+    deriving (Show, Eq, Generic, Hashable, Buildable)
 
 newtype CPassPhrase = CPassPhrase Text
     deriving (Eq, Generic)
@@ -144,7 +144,7 @@ instance Hashable CWAddressMeta
 
 newtype CCoin = CCoin
     { getCCoin :: Text
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Generic, Buildable)
 
 -- | Passphrase last update time
 type PassPhraseLU = POSIXTime

--- a/node/src/Pos/Web/Server.hs
+++ b/node/src/Pos/Web/Server.hs
@@ -16,41 +16,36 @@ module Pos.Web.Server
 
 import           Universum
 
-import qualified Control.Monad.Catch                  as Catch
-import           Control.Monad.Except                 (MonadError (throwError))
-import qualified Control.Monad.Reader                 as Mtl
-import           Mockable                             (Production (runProduction))
-import           Network.Wai                          (Application, Middleware)
-import           Network.Wai.Handler.Warp             (defaultSettings, runSettings,
-                                                       setHost, setPort)
-import           Network.Wai.Handler.WarpTLS          (TLSSettings, runTLS,
-                                                       tlsSettingsChain)
-import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
-import           Servant.API                          ((:<|>) ((:<|>)), FromHttpApiData)
-import           Servant.Server                       (Handler, ServantErr (errBody),
-                                                       Server, ServerT, err404, serve)
-import           Servant.Utils.Enter                  ((:~>) (NT), enter)
+import qualified Control.Monad.Catch         as Catch
+import           Control.Monad.Except        (MonadError (throwError))
+import qualified Control.Monad.Reader        as Mtl
+import           Mockable                    (Production (runProduction))
+import           Network.Wai                 (Application)
+import           Network.Wai.Handler.Warp    (defaultSettings, runSettings, setHost,
+                                              setPort)
+import           Network.Wai.Handler.WarpTLS (TLSSettings, runTLS, tlsSettingsChain)
+import           Servant.API                 ((:<|>) ((:<|>)), FromHttpApiData)
+import           Servant.Server              (Handler, ServantErr (errBody), Server,
+                                              ServerT, err404, serve)
+import           Servant.Utils.Enter         ((:~>) (NT), enter)
 
-import           Pos.Aeson.Types                      ()
-import           Pos.Constants                        (webLoggingEnabled)
-import           Pos.Context                          (HasNodeContext (..),
-                                                       HasSscContext (..), NodeContext,
-                                                       getOurPublicKey)
-import           Pos.Core                             (EpochIndex (..), SlotLeaders)
-import qualified Pos.DB                               as DB
-import qualified Pos.GState                           as GS
-import qualified Pos.Lrc.DB                           as LrcDB
-import           Pos.Ssc.Class                        (SscConstraint)
-import           Pos.Ssc.GodTossing                   (SscGodTossing, gtcParticipateSsc)
-import           Pos.Txp                              (TxOut (..), toaOut)
-import           Pos.Txp.MemState                     (GenericTxpLocalData, askTxpMem,
-                                                       getLocalTxs)
-import           Pos.Web.Mode                         (WebMode, WebModeContext (..))
-import           Pos.WorkMode.Class                   (TxpExtra_TMP, WorkMode)
+import           Pos.Aeson.Types             ()
+import           Pos.Context                 (HasNodeContext (..), HasSscContext (..),
+                                              NodeContext, getOurPublicKey)
+import           Pos.Core                    (EpochIndex (..), SlotLeaders)
+import qualified Pos.DB                      as DB
+import qualified Pos.GState                  as GS
+import qualified Pos.Lrc.DB                  as LrcDB
+import           Pos.Ssc.Class               (SscConstraint)
+import           Pos.Ssc.GodTossing          (SscGodTossing, gtcParticipateSsc)
+import           Pos.Txp                     (TxOut (..), toaOut)
+import           Pos.Txp.MemState            (GenericTxpLocalData, askTxpMem, getLocalTxs)
+import           Pos.Web.Mode                (WebMode, WebModeContext (..))
+import           Pos.WorkMode.Class          (TxpExtra_TMP, WorkMode)
 
-import           Pos.Web.Api                          (BaseNodeApi, GodTossingApi,
-                                                       GtNodeApi, baseNodeApi, gtNodeApi)
-import           Pos.Web.Types                        (TlsParams (..))
+import           Pos.Web.Api                 (BaseNodeApi, GodTossingApi, GtNodeApi,
+                                              baseNodeApi, gtNodeApi)
+import           Pos.Web.Types               (TlsParams (..))
 
 ----------------------------------------------------------------------------
 -- Top level functionality
@@ -81,7 +76,7 @@ applicationGT = do
 
 serveImplNoTLS :: MonadIO m => m Application -> String -> Word16 -> m ()
 serveImplNoTLS application host port =
-    liftIO . runSettings mySettings . webLogger =<< application
+    liftIO . runSettings mySettings =<< application
   where
     mySettings = setHost (fromString host) $
                  setPort (fromIntegral port) defaultSettings
@@ -90,17 +85,12 @@ serveImpl
     :: MonadIO m
     => m Application -> String -> Word16 -> Maybe TlsParams -> m ()
 serveImpl application host port walletTLSParams =
-    liftIO . maybe runSettings runTLS mTlsConfig mySettings . webLogger
+    liftIO . maybe runSettings runTLS mTlsConfig mySettings
         =<< application
   where
     mySettings = setHost (fromString host) $
                  setPort (fromIntegral port) defaultSettings
     mTlsConfig = tlsParamsToWai <$> walletTLSParams
-
-webLogger :: Middleware
-webLogger
-    | webLoggingEnabled = logStdoutDev
-    | otherwise         = identity
 
 tlsParamsToWai :: TlsParams -> TLSSettings
 tlsParamsToWai TlsParams{..} = tlsSettingsChain tpCertPath [tpCaPath] tpKeyPath

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1351,13 +1351,14 @@ self: {
           description = "Cardano SL - Auxx";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-core = callPackage ({ QuickCheck, aeson, autoexporter, base, base58-bytestring, binary, bytestring, cardano-crypto, cborg, cereal, concurrent-extra, containers, contravariant, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, ed25519, ether, exceptions, file-embed, filepath, formatting, generic-arbitrary, hashable, lens, log-warper, lrucache, memory, mkDerivation, mmorph, mtl, node-sketch, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, resourcet, safecopy, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector, yaml }:
+      cardano-sl-core = callPackage ({ QuickCheck, aeson, ansi-terminal, autoexporter, base, base58-bytestring, binary, bytestring, cardano-crypto, cborg, cereal, concurrent-extra, containers, contravariant, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, ed25519, ether, exceptions, file-embed, filepath, formatting, generic-arbitrary, hashable, lens, log-warper, lrucache, memory, mkDerivation, mmorph, mtl, node-sketch, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, resourcet, safecopy, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector, yaml }:
       mkDerivation {
           pname = "cardano-sl-core";
           version = "0.6.0";
           src = ./../core;
           libraryHaskellDepends = [
             aeson
+            ansi-terminal
             autoexporter
             base
             base58-bytestring
@@ -1956,7 +1957,7 @@ self: {
           description = "Cardano SL - update";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-wallet = callPackage ({ aeson, ansi-wl-pprint, base, base58-bytestring, binary, bytestring, cardano-report-server, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, containers, cpphs, data-default, directory, dlist, ether, exceptions, filepath, formatting, lens, log-warper, mkDerivation, mtl, network-transport, network-transport-tcp, node-sketch, optparse-applicative, parsec, purescript-bridge, random, semver, serokell-util, servant, servant-multipart, servant-server, servant-swagger, servant-swagger-ui, stdenv, stm, stm-containers, string-qq, swagger2, text, text-format, time, time-units, transformers, universum, unix, unordered-containers, wai, wai-websockets, websockets }:
+      cardano-sl-wallet = callPackage ({ aeson, ansi-wl-pprint, base, base58-bytestring, binary, bytestring, cardano-report-server, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, containers, cpphs, data-default, directory, dlist, ether, exceptions, filepath, formatting, lens, log-warper, mkDerivation, mtl, network-transport, network-transport-tcp, node-sketch, optparse-applicative, parsec, purescript-bridge, random, reflection, semver, serokell-util, servant, servant-multipart, servant-server, servant-swagger, servant-swagger-ui, stdenv, stm, stm-containers, string-qq, swagger2, text, text-format, time, time-units, transformers, universum, unix, unordered-containers, wai, wai-websockets, websockets }:
       mkDerivation {
           pname = "cardano-sl-wallet";
           version = "0.6.0";
@@ -1995,6 +1996,7 @@ self: {
             optparse-applicative
             parsec
             random
+            reflection
             semver
             serokell-util
             servant

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -95,6 +95,7 @@ library
                       , optparse-applicative
                       , parsec
                       , random
+                      , reflection
                       , semver
                       , serokell-util >= 0.1.3.4
                       , servant >= 0.8.1

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -121,7 +121,7 @@ data WalletLoggingConfig
 
 -- If logger config will ever be determined in runtime, `reify` can be used.
 instance Reifies WalletLoggingConfig ApiLoggingConfig where
-    reflect _ = "wallet" <> "servant"
+    reflect _ = "node" <> "wallet" <> "servant"
 
 -- | Shortcut for common api result types.
 type WRes verbType a = WalletVerb (verbType '[JSON] a)

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -65,7 +65,6 @@ module Pos.Wallet.Web.Api
 
 import           Control.Monad.Catch        (try)
 import           Data.Reflection            (Reifies (..))
-import           Formatting                 (build, sformat)
 import           Servant.API                ((:<|>), (:>), Capture, Delete, Get, JSON,
                                              Post, Put, QueryParam, ReflectMethod (..),
                                              ReqBody, Verb)
@@ -79,8 +78,7 @@ import           Pos.Util.Servant           (ApiLoggingConfig, CCapture, CQueryP
                                              HasLoggingServer (..), LoggingApi,
                                              ModifiesApiRes (..), ReportDecodeError (..),
                                              VerbMod, WithTruncatedLog (..),
-                                             applyLoggingToVerb, inRouteServer,
-                                             serverHandlerL)
+                                             applyLoggingToHandler, inRouteServer)
 import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit,
                                              CAccountMeta, CAddress, CCoin, CId,
                                              CInitialized, CPaperVendWalletRedeem,
@@ -116,13 +114,7 @@ instance ( HasServer (WalletVerb (Verb mt st ct a)) ctx
          HasLoggingServer config (WalletVerb (Verb (mt :: k1) (st :: Nat) (ct :: [*]) a)) ctx where
     routeWithLog =
         inRouteServer @(WalletVerb (Verb mt st ct a)) route $
-        \(paramsInfo, handler) ->
-            handler & serverHandlerL %~ withLogging paramsInfo
-      where
-        method = decodeUtf8 $ reflectMethod (Proxy @mt)
-        display = sformat build . WithTruncatedLog
-        withLogging params = applyLoggingToVerb (Proxy @config) method params display
-
+        applyLoggingToHandler (Proxy @config) (Proxy @mt)
 
 -- | Specifes servant logging config.
 data WalletLoggingConfig

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -64,23 +64,28 @@ module Pos.Wallet.Web.Api
 
 
 import           Control.Monad.Catch        (try)
+import           Data.Reflection            (Reifies (..))
 import           Servant.API                ((:<|>), (:>), Capture, Delete, Get, JSON,
-                                             Post, Put, QueryParam, ReqBody, Verb)
-import           Servant.Server             (Handler (..))
+                                             Post, Put, QueryParam, ReflectMethod (..),
+                                             ReqBody, Verb)
+import           Servant.Server             (Handler (..), HasServer (..))
 import           Servant.Swagger.UI         (SwaggerSchemaUI)
 import           Universum
 
 import           Pos.Types                  (Coin, SoftwareVersion)
-import           Pos.Util.Servant           (CCapture, CQueryParam, CReqBody,
-                                             DCQueryParam, ModifiesApiRes (..),
-                                             ReportDecodeError (..), VerbMod)
+import           Pos.Util.Servant           (ApiLoggingConfig, CCapture, CQueryParam,
+                                             CReqBody, DCQueryParam,
+                                             HasLoggingServer (..), LoggingApi,
+                                             ModifiesApiRes (..), ReportDecodeError (..),
+                                             VerbMod, applyLoggingToVerb, inRouteServer,
+                                             serverHandlerL)
 import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit,
-                                             CAccountMeta, CAddress, CCoin,
-                                             CId, CInitialized,
-                                             CPaperVendWalletRedeem, CPassPhrase,
-                                             CProfile, CTx, CTxId, CTxMeta, CUpdateInfo,
-                                             CWallet, CWalletInit, CWalletMeta,
-                                             CWalletRedeem, SyncProgress, Wal)
+                                             CAccountMeta, CAddress, CCoin, CId,
+                                             CInitialized, CPaperVendWalletRedeem,
+                                             CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
+                                             CUpdateInfo, CWallet, CWalletInit,
+                                             CWalletMeta, CWalletRedeem, SyncProgress,
+                                             Wal)
 import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
                                              catchEndpointErrors)
 
@@ -100,6 +105,28 @@ instance ModifiesApiRes WalletVerbTag where
 
 instance ReportDecodeError (WalletVerb (Verb (mt :: k1) (st :: Nat) (ct :: [*]) a)) where
     reportDecodeError _ err = Handler . ExceptT . throwM $ DecodeError err
+
+instance ( HasServer (WalletVerb (Verb mt st ct a)) ctx
+         , Reifies config ApiLoggingConfig
+         , ReflectMethod mt
+         , Show a
+         ) =>
+         HasLoggingServer config (WalletVerb (Verb (mt :: k1) (st :: Nat) (ct :: [*]) a)) ctx where
+    routeWithLog =
+        inRouteServer @(WalletVerb (Verb mt st ct a)) route $
+        \(paramsInfo, handler) ->
+            handler & serverHandlerL %~ withLogging paramsInfo
+      where
+        method = decodeUtf8 $ reflectMethod (Proxy @mt)
+        withLogging params = applyLoggingToVerb (Proxy @config) method params show
+
+
+-- | Specifes servant logging config.
+data WalletLoggingConfig
+
+-- If logger config will be ever determined in runtime, `reify` can be used.
+instance Reifies WalletLoggingConfig ApiLoggingConfig where
+    reflect _ = "wallet" <> "servant"
 
 -- | Shortcut for common api result types.
 type WRes verbType a = WalletVerb (verbType '[JSON] a)
@@ -464,7 +491,7 @@ type SwaggerApi =
     SwaggerSchemaUI "docs" "swagger.json"
 
 type WalletSwaggerApi =
-     WalletApi
+     LoggingApi WalletLoggingConfig WalletApi
     :<|>
      SwaggerApi
 

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -127,7 +127,7 @@ instance ( HasServer (WalletVerb (Verb mt st ct a)) ctx
 -- | Specifes servant logging config.
 data WalletLoggingConfig
 
--- If logger config will be ever determined in runtime, `reify` can be used.
+-- If logger config will ever be determined in runtime, `reify` can be used.
 instance Reifies WalletLoggingConfig ApiLoggingConfig where
     reflect _ = "wallet" <> "servant"
 

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE Rank2Types           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 -- | Descriptions for each endpoint, for Swagger-documentation.
@@ -9,16 +10,18 @@ module Pos.Wallet.Web.Swagger.Description where
 
 import           Universum
 
-import           Control.Lens                       ((?~))
-import           Data.Swagger                       (Operation, Swagger, description)
-import           Servant                            ((:>))
-import           Servant.Swagger                    (HasSwagger, subOperations)
-import           Servant.Swagger.Internal.TypeLevel (IsSubAPI)
+import           Control.Lens                             ((?~))
+import           Data.Swagger                             (Operation, Swagger,
+                                                           description)
+import           Servant                                  ((:>))
+import           Servant.Swagger                          (HasSwagger, subOperations)
+import           Servant.Swagger.Internal.TypeLevel       (IsSubAPI)
 
+import           Pos.Util.Servant                         (LoggingApi)
+import           Pos.Wallet.Web.Api
 import           Pos.Wallet.Web.Swagger.CustomSwagger     (HasCustomSwagger (..))
 import           Pos.Wallet.Web.Swagger.Instances.Schema  ()
 import           Pos.Wallet.Web.Swagger.Instances.Swagger ()
-import           Pos.Wallet.Web.Api
 
 -- | Wallet API operations, i.e. modifier of part of api related to
 -- single endpoint.
@@ -39,6 +42,9 @@ modifyDescription desc api = wop api . description ?~ desc
 
 
 instance HasCustomSwagger api => HasCustomSwagger (ApiPrefix :> api) where
+    swaggerModifier _ = swaggerModifier (Proxy @api)
+
+instance HasCustomSwagger api => HasCustomSwagger (LoggingApi __ api) where
     swaggerModifier _ = swaggerModifier (Proxy @api)
 
 instance HasCustomSwagger TestReset where


### PR DESCRIPTION
This PR enables manually written logging of incoming requests and responses based on servant-api. Please note that it's _really_ eassential to have in mainnet, it allows to understand user's operations flow, and testnet experience showed that we hardly benefit from user logs without requests logged if that user has problem on middleware.

Key points:

* `Buildable` instances are used for logging, and `instance Buildable` for all sensitive info (passwords and mnemonics) masks the content
* Now request bodies and responses are also logged. Responses are truncated where possible to save logging space
* Raw logging of http requests (which is/will be disabled in another PR) is totally removed

Testing:
* Daedalus acceptance tests pass in dev mode, which means that endpoints required for the client are still operational
* All endpoints are checked manually, passwords and mnemonics are masked

A small set of screenshots (on each picture new logging goes first, then old logging which got removed in one of the latest commits of this PR): 
https://imgur.com/a/CjIuH