### PR TITLE
[CSE-208] Track utxo sum

### DIFF
--- a/core/Pos/Util/Util.hs
+++ b/core/Pos/Util/Util.hs
@@ -15,6 +15,7 @@ module Pos.Util.Util
        , liftGetterSome
 
        -- * Something
+       , Sign (..)
        , maybeThrow
        , eitherToFail
        , eitherToThrow
@@ -347,6 +348,8 @@ type instance ChannelT (Ether.TaggedTrans tag t m) = ChannelT m
 ----------------------------------------------------------------------------
 -- Not instances
 ----------------------------------------------------------------------------
+
+data Sign = Plus | Minus
 
 maybeThrow :: (MonadThrow m, Exception e) => e -> Maybe a -> m a
 maybeThrow e = maybe (throwM e) pure

--- a/node/src/Pos/Explorer/Core/Types.hs
+++ b/node/src/Pos/Explorer/Core/Types.hs
@@ -16,5 +16,7 @@ type AddrHistory = NewestFirst [] TxId
 data TxExtra = TxExtra
     { teBlockchainPlace :: !(Maybe (HeaderHash, Word32))
     , teReceivedTime    :: !(Maybe Timestamp)
-    , teInputOutputs    :: TxUndo  -- non-strict on purpose, see `makeExtra` in Pos.Txp.Logic.Local
+    -- non-strict on purpose, see `makeExtra` in Pos.Txp.Logic.Local
+    -- TODO(thatguy): The comment above is obsolete, need to update it.
+    , teInputOutputs    :: TxUndo
     } deriving (Show, Generic, Eq)

