### PR TITLE
[CSL-1681] Make cardano-launcher depend on configuration not so much

### DIFF
--- a/auxx/src/Command/Run.hs
+++ b/auxx/src/Command/Run.hs
@@ -80,6 +80,8 @@ Avaliable commands:
    quit                           -- shutdown node wallet
 |]
 
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+
 runCmd ::
        HasConfigurations
     => SendActions AuxxMode

--- a/auxx/src/Command/Tx.hs
+++ b/auxx/src/Command/Tx.hs
@@ -39,8 +39,8 @@ import           Pos.Configuration                (HasNodeConfiguration)
 import           Pos.Core                         (BlockVersionData (bvdSlotDuration),
                                                    Timestamp (..), mkCoin)
 import           Pos.Core.Configuration           (HasConfiguration,
-                                                   genesisBlockVersionData)
-import           Pos.Core.Configuration           (genesisSecretKeys)
+                                                   genesisBlockVersionData,
+                                                   genesisSecretKeys)
 import           Pos.Core.Constants               (isDevelopment)
 import           Pos.Crypto                       (emptyPassphrase, encToPublic,
                                                    fakeSigner, safeToPublic, toPublic,

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1310,7 +1310,7 @@ self: {
           description = "Cardano SL main implementation";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-auxx = callPackage ({ QuickCheck, acid-state, ansi-wl-pprint, base, base58-bytestring, binary, bytestring, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, containers, cpphs, data-default, dlist, ether, exceptions, formatting, lens, log-warper, mkDerivation, mmorph, monad-control, monad-loops, mtl, neat-interpolation, network-transport-tcp, node-sketch, optparse-applicative, parsec, random, resourcet, safe-exceptions, safecopy, serokell-util, stdenv, stm, stm-containers, tagged, text, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers, yaml }:
+      cardano-sl-auxx = callPackage ({ QuickCheck, acid-state, aeson, ansi-wl-pprint, base, base58-bytestring, binary, bytestring, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, containers, cpphs, data-default, dlist, ether, exceptions, formatting, lens, log-warper, mkDerivation, mmorph, monad-control, monad-loops, mtl, neat-interpolation, network-transport-tcp, node-sketch, optparse-applicative, parsec, random, resourcet, safe-exceptions, safecopy, serokell-util, stdenv, stm, stm-containers, tagged, text, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers }:
       mkDerivation {
           pname = "cardano-sl-auxx";
           version = "0.6.0";
@@ -1319,6 +1319,7 @@ self: {
           isExecutable = true;
           executableHaskellDepends = [
             acid-state
+            aeson
             ansi-wl-pprint
             base
             base58-bytestring
@@ -1367,7 +1368,6 @@ self: {
             universum
             unix
             unordered-containers
-            yaml
           ];
           executableToolDepends = [
             cpphs
@@ -1814,7 +1814,7 @@ self: {
           description = "Cardano SL - the SSC class";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-tools = callPackage ({ Chart, Chart-diagrams, Glob, MonadRandom, QuickCheck, aeson, ansi-wl-pprint, array, async, attoparsec, base, bytestring, canonical-json, cardano-report-server, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, containers, cpphs, cryptonite, data-default, directory, ed25519, ether, fgl, filepath, foldl, formatting, graphviz, kademlia, lens, log-warper, mkDerivation, mtl, neat-interpolation, node-sketch, optparse-applicative, parsec, pipes, pipes-bytestring, pipes-interleave, pipes-safe, process, random, random-shuffle, safe-exceptions, serokell-util, stdenv, stm, system-filepath, tar, text, text-format, time, time-units, universum, unix-compat, unordered-containers, vector, yaml }:
+      cardano-sl-tools = callPackage ({ Chart, Chart-diagrams, Glob, MonadRandom, QuickCheck, aeson, ansi-wl-pprint, array, async, attoparsec, base, base58-bytestring, bytestring, canonical-json, cardano-report-server, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, containers, cpphs, cryptonite, data-default, directory, ed25519, ether, fgl, filepath, foldl, formatting, graphviz, kademlia, lens, log-warper, mkDerivation, mtl, neat-interpolation, node-sketch, optparse-applicative, parsec, pipes, pipes-bytestring, pipes-interleave, pipes-safe, process, random, random-shuffle, safe-exceptions, serokell-util, stdenv, stm, system-filepath, tar, text, text-format, time, time-units, universum, unix-compat, unordered-containers, vector, yaml }:
       mkDerivation {
           pname = "cardano-sl-tools";
           version = "0.6.2";
@@ -1828,6 +1828,7 @@ self: {
             async
             attoparsec
             base
+            base58-bytestring
             bytestring
             canonical-json
             cardano-report-server


### PR DESCRIPTION
Now it doesn't need configuration to process command line options, so
one can use `--help` without configuration.

I tried to eliminate this constraint further, but it's needed for 'sendReport'
function and then I stopped.