### PR TITLE
[CSL-1700] rework DNS subscription worker

### DIFF
--- a/infra/Pos/Network/DnsDomains.hs
+++ b/infra/Pos/Network/DnsDomains.hs
@@ -12,15 +12,16 @@ import           Universum
 
 -- | DNS domains for relay discovery
 --
--- We provide a list of list of domain names to query. The outer list
--- corresponds to backup DNS servers; the inner lists provide multiple
--- domain names which serve different purposes (e.g., the first might be
--- configured to return geolocated hosts, with the second a load-balancing
--- fall-back). The idea is that querying each of the elements of the inner
--- lists provides a complete set of relay nodes to be tried, using the
--- backup domain names only when one or more of the primary ones fail.
+-- We provide a list of list of domain names to query.
+-- Just like for static routes, it's a conjunction of disjuctions:
+-- try to use one alternative from each list. This implicitly encodes
+-- valency and fallbacks.
+-- The idea is that resolving at least one name from each of the inner lists
+-- provides a complete set of relay nodes to be tried, using the
+-- backup domain names (further back in the inner lists) only when one or more
+-- of the primary ones (further forward in the inner lists) fail.
 data DnsDomains a = DnsDomains {
-      dnsDomains :: !(Alts (AllOf (NodeAddr a)))
+      dnsDomains :: !(AllOf (Alts (NodeAddr a)))
     }
   deriving (Show)
 
@@ -38,46 +39,28 @@ data NodeAddr a =
   | NodeAddrDNS a (Maybe Word16)
   deriving (Show)
 
--- | Resolve 'DnsDomains'
+-- | Resolve a list of 'NodeAddr', possibly using DNS.
 --
--- See 'DnsDomains' for an explanation of the logic. This only returns a set
--- of errors if _all_ alternatives fail; in that case, it returns the (first)
--- error that occurred for all alternatives (we don't continue trying a set of
--- domains after the first error).
+-- Each element may resolve to 0 or more addresses, or fail with some error
+-- according to the 'resolve' function.
 resolveDnsDomains :: forall a e.
                      (a -> IO (Either e [IPv4])) -- ^ Actual resolution
                   -> Word16                      -- ^ Default port
-                  -> DnsDomains a
-                  -> IO (Either [e] [(ByteString, Word16)])
-resolveDnsDomains resolve defaultPort (DnsDomains{..}) =
-    findAlts [] dnsDomains
+                  -> [NodeAddr a]
+                  -> IO [Either e [(ByteString, Word16)]]
+resolveDnsDomains resolve defaultPort dnsDomains =
+    forM dnsDomains resolveOne
   where
-    -- Find a set of DNS names all of which we can resolve together
-    findAlts :: [e]
-             -> Alts (AllOf (NodeAddr a))
-             -> IO (Either [e] [(ByteString, Word16)])
-    findAlts errs []           = return $ Left (reverse errs)
-    findAlts errs (alts:altss) = do
-      mAddrs <- tryAlts alts
-      case mAddrs of
-        Left  err   -> findAlts (err:errs) altss
-        Right addrs -> return $ Right addrs
 
-    -- Resolve a set of domains names. If they can all be resolved, return
-    -- the set; if an error occurs, return Nothing.
-    tryAlts :: AllOf (NodeAddr a) -> IO (Either e [(ByteString, Word16)])
-    tryAlts = go []
-      where
-        go :: [(ByteString, Word16)] -> [NodeAddr a] -> IO (Either e [(ByteString, Word16)])
-        go acc []         = return $ Right (reverse acc)
-        go acc (NodeAddrDNS dom mPort:addrs) = do
-          let toAddr :: IPv4 -> (ByteString, Word16)
-              toAddr ip = (BS.C8.pack (show ip), fromMaybe defaultPort mPort)
-          mIPs <- resolve dom
-          case mIPs of
-            Left  err -> return $ Left err
-            Right ips -> go (reverse (map toAddr ips) ++ acc) addrs
-        go acc (NodeAddrExact ip mPort:addrs) = do
-          let port = fromMaybe defaultPort mPort
-              ipBS = encodeUtf8 @String . show $ ip
-          go ((ipBS, port):acc) addrs
+    resolveOne :: NodeAddr a -> IO (Either e [(ByteString, Word16)])
+    resolveOne (NodeAddrDNS dom mPort) = do
+        let toAddr :: IPv4 -> (ByteString, Word16)
+            toAddr ip = (BS.C8.pack (show ip), fromMaybe defaultPort mPort)
+        mIPs <- resolve dom
+        pure $ case mIPs of
+            Left  err -> Left err
+            Right ips -> Right $ map toAddr ips
+    resolveOne (NodeAddrExact ip mPort) = do
+        let port = fromMaybe defaultPort mPort
+            ipBS = encodeUtf8 @String . show $ ip
+        pure $ Right [(ipBS, port)]

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -50,7 +50,7 @@ import           Network.Broadcast.OutboundQueue.Types
 import           Network.DNS                           (DNSError)
 import qualified Network.DNS                           as DNS
 import           Node.Internal                         (NodeId (..))
