### PR TITLE
[CSL-1687] Treat fixedTimeCQ value as seconds

### DIFF
--- a/core/Pos/Aeson/Core.hs
+++ b/core/Pos/Aeson/Core.hs
@@ -9,7 +9,7 @@ import           Universum
 import           Data.Aeson             (FromJSON (..), ToJSON (toJSON))
 import           Data.Aeson.TH          (defaultOptions, deriveFromJSON, deriveJSON,
                                          deriveToJSON)
-import           Data.Time.Units        (Microsecond, Millisecond)
+import           Data.Time.Units        (Microsecond, Millisecond, Second)
 import qualified Serokell.Aeson.Options as S (defaultOptions)
 import           Serokell.Util.Base64   (JsonByteString (..))
 
@@ -42,6 +42,7 @@ instance FromJSON CoinPortion where
 deriveFromJSON S.defaultOptions ''VssCertificate
 deriveFromJSON S.defaultOptions ''Millisecond
 deriveFromJSON S.defaultOptions ''Microsecond
+deriveFromJSON S.defaultOptions ''Second
 deriveFromJSON S.defaultOptions ''SoftforkRule
 deriveFromJSON S.defaultOptions ''BlockVersionData
 

--- a/core/Pos/Core/Configuration/Core.hs
+++ b/core/Pos/Core/Configuration/Core.hs
@@ -76,7 +76,7 @@ data CoreConfiguration = CoreConfiguration
       -- back, it requires immediate reaction.
     , ccCriticalForkThreshold  :: !Int
       -- | Chain quality will be also calculated for this amount of seconds.
-    , ccFixedTimeCQ            :: !Microsecond
+    , ccFixedTimeCQ            :: !Second
 
       -- Web settings
 
@@ -131,11 +131,11 @@ criticalForkThreshold = fromIntegral . ccCriticalForkThreshold $ coreConfigurati
 
 -- | Chain quality will be also calculated for this amount of time.
 fixedTimeCQ :: HasCoreConfiguration => Microsecond
-fixedTimeCQ = ccFixedTimeCQ coreConfiguration
+fixedTimeCQ = convertUnit fixedTimeCQSec
 
 -- | 'fixedTimeCQ' expressed as seconds.
 fixedTimeCQSec :: HasCoreConfiguration => Second
-fixedTimeCQSec = convertUnit fixedTimeCQ
+fixedTimeCQSec = ccFixedTimeCQ coreConfiguration
 
 -- | Web logging might be disabled for security concerns.
 webLoggingEnabled :: HasCoreConfiguration => Bool

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2729,6 +2729,8 @@ self: {
           pname = "diagrams-postscript";
           version = "1.4";
           sha256 = "1d4dbwd4qgrlwm0m9spwqklpg3plf0ghrnrah1k6yw900l0z0n7y";
+          revision = "1";
+          editedCabalFile = "0vmiv3b74nml0ahb7dicq0m0vz2lahzfapln9aby0jb2saa0sf58";
           libraryHaskellDepends = [
             base
             containers


### PR DESCRIPTION
Before Configuration refactoring this value was treated as seconds, but it
was broken during the refactoring.

It solves (1) and (2) from CSL-1687. I have no idea why overall chain quality is 0 there. Most likely that's just another consequence of this misconfiguration. I couldn't reproduce it locally. I can try to understand it if I have logs, but probably it's not useful to do it, it's better to check whether this fix helps (it most likely does) first.