### PR TITLE
[CSL-1655] Ensure public logs contain no sensitive data

### DIFF
--- a/core/Pos/Crypto/Hashing.hs
+++ b/core/Pos/Crypto/Hashing.hs
@@ -163,7 +163,6 @@ hashHexF = later $ \(AbstractHash x) -> Buildable.build (show x :: Text)
 shortHashF :: Format r (AbstractHash algo a -> r)
 shortHashF = fitLeft 8 %. hashHexF
 
-
 -- | Type class for unsafe cast between hashes.
 -- You must ensure that types have identical Bi instances.
 class CastHash a b where

--- a/godtossing/Pos/Ssc/GodTossing/Workers.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Workers.hs
@@ -26,8 +26,6 @@ import           Formatting                            (build, int, ords, sforma
 import           Mockable                              (currentTime, delay)
 import           Serokell.Util.Exceptions              ()
 import           Serokell.Util.Text                    (listJson)
-import           System.Wlog                           (logDebug, logError, logInfo,
-                                                        logWarning)
 
 import           Pos.Binary.Class                      (AsBinary, Bi, asBinary)
 import           Pos.Binary.GodTossing                 ()
@@ -102,6 +100,8 @@ import           Pos.Ssc.GodTossing.Types.Message      (GtTag (..), MCCommitment
                                                         MCVssCertificate (..))
 import           Pos.Ssc.Mode                          (SscMode)
 import           Pos.Ssc.RichmenComponent              (getRichmenSsc)
+import           Pos.Util.LogSafe                      (logDebugS, logErrorS, logInfoS,
+                                                        logWarningS)
 import           Pos.Util.Util                         (getKeys, inAssertMode,
                                                         leftToPanic)
 
@@ -121,7 +121,7 @@ shouldParticipate epoch = do
     ourId <- getOurStakeholderId
     let enoughStake = ourId `HM.member` richmen
     when (participationEnabled && not enoughStake) $
-        logDebug "Not enough stake to participate in MPC"
+        logDebugS "Not enough stake to participate in MPC"
     return (participationEnabled && enoughStake)
 
 -- CHECK: @onNewSlotSsc
@@ -157,16 +157,16 @@ checkNSendOurCert sendActions = do
     ourId <- getOurStakeholderId
     let sendCert resend slot = do
             if resend then
-                logError "Our VSS certificate is in global state, but it has already expired, \
+                logErrorS "Our VSS certificate is in global state, but it has already expired, \
                          \apparently it's a bug, but we are announcing it just in case."
-                else logInfo
+                else logInfoS
                          "Our VssCertificate hasn't been announced yet or TTL has expired, \
                          \we will announce it now."
             ourVssCertificate <- getOurVssCertificate slot
             let contents = MCVssCertificate ourVssCertificate
             sscProcessOurMessage (sscProcessCertificate ourVssCertificate)
             _ <- invReqDataFlowTK "ssc" (enqueueMsg sendActions) (MsgMPC OriginSender) ourId contents
-            logDebug "Announced our VssCertificate."
+            logDebugS "Announced our VssCertificate."
 
     slMaybe <- getCurrentSlot
     case slMaybe of
@@ -177,7 +177,7 @@ checkNSendOurCert sendActions = do
             case ourCertMB of
                 Just ourCert
                     | vcExpiryEpoch ourCert >= siEpoch sl ->
-                        logDebug
+                        logDebugS
                             "Our VssCertificate has been already announced."
                     | otherwise -> sendCert True sl
                 Nothing -> sendCert False sl
@@ -215,22 +215,25 @@ onNewSlotCommitment slotId@SlotId {..} sendActions
         shouldSendCommitment <- andM
             [ not . hasCommitment ourId <$> gtGetGlobalState
             , memberVss ourId <$> getStableCerts siEpoch]
-        logDebug $ sformat ("shouldSendCommitment: "%shown) shouldSendCommitment
+        if shouldSendCommitment then
+            logDebugS $ sformat "We should send commitment"
+        else
+            logDebugS $ sformat "We shouldn't send commitment"
         when shouldSendCommitment $ do
             ourCommitment <- SS.getOurCommitment siEpoch
             let stillValidMsg = "We shouldn't generate secret, because we have already generated it"
             case ourCommitment of
-                Just comm -> logDebug stillValidMsg >> sendOurCommitment comm ourId
+                Just comm -> logDebugS stillValidMsg >> sendOurCommitment comm ourId
                 Nothing   -> onNewSlotCommDo ourId
   where
     onNewSlotCommDo ourId = do
         ourSk <- getOurSecretKey
-        logDebug $ sformat ("Generating secret for "%ords%" epoch") siEpoch
+        logDebugS $ sformat ("Generating secret for "%ords%" epoch") siEpoch
         generated <- generateAndSetNewSecret ourSk slotId
         case generated of
-            Nothing -> logWarning "I failed to generate secret for GodTossing"
+            Nothing -> logWarningS "I failed to generate secret for GodTossing"
             Just comm -> do
-              logInfo (sformat ("Generated secret for "%ords%" epoch") siEpoch)
+              logInfoS (sformat ("Generated secret for "%ords%" epoch") siEpoch)
               sendOurCommitment comm ourId
 
     sendOurCommitment comm ourId = do
@@ -249,9 +252,9 @@ onNewSlotOpening params SlotId {..} sendActions
         globalData <- gtGetGlobalState
         unless (hasOpening ourId globalData) $
             case globalData ^. gsCommitments . to getCommitmentsMap . at ourId of
-                Nothing -> logDebug noCommMsg
+                Nothing -> logDebugS noCommMsg
                 Just _  -> SS.getOurOpening siEpoch >>= \case
-                    Nothing   -> logWarning noOpenMsg
+                    Nothing   -> logWarningS noOpenMsg
                     Just open -> sendOpening ourId open
   where
     noCommMsg =
@@ -269,7 +272,7 @@ onNewSlotOpening params SlotId {..} sendActions
                 runErrorT (genCommitmentAndOpening 3 keys) >>= \case
                     Right (_, o) -> pure (Just o)
                     Left (err :: String) ->
-                        logError ("onNewSlotOpening: " <> toText err)
+                        logErrorS ("onNewSlotOpening: " <> toText err)
                         $> Nothing
         whenJust mbOpen' $ \open' -> do
             let msg = MCOpening ourId open'
@@ -312,9 +315,9 @@ sscProcessOurMessage
 sscProcessOurMessage action =
     runExceptT action >>= logResult
   where
-    logResult (Right _) = logDebug "We have accepted our message"
+    logResult (Right _) = logDebugS "We have accepted our message"
     logResult (Left er) =
-        logWarning $
+        logWarningS $
         sformat ("We have rejected our message, reason: "%build) er
 
 sendOurData ::
@@ -338,9 +341,9 @@ sendOurData enqueue msgTag ourId dt epoch slMultiplier = do
     -- in one invocation of onNewSlot we can't process more than one
     -- type of message.
     waitUntilSend msgTag epoch slMultiplier
-    logInfo $ sformat ("Announcing our "%build) msgTag
+    logInfoS $ sformat ("Announcing our "%build) msgTag
     _ <- invReqDataFlowTK "ssc" enqueue (MsgMPC OriginSender) ourId dt
-    logDebug $ sformat ("Sent our " %build%" to neighbors") msgTag
+    logDebugS $ sformat ("Sent our " %build%" to neighbors") msgTag
 
 -- Generate new commitment and opening and use them for the current
 -- epoch. It is also saved in persistent storage.
@@ -362,7 +365,7 @@ generateAndSetNewSecret sk SlotId {..} = do
         let participantIds =
                 HM.keys . getVssCertificatesMap $
                 computeParticipants (getKeys richmen) certs
-        logDebug $
+        logDebugS $
             sformat ("generating secret for: " %listJson) $ participantIds
     let participants = nonEmpty $
                        map (second vcVssKey) $
@@ -371,32 +374,32 @@ generateAndSetNewSecret sk SlotId {..} = do
     maybe (Nothing <$ warnNoPs) (generateAndSetNewSecretDo richmen) participants
   where
     here s = "generateAndSetNewSecret: " <> s
-    warnNoPs = logWarning (here "can't generate, no participants")
+    warnNoPs = logWarningS (here "can't generate, no participants")
     generateAndSetNewSecretDo :: RichmenStakes
                               -> NonEmpty (StakeholderId, AsBinary VssPublicKey)
                               -> m (Maybe SignedCommitment)
     generateAndSetNewSecretDo richmen ps = do
         let onLeft er =
                 Nothing <$
-                logWarning
+                logWarningS
                 (here $ sformat ("Couldn't compute shares distribution, reason: "%build) er)
         mpcThreshold <- bvdMpcThd <$> gsAdoptedBVData
         distrET <- runExceptT (computeSharesDistrPure richmen mpcThreshold)
         flip (either onLeft) distrET $ \distr -> do
-            logDebug $ here $ sformat ("Computed shares distribution: "%listJson) (HM.toList distr)
+            logDebugS $ here $ sformat ("Computed shares distribution: "%listJson) (HM.toList distr)
             let threshold = vssThreshold $ sum $ toList distr
             let multiPSmb = nonEmpty $
                             concatMap (\(c, x) -> replicate (fromIntegral c) x) $
                             NE.map (first $ flip (HM.lookupDefault 0) distr) ps
             case multiPSmb of
-                Nothing -> Nothing <$ logWarning (here "Couldn't compute participant's vss")
+                Nothing -> Nothing <$ logWarningS (here "Couldn't compute participant's vss")
                 Just multiPS ->
                     -- we use runErrorT and not runExceptT because we want
                     -- to get errors produced by 'fail'. In the future we'll
                     -- use MonadError everywhere and it won't be needed.
                     runErrorT (genCommitmentAndOpening threshold multiPS) >>= \case
                         Left (toText @String -> err) ->
-                            logError (here err) $> Nothing
+                            logErrorS (here err) $> Nothing
                         Right (comm, open) -> do
                             let signedComm = mkSignedCommitment sk siEpoch comm
                             SS.putOurSecret signedComm open siEpoch
@@ -430,7 +433,7 @@ waitUntilSend msgTag epoch slMultiplier = do
         timeToWait <- randomTimeInInterval delta
         let ttwMillisecond :: Millisecond
             ttwMillisecond = convertUnit timeToWait
-        logDebug $
+        logDebugS $
             sformat
                 ("Waiting for " %shown % " before sending " %build)
                 ttwMillisecond

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -45,6 +45,7 @@ import           Pos.DHT.Model.Types       (DHTData, DHTException (..), DHTKey,
 import           Pos.DHT.Real.Param        (KademliaParams (..))
 import           Pos.DHT.Real.Types        (KademliaDHTInstance (..))
 import           Pos.Infra.Configuration   (HasInfraConfiguration)
+import           Pos.Util.LogSafe          (logInfoS)
 import           Pos.Util.TimeLimit        (runWithRandomIntervals')
 import           Pos.Util.TimeWarp         (NetworkAddress)
 
@@ -90,7 +91,7 @@ startDHTInstance kconf@KademliaParams {..} defaultBind = do
         extAddr  = maybe bindAddr (first B8.unpack) kpExternalAddress
     logInfo "Generating dht key.."
     kdiKey <- maybe randomDHTKey pure kpKey
-    logInfo $ sformat ("Generated dht key "%build) kdiKey
+    logInfoS $ sformat ("Generated dht key "%build) kdiKey
     kdiDumpPath <- case kpDumpFile of
         Nothing -> pure Nothing
         Just fp -> do

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -10,44 +10,44 @@ module Pos.Wallet.Web.Methods.Payment
 
 import           Universum
 
-import qualified Data.List.NonEmpty             as NE
-import           Formatting                     (sformat, (%))
-import qualified Formatting                     as F
-import           System.Wlog                    (logInfo)
+import qualified Data.List.NonEmpty               as NE
+import           Formatting                       (sformat, (%))
+import qualified Formatting                       as F
 
-import           Pos.Aeson.ClientTypes          ()
-import           Pos.Aeson.WalletBackup         ()
-import           Pos.Client.Txp.Addresses       (MonadAddresses (..))
-import           Pos.Client.Txp.Balances        (getOwnUtxos)
-import           Pos.Client.Txp.History         (TxHistoryEntry (..))
-import           Pos.Client.Txp.Util            (computeTxFee, runTxCreator)
-import           Pos.Communication              (SendActions (..), prepareMTx)
-import           Pos.Configuration              (HasNodeConfiguration)
-import           Pos.Core                       (Coin, HasConfiguration, addressF,
-                                                 getCurrentTimestamp)
-import           Pos.Crypto                     (PassPhrase, hash, withSafeSigners)
-import           Pos.Infra.Configuration        (HasInfraConfiguration)
+import           Pos.Aeson.ClientTypes            ()
+import           Pos.Aeson.WalletBackup           ()
+import           Pos.Client.Txp.Addresses         (MonadAddresses (..))
+import           Pos.Client.Txp.Balances          (getOwnUtxos)
+import           Pos.Client.Txp.History           (TxHistoryEntry (..))
+import           Pos.Client.Txp.Util              (computeTxFee, runTxCreator)
+import           Pos.Communication                (SendActions (..), prepareMTx)
+import           Pos.Configuration                (HasNodeConfiguration)
+import           Pos.Core                         (Coin, HasConfiguration, addressF,
+                                                   getCurrentTimestamp)
+import           Pos.Crypto                       (PassPhrase, hash, withSafeSigners)
+import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Txp                        (TxFee (..), Utxo, _txOutputs)
-import           Pos.Txp.Core                   (TxAux (..), TxOut (..))
-import           Pos.Util                       (eitherToThrow, maybeThrow)
-import           Pos.Update.Configuration       (HasUpdateConfiguration)
-import           Pos.Wallet.Web.Account         (GenSeed (..), getSKByAccAddr)
-import           Pos.Wallet.Web.ClientTypes     (AccountId (..), Addr, CAddress (..),
-                                                 CCoin, CId, CTx (..), CWAddressMeta (..),
-                                                 Wal, addrMetaToAccount, mkCCoin)
-import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx)
-import qualified Pos.Wallet.Web.Methods.Logic   as L
-import           Pos.Wallet.Web.Methods.Txp     (coinDistrToOutputs, rewrapTxError,
-                                                 submitAndSaveNewPtx)
-import           Pos.Wallet.Web.Mode            (MonadWalletWebMode, WalletWebMode)
-import           Pos.Wallet.Web.Pending         (mkPendingTx)
-import           Pos.Wallet.Web.State           (AddressLookupMode (Existing))
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail,
-                                                 getAccountAddrsOrThrow,
-                                                 getWalletAccountIds)
-
+import           Pos.Txp                          (TxFee (..), Utxo, _txOutputs)
+import           Pos.Txp.Core                     (TxAux (..), TxOut (..))
+import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util                         (eitherToThrow, maybeThrow)
+import           Pos.Util.LogSafe                 (logInfoS)
+import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAccAddr)
+import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CAddress (..),
+                                                   CCoin, CId, CTx (..),
+                                                   CWAddressMeta (..), Wal,
+                                                   addrMetaToAccount, mkCCoin)
+import           Pos.Wallet.Web.Error             (WalletError (..))
+import           Pos.Wallet.Web.Methods.History   (addHistoryTx)
+import qualified Pos.Wallet.Web.Methods.Logic     as L
+import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
+                                                   submitAndSaveNewPtx)
+import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
+import           Pos.Wallet.Web.Pending           (mkPendingTx)
+import           Pos.Wallet.Web.State             (AddressLookupMode (Existing))
+import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
+                                                   getAccountAddrsOrThrow,
+                                                   getWalletAccountIds)
 
 newPayment
     :: MonadWalletWebMode m