-import           Pos.Network.DnsDomains                (DnsDomains (..))
+import           Pos.Network.DnsDomains                (DnsDomains (..), NodeAddr)
 import qualified Pos.Network.DnsDomains                as DnsDomains
 import qualified Pos.Network.Policy                    as Policy
 import           Pos.System.Metrics.Constants          (cardanoNamespace)
@@ -224,7 +224,7 @@ topologyUnknownNodeType topology = OQ.UnknownNodeType $ go topology
     go TopologyAuxx{}        = const NodeEdge   -- should never happen
 
 data SubscriptionWorker kademlia =
-    SubscriptionWorkerBehindNAT (DnsDomains DNS.Domain) Valency Fallbacks
+    SubscriptionWorkerBehindNAT (DnsDomains DNS.Domain)
   | SubscriptionWorkerKademlia kademlia NodeType Valency Fallbacks
 
 -- | What kind of subscription worker do we run?
@@ -236,12 +236,8 @@ topologySubscriptionWorker = go
                                = Nothing
     go TopologyRelay{..}       = Just $ SubscriptionWorkerBehindNAT
                                           topologyDnsDomains
-                                          topologyValency
-                                          topologyFallbacks
     go TopologyBehindNAT{..}   = Just $ SubscriptionWorkerBehindNAT
                                           topologyDnsDomains
-                                          topologyValency
-                                          topologyFallbacks
     go TopologyP2P{..}         = Just $ SubscriptionWorkerKademlia
                                           topologyKademlia
                                           NodeRelay
@@ -425,14 +421,13 @@ type Resolver = DNS.Domain -> IO (Either DNSError [IPv4])
 
 -- | Variation on resolveDnsDomains that returns node IDs
 resolveDnsDomains :: NetworkConfig kademlia
-                  -> DnsDomains DNS.Domain
-                  -> IO (Either [DNSError] [NodeId])
+                  -> [NodeAddr DNS.Domain]
+                  -> IO [Either DNSError [NodeId]]
 resolveDnsDomains NetworkConfig{..} dnsDomains =
-    initDnsOnUse $ \resolve ->
-      fmap (fmap addressToNodeId) <$> DnsDomains.resolveDnsDomains
-                                        resolve
-                                        ncDefaultPort
-                                        dnsDomains
+    initDnsOnUse $ \resolve -> (fmap . fmap . fmap . fmap) addressToNodeId $
+        DnsDomains.resolveDnsDomains resolve
+                                     ncDefaultPort
+                                     dnsDomains
 
 -- | Initialize the DNS library whenever it's used
 --

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -428,6 +428,8 @@ resolveDnsDomains NetworkConfig{..} dnsDomains =
         DnsDomains.resolveDnsDomains resolve
                                      ncDefaultPort
                                      dnsDomains
