### PR TITLE
Cherry-picking CSM changes into 1.0

### DIFF
--- a/core/Pos/Binary/Crypto.hs
+++ b/core/Pos/Binary/Crypto.hs
@@ -31,6 +31,7 @@ import           Pos.Crypto.RedeemSigning (RedeemPublicKey (..), RedeemSecretKey
                                            RedeemSignature (..))
 import           Pos.Crypto.SafeSigning   (EncryptedSecretKey (..), PassPhrase,
                                            passphraseLength)
+import           Pos.Crypto.Scrypt        (EncryptedPass (..))
 import qualified Pos.Crypto.SecretSharing as C
 import           Pos.Crypto.Signing       (ProxyCert (..), ProxySecretKey (..),
                                            ProxySignature (..), PublicKey (..),
@@ -214,6 +215,10 @@ instance Bi PassPhrase where
             else fail . toString $ sformat
                  ("put@PassPhrase: expected length 0 or "%int%", not "%int)
                  passphraseLength bl
+
+instance Bi EncryptedPass where
+    encode (EncryptedPass ep) = encode ep
+    decode = EncryptedPass <$> decode
 
 -------------------------------------------------------------------------------
 -- Hierarchical derivation

--- a/core/Pos/Crypto/HD.hs
+++ b/core/Pos/Crypto/HD.hs
@@ -28,8 +28,9 @@ import           Data.ByteString.Char8        as B
 import           Universum
 
 import           Pos.Binary.Class             (Bi, decodeFull, serialize')
-import           Pos.Crypto.Hashing           (hash)
-import           Pos.Crypto.SafeSigning       (EncryptedSecretKey (..), PassPhrase)
+import           Pos.Crypto.SafeSigning       (EncryptedSecretKey (..), PassPhrase,
+                                               checkPassMatches)
+import           Pos.Crypto.Scrypt            (EncryptedPass)
 import           Pos.Crypto.Signing           (PublicKey (..))
 
 -- | Passphrase is a hash of root public key.
@@ -90,11 +91,10 @@ deriveHDPublicKey (PublicKey xpub) childIndex
 
 -- | Derive secret key from secret key.
 deriveHDSecretKey
-    :: Bi PassPhrase
+    :: (Bi PassPhrase, Bi EncryptedPass)
     => PassPhrase -> EncryptedSecretKey -> Word32 -> Maybe EncryptedSecretKey
-deriveHDSecretKey passPhrase (EncryptedSecretKey xprv pph) childIndex
-    | hash passPhrase /= pph = Nothing
-    | otherwise = Just $
+deriveHDSecretKey passPhrase encSK@(EncryptedSecretKey xprv pph) childIndex =
+    checkPassMatches passPhrase encSK $>
         EncryptedSecretKey
             (deriveXPrv passPhrase xprv childIndex)
             pph

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -46,8 +46,8 @@ import           Pos.Crypto.Signing    (ProxyCert (..), ProxySecretKey (..),
 import           Pos.Crypto.SignTag    (SignTag (SignProxySK), signTag)
 
 data EncryptedSecretKey = EncryptedSecretKey
-    { eskPayload :: !CC.XPrv
-    , eskHash    :: !S.EncryptedPass
+    { eskPayload :: !CC.XPrv          -- ^ Secret key itself
+    , eskHash    :: !S.EncryptedPass  -- ^ Hash of passphrase used for key creation
     }
 
 instance Show EncryptedSecretKey where
@@ -103,12 +103,13 @@ mkEncSecret pp payload =
 encToPublic :: EncryptedSecretKey -> PublicKey
 encToPublic (EncryptedSecretKey sk _) = PublicKey (CC.toXPub sk)
 
--- | Re-wrap unencrypted secret key as an encrypted one
+-- | Re-wrap unencrypted secret key as an encrypted one.
+-- NB: for testing purposes only
 noPassEncrypt
     :: Bi PassPhrase
     => SecretKey -> EncryptedSecretKey
 noPassEncrypt (SecretKey k) =
-    mkEncSecretWithSalt (S.mkSalt ("" :: Text)) emptyPassphrase k
+    mkEncSecretWithSalt def emptyPassphrase k
 
 checkPassMatches
     :: (Bi PassPhrase, Alternative f)

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -75,13 +75,12 @@ instance Default PassPhrase where
     def = emptyPassphrase
 
 -- | Parameters used to evaluate hash of passphrase.
--- They influence on resulting hash length, memory and time consumption.
 passScryptParam :: S.ScryptParams
 passScryptParam =
     fromMaybe (error "Bad passphrase scrypt parameters") $
-    S.scryptParamsLen 14 8 1 hashLen  -- params recomended in documentation to scrypt
-  where
-    hashLen = 32  -- maximal passphrase length
+    S.mkScryptParams def
+        { S.spHashLen = 32  -- maximal passphrase length
+        }
 
 -- | Wrap raw secret key, attaching hash to it.
 -- Hash is evaluated using given salt.

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -10,6 +10,8 @@ module Pos.Crypto.SafeSigning
        , checkPassMatches
        , changeEncPassphrase
        , encToPublic
+       , mkEncSecret
+       , mkEncSecretWithSalt
        , safeSign
        , safeToPublic
        , safeKeyGen
@@ -36,7 +38,7 @@ import           Universum
 
 import           Pos.Binary.Class      (Bi, Raw)
 import qualified Pos.Binary.Class      as Bi
-import           Pos.Crypto.Hashing    (Hash, hash)
+import qualified Pos.Crypto.Scrypt     as S
 import           Pos.Crypto.Signing    (ProxyCert (..), ProxySecretKey (..),
                                         PublicKey (..), SecretKey (..), Signature (..),
                                         sign, toPublic)
@@ -44,7 +46,7 @@ import           Pos.Crypto.SignTag    (SignTag (SignProxySK), signTag)
 
 data EncryptedSecretKey = EncryptedSecretKey
     { eskPayload :: !CC.XPrv
-    , eskHash    :: !(Hash PassPhrase)
+    , eskHash    :: !S.EncryptedPass
     }
 
 instance Show EncryptedSecretKey where
@@ -72,33 +74,61 @@ emptyPassphrase = PassPhrase mempty
 instance Default PassPhrase where
     def = emptyPassphrase
 
-{-instance Monoid PassPhrase where
-    mempty = PassPhrase mempty
-    mappend (PassPhrase p1) (PassPhrase p2) = PassPhrase (p1 `mappend` p2)-}
+-- | Parameters used to evaluate hash of passphrase.
+-- They influence on resulting hash length, memory and time consumption.
+passScryptParam :: S.ScryptParams
+passScryptParam =
+    fromMaybe (error "Bad passphrase scrypt parameters") $
+    S.scryptParamsLen 14 8 1 hashLen  -- params recomended in documentation to scrypt
+  where
+    hashLen = 32  -- maximal passphrase length
 
-mkEncSecret :: Bi PassPhrase => PassPhrase -> CC.XPrv -> EncryptedSecretKey
-mkEncSecret pp payload = EncryptedSecretKey payload (hash pp)
+-- | Wrap raw secret key, attaching hash to it.
+-- Hash is evaluated using given salt.
+mkEncSecretWithSalt
+    :: Bi PassPhrase
+    => S.Salt -> PassPhrase -> CC.XPrv -> EncryptedSecretKey
+mkEncSecretWithSalt salt pp payload =
+    EncryptedSecretKey payload $ S.encryptPassWithSalt passScryptParam salt pp
+
+-- | Wrap raw secret key, attachind hash to it.
+-- Hash is evaluated using generated salt.
+mkEncSecret
+    :: (Bi PassPhrase, MonadRandom m)
+    => PassPhrase -> CC.XPrv -> m EncryptedSecretKey
+mkEncSecret pp payload =
+    EncryptedSecretKey payload <$> S.encryptPass passScryptParam pp
 
 -- | Generate a public key using an encrypted secret key and passphrase
 encToPublic :: EncryptedSecretKey -> PublicKey
 encToPublic (EncryptedSecretKey sk _) = PublicKey (CC.toXPub sk)
 
 -- | Re-wrap unencrypted secret key as an encrypted one
-noPassEncrypt :: Bi PassPhrase => SecretKey -> EncryptedSecretKey
-noPassEncrypt (SecretKey k) = mkEncSecret emptyPassphrase k
-
-checkPassMatches :: (Bi PassPhrase, Alternative f) => PassPhrase -> EncryptedSecretKey -> f ()
-checkPassMatches pp (EncryptedSecretKey _ pph) = guard (hash pp == pph)
-
-changeEncPassphrase
+noPassEncrypt
     :: Bi PassPhrase
+    => SecretKey -> EncryptedSecretKey
+noPassEncrypt (SecretKey k) =
+    mkEncSecretWithSalt (S.mkSalt ("" :: Text)) emptyPassphrase k
+
+checkPassMatches
+    :: (Bi PassPhrase, Alternative f)
+    => PassPhrase -> EncryptedSecretKey -> f ()
+checkPassMatches pp (EncryptedSecretKey _ pph) =
+    guard (S.verifyPass passScryptParam pp pph)
+
+-- | Regerates secret key with new passphrase.
+-- This operation remains corresponding public key unchanged.
+-- However, derived (child) keys change.
+changeEncPassphrase
+    :: (Bi PassPhrase, MonadRandom m)
     => PassPhrase
     -> PassPhrase
     -> EncryptedSecretKey
-    -> Maybe EncryptedSecretKey
-changeEncPassphrase oldPass newPass esk@(EncryptedSecretKey sk _) = do
-    checkPassMatches oldPass esk
-    return $ mkEncSecret newPass $ CC.xPrvChangePass oldPass newPass sk
+    -> m (Maybe EncryptedSecretKey)
+changeEncPassphrase oldPass newPass esk@(EncryptedSecretKey sk _)
+    | isJust $ checkPassMatches oldPass esk =
+        Just <$> mkEncSecret newPass (CC.xPrvChangePass oldPass newPass sk)
+    | otherwise = return Nothing
 
 signRaw' :: Maybe SignTag
          -> PassPhrase
@@ -139,7 +169,7 @@ safeDeterministicKeyGen
     -> PassPhrase
     -> (PublicKey, EncryptedSecretKey)
 safeDeterministicKeyGen seed pp =
-    bimap PublicKey (mkEncSecret pp) (safeCreateKeypairFromSeed seed pp)
+    bimap PublicKey (mkEncSecretWithSalt (S.mkSalt seed) pp) (safeCreateKeypairFromSeed seed pp)
 
 -- | SafeSigner datatype to encapsulate sensible data
 data SafeSigner = SafeSigner EncryptedSecretKey PassPhrase

--- a/core/Pos/Crypto/SafeSigning.hs
+++ b/core/Pos/Crypto/SafeSigning.hs
@@ -38,6 +38,7 @@ import           Universum
 
 import           Pos.Binary.Class      (Bi, Raw)
 import qualified Pos.Binary.Class      as Bi
+import           Pos.Crypto.Hashing    (Hash, hash)
 import qualified Pos.Crypto.Scrypt     as S
 import           Pos.Crypto.Signing    (ProxyCert (..), ProxySecretKey (..),
                                         PublicKey (..), SecretKey (..), Signature (..),
@@ -156,19 +157,22 @@ safeCreateKeypairFromSeed seed (PassPhrase pp) =
 -- "Pos.Crypto.Random" because the OpenSSL generator is probably safer than
 -- the default IO generator.
 safeKeyGen
-    :: (MonadRandom m, Bi PassPhrase)
+    :: (MonadRandom m, Bi PassPhrase, Bi (Hash ByteString))
     => PassPhrase -> m (PublicKey, EncryptedSecretKey)
 safeKeyGen pp = do
     seed <- getRandomBytes 32
     pure $ safeDeterministicKeyGen seed pp
 
 safeDeterministicKeyGen
-    :: Bi PassPhrase
+    :: (Bi PassPhrase, Bi (Hash ByteString))
     => BS.ByteString
     -> PassPhrase
     -> (PublicKey, EncryptedSecretKey)
 safeDeterministicKeyGen seed pp =
-    bimap PublicKey (mkEncSecretWithSalt (S.mkSalt seed) pp) (safeCreateKeypairFromSeed seed pp)
+    bimap
+        PublicKey
+        (mkEncSecretWithSalt (S.mkSalt (hash seed)) pp)
+        (safeCreateKeypairFromSeed seed pp)
 
 -- | SafeSigner datatype to encapsulate sensible data
 data SafeSigner = SafeSigner EncryptedSecretKey PassPhrase

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -6,8 +6,8 @@ module Pos.Crypto.Scrypt
     , S.Pass (..)
     , S.EncryptedPass (..)
 
-    , S.scryptParams
-    , S.scryptParamsLen
+    , ScryptParamsBuilder (..)
+    , mkScryptParams
 
     , mkSalt
     , genSalt
@@ -20,8 +20,30 @@ import           Universum
 
 import           Crypto.Random    (MonadRandom, getRandomBytes)
 import qualified Crypto.Scrypt    as S
+import           Data.Default     (Default (..))
 
 import           Pos.Binary.Class (Bi, serialize')
+
+-- | This corresponds to 'ScryptParams' datatype.
+-- These parameters influence on resulting hash length, memory and time
+-- consumption. See documentation for exact details.
+data ScryptParamsBuilder = ScryptParamsBuilder
+    { spLogN    :: Word
+    , spR       :: Word
+    , spP       :: Word
+    , spHashLen :: Word
+    }
+
+mkScryptParams :: ScryptParamsBuilder -> Maybe S.ScryptParams
+mkScryptParams ScryptParamsBuilder {..} =
+    S.scryptParamsLen
+        (fromIntegral spLogN)
+        (fromIntegral spR)
+        (fromIntegral spP)
+        (fromIntegral spHashLen)
+
+instance Default ScryptParamsBuilder where
+    def = ScryptParamsBuilder { spLogN = 14, spR = 8, spP = 1, spHashLen = 64 }
 
 mkSalt :: Bi salt => salt -> S.Salt
 mkSalt = S.Salt . serialize'

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -1,20 +1,20 @@
 -- | Wrapper over scrypt library
 
 module Pos.Crypto.Scrypt
-    ( S.ScryptParams
-    , S.Salt (..)
-    , S.Pass (..)
-    , S.EncryptedPass (..)
+       ( S.ScryptParams
+       , S.Salt (..)
+       , S.Pass (..)
+       , S.EncryptedPass (..)
 
-    , ScryptParamsBuilder (..)
-    , mkScryptParams
+       , ScryptParamsBuilder (..)
+       , mkScryptParams
 
-    , mkSalt
-    , genSalt
-    , encryptPass
-    , encryptPassWithSalt
-    , verifyPass
-    ) where
+       , mkSalt
+       , genSalt
+       , encryptPass
+       , encryptPassWithSalt
+       , verifyPass
+       ) where
 
 import           Universum
 
@@ -47,6 +47,10 @@ instance Default ScryptParamsBuilder where
 
 mkSalt :: Bi salt => salt -> S.Salt
 mkSalt = S.Salt . serialize'
+
+-- | Salt which can be used for hardcoded values.
+instance Default S.Salt where
+    def = mkSalt ("" :: Text)
 
 genSalt :: MonadRandom m => m S.Salt
 genSalt = S.Salt <$> getRandomBytes 32

--- a/core/Pos/Crypto/Scrypt.hs
+++ b/core/Pos/Crypto/Scrypt.hs
@@ -1,0 +1,46 @@
+-- | Wrapper over scrypt library
+
+module Pos.Crypto.Scrypt
+    ( S.ScryptParams
+    , S.Salt (..)
+    , S.Pass (..)
+    , S.EncryptedPass (..)
+
+    , S.scryptParams
+    , S.scryptParamsLen
+
+    , mkSalt
+    , genSalt
+    , encryptPass
+    , encryptPassWithSalt
+    , verifyPass
+    ) where
+
+import           Universum
+
+import           Crypto.Random    (MonadRandom, getRandomBytes)
+import qualified Crypto.Scrypt    as S
+
+import           Pos.Binary.Class (Bi, serialize')
+
+mkSalt :: Bi salt => salt -> S.Salt
+mkSalt = S.Salt . serialize'
+
+genSalt :: MonadRandom m => m S.Salt
+genSalt = S.Salt <$> getRandomBytes 32
+
+mkPass :: Bi pass => pass -> S.Pass
+mkPass = S.Pass . serialize'
+
+encryptPass
+    :: (Bi pass, MonadRandom m)
+    => S.ScryptParams -> pass -> m S.EncryptedPass
+encryptPass params passphrase =
+    genSalt <&> \salt -> encryptPassWithSalt params salt passphrase
+
+encryptPassWithSalt :: Bi pass => S.ScryptParams -> S.Salt -> pass -> S.EncryptedPass
+encryptPassWithSalt params salt passphrase =
+    S.encryptPass params salt (mkPass passphrase)
+
+verifyPass :: Bi pass => S.ScryptParams -> pass -> S.EncryptedPass -> Bool
+verifyPass params passphrase = fst . S.verifyPass params (mkPass passphrase)

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -68,6 +68,7 @@ library
                        Pos.Crypto.SafeSigning
                        Pos.Crypto.Signing
                        Pos.Crypto.SignTag
+                       Pos.Crypto.Scrypt
                        Pos.Crypto.SecretSharing
                        Pos.Crypto.RedeemSigning
 
@@ -161,6 +162,7 @@ library
                      , reflection
                      , resourcet
                      , safecopy
+                     , scrypt >= 0.5
                      , semigroups
                      , serokell-util
                      , stm

--- a/daedalus/src/Daedalus/BackendApi.purs
+++ b/daedalus/src/Daedalus/BackendApi.purs
@@ -214,8 +214,11 @@ getHistory tls walletId accountId addr skip limit =
 nextUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) CUpdateInfo
 nextUpdate tls = getR tls $ noQueryParam ["update"]
 
+postponeUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
+postponeUpdate tls = postR tls $ noQueryParam ["update", "postpone"]
+
 applyUpdate :: forall eff. TLSOptions -> Aff (http :: HTTP, exception :: EXCEPTION | eff) Unit
-applyUpdate tls = postR tls $ noQueryParam ["update"]
+applyUpdate tls = postR tls $ noQueryParam ["update", "apply"]
 
 --------------------------------------------------------------------------------
 -- Redemptions -----------------------------------------------------------------

--- a/daedalus/src/Daedalus/ClientApi.purs
+++ b/daedalus/src/Daedalus/ClientApi.purs
@@ -726,6 +726,15 @@ nextUpdate = mkEffFn1 $ fromAff <<< map encodeJson <<< B.nextUpdate
 
 -- Example in nodejs:
 -- | ```js
+-- | > api.postponeUpdate().then(console.log).catch(console.log)
+-- | Promise { <pending> }
+-- | > {}
+-- | ```
+postponeUpdate :: forall eff. EffFn1 (http :: HTTP, exception :: EXCEPTION | eff) TLSOptions (Promise Unit)
+postponeUpdate = mkEffFn1 $ fromAff <<< B.postponeUpdate
+
+-- Example in nodejs:
+-- | ```js
 -- | > api.applyUpdate().then(console.log).catch(console.log)
 -- | Promise { <pending> }
 -- | > {}

--- a/db/Pos/DB/GState/Common.hs
+++ b/db/Pos/DB/GState/Common.hs
@@ -7,6 +7,7 @@ module Pos.DB.GState.Common
          -- * Getters
          getTip
        , getMaxSeenDifficulty
+       , getMaxSeenDifficultyMaybe
        , getTipBlockGeneric
        , getTipHeaderGeneric
 

--- a/node/src/Pos/Client/CLI/Options.hs
+++ b/node/src/Pos/Client/CLI/Options.hs
@@ -11,7 +11,7 @@ module Pos.Client.CLI.Options
        , portOption
        , timeLordOption
        , webPortOption
-       , daedalusWalletAddressOption
+       , walletAddressOption
        , networkAddressOption
        , externalNetworkAddressOption
        , listenNetworkAddressOption
@@ -191,8 +191,8 @@ webPortOption portNum help =
         <> Opt.value portNum
         <> Opt.showDefault
 
-daedalusWalletAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
-daedalusWalletAddressOption na =
+walletAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
+walletAddressOption na =
     Opt.option (fromParsec addrParser) $
             Opt.long "wallet-address"
          <> Opt.metavar "IP:PORT"
@@ -200,7 +200,7 @@ daedalusWalletAddressOption na =
          <> Opt.showDefault
          <> maybe mempty Opt.value na
   where
-    helpMsg = "IP and port for Daedalus wallet API."
+    helpMsg = "IP and port for backend wallet API."
 
 externalNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
 externalNetworkAddressOption na =

--- a/node/src/Pos/Client/CLI/Options.hs
+++ b/node/src/Pos/Client/CLI/Options.hs
@@ -11,7 +11,7 @@ module Pos.Client.CLI.Options
        , portOption
        , timeLordOption
        , webPortOption
-       , walletPortOption
+       , daedalusWalletAddressOption
        , networkAddressOption
        , externalNetworkAddressOption
        , listenNetworkAddressOption
@@ -191,12 +191,16 @@ webPortOption portNum help =
         <> Opt.value portNum
         <> Opt.showDefault
 
-walletPortOption :: Word16 -> String -> Opt.Parser Word16
-walletPortOption portNum help =
-    Opt.option Opt.auto $
-        templateParser "wallet-port" "PORT" help -- "Port for wallet"
-        <> Opt.value portNum
-        <> Opt.showDefault
+daedalusWalletAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
+daedalusWalletAddressOption na =
+    Opt.option (fromParsec addrParser) $
+            Opt.long "wallet-address"
+         <> Opt.metavar "IP:PORT"
+         <> Opt.help helpMsg
+         <> Opt.showDefault
+         <> maybe mempty Opt.value na
+  where
+    helpMsg = "IP and port for Daedalus wallet API."
 
 externalNetworkAddressOption :: Maybe NetworkAddress -> Opt.Parser NetworkAddress
 externalNetworkAddressOption na =

--- a/node/test/Test/Pos/CryptoSpec.hs
+++ b/node/test/Test/Pos/CryptoSpec.hs
@@ -576,6 +576,6 @@ passphraseChangeLeavesAddressUnmodified
     -> Property
 passphraseChangeLeavesAddressUnmodified oldPass newPass = ioProperty $ do
     (_, oldKey) <- Crypto.safeKeyGen oldPass
-    let newKey = fromMaybe (error "Passphrase didn't match") $
-                 Crypto.changeEncPassphrase oldPass newPass oldKey
+    newKey <- fromMaybe (error "Passphrase didn't match") <$>
+              Crypto.changeEncPassphrase oldPass newPass oldKey
     return $ Crypto.encToPublic oldKey === Crypto.encToPublic newKey

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -56,7 +56,7 @@ walletProd WalletArgs {..} = first pure $ worker walletServerOuts $ \sendActions
     walletServeWebFull
         sendActions
         walletDebug
-        walletPort
+        walletAddress
         (Just walletTLSParams)
 
 pluginsGT ::

--- a/wallet/node/NodeOptions.hs
+++ b/wallet/node/NodeOptions.hs
@@ -10,17 +10,18 @@ module NodeOptions
        , getWalletNodeOptions
        ) where
 
-import           Data.Version               (showVersion)
-import           Options.Applicative        (Parser, execParser, footerDoc, fullDesc,
-                                             header, help, helper, info, infoOption, long,
-                                             progDesc, strOption, switch, value)
-import qualified Options.Applicative        as Opt
-import           Universum                  hiding (show)
+import           Data.Version        (showVersion)
+import           Options.Applicative (Parser, execParser, footerDoc, fullDesc, header,
+                                      help, helper, info, infoOption, long, progDesc,
+                                      strOption, switch, value)
+import qualified Options.Applicative as Opt
+import           Universum           hiding (show)
 
-import           Paths_cardano_sl           (version)
-import           Pos.Client.CLI             (CommonNodeArgs (..))
-import qualified Pos.Client.CLI             as CLI
-import           Pos.Web.Types              (TlsParams (..))
+import           Paths_cardano_sl    (version)
+import           Pos.Client.CLI      (CommonNodeArgs (..))
+import qualified Pos.Client.CLI      as CLI
+import           Pos.Util.TimeWarp   (NetworkAddress, localhost)
+import           Pos.Web.Types       (TlsParams (..))
 
 data WalletNodeArgs = WalletNodeArgs CommonNodeArgs WalletArgs
 
@@ -28,7 +29,7 @@ data WalletArgs = WalletArgs
     { enableWeb       :: !Bool
     , webPort         :: !Word16
     , walletTLSParams :: !TlsParams
-    , walletPort      :: !Word16
+    , walletAddress   :: !NetworkAddress
     , walletDbPath    :: !FilePath
     , walletRebuildDb :: !Bool
     , walletDebug     :: !Bool
@@ -43,8 +44,7 @@ walletArgsParser = do
     webPort <-
         CLI.webPortOption 8080 "Port for web API."
     walletTLSParams <- tlsParamsOption
-    walletPort <-
-        CLI.walletPortOption 8090 "Port for Daedalus Wallet API."
+    walletAddress <- CLI.daedalusWalletAddressOption $ Just (localhost, 8090)
     walletDbPath <- strOption $
         long  "wallet-db-path" <>
         help  "Path to the wallet's database." <>
@@ -71,7 +71,6 @@ getWalletNodeOptions = execParser programInfo
     versionOption = infoOption
         ("cardano-node-" <> showVersion version)
         (long "version" <> help "Show version.")
-
 
 tlsParamsOption :: Opt.Parser TlsParams
 tlsParamsOption = do

--- a/wallet/node/NodeOptions.hs
+++ b/wallet/node/NodeOptions.hs
@@ -44,7 +44,7 @@ walletArgsParser = do
     webPort <-
         CLI.webPortOption 8080 "Port for web API."
     walletTLSParams <- tlsParamsOption
-    walletAddress <- CLI.daedalusWalletAddressOption $ Just (localhost, 8090)
+    walletAddress <- CLI.walletAddressOption $ Just (localhost, 8090)
     walletDbPath <- strOption $
         long  "wallet-db-path" <>
         help  "Path to the wallet's database." <>

--- a/wallet/src/Pos/Wallet/Redirect.hs
+++ b/wallet/src/Pos/Wallet/Redirect.hs
@@ -80,10 +80,10 @@ localChainDifficultyWebWallet
     :: forall ssc ctx m. BlockchainInfoEnv ssc ctx m
     => m ChainDifficulty
 localChainDifficultyWebWallet = do
-  -- Workaround: Make local chain difficulty monotonic
-  prevMaxDifficulty <- GS.getMaxSeenDifficulty
-  currDifficulty <- view difficultyL <$> getTipHeader @ssc
-  return $ max prevMaxDifficulty currDifficulty
+    -- Workaround: Make local chain difficulty monotonic
+    prevMaxDifficulty <- fromMaybe 0 <$> GS.getMaxSeenDifficultyMaybe
+    currDifficulty <- view difficultyL <$> getTipHeader @ssc
+    return $ max prevMaxDifficulty currDifficulty
 
 connectedPeersWebWallet
     :: forall ssc ctx m. BlockchainInfoEnv ssc ctx m

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -44,6 +44,7 @@ module Pos.Wallet.Web.Api
        , GetHistory
 
        , NextUpdate
+       , PostponeUpdate
        , ApplyUpdate
 
        , RedeemADA
@@ -299,8 +300,14 @@ type NextUpdate =
        "update"
     :> WRes Get CUpdateInfo
 
+type PostponeUpdate =
+       "update"
+    :> "postpone"
+    :> WRes Post ()
+
 type ApplyUpdate =
        "update"
+    :> "apply"
     :> WRes Post ()
 
 -------------------------------------------------------------------------
@@ -445,6 +452,8 @@ type WalletApi = ApiPrefix :> (
      -- Updates
      -------------------------------------------------------------------------
      NextUpdate
+    :<|>
+     PostponeUpdate
     :<|>
      ApplyUpdate
     :<|>

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -55,11 +55,12 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Existing),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              addWAddress, createAccount, createWallet,
                                              getAccountIds, getAccountMeta,
-                                             getWalletAddresses, getWalletMetaIncludeUnready,
-                                             getWalletPassLU, isCustomAddress,
-                                             removeAccount, removeHistoryCache,
-                                             removeTxMetas, removeWallet, setAccountMeta,
-                                             setWalletMeta, setWalletPassLU, setWalletReady)
+                                             getWalletAddresses,
+                                             getWalletMetaIncludeUnready, getWalletPassLU,
+                                             isCustomAddress, removeAccount,
+                                             removeHistoryCache, removeTxMetas,
+                                             removeWallet, setAccountMeta, setWalletMeta,
+                                             setWalletPassLU, setWalletReady)
 import           Pos.Wallet.Web.Tracking    (CAccModifier (..), CachedCAccModifier,
                                              fixCachedAccModifierFor,
                                              fixingCachedAccModifier, sortedInsertions)
@@ -248,7 +249,7 @@ changeWalletPassphrase wid oldPass newPass = do
     oldSK <- getSKById wid
 
     unless (isJust $ checkPassMatches newPass oldSK) $ do
-        newSK <- maybeThrow badPass $ changeEncPassphrase oldPass newPass oldSK
+        newSK <- maybeThrow badPass =<< changeEncPassphrase oldPass newPass oldSK
         deleteSK oldPass
         addSecretKey newSK
         setWalletPassLU wid =<< liftIO getPOSIXTime

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -9,6 +9,7 @@ module Pos.Wallet.Web.Methods.Misc
        , isValidAddress
 
        , nextUpdate
+       , postponeUpdate
        , applyUpdate
 
        , syncProgress
@@ -25,7 +26,7 @@ import           Pos.Util                   (maybeThrow)
 import           Pos.Wallet.KeyStorage      (deleteSecretKey, getSecretKeys)
 import           Pos.Wallet.WalletMode      (applyLastUpdate, connectedPeers,
                                              localChainDifficulty, networkChainDifficulty)
-import           Pos.Wallet.Web.ClientTypes (CProfile, CProfile (..), CUpdateInfo (..),
+import           Pos.Wallet.Web.ClientTypes (CProfile (..), CUpdateInfo (..),
                                              SyncProgress (..))
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
@@ -61,6 +62,11 @@ nextUpdate :: MonadWalletWebMode m => m CUpdateInfo
 nextUpdate = getNextUpdate >>=
              maybeThrow (RequestError "No updates available")
 
+-- | Postpone next update after restart
+postponeUpdate :: MonadWalletWebMode m => m ()
+postponeUpdate = removeNextUpdate
+
+-- | Delete next update info and restart immediately
 applyUpdate :: MonadWalletWebMode m => m ()
 applyUpdate = removeNextUpdate >> applyLastUpdate
 

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -77,6 +77,8 @@ servantHandlers sendActions =
 
      M.nextUpdate
     :<|>
+     M.postponeUpdate
+    :<|>
      M.applyUpdate
     :<|>
 

--- a/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
@@ -51,8 +51,8 @@ walletServeImpl
     -> NetworkAddress    -- ^ IP and port to listen
     -> Maybe TlsParams
     -> m ()
-walletServeImpl app (ip, addr) =
-    serveImpl app (BS8.unpack ip) addr
+walletServeImpl app (ip, port) =
+    serveImpl app (BS8.unpack ip) port
 
 walletApplication
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
@@ -24,8 +24,10 @@ import           Servant.Server                   (Handler, Server, serve)
 import           Servant.Swagger.UI               (swaggerSchemaUIServer)
 import           Servant.Utils.Enter              ((:~>) (..), enter)
 
+import qualified Data.ByteString.Char8            as BS8
 import           Pos.Communication                (OutSpecs, SendActions (..), sendTxOuts)
 import           Pos.Core.Context                 (HasCoreConstants)
+import           Pos.Util.TimeWarp                (NetworkAddress)
 import           Pos.Wallet.SscType               (WalletSscType)
 import           Pos.Wallet.Web.Account           (findKey, myRootAddresses)
 import           Pos.Wallet.Web.Api               (WalletSwaggerApi, swaggerWalletApi)
@@ -46,11 +48,11 @@ import           Pos.Web                          (TlsParams, serveImpl)
 walletServeImpl
     :: MonadWalletWebMode m
     => m Application     -- ^ Application getter
-    -> Word16            -- ^ Port to listen
+    -> NetworkAddress    -- ^ IP and port to listen
     -> Maybe TlsParams
     -> m ()
-walletServeImpl app =
-    serveImpl app "127.0.0.1"
+walletServeImpl app (ip, addr) =
+    serveImpl app (BS8.unpack ip) addr
 
 walletApplication
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -28,6 +28,7 @@ import           Pos.Communication.Protocol     (SendActions)
 import           Pos.Core                       (HasCoreConstants)
 import           Pos.Launcher.Resource          (NodeResources)
 import           Pos.Launcher.Runner            (runRealBasedMode)
+import           Pos.Util.TimeWarp              (NetworkAddress)
 import           Pos.Wallet.SscType             (WalletSscType)
 import           Pos.Wallet.Web.Methods         (addInitialRichAccount)
 import           Pos.Wallet.Web.Mode            (WalletWebMode, WalletWebModeContext (..),
@@ -54,8 +55,8 @@ runWRealMode db conn =
 walletServeWebFull
     :: HasCoreConstants
     => SendActions WalletWebMode
-    -> Bool      -- whether to include genesis keys
-    -> Word16    -- ^ Port to listen
+    -> Bool              -- whether to include genesis keys
+    -> NetworkAddress    -- ^ IP and Port to listen
     -> Maybe TlsParams
     -> WalletWebMode ()
 walletServeWebFull sendActions debug = walletServeImpl action

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -149,6 +149,10 @@ instance HasCustomSwagger NextUpdate where
     swaggerModifier = modifyDescription
         "Get information about the next update."
 
+instance HasCustomSwagger PostponeUpdate where
+    swaggerModifier = modifyDescription
+        "Postpone last update."
+
 instance HasCustomSwagger ApplyUpdate where
     swaggerModifier = modifyDescription
         "Apply last update."


### PR DESCRIPTION
PRs which are included here:

- [x] #1584 Use `scrypt` for password hashing - *required for mainnet*
- [x] #1585 Make `localDifficulty` monotonic - very desirable to have in mainnet
- [x] #1586 Endpoint for postponing the update - *required for mainnet*
- [x] #1592 Expose Daedalus backend IP:PORT - *required for mainnet* (necessary for integration with exchanges)