### PR TITLE
[CSL-1708] Update to latest version of log-warper to fix leaks

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4415,8 +4415,8 @@ self: {
       log-warper = callPackage ({ aeson, ansi-terminal, base, containers, directory, dlist, errors, exceptions, extra, filepath, formatting, hashable, lens, mkDerivation, mmorph, monad-control, monad-loops, mtl, network, safecopy, stdenv, text, text-format, time, transformers, transformers-base, universum, unix, unordered-containers, yaml }:
       mkDerivation {
           pname = "log-warper";
-          version = "1.2.1";
-          sha256 = "0qy1i40ypjcsvqy63jgn824a8iclvw49bhnkxab4k5vjhypd78ga";
+          version = "1.2.2";
+          sha256 = "0hxw0j3zp6vs4si1v8ziy0g2a06smny6fmjqhd9v5hvdcfnqnm9b";
           isLibrary = true;
           isExecutable = true;
           libraryHaskellDepends = [

--- a/stack.yaml
+++ b/stack.yaml
@@ -100,7 +100,7 @@ extra-deps:
 - serokell-util-0.5.0
 - pvss-0.2.0
 - base58-bytestring-0.1.0
-- log-warper-1.2.1
+- log-warper-1.2.2
 - concurrent-extra-0.7.0.10       # not yet on Stackage
 # - purescript-bridge-0.8.0.1
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8


### PR DESCRIPTION
This PR bumps `log-warper` to 1.2.2 in order to benefit from the memory leak fix @avieth found & fixed.