--- a/node/src/Pos/Explorer/DB.hs
+++ b/node/src/Pos/Explorer/DB.hs
@@ -31,7 +31,6 @@ import           Serokell.Util                (Color (Red), colorize, mapJson)
 import           System.Wlog                  (WithLogger, logError)
 
 import           Pos.Binary.Class             (UnsignedVarInt (..), serialize')
-import           Pos.Context.Functions        (genesisUtxo)
 import           Pos.Core                     (Address, Coin, EpochIndex, HeaderHash,
                                                sumCoins, unsafeAddCoin)
 import           Pos.Core.Configuration       (HasConfiguration)
@@ -44,6 +43,7 @@ import           Pos.DB.GState.Common         (gsGetBi, gsPutBi, writeBatchGStat
 import           Pos.Explorer.Core            (AddrHistory, TxExtra (..))
 import           Pos.Txp.Core                 (Tx, TxId, TxOut (..), TxOutAux (..))
 import           Pos.Txp.DB                   (getAllPotentiallyHugeUtxo, utxoSource)
+import           Pos.Txp.GenesisUtxo          (genesisUtxo)
 import           Pos.Txp.Toil                 (GenesisUtxo (..), utxoF,
                                                utxoToAddressCoinPairs)
 import           Pos.Util.Chrono              (NewestFirst (..))
@@ -100,8 +100,8 @@ getLastTransactions = gsGetBi lastTxsPrefix
 prepareExplorerDB :: (MonadReader ctx m, MonadDB m) => m ()
 prepareExplorerDB =
     unlessM areBalancesInitialized $ do
-        GenesisUtxo genesisUtxo <- genesisUtxoM
-        let addressCoinPairs = utxoToAddressCoinPairs genesisUtxo
+        let GenesisUtxo utxo = genesisUtxo
+            addressCoinPairs = utxoToAddressCoinPairs utxo
         putGenesisBalances addressCoinPairs
         putGenesisUtxoSum addressCoinPairs
         putInitFlag

--- a/node/src/Pos/Explorer/DB.hs
+++ b/node/src/Pos/Explorer/DB.hs
@@ -79,7 +79,9 @@ getAddrBalance :: MonadDBRead m => Address -> m (Maybe Coin)
 getAddrBalance = gsGetBi . addrBalanceKey
 
 getUtxoSum :: MonadDBRead m => m Integer
-getUtxoSum = fromMaybe 0 <$> gsGetBi utxoSumPrefix
+getUtxoSum = fromMaybe dbNotInitialized <$> gsGetBi utxoSumPrefix
+  where
+    dbNotInitialized = error "getUtxoSum: DB is not initialized"
 
 getPageBlocks :: MonadDBRead m => Page -> m (Maybe [HeaderHash])
 getPageBlocks = gsGetBi . blockPagePrefix

--- a/node/src/Pos/Explorer/Txp/Global.hs
+++ b/node/src/Pos/Explorer/Txp/Global.hs
@@ -46,13 +46,14 @@ eApplyBlocksSettings =
     }
 
 extraOps :: HasConfiguration => ExplorerExtra -> SomeBatchOp
-extraOps (ExplorerExtra em (HM.toList -> histories) balances) =
+extraOps (ExplorerExtra em (HM.toList -> histories) balances utxoNewSum) =
     SomeBatchOp $
     map GS.DelTxExtra (MM.deletions em) ++
     map (uncurry GS.AddTxExtra) (MM.insertions em) ++
     map (uncurry GS.UpdateAddrHistory) histories ++
     map (uncurry GS.PutAddrBalance) (MM.insertions balances) ++
-    map GS.DelAddrBalance (MM.deletions balances)
+    map GS.DelAddrBalance (MM.deletions balances) ++
+    map GS.PutUtxoSum (maybeToList utxoNewSum)
 
 applyBlund
     :: (HasConfiguration, MonadSlots ctx m, EGlobalApplyToilMode m)
@@ -70,8 +71,8 @@ applyBlund txpBlund = do
 
     let txpBlock = txpBlund ^. _1
     let slotId   = case txpBlock of
-            Left gensisBlock -> SlotId
-                                  { siEpoch = gensisBlock ^. epochIndexL
+            Left genesisBlock -> SlotId
+                                  { siEpoch = genesisBlock ^. epochIndexL
                                   , siSlot  = minBound
                                   -- ^ Genesis block doesn't have a slot, set to minBound
                                   }

--- a/node/src/Pos/Explorer/Txp/Toil/Class.hs
+++ b/node/src/Pos/Explorer/Txp/Toil/Class.hs
@@ -12,7 +12,7 @@ import           Universum
 import           Control.Lens                (at, (%=), (.=))
 import           Control.Monad.Trans.Class   (MonadTrans)
 
-import           Pos.Core                    (Address, Coin, unsafeAddCoin, unsafeSubCoin)
+import           Pos.Core                    (Address, Coin)
 import           Pos.DB.Class                (MonadDBRead)
 import           Pos.Explorer.Core           (AddrHistory, TxExtra)
 import qualified Pos.Explorer.DB             as DB
@@ -23,13 +23,12 @@ import           Pos.Txp.Core                (TxId)
 import           Pos.Txp.Toil                (DBToil, ToilT, tmExtra)
 import           Pos.Util                    (ether)
 import qualified Pos.Util.Modifier           as MM
-import           Pos.Util.Util               (Sign (..))
 
 class Monad m => MonadTxExtraRead m where
     getTxExtra :: TxId -> m (Maybe TxExtra)
     getAddrHistory :: Address -> m AddrHistory
     getAddrBalance :: Address -> m (Maybe Coin)
-    getUtxoSum :: m Coin
+    getUtxoSum :: m Integer
 
 instance {-# OVERLAPPABLE #-}
     (MonadTxExtraRead m, MonadTrans t, Monad (t m)) =>
@@ -47,7 +46,7 @@ class MonadTxExtraRead m => MonadTxExtra m where
     updateAddrHistory :: Address -> AddrHistory -> m ()
     putAddrBalance :: Address -> Coin -> m ()
     delAddrBalance :: Address -> m ()
-    updateUtxoSum :: Sign -> Coin -> m ()
+    putUtxoSum :: Integer -> m ()
 
 instance {-# OVERLAPPABLE #-}
     (MonadTxExtra m, MonadTrans t, Monad (t m)) =>
@@ -58,7 +57,7 @@ instance {-# OVERLAPPABLE #-}
     updateAddrHistory addr = lift . updateAddrHistory addr
     putAddrBalance addr = lift . putAddrBalance addr
     delAddrBalance = lift . delAddrBalance
-    updateUtxoSum sign = lift . updateUtxoSum sign
+    putUtxoSum = lift . putUtxoSum
 
 ----------------------------------------------------------------------------
 -- ToilT instances
@@ -87,11 +86,8 @@ instance MonadTxExtraRead m => MonadTxExtra (ToilT ExplorerExtra m) where
         tmExtra . eeAddrBalances %= MM.insert addr coin
     delAddrBalance addr = ether $
         tmExtra . eeAddrBalances %= MM.delete addr
-    updateUtxoSum sign coin = ether $ do
-        currentVal <- getUtxoSum
-        case sign of
-            Plus  -> tmExtra . eeNewUtxoSum .= Just (unsafeAddCoin currentVal coin)
-            Minus -> tmExtra . eeNewUtxoSum .= Just (unsafeSubCoin currentVal coin)
+    putUtxoSum utxoSum = ether $ do
+        tmExtra . eeNewUtxoSum .= Just utxoSum
 
 ----------------------------------------------------------------------------
 -- DBToil instances

--- a/node/src/Pos/Explorer/Txp/Toil/Logic.hs
+++ b/node/src/Pos/Explorer/Txp/Toil/Logic.hs
@@ -23,8 +23,8 @@ import           System.Wlog                 (WithLogger, logError, runNamedPure
                                               usingLoggerName)
 
 import           Pos.Core                    (Address, Coin, EpochIndex, HeaderHash,
-                                              Timestamp, coinToInteger, mkCoin,
-                                              unsafeAddCoin, unsafeSubCoin)
+                                              Timestamp, mkCoin, sumCoins, unsafeAddCoin,
+                                              unsafeSubCoin)
 import           Pos.Crypto                  (WithHash (..), hash)
 import           Pos.Explorer.Core           (AddrHistory, TxExtra (..))
 import           Pos.Explorer.Txp.Toil.Class (MonadTxExtra (..), MonadTxExtraRead (..))
@@ -165,8 +165,8 @@ delTxExtraWithHistory id addrs = do
 
 updateUtxoSumFromBalanceUpdate :: MonadTxExtra m => BalanceUpdate -> m ()
 updateUtxoSumFromBalanceUpdate balanceUpdate = do
-    let plusChange  = sum $ map (coinToInteger . snd) $ plusBalance  balanceUpdate
-        minusChange = sum $ map (coinToInteger . snd) $ minusBalance balanceUpdate
+    let plusChange  = sumCoins $ map snd $ plusBalance  balanceUpdate
+        minusChange = sumCoins $ map snd $ minusBalance balanceUpdate
         utxoChange  = plusChange - minusChange
     utxoSum <- getUtxoSum
     putUtxoSum $ utxoSum + utxoChange

--- a/node/src/Pos/Explorer/Txp/Toil/Types.hs
+++ b/node/src/Pos/Explorer/Txp/Toil/Types.hs
@@ -6,6 +6,7 @@ module Pos.Explorer.Txp.Toil.Types
        , eeLocalTxsExtra
        , eeAddrHistories
        , eeAddrBalances
+       , eeNewUtxoSum
        , ExplorerExtraTxp (..)
        ) where
 
@@ -28,6 +29,7 @@ data ExplorerExtra = ExplorerExtra
     { _eeLocalTxsExtra :: !TxMapExtra
     , _eeAddrHistories :: !UpdatedAddrHistories
     , _eeAddrBalances  :: !TxMapBalances
+    , _eeNewUtxoSum    :: !(Maybe Coin)
     }
 
 makeLenses ''ExplorerExtra
@@ -38,6 +40,7 @@ instance Default ExplorerExtra where
         { _eeLocalTxsExtra = mempty
         , _eeAddrHistories = mempty
         , _eeAddrBalances  = mempty
+        , _eeNewUtxoSum    = Nothing
         }
 
 type EToilModifier = GenericToilModifier ExplorerExtra
@@ -46,4 +49,5 @@ data ExplorerExtraTxp = ExplorerExtraTxp
     { eetTxExtra       :: !(HashMap TxId TxExtra)
     , eetAddrHistories :: !(HashMap Address AddrHistory)
     , eetAddrBalances  :: !(HashMap Address Coin)
+    , eetUtxoSum       :: !Coin
     }

--- a/node/src/Pos/Explorer/Txp/Toil/Types.hs
+++ b/node/src/Pos/Explorer/Txp/Toil/Types.hs
@@ -29,7 +29,7 @@ data ExplorerExtra = ExplorerExtra
     { _eeLocalTxsExtra :: !TxMapExtra
     , _eeAddrHistories :: !UpdatedAddrHistories
     , _eeAddrBalances  :: !TxMapBalances
-    , _eeNewUtxoSum    :: !(Maybe Coin)
+    , _eeNewUtxoSum    :: !(Maybe Integer)
     }
 
 makeLenses ''ExplorerExtra
@@ -49,5 +49,5 @@ data ExplorerExtraTxp = ExplorerExtraTxp
     { eetTxExtra       :: !(HashMap TxId TxExtra)
     , eetAddrHistories :: !(HashMap Address AddrHistory)
     , eetAddrBalances  :: !(HashMap Address Coin)
-    , eetUtxoSum       :: !Coin
+    , eetUtxoSum       :: !Integer
     }


### PR DESCRIPTION
Track current utxo sum in the Explorer DB.

Note that utxo sum is stored as `Integer` and not `Coin` because we want it to provide correct data even in the unlikely case where someone manages to create utxo out of thin air and thus utxo sum overflows `maxBound :: Coin`.