### PR TITLE
[CSM-463] Expose tx inputs and outputs with according amounts

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -8,12 +8,12 @@ import           Universum
 
 import qualified Data.ByteArray                       as ByteArray
 import qualified Data.ByteString                      as BS
-import           Data.List                            (partition)
+import           Data.List                            (intersperse, partition)
 import           Data.Text                            (splitOn)
 import qualified Data.Text.Buildable
-import           Formatting                           (bprint, build, int, sformat, shown,
-                                                       (%))
-import           Serokell.Util                        (listJson, listJsonIndent)
+import           Formatting                           (bprint, build, builder, int,
+                                                       sformat, shown, (%))
+import           Serokell.Util                        (listJsonIndent)
 import qualified Serokell.Util.Base16                 as Base16
 import           Servant.API                          (FromHttpApiData (..))
 import           Servant.Multipart                    (FromMultipart (..), lookupFile,
@@ -132,8 +132,8 @@ instance Buildable CTx where
                 %" amount="%build
                 %" confirms="%build
                 %" meta="%build%"\n"
-                %" inputs="%listJson%"\n"
-                %" outputs="%listJson%"\n"
+                %" inputs="%builder%"\n"
+                %" outputs="%builder%"\n"
                 %" local="%build
                 %" outgoing="%build
                 %" condition="%build
@@ -142,11 +142,15 @@ instance Buildable CTx where
         ctAmount
         ctConfirmations
         ctMeta
-        ctInputAddrs
-        ctOutputAddrs
+        (buildTxEnds ctInputs)
+        (buildTxEnds ctOutputs)
         ctIsLocal
         ctIsOutgoing
         ctCondition
+      where
+        buildTxEnds =
+            mconcat . intersperse ", " .
+            map (uncurry $ bprint (build%" - "%build))
 
 instance Buildable CProfile where
     build CProfile{..} =

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -274,8 +274,8 @@ data CTx = CTx
     , ctAmount        :: CCoin
     , ctConfirmations :: Word
     , ctMeta          :: CTxMeta
-    , ctInputAddrs    :: [CId Addr]
-    , ctOutputAddrs   :: [CId Addr]
+    , ctInputs        :: [(CId Addr, CCoin)]
+    , ctOutputs       :: [(CId Addr, CCoin)]
     , ctIsLocal       :: Bool
     , ctIsOutgoing    :: Bool
     , ctCondition     :: CPtxCondition

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -92,7 +92,7 @@ getHistory mCWalId mAccountId mAddrId = do
   where
     fits :: [CId Addr] -> CTx -> Bool
     fits addrs ctx = any (relatesToAddr ctx) addrs
-    relatesToAddr CTx {..} = (`elem` (ctInputAddrs ++ ctOutputAddrs))
+    relatesToAddr CTx {..} = (`elem` (map fst $ ctInputs ++ ctOutputs))
     errorSpecifySomething = RequestError $
         "Please specify either walletId or accountId"
     errorDontSpecifyBoth = RequestError $


### PR DESCRIPTION
Displays coins attached to inputs and outputs of transaction.

Tested
* with postman on A -> A and foreign transactions, and with case when multiple transactions send money to same address, when whole this address is depleted (inputs should be displayed merged).
* daedalus-bridge works

New format of `CTx` is the following
![2017-09-21 21 55 52](https://user-images.githubusercontent.com/5394217/30713573-5f2a0a3a-9f18-11e7-896a-6e0577a858ee.png)