@@ -167,7 +167,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
 
                 (th, dstAddrs) <$ submitAndSaveNewPtx enqueueMsg ptx
 
-        logInfo $
+        logInfoS $
             sformat ("Successfully spent money from "%
                      listF ", " addressF % " addresses on " %
                      listF ", " addressF)

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -82,6 +82,7 @@ import           Pos.Util.Chrono                  (getNewestFirst)
 import qualified Pos.Util.Modifier                as MM
 
 import           Pos.Ssc.Class                    (SscHelpersClass)
+import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
 import           Pos.Util.Servant                 (encodeCType)
 import           Pos.Wallet.SscType               (WalletSscType)
 import           Pos.Wallet.Web.Account           (MonadKeySearch (..))
@@ -163,7 +164,7 @@ syncWalletsWithGState
 syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) $ do
     let wAddr = encToCId encSK
     WS.getWalletSyncTip wAddr >>= \case
-        Nothing                -> logWarning $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
+        Nothing                -> logWarningS $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
         Just NotSynced         -> syncDo encSK Nothing
         Just (SyncedWith wTip) -> DB.blkGetHeader wTip >>= \case
             Nothing ->
@@ -172,7 +173,7 @@ syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) 
                                 %" by last synced hh: "%build) wAddr wTip
             Just wHeader -> syncDo encSK (Just wHeader)
   where
