### PR TITLE
[CSM-475] Sort transaction history to remove on tracked rollback

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
@@ -63,7 +63,7 @@ data CAccModifier = CAccModifier
     , camChange               :: !(VoidModifier (CId Addr, HeaderHash))
     , camUtxo                 :: !UtxoModifier
     , camAddedHistory         :: !(DList TxHistoryEntry)
-    , camDeletedHistory       :: !(DList TxId)
+    , camDeletedHistory       :: !(DList TxHistoryEntry)
     , camAddedPtxCandidates   :: !(DList (TxId, PtxBlockInfo))
     , camDeletedPtxCandidates :: !(DList (TxId, TxHistoryEntry))
     }

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -58,8 +58,7 @@ import           Pos.Core                         (Address (..), BlockHeaderStub
                                                    addrAttributesUnwrapped,
                                                    blkSecurityParam, genesisHash,
                                                    headerHash, headerSlotL,
-                                                   makeRootPubKeyAddress,
-                                                   timestampToPosix)
+                                                   makeRootPubKeyAddress)
 import           Pos.Crypto                       (EncryptedSecretKey, HDPassphrase,
                                                    WithHash (..), deriveHDPassphrase,
                                                    encToPublic, hash, shortHashF,
@@ -74,7 +73,7 @@ import           Pos.Slotting                     (MonadSlots (..), MonadSlotsDa
 import           Pos.StateLock                    (Priority (..), StateLock,
                                                    withStateLockNoMetrics)
 import           Pos.Txp                          (GenesisUtxo (..), Tx (..), TxAux (..),
-                                                   TxId, TxIn (..), TxOutAux (..), TxUndo,
+                                                   TxIn (..), TxOutAux (..), TxUndo,
                                                    flattenTxPayload, genesisUtxo, toaOut,
                                                    topsortTxs, txOutAddress)
 import           Pos.Txp.MemState.Class           (MonadTxpMem, getLocalTxsNUndo)
@@ -83,11 +82,10 @@ import qualified Pos.Util.Modifier                as MM
 
 import           Pos.Ssc.Class                    (SscHelpersClass)
 import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
-import           Pos.Util.Servant                 (encodeCType)
 import           Pos.Wallet.SscType               (WalletSscType)
 import           Pos.Wallet.Web.Account           (MonadKeySearch (..))
 import           Pos.Wallet.Web.ClientTypes       (Addr, CId, CWAddressMeta (..), Wal,
-                                                   addressToCId, ctmDate, encToCId,
+                                                   addressToCId, encToCId,
                                                    isTxLocalAddress)
 import           Pos.Wallet.Web.Error.Types       (WalletError (..))
 import           Pos.Wallet.Web.Pending.Types     (PtxBlockInfo, PtxCondition (PtxApplying, PtxInNewestBlocks))
@@ -99,7 +97,7 @@ import           Pos.Wallet.Web.Tracking.Modifier (CAccModifier (..), CachedCAcc
                                                    deleteAndInsertIMM, deleteAndInsertMM,
                                                    deleteAndInsertVM, indexedDeletions,
                                                    sortedInsertions)
-import           Pos.Wallet.Web.Util              (getWalletAddrMetas)
+import           Pos.Wallet.Web.Util              (getWalletAddrMetas, sortWalletThByTime)
 
 
 type BlockLockMode ssc ctx m =
@@ -414,7 +412,7 @@ trackingRollbackTxs (getEncInfo -> encInfo) allAddress getDiff getTs txs =
 
             deletedHistory =
                 if (not $ null ownInputAddrs) || (not $ null ownOutputAddrs)
-                then DL.snoc camDeletedHistory $ hash taTx
+                then DL.snoc camDeletedHistory th
                 else camDeletedHistory
 
             deletedPtxCandidates = DL.cons (txid, th) camDeletedPtxCandidates
@@ -446,20 +444,14 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     mapM_ (WS.addCustomAddress ChangeAddr . fst) (MM.insertions camChange)
     WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
     oldCachedHist <- fromMaybe [] <$> WS.getHistoryCache wid
-    sortedAddedHistory <- sortTxs (DL.toList camAddedHistory)
+    sortedAddedHistory <-
+        getNewestFirst <$> sortWalletThByTime wid (DL.toList camAddedHistory)
     WS.updateHistoryCache wid $ sortedAddedHistory <> oldCachedHist
     -- resubmitting worker can change ptx in db nonatomically, but
     -- tracker has priority over the resubmiter, thus do not use CAS here
     forM_ camAddedPtxCandidates $ \(txid, ptxBlkInfo) ->
         WS.setPtxCondition wid txid (PtxInNewestBlocks ptxBlkInfo)
     WS.setWalletSyncTip wid newTip
-  where
-    getTxTime tx = ctmDate <<$>> WS.getTxMeta wid (encodeCType $ _thTxId tx)
-    sortTxs txs = do
-        txsWTime <- forM txs $ \tx -> (tx, ) <$> getTxTime tx
-        let txRealTime (THEntry{..}, mtime) =
-                mtime <|> (timestampToPosix <$> _thTimestamp)
-        return $ map fst $ sortOn (fmap Down . txRealTime) txsWTime
 
 rollbackModifierFromWallet
     :: (WebWalletModeDB ctx m, MonadSlots ctx m)
@@ -480,16 +472,18 @@ rollbackModifierFromWallet wid newTip CAccModifier{..} = do
     WS.getHistoryCache wid >>= \case
         Nothing -> pure ()
         Just oldCachedHist -> do
+            sortedDeletedHistory <-
+                getNewestFirst <$> sortWalletThByTime wid (DL.toList camDeletedHistory)
             WS.updateHistoryCache wid $
-                removeFromHead (DL.toList camDeletedHistory) oldCachedHist
+                removeFromHead sortedDeletedHistory oldCachedHist
     WS.setWalletSyncTip wid newTip
   where
-    removeFromHead :: [TxId] -> [TxHistoryEntry] -> [TxHistoryEntry]
+    removeFromHead :: [TxHistoryEntry] -> [TxHistoryEntry] -> [TxHistoryEntry]
     removeFromHead [] ths = ths
     removeFromHead _ [] = []
-    removeFromHead (txId : txIds) (THEntry {..} : thes) =
-        if txId == _thTxId
-        then removeFromHead txIds thes
+    removeFromHead (dTh : dThes) (th : thes) =
+        if _thTxId dTh == _thTxId th
+        then removeFromHead dThes thes
         else error "rollbackModifierFromWallet: removeFromHead: \
                    \rollbacked tx ID is not present in history cache!"
 


### PR DESCRIPTION
On block applying txs are sorted before being added to tx history.
On rollback we expect transactions to be removed from history in opposite
order, so transactions of rollbacked block should be sorted as well to
allow us properly drain them from the top of current history.