### PR TITLE
[CSL-1683] Add configuration options to launcher, propagate to node

### DIFF
--- a/node/src/Pos/Client/CLI/Options.hs
+++ b/node/src/Pos/Client/CLI/Options.hs
@@ -58,6 +58,8 @@ commonArgsParser = do
     configurationOptions <- configurationOptionsParser
     pure CommonArgs{..}
 
+-- Note: if you want to change names of these options, please also
+-- update cardano-launcher accordingly (grep for these names).
 configurationOptionsParser :: Opt.Parser ConfigurationOptions
 configurationOptionsParser = do
     cfoFilePath    <- filePathParser

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -269,20 +269,22 @@ executable cardano-launcher
                      , async
                      , base
                      , cardano-report-server >= 0.2.1
-                     , log-warper
                      , cardano-sl
+                     , cardano-sl-core
                      , cardano-sl-infra
                      , data-default
                      , directory
                      , filepath
+                     , lens
+                     , log-warper
                      , neat-interpolation
                      , optparse-applicative
                      , formatting
                      , process
                      , system-filepath
                      , text
+                     , time-units
                      , universum
-                     , lens
   default-language:    Haskell2010
   ghc-options:         -threaded
                        -Wall


### PR DESCRIPTION
Now cardano-launcher has options to set configuration path and key.
It also passes their values to node, unless they are explicitly specified
with '-n'.