-    onErr encSK = logWarning . sformat fmt (encToCId encSK)
+    onErr encSK = logWarningS . sformat fmt (encToCId encSK)
     fmt = "Sync of wallet "%build%" failed: "%build
     syncDo :: EncryptedSecretKey -> Maybe (BlockHeader ssc) -> m ()
     syncDo encSK wTipH = do
@@ -253,7 +254,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
         computeAccModifier :: BlockHeader ssc -> m CAccModifier
         computeAccModifier wHeader = do
             allAddresses <- getWalletAddrMetas Ever wAddr
-            logInfo $
+            logInfoS $
                 sformat ("Wallet "%build%" header: "%build%", current tip header: "%build)
                 wAddr wHeader gstateH
             if | diff gstateH > diff wHeader -> do
@@ -273,7 +274,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
                      blunds <- getNewestFirst <$>
                          DB.loadBlundsWhile (\b -> getBlockHeader b /= gstateH) (headerHash wHeader)
                      pure $ foldl' (\r b -> r <> rollbackBlock allAddresses b) mempty blunds
-               | otherwise -> mempty <$ logInfo (sformat ("Wallet "%build%" is already synced") wAddr)
+               | otherwise -> mempty <$ logInfoS (sformat ("Wallet "%build%" is already synced") wAddr)
 
     whenNothing_ wTipHeader $ do
         let encInfo = getEncInfo encSK
@@ -290,8 +291,9 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
     applyModifierToWallet wAddr gstateHHash mapModifier
     -- Mark the wallet as ready, so it will be available from api endpoints.
     WS.setWalletReady wAddr True
-    logInfo $ sformat ("Wallet "%build%" has been synced with tip "
-                    %shortHashF%", "%build)
+    logInfoS $
+        sformat ("Wallet "%build%" has been synced with tip "
+                %shortHashF%", "%build)
                 wAddr (maybe genesisHash headerHash wTipHeader) mapModifier
   where
     firstGenesisHeader :: m (BlockHeader ssc)


### PR DESCRIPTION
We don't print the following messages to the public logs anymore:
1. Logs about creating a block by ourselves
2. Our DHT-key
3. CHash of addresses in wallet tracking
4. GodTossing logs