### PR TITLE
[CSL-1655] Ensure public logs contain no sensitive data

### DIFF
--- a/core/Pos/Crypto/Hashing.hs
+++ b/core/Pos/Crypto/Hashing.hs
@@ -163,7 +163,6 @@ hashHexF = later $ \(AbstractHash x) -> Buildable.build (show x :: Text)
 shortHashF :: Format r (AbstractHash algo a -> r)
 shortHashF = fitLeft 8 %. hashHexF
 
-
 -- | Type class for unsafe cast between hashes.
 -- You must ensure that types have identical Bi instances.
 class CastHash a b where

--- a/godtossing/Pos/Ssc/GodTossing/Workers.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Workers.hs
@@ -26,8 +26,6 @@ import           Formatting                            (build, int, ords, sforma
 import           Mockable                              (currentTime, delay)
 import           Serokell.Util.Exceptions              ()
 import           Serokell.Util.Text                    (listJson)
-import           System.Wlog                           (logDebug, logError, logInfo,
-                                                        logWarning)
 
 import           Pos.Binary.Class                      (AsBinary, Bi, asBinary)
 import           Pos.Binary.GodTossing                 ()
@@ -46,13 +44,12 @@ import           Pos.Core                              (EpochIndex, HasConfigura
                                                         Timestamp (..),
                                                         VssCertificate (..),
                                                         VssCertificatesMap, addressHash,
-                                                        bvdMpcThd, getOurSecretKey,
+                                                        blkSecurityParam, bvdMpcThd,
+                                                        getOurSecretKey,
                                                         getOurStakeholderId, getSlotIndex,
                                                         mkLocalSlotIndex,
                                                         mkVssCertificate,
-                                                        slotSecurityParam,
-                                                        blkSecurityParam,
-                                                        vssMaxTTL)
+                                                        slotSecurityParam, vssMaxTTL)
 import           Pos.Crypto                            (SecretKey, VssKeyPair,
                                                         VssPublicKey, randomNumber,
                                                         runSecureRandom, vssKeyGen)
@@ -102,6 +99,8 @@ import           Pos.Ssc.GodTossing.Types.Message      (GtTag (..), MCCommitment
                                                         MCVssCertificate (..))
 import           Pos.Ssc.Mode                          (SscMode)
 import           Pos.Ssc.RichmenComponent              (getRichmenSsc)
+import           Pos.Util.LogSafe                      (logDebugS, logErrorS, logInfoS,
+                                                        logWarningS)
 import           Pos.Util.Util                         (getKeys, inAssertMode,
                                                         leftToPanic)
 
@@ -121,7 +120,7 @@ shouldParticipate epoch = do
     ourId <- getOurStakeholderId
     let enoughStake = ourId `HM.member` richmen
     when (participationEnabled && not enoughStake) $
-        logDebug "Not enough stake to participate in MPC"
+        logDebugS "Not enough stake to participate in MPC"
     return (participationEnabled && enoughStake)
 
 -- CHECK: @onNewSlotSsc
@@ -157,16 +156,16 @@ checkNSendOurCert sendActions = do
     ourId <- getOurStakeholderId
     let sendCert resend slot = do
             if resend then
-                logError "Our VSS certificate is in global state, but it has already expired, \
+                logErrorS "Our VSS certificate is in global state, but it has already expired, \
                          \apparently it's a bug, but we are announcing it just in case."
-                else logInfo
+                else logInfoS
                          "Our VssCertificate hasn't been announced yet or TTL has expired, \
                          \we will announce it now."
             ourVssCertificate <- getOurVssCertificate slot
             let contents = MCVssCertificate ourVssCertificate
             sscProcessOurMessage (sscProcessCertificate ourVssCertificate)
             _ <- invReqDataFlowTK "ssc" (enqueueMsg sendActions) (MsgMPC OriginSender) ourId contents
-            logDebug "Announced our VssCertificate."
+            logDebugS "Announced our VssCertificate."
 
     slMaybe <- getCurrentSlot
     case slMaybe of
@@ -177,7 +176,7 @@ checkNSendOurCert sendActions = do
             case ourCertMB of
                 Just ourCert
                     | vcExpiryEpoch ourCert >= siEpoch sl ->
