### PR TITLE
[CSM-464] Fix inconsistent fee calculation

### DIFF
--- a/node/src/Pos/Client/Txp/Util.hs
+++ b/node/src/Pos/Client/Txp/Util.hs
@@ -475,11 +475,12 @@ computeTxFee
     => Utxo
     -> TxOutputs
     -> TxCreator m TxFee
-computeTxFee utxo outputs = withLinearFeePolicy $ \linearPolicy -> do
-    TxRaw {..} <- stabilizeTxFee linearPolicy utxo outputs
+computeTxFee utxo outputs = do
+    TxRaw {..} <- prepareTxWithFee utxo outputs
     let outAmount = sumTxOutCoins trOutputs
         inAmount = sumCoins $ map (txOutValue . fst) trInputs
-    integerToFee $ inAmount - outAmount
+        remaining = coinToInteger trRemainingMoney
+    integerToFee $ inAmount - outAmount - remaining
 
 -- | Search such spendings that transaction's fee would be stable.
 --


### PR DESCRIPTION
Cause of the CSM-464 bug: `txFee` endpoint formed a transaction identical to one formed by calling `newPayment` endpoint, but then it calculated _minimal allowed fee_ for given transaction size. But in edge cases (like sending almost all money a user have) minimal possible transaction fee is not equal to minimal allowed transaction fee for given transaction size.
This PR changes how `txFee` endpoint calculates fee: now returned value is calculated by definition, as difference between total input amount and total output amount.