### PR TITLE
CSL-1710 Test block-gen and rollback tools

### DIFF
--- a/auxx/src/Command/Tx.hs
+++ b/auxx/src/Command/Tx.hs
@@ -46,8 +46,10 @@ import           Pos.Crypto                       (emptyPassphrase, encToPublic,
                                                    withSafeSigner)
 import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Txp                          (TxAux, TxOut (..), TxOutAux (..), txaF)
+import           Pos.Txp                          (TxAux, TxOut (..), TxOutAux (..),
+                                                   topsortTxAuxes, txaF)
 import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util.Util                    (maybeThrow)
 import           Pos.Wallet                       (getSecretKeys)
 
 import           Command.Types                    (SendMode (..),
@@ -228,8 +230,12 @@ sendTxsFromFile sendActions txsFile = do
             sformat
                 ("Going to send "%int%" transactions one-by-one")
                 (length txAuxes)
+        sortedTxAuxes <-
+            maybeThrow
+                (AuxxException "txs form a cycle")
+                (topsortTxAuxes txAuxes)
         CmdCtx {ccPeers} <- getCmdCtx
         let submitOne =
                 submitTxRaw
                     (immediateConcurrentConversations sendActions ccPeers)
-        mapM_ submitOne txAuxes
+        mapM_ submitOne sortedTxAuxes

--- a/infra/Pos/Recovery/Info.hs
+++ b/infra/Pos/Recovery/Info.hs
@@ -32,6 +32,11 @@ data SyncStatus
                   , sslbCurrentSlot :: !SlotId }
     -- ^ We know current slot, but our tip's slot lags behind current
     -- slot too much.
+    | SSInFuture { sslbTipSlot     :: !SlotId
+                 , sslbCurrentSlot :: !SlotId }
+    -- ^ We know current slot and our tip's slot is greater than the
+    -- current one. Most likely we are misconfigured or we are
+    -- cheating somehow (e. g. creating blocks using block-gen).
     | SSKindaSynced
     -- ^ We are kinda synchronized, i. e. all previously described
     -- statuses are not about us.
@@ -45,6 +50,12 @@ instance Buildable SyncStatus where
                 bprint
                     ("we lag behind too much, our tip's slot is: " %slotIdF %
                      ", but current slot is " %slotIdF)
+                    sslbTipSlot
+                    sslbCurrentSlot
+            SSInFuture {..} ->
+                bprint
+                    ("we invented time machine, our tip's slot is: " %slotIdF %
+                     " and it's greater than current slot: " %slotIdF)
                     sslbTipSlot
                     sslbCurrentSlot
             SSKindaSynced -> "we are moderately synchronized"

--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -138,7 +138,7 @@ bench: &bench
           testnetInitializer:
             testBalance:
               poors:        50000
-              richmen:      4
+              richmen:      3
               richmenShare: 0.99
               useHDAddresses: False
               totalBalance: 6000000000

--- a/node/src/Pos/Recovery/Instance.hs
+++ b/node/src/Pos/Recovery/Instance.hs
@@ -35,6 +35,10 @@ instance ( Monad m
             curSlot <- note SSUnknownSlot =<< getCurrentSlot
             tipHeader <- getTipHeader @ssc
             let tipSlot = epochOrSlotToSlot (tipHeader ^. epochOrSlotG)
+            unless (tipSlot <= curSlot) $
+                throwError
+                    SSInFuture
+                    {sslbCurrentSlot = curSlot, sslbTipSlot = tipSlot}
             let slotDiff = flattenSlotId curSlot - flattenSlotId tipSlot
             unless (slotDiff < fromIntegral lagBehindParam) $
                 throwError

--- a/node/src/Pos/Worker.hs
+++ b/node/src/Pos/Worker.hs
@@ -14,7 +14,7 @@ import           Data.Tagged             (untag)
 import           Pos.Block.Worker        (blkWorkers)
 import           Pos.Communication       (OutSpecs, Relay, WorkerSpec, localWorker,
                                           relayPropagateOut, wrapActionSpec)
-import           Pos.Context             (NodeContext (..), recoveryCommGuard)
+import           Pos.Context             (NodeContext (..))
 import           Pos.Delegation          (delegationRelays, dlgWorkers)
 import           Pos.DHT.Workers         (dhtWorkers)
 import           Pos.Launcher.Resource   (NodeResources (..))
@@ -80,6 +80,6 @@ allWorkers NodeResources {..} = mconcatPair
   where
     NodeContext {..} = nrContext
     properSlottingWorkers =
-       fst (localWorker (recoveryCommGuard "logNewSlot" logNewSlotWorker)) :
+       fst (localWorker logNewSlotWorker) :
        map (fst . localWorker) (slottingWorkers ncSlottingContext)
     wrap' lname = first (map $ wrapActionSpec $ "worker" <> lname)

--- a/scripts/bench/runbench.sh
+++ b/scripts/bench/runbench.sh
@@ -16,7 +16,7 @@
 #
 # node_cmd , bench_cmd defined in scripts/common_functions.sh
 
-RICH_NODES=3 CONC=4 NUM_TXS=$1 CONFIG_KEY="bench" scripts/launch/demo.sh 5 `dirname $0`/topology rich_poor
+RICH_NODES=3 CONC=4 NUM_TXS=$1 CONFIG_KEY="bench" scripts/launch/demo.sh 6 `dirname $0`/topology rich_poor
 
 # transaction generator generates file tps-sent.csv
 #

--- a/scripts/launch/auxx.sh
+++ b/scripts/launch/auxx.sh
@@ -21,7 +21,7 @@ template="$binary $dht_conf $logs_conf \
                  --system-start 100500"  # random value, not used, but mandatory
 
 if [[ $1 == "init-dev" ]]; then
-    commands="add-key-pool 0,add-key-pool 1,add-key-pool 2,add-key-pool 3"
+    commands="add-key-pool 0,add-key-pool 1,add-key-pool 2,add-key-pool 3,add-key-pool 4"
 fi
 
 if [[ "$commands" != "" ]]; then

--- a/txp/Pos/Txp/Core/Tx.hs
+++ b/txp/Pos/Txp/Core/Tx.hs
@@ -2,16 +2,19 @@
 
 module Pos.Txp.Core.Tx
        ( topsortTxs
+       , topsortTxAuxes
        ) where
+
+import           Universum
 
 import           Control.Lens        (makeLenses, to, uses, (%=), (.=))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet        as HS
 import           Data.List           (nub, tail)
-import           Universum
 
-import           Pos.Crypto          (Hash, WithHash (..))
-import           Pos.Txp.Core.Types  (Tx (..), TxIn (..), txInputs)
+import           Pos.Binary.Txp.Core ()
+import           Pos.Crypto          (Hash, WithHash (..), withHash)
+import           Pos.Txp.Core.Types  (Tx (..), TxAux (..), TxIn (..), txInputs)
 
 ----------------------------------------------------------------------------
 -- Topsorting
@@ -77,3 +80,9 @@ topsortTxs toTx input =
                 dependsUnfiltered
             for_ depends $ \a' -> dfs2 visitedNew a'
             tsResult %= (a:)
+
+-- | Specialied version of 'topsortTxs'.
+topsortTxAuxes :: [TxAux] -> Maybe [TxAux]
+topsortTxAuxes = topsortTxs converter
+  where
+    converter TxAux {..} = withHash taTx


### PR DESCRIPTION
The task was to test block-gen and rollback tools.
Results can be found in comments to CSL-1710.
During the testing I found some bad things and fixed them. The most important fix is topological sort in `send-from-file` command.
It's probably better to review this PR per commit, all of them are rather small and self-contained.