### PR TITLE
[CSL-969] Use `scrypt` for passphrases hashing

### DIFF
--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -31,6 +31,7 @@ import           Pos.Crypto.RedeemSigning (RedeemPublicKey (..), RedeemSecretKey
                                            RedeemSignature (..))
 import           Pos.Crypto.SafeSigning   (EncryptedSecretKey (..), PassPhrase,
                                            passphraseLength)
+import           Pos.Crypto.Scrypt        (EncryptedPass (..))
 import qualified Pos.Crypto.SecretSharing as C
 import           Pos.Crypto.Signing       (ProxyCert (..), ProxySecretKey (..),
                                            ProxySignature (..), PublicKey (..),
@@ -214,6 +215,10 @@ instance Bi PassPhrase where
             else fail . toString $ sformat
                  ("put@PassPhrase: expected length 0 or "%int%", not "%int)
                  passphraseLength bl
+
+instance Bi EncryptedPass where
+    encode (EncryptedPass ep) = encode ep
+    decode = EncryptedPass <$> decode
 
 -------------------------------------------------------------------------------
 -- Hierarchical derivation

--- a/core/Pos/Crypto/HD.hs
+++ b/core/Pos/Crypto/HD.hs
@@ -28,8 +28,9 @@ import           Data.ByteString.Char8        as B
 import           Universum
 
 import           Pos.Binary.Class             (Bi, decodeFull, serialize')
-import           Pos.Crypto.Hashing           (hash)
-import           Pos.Crypto.SafeSigning       (EncryptedSecretKey (..), PassPhrase)
+import           Pos.Crypto.SafeSigning       (EncryptedSecretKey (..), PassPhrase,
+                                               checkPassMatches)
+import           Pos.Crypto.Scrypt            (EncryptedPass)
 import           Pos.Crypto.Signing           (PublicKey (..))
 
 -- | Passphrase is a hash of root public key.
@@ -90,11 +91,10 @@ deriveHDPublicKey (PublicKey xpub) childIndex
 
 -- | Derive secret key from secret key.
 deriveHDSecretKey
-    :: Bi PassPhrase
+    :: (Bi PassPhrase, Bi EncryptedPass)
     => PassPhrase -> EncryptedSecretKey -> Word32 -> Maybe EncryptedSecretKey
-deriveHDSecretKey passPhrase (EncryptedSecretKey xprv pph) childIndex
-    | hash passPhrase /= pph = Nothing
-    | otherwise = Just $
+deriveHDSecretKey passPhrase encSK@(EncryptedSecretKey xprv pph) childIndex =
+    checkPassMatches passPhrase encSK $>
         EncryptedSecretKey
             (deriveXPrv passPhrase xprv childIndex)
             pph

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -46,8 +46,8 @@ import           Pos.Crypto.Signing    (ProxyCert (..), ProxySecretKey (..),
 import           Pos.Crypto.SignTag    (SignTag (SignProxySK), signTag)
 
 data EncryptedSecretKey = EncryptedSecretKey
-    { eskPayload :: !CC.XPrv
-    , eskHash    :: !S.EncryptedPass
+    { eskPayload :: !CC.XPrv          -- ^ Secret key itself
+    , eskHash    :: !S.EncryptedPass  -- ^ Hash of passphrase used for key creation
     }
 
 instance Show EncryptedSecretKey where
@@ -103,12 +103,13 @@ mkEncSecret pp payload =
 encToPublic :: EncryptedSecretKey -> PublicKey
 encToPublic (EncryptedSecretKey sk _) = PublicKey (CC.toXPub sk)
 
--- | Re-wrap unencrypted secret key as an encrypted one
+-- | Re-wrap unencrypted secret key as an encrypted one.
+-- NB: for testing purposes only
 noPassEncrypt
     :: Bi PassPhrase
     => SecretKey -> EncryptedSecretKey
 noPassEncrypt (SecretKey k) =
-    mkEncSecretWithSalt (S.mkSalt ("" :: Text)) emptyPassphrase k
+    mkEncSecretWithSalt def emptyPassphrase k
 
 checkPassMatches
     :: (Bi PassPhrase, Alternative f)

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -75,13 +75,12 @@ instance Default PassPhrase where
     def = emptyPassphrase
 
 -- | Parameters used to evaluate hash of passphrase.
--- They influence on resulting hash length, memory and time consumption.
 passScryptParam :: S.ScryptParams
 passScryptParam =
     fromMaybe (error "Bad passphrase scrypt parameters") $
-    S.scryptParamsLen 14 8 1 hashLen  -- params recomended in documentation to scrypt
-  where
-    hashLen = 32  -- maximal passphrase length
+    S.mkScryptParams def
+        { S.spHashLen = 32  -- maximal passphrase length
+        }
 
 -- | Wrap raw secret key, attaching hash to it.
 -- Hash is evaluated using given salt.

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -6,8 +6,8 @@ module Pos.Crypto.Scrypt
     , S.Pass (..)
     , S.EncryptedPass (..)
 
-    , S.scryptParams
-    , S.scryptParamsLen
+    , ScryptParamsBuilder (..)
+    , mkScryptParams
 
     , mkSalt
     , genSalt
@@ -20,8 +20,30 @@ import           Universum
 
 import           Crypto.Random    (MonadRandom, getRandomBytes)
 import qualified Crypto.Scrypt    as S
+import           Data.Default     (Default (..))
 
 import           Pos.Binary.Class (Bi, serialize')
+
+-- | This corresponds to 'ScryptParams' datatype.
+-- These parameters influence on resulting hash length, memory and time
+-- consumption. See documentation for exact details.
+data ScryptParamsBuilder = ScryptParamsBuilder
+    { spLogN    :: Word
+    , spR       :: Word
+    , spP       :: Word
+    , spHashLen :: Word
+    }
+
+mkScryptParams :: ScryptParamsBuilder -> Maybe S.ScryptParams
+mkScryptParams ScryptParamsBuilder {..} =
+    S.scryptParamsLen
+        (fromIntegral spLogN)
+        (fromIntegral spR)
+        (fromIntegral spP)
+        (fromIntegral spHashLen)
+
+instance Default ScryptParamsBuilder where
+    def = ScryptParamsBuilder { spLogN = 14, spR = 8, spP = 1, spHashLen = 64 }
 
 mkSalt :: Bi salt => salt -> S.Salt
 mkSalt = S.Salt . serialize'

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -1,20 +1,20 @@
 -- | Wrapper over scrypt library
 
 module Pos.Crypto.Scrypt
-    ( S.ScryptParams
-    , S.Salt (..)
-    , S.Pass (..)
-    , S.EncryptedPass (..)
+       ( S.ScryptParams
+       , S.Salt (..)
+       , S.Pass (..)
+       , S.EncryptedPass (..)
 
-    , ScryptParamsBuilder (..)
-    , mkScryptParams
+       , ScryptParamsBuilder (..)
+       , mkScryptParams
 
-    , mkSalt
-    , genSalt
-    , encryptPass
-    , encryptPassWithSalt
-    , verifyPass
-    ) where
+       , mkSalt
+       , genSalt
+       , encryptPass
+       , encryptPassWithSalt
+       , verifyPass
+       ) where
 
 import           Universum
 
@@ -47,6 +47,10 @@ instance Default ScryptParamsBuilder where
 
 mkSalt :: Bi salt => salt -> S.Salt
 mkSalt = S.Salt . serialize'
+
+-- | Salt which can be used for hardcoded values.
+instance Default S.Salt where
+    def = mkSalt ("" :: Text)
 
 genSalt :: MonadRandom m => m S.Salt
 genSalt = S.Salt <$> getRandomBytes 32

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -1,0 +1,46 @@
+-- | Wrapper over scrypt library
+
+module Pos.Crypto.Scrypt
+    ( S.ScryptParams
+    , S.Salt (..)
+    , S.Pass (..)
+    , S.EncryptedPass (..)
+
+    , S.scryptParams
+    , S.scryptParamsLen
+
+    , mkSalt
+    , genSalt
+    , encryptPass
+    , encryptPassWithSalt
+    , verifyPass
+    ) where
+
+import           Universum
+
+import           Crypto.Random    (MonadRandom, getRandomBytes)
+import qualified Crypto.Scrypt    as S
+
+import           Pos.Binary.Class (Bi, serialize')
+
+mkSalt :: Bi salt => salt -> S.Salt
+mkSalt = S.Salt . serialize'
+
+genSalt :: MonadRandom m => m S.Salt
+genSalt = S.Salt <$> getRandomBytes 32
+
+mkPass :: Bi pass => pass -> S.Pass
+mkPass = S.Pass . serialize'
+
+encryptPass
+    :: (Bi pass, MonadRandom m)
+    => S.ScryptParams -> pass -> m S.EncryptedPass
+encryptPass params passphrase =
+    genSalt <&> \salt -> encryptPassWithSalt params salt passphrase
+
+encryptPassWithSalt :: Bi pass => S.ScryptParams -> S.Salt -> pass -> S.EncryptedPass
+encryptPassWithSalt params salt passphrase =
+    S.encryptPass params salt (mkPass passphrase)
+
+verifyPass :: Bi pass => S.ScryptParams -> pass -> S.EncryptedPass -> Bool
+verifyPass params passphrase = fst . S.verifyPass params (mkPass passphrase)

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -68,6 +68,7 @@ library
                        Pos.Crypto.SafeSigning
                        Pos.Crypto.Signing
                        Pos.Crypto.SignTag
+                       Pos.Crypto.Scrypt
                        Pos.Crypto.SecretSharing
                        Pos.Crypto.RedeemSigning
 
@@ -161,6 +162,7 @@ library
                      , reflection
                      , resourcet
                      , safecopy
+                     , scrypt >= 0.5
                      , semigroups
                      , serokell-util
                      , stm

--- a/node/test/Test/Pos/CryptoSpec.hs
+++ b/node/test/Test/Pos/CryptoSpec.hs
@@ -576,6 +576,6 @@ passphraseChangeLeavesAddressUnmodified
     -> Property
 passphraseChangeLeavesAddressUnmodified oldPass newPass = ioProperty $ do
     (_, oldKey) <- Crypto.safeKeyGen oldPass
-    let newKey = fromMaybe (error "Passphrase didn't match") $
-                 Crypto.changeEncPassphrase oldPass newPass oldKey
+    newKey <- fromMaybe (error "Passphrase didn't match") <$>
+              Crypto.changeEncPassphrase oldPass newPass oldKey
     return $ Crypto.encToPublic oldKey === Crypto.encToPublic newKey

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1351,7 +1351,7 @@ self: {
           description = "Cardano SL - Auxx";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-core = callPackage ({ QuickCheck, aeson, ansi-terminal, autoexporter, base, base58-bytestring, binary, bytestring, cardano-crypto, cborg, cereal, concurrent-extra, containers, contravariant, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, ed25519, ether, exceptions, file-embed, filepath, formatting, generic-arbitrary, hashable, lens, log-warper, lrucache, memory, mkDerivation, mmorph, mtl, node-sketch, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, resourcet, safecopy, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector, yaml }:
+      cardano-sl-core = callPackage ({ QuickCheck, aeson, ansi-terminal, autoexporter, base, base58-bytestring, binary, bytestring, cardano-crypto, cborg, cereal, concurrent-extra, containers, contravariant, cpphs, cryptonite, cryptonite-openssl, data-default, deepseq, deriving-compat, digest, directory, ed25519, ether, exceptions, file-embed, filepath, formatting, generic-arbitrary, hashable, lens, log-warper, lrucache, memory, mkDerivation, mmorph, mtl, node-sketch, parsec, plutus-prototype, pvss, quickcheck-instances, random, reflection, resourcet, safecopy, scrypt, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector, yaml }:
       mkDerivation {
           pname = "cardano-sl-core";
           version = "0.6.0";
@@ -1401,6 +1401,7 @@ self: {
             reflection
             resourcet
             safecopy
+            scrypt
             semigroups
             serokell-util
             stm
@@ -4455,6 +4456,8 @@ self: {
           pname = "memory";
           version = "0.14.6";
           sha256 = "0q61zxdlgcw7wg244hb3c11qm5agrmnmln0h61sz2mj72xqc1pn7";
+          revision = "1";
+          editedCabalFile = "0pyzdy5ca1cbkjzy1scnz6mr9251ap4w8a5phzxp91wkxpc45538";
           libraryHaskellDepends = [
             base
             bytestring
@@ -5615,6 +5618,23 @@ self: {
           doCheck = false;
           homepage = "https://github.com/basvandijk/scientific";
           description = "Numbers represented using scientific notation";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
+      scrypt = callPackage ({ base, base64-bytestring, bytestring, entropy, mkDerivation, stdenv }:
+      mkDerivation {
+          pname = "scrypt";
+          version = "0.5.0";
+          sha256 = "1cnrjdq1ncv224dlk236a7w29na8r019d2acrsxlsaiy74iadh1y";
+          libraryHaskellDepends = [
+            base
+            base64-bytestring
+            bytestring
+            entropy
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "http://github.com/informatikr/scrypt";
+          description = "Stronger password hashing via sequential memory-hard functions";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       semigroupoids = callPackage ({ Cabal, base, base-orphans, bifunctors, cabal-doctest, comonad, containers, contravariant, distributive, hashable, mkDerivation, semigroups, stdenv, tagged, transformers, transformers-compat, unordered-containers }:

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -55,11 +55,12 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Existing),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              addWAddress, createAccount, createWallet,
                                              getAccountIds, getAccountMeta,
-                                             getWalletAddresses, getWalletMetaIncludeUnready,
-                                             getWalletPassLU, isCustomAddress,
-                                             removeAccount, removeHistoryCache,
-                                             removeTxMetas, removeWallet, setAccountMeta,
-                                             setWalletMeta, setWalletPassLU, setWalletReady)
+                                             getWalletAddresses,
+                                             getWalletMetaIncludeUnready, getWalletPassLU,
+                                             isCustomAddress, removeAccount,
+                                             removeHistoryCache, removeTxMetas,
+                                             removeWallet, setAccountMeta, setWalletMeta,
+                                             setWalletPassLU, setWalletReady)
 import           Pos.Wallet.Web.Tracking    (CAccModifier (..), CachedCAccModifier,
                                              fixCachedAccModifierFor,
                                              fixingCachedAccModifier, sortedInsertions)
@@ -248,7 +249,7 @@ changeWalletPassphrase wid oldPass newPass = do
     oldSK <- getSKById wid
 
     unless (isJust $ checkPassMatches newPass oldSK) $ do
-        newSK <- maybeThrow badPass $ changeEncPassphrase oldPass newPass oldSK
+        newSK <- maybeThrow badPass =<< changeEncPassphrase oldPass newPass oldSK
         deleteSK oldPass
         addSecretKey newSK
         setWalletPassLU wid =<< liftIO getPOSIXTime


### PR DESCRIPTION
We need to keep a hash of password in secret key to check whether password matches.
This PR switches from `blake256` hashing to `scrypt` with [secure-] randomly generated salt.