-                        logDebug
+                        logDebugS
                             "Our VssCertificate has been already announced."
                     | otherwise -> sendCert True sl
                 Nothing -> sendCert False sl
@@ -215,22 +214,25 @@ onNewSlotCommitment slotId@SlotId {..} sendActions
         shouldSendCommitment <- andM
             [ not . hasCommitment ourId <$> gtGetGlobalState
             , HM.member ourId <$> getStableCerts siEpoch]
-        logDebug $ sformat ("shouldSendCommitment: "%shown) shouldSendCommitment
+        if shouldSendCommitment then
+            logDebugS $ sformat "We should send commitment"
+        else
+            logDebugS $ sformat "We shouldn't send commitment"
         when shouldSendCommitment $ do
             ourCommitment <- SS.getOurCommitment siEpoch
             let stillValidMsg = "We shouldn't generate secret, because we have already generated it"
             case ourCommitment of
-                Just comm -> logDebug stillValidMsg >> sendOurCommitment comm ourId
+                Just comm -> logDebugS stillValidMsg >> sendOurCommitment comm ourId
                 Nothing   -> onNewSlotCommDo ourId
   where
     onNewSlotCommDo ourId = do
         ourSk <- getOurSecretKey
-        logDebug $ sformat ("Generating secret for "%ords%" epoch") siEpoch
+        logDebugS $ sformat ("Generating secret for "%ords%" epoch") siEpoch
         generated <- generateAndSetNewSecret ourSk slotId
         case generated of
-            Nothing -> logWarning "I failed to generate secret for GodTossing"
+            Nothing -> logWarningS "I failed to generate secret for GodTossing"
             Just comm -> do
-              logInfo (sformat ("Generated secret for "%ords%" epoch") siEpoch)
+              logInfoS (sformat ("Generated secret for "%ords%" epoch") siEpoch)
               sendOurCommitment comm ourId
 
     sendOurCommitment comm ourId = do
@@ -249,9 +251,9 @@ onNewSlotOpening params SlotId {..} sendActions
         globalData <- gtGetGlobalState
         unless (hasOpening ourId globalData) $
             case globalData ^. gsCommitments . to getCommitmentsMap . at ourId of
-                Nothing -> logDebug noCommMsg
+                Nothing -> logDebugS noCommMsg
                 Just _  -> SS.getOurOpening siEpoch >>= \case
-                    Nothing   -> logWarning noOpenMsg
+                    Nothing   -> logWarningS noOpenMsg
                     Just open -> sendOpening ourId open
   where
     noCommMsg =
@@ -269,7 +271,7 @@ onNewSlotOpening params SlotId {..} sendActions
                 runErrorT (genCommitmentAndOpening 3 keys) >>= \case
                     Right (_, o) -> pure (Just o)
                     Left (err :: String) ->
-                        logError ("onNewSlotOpening: " <> toText err)
+                        logErrorS ("onNewSlotOpening: " <> toText err)
                         $> Nothing
         whenJust mbOpen' $ \open' -> do
             let msg = MCOpening ourId open'
@@ -312,9 +314,9 @@ sscProcessOurMessage
 sscProcessOurMessage action =
     runExceptT action >>= logResult
   where
-    logResult (Right _) = logDebug "We have accepted our message"
+    logResult (Right _) = logDebugS "We have accepted our message"
     logResult (Left er) =
-        logWarning $
+        logWarningS $
         sformat ("We have rejected our message, reason: "%build) er
 
 sendOurData ::
@@ -338,9 +340,9 @@ sendOurData enqueue msgTag ourId dt epoch slMultiplier = do
     -- in one invocation of onNewSlot we can't process more than one
     -- type of message.
     waitUntilSend msgTag epoch slMultiplier
-    logInfo $ sformat ("Announcing our "%build) msgTag
+    logInfoS $ sformat ("Announcing our "%build) msgTag
     _ <- invReqDataFlowTK "ssc" enqueue (MsgMPC OriginSender) ourId dt
-    logDebug $ sformat ("Sent our " %build%" to neighbors") msgTag
+    logDebugS $ sformat ("Sent our " %build%" to neighbors") msgTag
 
 -- Generate new commitment and opening and use them for the current
 -- epoch. It is also saved in persistent storage.
