### PR TITLE
[CSL-1678] Make genesis hash part of configuration

### DIFF
--- a/core/Pos/Core/Configuration.hs
+++ b/core/Pos/Core/Configuration.hs
@@ -13,13 +13,13 @@ module Pos.Core.Configuration
 
 import           Universum
 
-import qualified Crypto.Hash                             as Hash
 import qualified Data.ByteString                         as BS
 import qualified Data.ByteString.Lazy                    as BSL
 import           Formatting                              (sformat, shown, (%))
 import           System.Wlog                             (WithLogger, logInfo)
 import qualified Text.JSON.Canonical                     as Canonical
 
+import           Pos.Binary.Class                        (Raw)
 import           Pos.Core.Coin                           (coinToInteger)
 import           Pos.Core.Configuration.BlockVersionData as E
 import           Pos.Core.Configuration.Core             as E
@@ -27,7 +27,6 @@ import           Pos.Core.Configuration.GeneratedSecrets as E
 import           Pos.Core.Configuration.GenesisData      as E
 import           Pos.Core.Configuration.GenesisHash      as E
 import           Pos.Core.Configuration.Protocol         as E
-import           Pos.Core.Constants                      (genesisDataDigest)
 import           Pos.Core.Genesis.Canonical              ()
 import           Pos.Core.Genesis.Generate               (GeneratedGenesisData (..),
                                                           generateGenesisData)
@@ -36,7 +35,7 @@ import           Pos.Core.Genesis.Types                  (GenesisData (..),
                                                           GenesisSpec (..),
                                                           getGenesisAvvmBalances)
 import           Pos.Core.Types                          (Coin, Timestamp)
-import           Pos.Crypto.Hashing                      (AbstractHash (..), unsafeHash)
+import           Pos.Crypto.Hashing                      (Hash, hashRaw, unsafeHash)
 
 -- | Coarse catch-all configuration constraint for use by depending modules.
 type HasConfiguration =
@@ -48,10 +47,10 @@ type HasConfiguration =
     , HasProtocolConstants
     )
 
-canonicalGenesisJson :: GenesisData -> (BSL.ByteString, Hash.Digest Hash.Blake2b_256)
+canonicalGenesisJson :: GenesisData -> (BSL.ByteString, Hash Raw)
 canonicalGenesisJson theGenesisData = (canonicalJsonBytes, jsonHash)
   where
-    jsonHash = Hash.hash $ BSL.toStrict canonicalJsonBytes
+    jsonHash = hashRaw $ BSL.toStrict canonicalJsonBytes
     canonicalJsonBytes = Canonical.renderCanonicalJSON $ runIdentity $ Canonical.toJSON theGenesisData
 
 -- | Come up with a HasConfiguration constraint using a Configuration.
@@ -60,7 +59,7 @@ canonicalGenesisJson theGenesisData = (canonicalJsonBytes, jsonHash)
 -- the canonical JSON encoding of a mainnet genesis.
 --
 -- If the canonical JSON source is given, then it will be hashed and checked
--- against the constant expected genesisDataDigest.
+-- against expected hash (which is also part of configuration in this case).
 --
 -- If the configuration gives a testnet genesis spec, then a start time must
 -- be provided, probably sourced from command line arguments.
@@ -78,9 +77,9 @@ withCoreConfigurations
     -> m r
 withCoreConfigurations conf@CoreConfiguration{..} mSystemStart act = case ccGenesis of
     -- If a 'GenesisData' source file is given, we check its hash against the
-    -- built-in constant, parse it, and use the GenesisData to fill in all of]
+    -- given expected hash, parse it, and use the GenesisData to fill in all of
     -- the obligations.
-    GCSrc fp -> do
+    GCSrc fp expectedHash -> do
         !bytes <- liftIO $ BS.readFile fp
 
         gdataJSON <- case Canonical.parseCanonicalJSON (BSL.fromStrict bytes) of
@@ -92,17 +91,15 @@ withCoreConfigurations conf@CoreConfiguration{..} mSystemStart act = case ccGene
             Right it -> return it
 
         let (_, theGenesisHash) = canonicalGenesisJson theGenesisData
-        when (theGenesisHash /= genesisDataDigest) $
-            throwM $ GenesisHashMismatch (show theGenesisHash) (show genesisDataDigest)
-        -- See Pos.Core.Constants. The genesisHash is conceptually distinct
-        -- from the genesisDataDigest, they just happen to coincide for
-        -- mainnet.
+        when (theGenesisHash /= expectedHash) $
+            throwM $ GenesisHashMismatch
+                     (show theGenesisHash) (show expectedHash)
 
         withCoreConfiguration conf $
             withProtocolConstants (gdProtocolConsts theGenesisData) $
             withGenesisBlockVersionData (gdBlockVersionData theGenesisData) $
             withGenesisData theGenesisData $
-            withGenesisHash (AbstractHash theGenesisHash) $
+            withGenesisHash theGenesisHash $
             withGeneratedSecrets Nothing $
             act
 
@@ -130,7 +127,7 @@ withGenesisSpec
     -> (HasConfiguration => r)
     -> r
 withGenesisSpec theSystemStart conf@CoreConfiguration{..} val = case ccGenesis of
