### PR TITLE
[CSL-1663] Depend on custom version of ekg-statsd

### DIFF
--- a/node/src/Pos/Launcher/Runner.hs
+++ b/node/src/Pos/Launcher/Runner.hs
@@ -138,6 +138,7 @@ runRealModeDo NodeResources {..} outSpecs action =
                                 { Monitoring.host = statsdHost
                                 , Monitoring.port = statsdPort
                                 , Monitoring.flushInterval = statsdInterval
+                                , Monitoring.fullFlushIterations = Just 1
                                 , Monitoring.debug = statsdDebug
                                 , Monitoring.prefix = statsdPrefix
                                 , Monitoring.suffix = statsdSuffix

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2993,7 +2993,7 @@ self: {
           description = "JSON encoding of ekg metrics";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      ekg-statsd = callPackage ({ base, bytestring, ekg-core, mkDerivation, network, stdenv, text, time, unordered-containers }:
+      ekg-statsd = callPackage ({ base, bytestring, ekg-core, fetchgit, mkDerivation, network, stdenv, text, time, unordered-containers }:
       mkDerivation {
           pname = "ekg-statsd";
           version = "0.2.1.1";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2997,7 +2997,11 @@ self: {
       mkDerivation {
           pname = "ekg-statsd";
           version = "0.2.1.1";
-          sha256 = "1r0x26aqj0nbdl9nrj26xsb5np20bg6mihams394a0c41pv85j6k";
+          src = fetchgit {
+            url = "https://github.com/input-output-hk/ekg-statsd.git";
+            sha256 = "139612fiacdsh6hgq7bbf3vagrq47h947hcdi0i7mjcqf592i4bb";
+            rev = "5e4596da88f280d1efb432fdaa0dbc7d8553948e";
+          };
           libraryHaskellDepends = [
             base
             bytestring

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4457,6 +4457,8 @@ self: {
           pname = "memory";
           version = "0.14.6";
           sha256 = "0q61zxdlgcw7wg244hb3c11qm5agrmnmln0h61sz2mj72xqc1pn7";
+          revision = "1";
+          editedCabalFile = "0pyzdy5ca1cbkjzy1scnz6mr9251ap4w8a5phzxp91wkxpc45538";
           libraryHaskellDepends = [
             base
             bytestring

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,6 +87,13 @@ packages:
     commit: 6da3cd051bd6f6415c8ec3b53f1c0372a80a4376
   extra-dep: true
 
+# Forked version of "ekg-statsd" with full flushing support
+# https://issues.serokell.io/issue/CSL-1663
+- location:
+    git: https://github.com/input-output-hk/ekg-statsd.git
+    commit: 5e4596da88f280d1efb432fdaa0dbc7d8553948e
+  extra-dep: true
+
 nix:
   shell-file: shell.nix
 


### PR DESCRIPTION
This PR uses our custom fork on `ekg-statsd` to be able to send stats to `statsd` more frequently.

We are currently discussing with the `ekg-statsd` maintainers whether or not it would make sense to simply drop the optimisation the library is performing in sending only the diff of what's changed after every iteration, but in the meantime, using our custom version should achieve the same effect by using `defaultStatsOptions { fullFlushIterations = Just 1 }`