@@ -362,7 +364,7 @@ generateAndSetNewSecret sk SlotId {..} = do
         let participantIds =
                 map (addressHash . vcSigningKey) $
                 computeParticipants (getKeys richmen) certs
-        logDebug $
+        logDebugS $
             sformat ("generating secret for: " %listJson) $ participantIds
     let participants = nonEmpty $
                        map (second vcVssKey) $
@@ -371,32 +373,32 @@ generateAndSetNewSecret sk SlotId {..} = do
     maybe (Nothing <$ warnNoPs) (generateAndSetNewSecretDo richmen) participants
   where
     here s = "generateAndSetNewSecret: " <> s
-    warnNoPs = logWarning (here "can't generate, no participants")
+    warnNoPs = logWarningS (here "can't generate, no participants")
     generateAndSetNewSecretDo :: RichmenStakes
                               -> NonEmpty (StakeholderId, AsBinary VssPublicKey)
                               -> m (Maybe SignedCommitment)
     generateAndSetNewSecretDo richmen ps = do
         let onLeft er =
                 Nothing <$
-                logWarning
+                logWarningS
                 (here $ sformat ("Couldn't compute shares distribution, reason: "%build) er)
         mpcThreshold <- bvdMpcThd <$> gsAdoptedBVData
         distrET <- runExceptT (computeSharesDistrPure richmen mpcThreshold)
         flip (either onLeft) distrET $ \distr -> do
-            logDebug $ here $ sformat ("Computed shares distribution: "%listJson) (HM.toList distr)
+            logDebugS $ here $ sformat ("Computed shares distribution: "%listJson) (HM.toList distr)
             let threshold = vssThreshold $ sum $ toList distr
             let multiPSmb = nonEmpty $
                             concatMap (\(c, x) -> replicate (fromIntegral c) x) $
                             NE.map (first $ flip (HM.lookupDefault 0) distr) ps
             case multiPSmb of
-                Nothing -> Nothing <$ logWarning (here "Couldn't compute participant's vss")
+                Nothing -> Nothing <$ logWarningS (here "Couldn't compute participant's vss")
                 Just multiPS ->
                     -- we use runErrorT and not runExceptT because we want
                     -- to get errors produced by 'fail'. In the future we'll
                     -- use MonadError everywhere and it won't be needed.
                     runErrorT (genCommitmentAndOpening threshold multiPS) >>= \case
                         Left (toText @String -> err) ->
-                            logError (here err) $> Nothing
+                            logErrorS (here err) $> Nothing
                         Right (comm, open) -> do
                             let signedComm = mkSignedCommitment sk siEpoch comm
                             SS.putOurSecret signedComm open siEpoch
@@ -430,7 +432,7 @@ waitUntilSend msgTag epoch slMultiplier = do
         timeToWait <- randomTimeInInterval delta
         let ttwMillisecond :: Millisecond
             ttwMillisecond = convertUnit timeToWait
-        logDebug $
+        logDebugS $
             sformat
                 ("Waiting for " %shown % " before sending " %build)
                 ttwMillisecond