+{-# ANN resolveDnsDomains ("HLint: ignore Use <$>" :: String) #-}
+
 
 -- | Initialize the DNS library whenever it's used
 --

--- a/infra/Pos/Subscription/Dns.hs
+++ b/infra/Pos/Subscription/Dns.hs
@@ -122,3 +122,5 @@ dnsSubscriptionWorker networkCfg DnsDomains{..} sendActions = do
 
     msgNoRelays :: Int -> Text
     msgNoRelays = sformat ("dnsSubscriptionWorker: no relays found for index "%int)
+
+{-# ANN dnsSubscriptionWorker ("HLint: ignore Use unless" :: String) #-}

--- a/infra/Pos/Subscription/Dns.hs
+++ b/infra/Pos/Subscription/Dns.hs
@@ -3,147 +3,119 @@ module Pos.Subscription.Dns
     ( dnsSubscriptionWorker
     ) where
 
+import           Data.Either                           (partitionEithers)
 import qualified Data.Map.Strict                       as M
-import           Data.Time                             (NominalDiffTime, UTCTime,
-                                                        diffUTCTime, getCurrentTime)
 import           Data.Time.Units                       (Millisecond, Second, convertUnit)
-import           Formatting                            (sformat, shown, (%))
+import           Formatting                            (sformat, shown, int, (%))
 import qualified Network.DNS                           as DNS
-import           System.Wlog                           (logError)
+import           System.Wlog                           (logError, logNotice)
 import           Universum
 
-import           Mockable                              (Delay, Mockable, delay)
-import           Network.Broadcast.OutboundQueue.Types (peersFromList)
+import           Mockable                              (Delay, Mockable, delay,
+                                                        Concurrently,
+                                                        forConcurrently,
+                                                        SharedAtomic,
+                                                        SharedAtomicT,
+                                                        newSharedAtomic,
+                                                        modifySharedAtomic)
+import           Network.Broadcast.OutboundQueue.Types (peersFromList, Alts)
 
 import           Pos.Communication.Protocol            (Worker)
 import           Pos.KnownPeers                        (MonadKnownPeers (..))
+import           Pos.Network.DnsDomains                (NodeAddr)
 import           Pos.Network.Types                     (Bucket (..), DnsDomains (..),
-                                                        Fallbacks, NetworkConfig (..),
+                                                        NetworkConfig (..),
                                                         NodeId (..), NodeType (..),
-                                                        Valency, resolveDnsDomains)
+                                                        resolveDnsDomains)
 import           Pos.Slotting                          (MonadSlotsData,
                                                         getNextEpochSlotDuration)
 import           Pos.Subscription.Common
 
-data KnownRelay = Relay {
-      -- | When did we find out about this relay?
-      relayDiscovered :: UTCTime
-
-      -- | Was this relay reported last call to findRelays?
-    , relayActive     :: Bool
-
-      -- | When was the last time it _was_ reported by findRelays?
-    , relayLastSeen   :: UTCTime
-
-      -- | When did we last experience an error communicating with this relay?
-    , relayException  :: Maybe (UTCTime, SubscriptionTerminationReason)
-    }
-
-type KnownRelays = Map NodeId KnownRelay
-
-activeRelays :: KnownRelays -> [NodeId]
-activeRelays = map fst . filter (relayActive . snd) . M.toList
-
--- TODO: Use valency and fallbacks
 dnsSubscriptionWorker
     :: forall kademlia ctx m.
-     ( SubscriptionMode m, Mockable Delay m, MonadSlotsData ctx m)
+     ( SubscriptionMode m
+     , MonadSlotsData ctx m
+     , Mockable Delay m
+     , Mockable SharedAtomic m
+     , Mockable Concurrently m
+     )
     => NetworkConfig kademlia
     -> DnsDomains DNS.Domain
-    -> Valency
-    -> Fallbacks
     -> Worker m
-dnsSubscriptionWorker networkCfg dnsDomains _valency _fallbacks sendActions =
-    loop M.empty
+dnsSubscriptionWorker networkCfg DnsDomains{..} sendActions = do
+    -- Shared state between the threads which do subscriptions.
+    -- It's a 'Map Int (Alts NodeId)' used to determine the current
+    -- peers set for our bucket 'BucketBehindNatWorker'. Each thread takes
+    -- care of its own index and updates the peers while holding the lock, so
+    -- that the threads don't erase each-others' work.
+    let initialDnsPeers :: Map Int (Alts NodeId)
+        initialDnsPeers = M.fromList $ map (\(i, _) -> (i, [])) allOf
+    dnsPeersVar <- newSharedAtomic initialDnsPeers
+    -- There's a thread for each conjunct which attempts to subscribe to one of
+    -- the alternatives.
+    -- This gives valency and fallbacks implicitly, just as for static
+    -- routes. Valency is the length of the outer list (conjuncts) and
+    -- fallbacks (for a given outer list element) is the length of the inner
+    -- list (disjuncts).
+    logNotice $ sformat ("dnsSubscriptionWorker: valency "%int) (length allOf)
+    void $ forConcurrently allOf (subscribeAlts dnsPeersVar)
   where
-    loop :: KnownRelays -> m ()
-    loop oldRelays = do
-      slotDur <- getNextEpochSlotDuration
-      now     <- liftIO $ getCurrentTime
-      peers   <- findRelays
 
-      let delayInterval :: Millisecond
-          delayInterval = max (slotDur `div` 4) (convertUnit (5 :: Second))
+    allOf :: [(Int, Alts (NodeAddr DNS.Domain))]
+    allOf = zip [1..] dnsDomains
 
-          updatedRelays :: KnownRelays
-          updatedRelays = updateKnownRelays now peers oldRelays
+    -- Resolve all of the names and try to subscribe to one.
+    -- If a subscription goes down, try later names.
+    -- When the list is exhausted (either because it's empty to begin with, or
+    -- because all subscriptions to have failed), wait a while before retrying
+    -- (see 'retryInterval').
+    subscribeAlts
+        :: SharedAtomicT m (Map Int (Alts NodeId))
+        -> (Int, Alts (NodeAddr DNS.Domain))
+        -> m ()
+    subscribeAlts dnsPeersVar (index, alts) = do
+        -- Resolve all of the names and update the known peers in the queue.
+        dnsPeersList <- findDnsPeers index alts
+        modifySharedAtomic dnsPeersVar $ \dnsPeers -> do
+            let dnsPeers' = M.insert index dnsPeersList dnsPeers
+            void $ updatePeersBucket BucketBehindNatWorker $ \_ ->
+                peersFromList mempty ((,) NodeRelay <$> M.elems dnsPeers')
+            pure (dnsPeers', ())
+        -- Try to subscribe to some peer.
+        -- If they all fail, wait a while before trying again.
+        subscribeToOne dnsPeersList
+        retryInterval >>= delay
+        subscribeAlts dnsPeersVar (index, alts)
 
-      -- Declare all active relays as a single list of alternative relays
-      void $ updatePeersBucket BucketBehindNatWorker $ \_ ->
-        peersFromList mempty [(NodeRelay, activeRelays updatedRelays)]
+    subscribeToOne :: Alts NodeId -> m ()
+    subscribeToOne dnsPeers = case dnsPeers of
+        [] -> return ()
+        (peer:peers) -> do
+            void $ subscribeTo sendActions peer
+            subscribeToOne peers
 
-      -- Subscribe only to a single relay (if we found one)
-      --
-      -- TODO: Make it configurable how many relays we subscribe to (should
-      -- probably share logic with the Kademlia worker).
-      case preferredRelays now updatedRelays of
-        [] -> do
-          logError msgNoRelays
-          delay delayInterval
-          loop updatedRelays
-        (relay:_) -> do
-          terminationReason <- subscribeTo sendActions relay
-          timeOfEx <- liftIO $ getCurrentTime
-          loop $ M.adjust (\r -> r { relayException = Just (timeOfEx, terminationReason) })
-                          relay
-                          updatedRelays
+    -- Find peers via DNS, preserving order.
+    -- In case multiple addresses are returned for one name, they're flattened
+    -- and we forget the boundaries, but all of the addresses for a given name
+    -- are adjacent.
+    findDnsPeers :: Int -> Alts (NodeAddr DNS.Domain) -> m (Alts NodeId)
+    findDnsPeers index alts = do
+        mNodeIds <- liftIO $ resolveDnsDomains networkCfg alts
+        let (errs, nids_) = partitionEithers mNodeIds
+            nids = mconcat nids_
+        when (null nids)       $ logError (msgNoRelays index)
+        when (not (null errs)) $ logError (msgDnsFailure index errs)
+        return nids
 
-    -- Find relays
-    findRelays :: m [NodeId]
-    findRelays = do
-        mNodeIds <- liftIO $ resolveDnsDomains networkCfg dnsDomains
-        case mNodeIds of
-          Left errs -> logError (msgDnsFailure errs) >> return []
-          Right ids -> return ids
+    -- How long to wait before retrying in case no alternative can be
+    -- subscribed to.
+    retryInterval :: m Millisecond
+    retryInterval = do
+        slotDur <- getNextEpochSlotDuration
+        pure $ max (slotDur `div` 4) (convertUnit (5 :: Second))
 
-    -- Suitable relays in order of preference
-    --
-    -- We prefer older relays over newer ones
-    preferredRelays :: UTCTime -> KnownRelays -> [NodeId]
-    preferredRelays now =
-          map fst
-        . sortOn (relayDiscovered . snd)
-        . filter (relaySuitable now . snd)
-        . M.toList
+    msgDnsFailure :: Int -> [DNS.DNSError] -> Text
+    msgDnsFailure = sformat ("subscriptionWorker: DNS failure for index "%int%": "%shown)
 
-    -- Suitable relay (one that we might try to connect to)
-    relaySuitable :: UTCTime -> KnownRelay -> Bool
-    relaySuitable now Relay{..} = and [
-          relayActive
-        , case relayException of
-            Nothing -> True
-            Just (timeOfErr, _err) ->
-              now `diffUTCTime` timeOfErr > errorExpiry
-        ]
-
-    -- Time after an error after which we reconsider a relay (in sec.)
-    errorExpiry :: NominalDiffTime
-    errorExpiry = 60
-
-    updateKnownRelays :: UTCTime -> [NodeId] -> KnownRelays -> KnownRelays
-    updateKnownRelays now =
-        M.mergeWithKey
-          -- Relays we already knew about
-          (\_nodeId () relay -> Just $ relay { relayLastSeen = now
-                                             , relayActive   = True
-                                             })
-          -- Newly discovered delays
-          (M.map $ \() -> initKnownRelay now)
-          -- Relays that seem to have disappeared
-          (M.map $ \relay -> relay { relayActive = False })
-      . M.fromList
-      . map (, ())
-
-    initKnownRelay :: UTCTime -> KnownRelay
-    initKnownRelay now = Relay {
-          relayDiscovered = now
-        , relayActive     = True
-        , relayLastSeen   = now
-        , relayException  = Nothing
-        }
-
-    msgDnsFailure :: [DNS.DNSError] -> Text
-    msgDnsFailure = sformat $ "subscriptionWorker: DNS failure: " % shown
-
-    msgNoRelays :: Text
-    msgNoRelays = sformat $ "subscriptionWorker: no relays found"
+    msgNoRelays :: Int -> Text
+    msgNoRelays = sformat ("subscriptionWorker: no relays found for index "%int)

--- a/node/src/Pos/Worker.hs
+++ b/node/src/Pos/Worker.hs
@@ -56,8 +56,8 @@ allWorkers NodeResources {..} = mconcatPair
     , wrap' "slotting"   $ (properSlottingWorkers, mempty)
 
     , wrap' "subscription" $ case topologySubscriptionWorker (ncTopology ncNetworkConfig) of
-        Just (SubscriptionWorkerBehindNAT dnsDomains valency fallbacks) ->
-          subscriptionWorker (dnsSubscriptionWorker ncNetworkConfig dnsDomains valency fallbacks)
+        Just (SubscriptionWorkerBehindNAT dnsDomains) ->
+          subscriptionWorker (dnsSubscriptionWorker ncNetworkConfig dnsDomains)
         Just (SubscriptionWorkerKademlia kinst nodeType valency fallbacks) ->
           subscriptionWorker (dhtSubscriptionWorker kinst nodeType valency fallbacks)
         Nothing ->


### PR DESCRIPTION
Previously there were unused valency and fallbacks parameters, and the
worker would choose a relay according not to the structure of the list
given in the topology yaml file, but according to recent failures,
time of discovery, and in one common case, to the lexicographic ordering
of its resolved address.

This patch makes the dynamic-subscribe work like static-routes: it's a
conjunction of disjunctions, implicitly giving the valency and number of
fallbacks. The worker will attempt to subscribe to one peer from each of
the conjuncts (outer list) concurrently. If/when all of the disjuncts in
that list have failed (subscription attempted/broken) it will delay
according to the current slot duration before resolving all of the names
and trying again.

Each thread will update the outbound queue's known peers using the new
resolved names, whenever it resolves them. But updatePeersBucket insists
that only one thread should update for a given bucket, to avoid one
thread removing the additions given by another. To make it work, the
subscription threads update it while holding a shared atomic, and put
their work into a map keyed on an Int to identify the thread (so the
size of this map will equal the valency).

Topology files which use dynamic-subscribe should be updated to get rid
of the useless valency and fallbacks keys. The dynamic-subscribe value
should also be updated: we don't want a singleton list of a singleton
list of a bunch of names, but a valency * fallbacks grid of names.

We'll probably want to make some further changes here but this at least
fixes CSL-1700.