-    GCSrc _ -> error "withGenesisSpec called with GCSrc"
+    GCSrc {} -> error "withGenesisSpec called with GCSrc"
     GCSpec spec ->
         withProtocolConstants (gsProtocolConstants spec) $
         withGenesisBlockVersionData (gsBlockVersionData spec) $

--- a/core/Pos/Core/Configuration/Core.hs
+++ b/core/Pos/Core/Configuration/Core.hs
@@ -30,13 +30,20 @@ import           Universum
 import           Data.Reflection        (Given (..), give)
 import           Data.Time.Units        (Microsecond, Second, convertUnit)
 
+import           Pos.Binary.Class       (Raw)
 import           Pos.Core.Genesis.Types (GenesisSpec (..))
+import           Pos.Crypto.Hashing     (Hash)
 
-data GenesisConfiguration =
+data GenesisConfiguration
       -- | Genesis from a 'GenesisSpec'.
-      GCSpec !GenesisSpec
-      -- | 'GenesisData' in canonical JSON at this location.
-    | GCSrc !FilePath
+    = GCSpec !GenesisSpec
+      -- | 'GenesisData' is stored in a file.
+    | GCSrc { gcsFile :: !FilePath
+            -- ^ Path to file where 'GenesisData' is stored. Must be
+            -- in JSON, not necessary canonical.
+            , gcsHash :: !(Hash Raw)
+            -- ^ Hash of canonically encoded 'GenesisData'.
+            }
     deriving (Show)
 
 data CoreConfiguration = CoreConfiguration

--- a/core/Pos/Core/Configuration/GenesisHash.hs
+++ b/core/Pos/Core/Configuration/GenesisHash.hs
@@ -6,15 +6,18 @@ module Pos.Core.Configuration.GenesisHash
        , genesisHash
        ) where
 
+import           Data.Coerce        (coerce)
 import           Data.Reflection    (Given (..), give)
+
+import           Pos.Binary.Class   (Raw)
 import           Pos.Crypto.Hashing (Hash)
 
 newtype GenesisHash = GenesisHash { getGenesisHash :: forall a . Hash a }
 
 type HasGenesisHash = Given GenesisHash
 
-withGenesisHash :: (forall a . Hash a) -> (HasGenesisHash => r) -> r
-withGenesisHash gh = give (GenesisHash gh)
+withGenesisHash :: (Hash Raw) -> (HasGenesisHash => r) -> r
+withGenesisHash gh = give (GenesisHash (coerce gh))
 
 genesisHash :: HasGenesisHash => Hash a
 genesisHash = getGenesisHash given

--- a/core/Pos/Core/Constants.hs
+++ b/core/Pos/Core/Constants.hs
@@ -5,13 +5,9 @@
 
 module Pos.Core.Constants
        ( sharedSeedLength
-       , genesisDataDigest
        , isDevelopment
        ) where
 
-import           Crypto.Hash            (Blake2b_256, Digest, digestFromByteString)
-import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Base16 as B16
 import           Universum
 
 ----------------------------------------------------------------------------
@@ -21,28 +17,6 @@ import           Universum
 -- | Length of shared seed.
 sharedSeedLength :: Integral a => a
 sharedSeedLength = 32
-
--- | Digest of the canonical JSON of the mainnet 'GenesisData'
---
--- FIXME avieth
--- This is the blake2b_256 digest of an empty file (touch <file name>).
--- Put in the right value once we know it (digest of actual canonical JSON
--- of genesis data.
---
--- It is also the predefined 'Hash' of the parent of the 0-th genesis block
--- (which is the only block without a real parent). But that's coincidental
--- rather than essential.
--- It doesn't have to be the digest of the canonical JSON; it could be any
--- Blake2b_256 digest so long as it's determined by the 'GenesisData'. This is
--- just a very convenient choice because it means we don't have to parse a
--- digest from the 'GensisData' canonical JSON.
-genesisDataDigest :: Digest Blake2b_256
-Just genesisDataDigest = digestFromByteString @_ @BS.ByteString bytesDigest
-  where
-    hexDigest = "bcfbfcad6cf78f2363568e76af9d6e927f71c3683aafe5e289796579792dccdb"
-    (bytesDigest, _) = B16.decode hexDigest
-
-{-# INLINE genesisDataDigest #-}
 
 -- | @True@ if current mode is 'Development'.
 --

--- a/node/configuration.mainnet.yaml
+++ b/node/configuration.mainnet.yaml
@@ -14595,7 +14595,9 @@ mainnet: &mainnet
   core:
     <<: *mainnet_base_core
     genesis:
-      src: sample-mainnet-genesis.json
+      src:
+        file: sample-mainnet-genesis.json
+        hash: bcfbfcad6cf78f2363568e76af9d6e927f71c3683aafe5e289796579792dccdb # TODO: set proper hash
 
 
 


### PR DESCRIPTION
Previously it was hardcoded as 'genesisDataDigest', but it wasn't convenient
for some people. Now this hash is taken from configuration file if 'genesis'
is specified as 'src', not as 'spec'.
For format see changes in 'configuration.mainnet.yaml' file.