--- a/infra/Pos/DHT/Real/Real.hs
+++ b/infra/Pos/DHT/Real/Real.hs
@@ -45,6 +45,7 @@ import           Pos.DHT.Model.Types       (DHTData, DHTException (..), DHTKey,
 import           Pos.DHT.Real.Param        (KademliaParams (..))
 import           Pos.DHT.Real.Types        (KademliaDHTInstance (..))
 import           Pos.Infra.Configuration   (HasInfraConfiguration)
+import           Pos.Util.LogSafe          (logInfoS)
 import           Pos.Util.TimeLimit        (runWithRandomIntervals')
 import           Pos.Util.TimeWarp         (NetworkAddress)
 
@@ -90,7 +91,7 @@ startDHTInstance kconf@KademliaParams {..} defaultBind = do
         extAddr  = maybe bindAddr (first B8.unpack) kpExternalAddress
     logInfo "Generating dht key.."
     kdiKey <- maybe randomDHTKey pure kpKey
-    logInfo $ sformat ("Generated dht key "%build) kdiKey
+    logInfoS $ sformat ("Generated dht key "%build) kdiKey
     kdiDumpPath <- case kpDumpFile of
         Nothing -> pure Nothing
         Just fp -> do

--- a/infra/Pos/Util/LogSafe.hs
+++ b/infra/Pos/Util/LogSafe.hs
@@ -9,14 +9,14 @@ module Pos.Util.LogSafe
        , logErrorS
        ) where
 
+import           Universum
+
 import           Control.Monad.Trans (MonadTrans)
 import           Data.List           (isSuffixOf)
 import           System.Wlog         (CanLog (..), HasLoggerName (..), Severity (..),
                                       loggerName)
 import           System.Wlog.Handler (LogHandlerTag (HandlerFilelike))
 import           System.Wlog.Logger  (logMCond)
-import           Universum
-
 
 newtype SecureLogWrapped m a = SecureLogWrapped
     { getSecureLogWrapped :: m a

--- a/node/src/Pos/Block/Logic/Creation.hs
+++ b/node/src/Pos/Block/Logic/Creation.hs
@@ -20,7 +20,7 @@ import           Control.Monad.Except       (MonadError (throwError), runExceptT
 import           Data.Default               (Default (def))
 import           Formatting                 (build, fixed, ords, sformat, stext, (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
-import           System.Wlog                (WithLogger, logDebug, logInfo)
+import           System.Wlog                (WithLogger, logDebug)
 
 import           Pos.Binary.Class           (biSize)
 import           Pos.Block.Core             (BlockHeader, GenesisBlock, MainBlock,
@@ -59,12 +59,13 @@ import           Pos.StateLock              (Priority (..), StateLock, StateLock
 import           Pos.Txp                    (MonadTxpMem, clearTxpMemPool, txGetPayload)
 import           Pos.Txp.Core               (TxAux (..), emptyTxPayload, mkTxPayload)
 import           Pos.Update                 (UpdateContext)
-import           Pos.Update.Core            (UpdatePayload (..))
 import           Pos.Update.Configuration   (HasUpdateConfiguration)
+import           Pos.Update.Core            (UpdatePayload (..))
 import qualified Pos.Update.DB              as UDB
 import           Pos.Update.Logic           (clearUSMemPool, usCanCreateBlock,
                                              usPreparePayload)
 import           Pos.Util                   (maybeThrow, _neHead)
+import           Pos.Util.LogSafe           (logInfoS)
 import           Pos.Util.Util              (HasLens (..), HasLens', leftToPanic)
 import           Pos.WorkMode.Class         (TxpExtra_TMP)
 
@@ -225,7 +226,7 @@ createMainBlockInternal ::
     -> m (Either Text (MainBlock ssc))
 createMainBlockInternal sId pske = do
     tipHeader <- DB.getTipHeader @ssc
-    logInfo $ sformat msgFmt tipHeader
+    logInfoS $ sformat msgFmt tipHeader
     canCreateBlock sId tipHeader >>= \case
         Left reason -> pure (Left reason)
         Right () -> runExceptT (createMainBlockFinish tipHeader)
@@ -240,7 +241,7 @@ createMainBlockInternal sId pske = do
         -- than limit. So i guess it's fine in general.
         sizeLimit <- (\x -> bool 0 (x - 100) (x > 100)) <$> UDB.getMaxBlockSize
         block <- createMainBlockPure sizeLimit prevHeader pske sId sk rawPay
-        logInfo $
+        logInfoS $
             "Created main block of size: " <> sformat memory (biSize block)
         block <$ evaluateNF_ block
 

--- a/node/src/Pos/Util/Servant.hs
+++ b/node/src/Pos/Util/Servant.hs
@@ -57,9 +57,10 @@ import           Servant.API             ((:<|>) (..), (:>), Capture, QueryParam
 import           Servant.Server          (Handler (..), HasServer (..), ServantErr (..),
                                           Server)
 import qualified Servant.Server.Internal as SI
-import           System.Wlog             (LoggerName, logInfo, usingLoggerName)
+import           System.Wlog             (LoggerName, usingLoggerName)
 
 import           Pos.Util.Util           (colorizeDull)
+import           Pos.Util.LogSafe        (logInfoS)
 
 -------------------------------------------------------------------------
 -- Utility functions
@@ -428,7 +429,7 @@ applyServantLogging configP methodP paramsInfo showResponse action = do
             return $ sformat shown (endTime - startTime)
     performLogging msg = do
         let loggerName = reflect configP
-        liftIO . usingLoggerName loggerName $ logInfo msg
+        liftIO . usingLoggerName loggerName $ logInfoS msg
     eParamLogs = case paramsInfo of
         ApiParamsLogInfo info -> do
             let params = mconcat $ reverse info <&>

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -13,7 +13,7 @@ import           Control.Lens                 (each)
 import qualified Data.Aeson                   as A
 import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.HashMap.Strict          as HM
-import           Formatting                   (build, sformat, stext, (%))
+import           Formatting                   (sformat, stext, (%))
 
 import           Pos.Aeson.ClientTypes        ()
 import           Pos.Aeson.WalletBackup       ()
@@ -36,8 +36,7 @@ restoreWalletFromBackup WalletBackup {..} = do
 
     if wExists
         then do
-            throwM . RequestError $
-                sformat ("Wallet with id "%build%" already exists") wId
+            throwM $ RequestError "Wallet with id already exists"
 
         else do
             let (WalletMetaBackup wMeta) = wbMeta

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -15,12 +15,13 @@ import qualified Data.Set                   as S
 import           Data.Time.Clock.POSIX      (getPOSIXTime)
 import           Formatting                 (build, sformat, stext, (%))
 import           Serokell.Util              (listJson)
-import           System.Wlog                (WithLogger, logError, logInfo, logWarning)
+import           System.Wlog                (WithLogger, logError, logWarning)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
 import           Pos.Client.Txp.History     (TxHistoryEntry (..))
 import           Pos.Core                   (getTimestamp, timestampToPosix)
+import           Pos.Util.LogSafe           (logInfoS)
 import           Pos.Util.Servant           (encodeCType)
 import           Pos.Wallet.WalletMode      (getLocalHistory, localChainDifficulty,
                                              networkChainDifficulty)
@@ -173,9 +174,9 @@ addRecentPtxHistory wid currentHistory = do
 
 
 logTxHistory
-    :: (Container t, Element t ~ TxHistoryEntry, WithLogger m)
+    :: (Container t, Element t ~ TxHistoryEntry, WithLogger m, MonadIO m)
     => Text -> t -> m ()
 logTxHistory desc =
-    logInfo .
+    logInfoS .
     sformat (stext%" transactions history: "%listJson) desc .
     map _thTxId . toList

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -10,44 +10,44 @@ module Pos.Wallet.Web.Methods.Payment
 
 import           Universum
 
-import qualified Data.List.NonEmpty             as NE
-import           Formatting                     (sformat, (%))
-import qualified Formatting                     as F
-import           System.Wlog                    (logInfo)
+import qualified Data.List.NonEmpty               as NE
+import           Formatting                       (sformat, (%))
+import qualified Formatting                       as F
 
-import           Pos.Aeson.ClientTypes          ()
-import           Pos.Aeson.WalletBackup         ()
-import           Pos.Client.Txp.Addresses       (MonadAddresses (..))
-import           Pos.Client.Txp.Balances        (getOwnUtxos)
-import           Pos.Client.Txp.History         (TxHistoryEntry (..))
-import           Pos.Client.Txp.Util            (computeTxFee, runTxCreator)
-import           Pos.Communication              (SendActions (..), prepareMTx)
-import           Pos.Configuration              (HasNodeConfiguration)
-import           Pos.Core                       (Coin, HasConfiguration, addressF,
-                                                 getCurrentTimestamp)
-import           Pos.Crypto                     (PassPhrase, hash, withSafeSigners)
-import           Pos.Infra.Configuration        (HasInfraConfiguration)
+import           Pos.Aeson.ClientTypes            ()
+import           Pos.Aeson.WalletBackup           ()
+import           Pos.Client.Txp.Addresses         (MonadAddresses (..))
+import           Pos.Client.Txp.Balances          (getOwnUtxos)
+import           Pos.Client.Txp.History           (TxHistoryEntry (..))
+import           Pos.Client.Txp.Util              (computeTxFee, runTxCreator)
+import           Pos.Communication                (SendActions (..), prepareMTx)
+import           Pos.Configuration                (HasNodeConfiguration)
+import           Pos.Core                         (Coin, HasConfiguration, addressF,
+                                                   getCurrentTimestamp)
+import           Pos.Crypto                       (PassPhrase, hash, withSafeSigners)
+import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Txp                        (TxFee (..), Utxo, _txOutputs)
-import           Pos.Txp.Core                   (TxAux (..), TxOut (..))
-import           Pos.Util                       (eitherToThrow, maybeThrow)
-import           Pos.Update.Configuration       (HasUpdateConfiguration)
-import           Pos.Wallet.Web.Account         (GenSeed (..), getSKByAccAddr)
-import           Pos.Wallet.Web.ClientTypes     (AccountId (..), Addr, CAddress (..),
-                                                 CCoin, CId, CTx (..), CWAddressMeta (..),
-                                                 Wal, addrMetaToAccount, mkCCoin)
-import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx)
-import qualified Pos.Wallet.Web.Methods.Logic   as L
-import           Pos.Wallet.Web.Methods.Txp     (coinDistrToOutputs, rewrapTxError,
-                                                 submitAndSaveNewPtx)
-import           Pos.Wallet.Web.Mode            (MonadWalletWebMode, WalletWebMode)
-import           Pos.Wallet.Web.Pending         (mkPendingTx)
-import           Pos.Wallet.Web.State           (AddressLookupMode (Existing))
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail,
-                                                 getAccountAddrsOrThrow,
-                                                 getWalletAccountIds)
-
+import           Pos.Txp                          (TxFee (..), Utxo, _txOutputs)
+import           Pos.Txp.Core                     (TxAux (..), TxOut (..))
+import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util                         (eitherToThrow, maybeThrow)
+import           Pos.Util.LogSafe                 (logInfoS)
+import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAccAddr)
+import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CAddress (..),
+                                                   CCoin, CId, CTx (..),
+                                                   CWAddressMeta (..), Wal,
+                                                   addrMetaToAccount, mkCCoin)
+import           Pos.Wallet.Web.Error             (WalletError (..))
+import           Pos.Wallet.Web.Methods.History   (addHistoryTx)
+import qualified Pos.Wallet.Web.Methods.Logic     as L
+import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
+                                                   submitAndSaveNewPtx)
+import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
+import           Pos.Wallet.Web.Pending           (mkPendingTx)
+import           Pos.Wallet.Web.State             (AddressLookupMode (Existing))
+import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
+                                                   getAccountAddrsOrThrow,
+                                                   getWalletAccountIds)
 
 newPayment
     :: MonadWalletWebMode m
@@ -167,7 +167,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
 
                 (th, dstAddrs) <$ submitAndSaveNewPtx enqueueMsg ptx
 
-        logInfo $
+        logInfoS $
             sformat ("Successfully spent money from "%
                      listF ", " addressF % " addresses on " %
                      listF ", " addressF)

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -15,10 +15,11 @@ import           Universum
 
 import           Control.Monad.Catch          (Handler (..), catches)
 import           Formatting                   (build, sformat, shown, stext, (%))
-import           System.Wlog                  (WithLogger, logInfo, logWarning)
+import           System.Wlog                  (WithLogger, logInfo)
 
 import           Pos.Client.Txp.History       (saveTx)
 import           Pos.Communication            (EnqueueMsg, submitTxRaw)
+import           Pos.Util.LogSafe             (logInfoS, logWarningS)
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..),
                                                PtxPoolInfo)
@@ -84,25 +85,24 @@ ptxResubmissionHandler PendingTx{..} =
         reportCanceled
 
     reportPeerAppliedEarlier =
-        logInfo $
+        logInfoS $
         sformat ("Some peer applied tx #"%build%" earlier - continuing \
             \tracking")
             _ptxTxId
     reportPeerApplied =
-        logInfo $
+        logInfoS $
         sformat ("Peer applied tx #"%build%", while we didn't - continuing \
             \tracking")
             _ptxTxId
     reportCanceled =
-        logInfo $
+        logInfoS $
         sformat ("Pending transaction #"%build%" was canceled")
             _ptxTxId
     reportBadCondition =
-        logWarning $
+        logWarningS $
         sformat ("Processing failure of "%build%" resubmission, but \
             \this transaction has unexpected condition "%build)
             _ptxTxId _ptxCond
-
 
 -- | Like 'Pos.Communication.Tx.submitAndSaveTx',
 -- but treats tx as future /pending/ transaction.
@@ -135,6 +135,6 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
         pshOnNonReclaimable accepted e
 
     reportError desc e outcome =
-        logInfo $
+        logInfoS $
         sformat ("Transaction #"%build%" application failed ("%shown%" - "
                 %stext%")"%stext) _ptxTxId e desc outcome

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -82,6 +82,7 @@ import           Pos.Util.Chrono                  (getNewestFirst)
 import qualified Pos.Util.Modifier                as MM
 
 import           Pos.Ssc.Class                    (SscHelpersClass)
+import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
 import           Pos.Util.Servant                 (encodeCType)
 import           Pos.Wallet.SscType               (WalletSscType)
 import           Pos.Wallet.Web.Account           (MonadKeySearch (..))
@@ -163,7 +164,7 @@ syncWalletsWithGState
 syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) $ do
     let wAddr = encToCId encSK
     WS.getWalletSyncTip wAddr >>= \case
