### PR TITLE
[CSM-458] Endpoint for postponing the update

### DIFF
--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -214,8 +214,11 @@ getHistory tls walletId accountId addr skip limit =
 nextUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) CUpdateInfo
 nextUpdate tls = getR tls $ noQueryParam ["update"]
 
+postponeUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
+postponeUpdate tls = postR tls $ noQueryParam ["update", "postpone"]
+
 applyUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
-applyUpdate tls = postR tls $ noQueryParam ["update"]
+applyUpdate tls = postR tls $ noQueryParam ["update", "apply"]
 
 --------------------------------------------------------------------------------
 -- Redemptions -----------------------------------------------------------------

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -726,6 +726,15 @@ nextUpdate = mkEffFn1 $ fromAff <<< map encodeJson <<< B.nextUpdate
 
 -- Example in nodejs:
 -- | ```js
+-- | > api.postponeUpdate().then(console.log).catch(console.log)
+-- | Promise { <pending> }
+-- | > {}
+-- | ```
+postponeUpdate :: forall eff. EffFn1 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions (Promise Unit)
+postponeUpdate = mkEffFn1 $ fromAff <<< B.postponeUpdate
+
+-- Example in nodejs:
+-- | ```js
 -- | > api.applyUpdate().then(console.log).catch(console.log)
 -- | Promise { <pending> }
 -- | > {}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4455,6 +4455,8 @@ self: {
           pname = "memory";
           version = "0.14.6";
           sha256 = "0q61zxdlgcw7wg244hb3c11qm5agrmnmln0h61sz2mj72xqc1pn7";
+          revision = "1";
+          editedCabalFile = "0pyzdy5ca1cbkjzy1scnz6mr9251ap4w8a5phzxp91wkxpc45538";
           libraryHaskellDepends = [
             base
             bytestring

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -44,6 +44,7 @@ module Pos.Wallet.Web.Api
        , GetHistory
 
        , NextUpdate
+       , PostponeUpdate
        , ApplyUpdate
 
        , RedeemADA
@@ -299,8 +300,14 @@ type NextUpdate =
        "update"
     :> WRes Get CUpdateInfo
 
+type PostponeUpdate =
+       "update"
+    :> "postpone"
+    :> WRes Post ()
+
 type ApplyUpdate =
        "update"
+    :> "apply"
     :> WRes Post ()
 
 -------------------------------------------------------------------------
@@ -445,6 +452,8 @@ type WalletApi = ApiPrefix :> (
      -- Updates
      -------------------------------------------------------------------------
      NextUpdate
+    :<|>
+     PostponeUpdate
     :<|>
      ApplyUpdate
     :<|>

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -9,6 +9,7 @@ module Pos.Wallet.Web.Methods.Misc
        , isValidAddress
 
        , nextUpdate
+       , postponeUpdate
        , applyUpdate
 
        , syncProgress
@@ -25,7 +26,7 @@ import           Pos.Util                   (maybeThrow)
 import           Pos.Wallet.KeyStorage      (deleteSecretKey, getSecretKeys)
 import           Pos.Wallet.WalletMode      (applyLastUpdate, connectedPeers,
                                              localChainDifficulty, networkChainDifficulty)
-import           Pos.Wallet.Web.ClientTypes (CProfile, CProfile (..), CUpdateInfo (..),
+import           Pos.Wallet.Web.ClientTypes (CProfile (..), CUpdateInfo (..),
                                              SyncProgress (..))
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
@@ -61,6 +62,11 @@ nextUpdate :: MonadWalletWebMode m => m CUpdateInfo
 nextUpdate = getNextUpdate >>=
              maybeThrow (RequestError "No updates available")
 
+-- | Postpone next update after restart
+postponeUpdate :: MonadWalletWebMode m => m ()
+postponeUpdate = removeNextUpdate
+
+-- | Delete next update info and restart immediately
 applyUpdate :: MonadWalletWebMode m => m ()
 applyUpdate = removeNextUpdate >> applyLastUpdate
 

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -77,6 +77,8 @@ servantHandlers sendActions =
 
      M.nextUpdate
     :<|>
+     M.postponeUpdate
+    :<|>
      M.applyUpdate
     :<|>
 

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -149,6 +149,10 @@ instance HasCustomSwagger NextUpdate where
     swaggerModifier = modifyDescription
         "Get information about the next update."
 
+instance HasCustomSwagger PostponeUpdate where
+    swaggerModifier = modifyDescription
+        "Postpone last update."
+
 instance HasCustomSwagger ApplyUpdate where
     swaggerModifier = modifyDescription
         "Apply last update."


### PR DESCRIPTION
This endpoint should be triggered when postponing the update until restart to avoid stale data about update remaining in `wallet-db` (which causes update notifications to appear again after restart, even though update has been already applied).