### PR TITLE
[CSL-1706] Fix old data problems in retrieval worker/queue

### DIFF
--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -114,7 +114,7 @@ dev: &dev
     dlgCacheParam: 500
     recoveryHeadersMessage: 20 # should be greater than k
     messageCacheTimeout: 30
-    networkConnectionTimeout: 2000
+    networkConnectionTimeout: 2000 # ms
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds

--- a/node/src/Pos/Block/Network/Logic.hs
+++ b/node/src/Pos/Block/Network/Logic.hs
@@ -59,9 +59,8 @@ import           Pos.Communication.Protocol (Conversation (..), ConversationActi
 import           Pos.Context                (BlockRetrievalQueueTag, LastKnownHeaderTag,
                                              recoveryCommGuard, recoveryInProgress)
 import           Pos.Core                   (HasConfiguration, HasHeaderHash (..),
-                                             HeaderHash, gbHeader, headerHashG,
-                                             isMoreDifficult, prevBlockL,
-                                             criticalForkThreshold)
+                                             HeaderHash, criticalForkThreshold, gbHeader,
+                                             headerHashG, isMoreDifficult, prevBlockL)
 import           Pos.Crypto                 (shortHashF)
 import           Pos.DB.Block               (blkGetHeader)
 import qualified Pos.DB.DB                  as DB
@@ -371,7 +370,7 @@ addHeaderToBlockRequestQueue
        (WorkMode ssc ctx m)
     => NodeId
     -> BlockHeader ssc
-    -> Bool -- Continues?
+    -> Bool -- ^ Was classified as chain continuation
     -> m ()
 addHeaderToBlockRequestQueue nodeId header continues = do
     logDebug $ sformat ("addToBlockRequestQueue, : "%build) header

--- a/node/src/Pos/Block/RetrievalQueue.hs
+++ b/node/src/Pos/Block/RetrievalQueue.hs
@@ -1,3 +1,4 @@
+-- | Block retrieval queue with accompanied datatypes.
 module Pos.Block.RetrievalQueue
        ( BlockRetrievalQueueTag
        , BlockRetrievalQueue
@@ -11,11 +12,16 @@ import           Control.Concurrent.STM  (TBQueue)
 import           Pos.Block.Core          (BlockHeader)
 import           Pos.Communication.Types (NodeId)
 
+-- | Task that block retrieval queue is asked to do.
 data BlockRetrievalTask ssc = BlockRetrievalTask
     { brtHeader    :: !(BlockHeader ssc)
+      -- ^ Header we're insterested in.
     , brtContinues :: !Bool
+      -- ^ If it was tentatively classified as "direct continuation of
+      -- our chain".
     }
 
 data BlockRetrievalQueueTag
 
+-- | Queue types.
 type BlockRetrievalQueue ssc = TBQueue (NodeId, BlockRetrievalTask ssc)

--- a/scripts/grep.sh
+++ b/scripts/grep.sh
@@ -1,5 +1,5 @@
 # This utility script is written by @gromak and is provided "as is".
 # The author doesn't guarantee anything about it. It might work.
 
-grep --color=auto -r "$@" node/src node/test node/bench core/Pos update/Pos db/Pos lrc/Pos infra/Pos ssc/Pos godtossing/Pos tools/src txp/Pos auxx/Pos auxx/*.hs wallet explorer/*.hs --exclude-dir='.stack-work'
+grep --color=auto -r "$@" node/src node/test node/bench core/Pos update/Pos db/Pos lrc/Pos infra/Pos ssc/Pos godtossing/Pos tools/src txp/Pos auxx/src auxx/*.hs wallet explorer/*.hs --exclude-dir='.stack-work'
 # grep -r --exclude-dir={.stack-work,.git} "$@" .


### PR DESCRIPTION
This PR fixes the following problem:
1. We've just launched and recovery queue has header H.
2. We start recovery to header H. It's classified as alternative (not continuation).
3. In the meanwhile we get headers H+1, H+2, H+3... H+n (recovery can be long).
4. Recovery is over, we get task H+1 and apply it (fetch one header). Then we get task H+2 and apply it (fetch one header also). It continues until we free the queue completely.

Problem is that step (4) may slow down recovery significantly.

What does this PR introduce:
1. Task dispatching's alternative branch now only sets recovery variable instead of starting to query blocks immediately. 
2. Bugfixes (added extra `classifyNewHeader` in alternative that was crucially needed to avoid extra requests, exceptions handlers were reworked slightly to avoid logical overhead).

What will happen after this fix after step 3:
4'. We get through all tasks in queue and try to replace recovery header with something newer (so choose H+n). When queue is empty, we do recovery.