-        Nothing                -> logWarning $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
+        Nothing                -> logWarningS $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
         Just NotSynced         -> syncDo encSK Nothing
         Just (SyncedWith wTip) -> DB.blkGetHeader wTip >>= \case
             Nothing ->
@@ -172,7 +173,7 @@ syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) 
                                 %" by last synced hh: "%build) wAddr wTip
             Just wHeader -> syncDo encSK (Just wHeader)
   where
-    onErr encSK = logWarning . sformat fmt (encToCId encSK)
+    onErr encSK = logWarningS . sformat fmt (encToCId encSK)
     fmt = "Sync of wallet "%build%" failed: "%build
     syncDo :: EncryptedSecretKey -> Maybe (BlockHeader ssc) -> m ()
     syncDo encSK wTipH = do
@@ -253,7 +254,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
         computeAccModifier :: BlockHeader ssc -> m CAccModifier
         computeAccModifier wHeader = do
             allAddresses <- getWalletAddrMetas Ever wAddr
-            logInfo $
+            logInfoS $
                 sformat ("Wallet "%build%" header: "%build%", current tip header: "%build)
                 wAddr wHeader gstateH
             if | diff gstateH > diff wHeader -> do
@@ -273,7 +274,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
                      blunds <- getNewestFirst <$>
                          DB.loadBlundsWhile (\b -> getBlockHeader b /= gstateH) (headerHash wHeader)
                      pure $ foldl' (\r b -> r <> rollbackBlock allAddresses b) mempty blunds
