### PR TITLE
[CSL-1672] Set relay networking policy

### DIFF
--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -68,8 +68,8 @@ defaultEnqueuePolicyRelay = go
         EnqueueOne [NodeRelay, NodeCore] (MaxAhead 3) PHigh
       ]
     go (MsgTransaction _) = [
-        EnqueueAll NodeCore  (MaxAhead 20) PLow
-      , EnqueueAll NodeRelay (MaxAhead 20) PLow
+        EnqueueAll NodeCore  (MaxAhead 200) PLow
+      , EnqueueAll NodeRelay (MaxAhead 200) PLow
         -- transactions not forwarded to edge nodes
       ]
     go (MsgMPC _) = [
@@ -142,7 +142,7 @@ defaultDequeuePolicyRelay :: DequeuePolicy
 defaultDequeuePolicyRelay = go
   where
     go :: DequeuePolicy
-    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+    go NodeCore  = Dequeue (MaxMsgPerSec 3) (MaxInFlight 2)
     go NodeRelay = Dequeue (MaxMsgPerSec 3) (MaxInFlight 2)
     go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
 


### PR DESCRIPTION
- increase the MaxAhead for messages to 200, to match the current
  mempool size
- set the rate limiting towards core nodes to 3 Hz

These settings led to a decent throughput of ~6 transactions per
second, while keeping the core network running stably even when the
relays were exposed to higher transaction rates.