-               | otherwise -> mempty <$ logInfo (sformat ("Wallet "%build%" is already synced") wAddr)
+               | otherwise -> mempty <$ logInfoS (sformat ("Wallet "%build%" is already synced") wAddr)
 
     whenNothing_ wTipHeader $ do
         let encInfo = getEncInfo encSK
@@ -290,8 +291,9 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
     applyModifierToWallet wAddr gstateHHash mapModifier
     -- Mark the wallet as ready, so it will be available from api endpoints.
     WS.setWalletReady wAddr True
-    logInfo $ sformat ("Wallet "%build%" has been synced with tip "
-                    %shortHashF%", "%build)
+    logInfoS $
+        sformat ("Wallet "%build%" has been synced with tip "
+                %shortHashF%", "%build)
                 wAddr (maybe genesisHash headerHash wTipHeader) mapModifier
   where
     firstGenesisHeader :: m (BlockHeader ssc)

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -169,8 +169,7 @@ syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) 
         Just (SyncedWith wTip) -> DB.blkGetHeader wTip >>= \case
             Nothing ->
                 throwM $ InternalError $
-                    sformat ("Couldn't get block header of wallet "%build
-                                %" by last synced hh: "%build) wAddr wTip
+                    sformat ("Couldn't get block header of wallet by last synced hh: "%build) wTip
             Just wHeader -> syncDo encSK (Just wHeader)
   where
     onErr encSK = logWarningS . sformat fmt (encToCId encSK)


### PR DESCRIPTION
We don't print the following messages to the public logs anymore:
    1. Logs about creating a block by ourselves
    2. Our DHT-key
    3. CHash of addresses in wallet tracking
    4. Servant's logs
    5. Resubmitter's logs
    6. Wallet's history logs
    7. GodTossing logs