### PR TITLE
[CSE-231] 'Address does not exist' error for existing addresses.

### DIFF
--- a/explorer/test/Test/Pos/Explorer/Web/ClientTypesSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Web/ClientTypesSpec.hs
@@ -14,7 +14,6 @@ import           Prelude                      (id)
 import           Pos.Binary                   (Bi)
 import           Pos.Crypto
 import           Pos.Explorer.Web.ClientTypes
--- import           Pos.Explorer.Web.Server      (cAddrToAddr)
 import           Pos.Txp                      (TxId)
 import           Pos.Types                    (Address)
 import           Test.Hspec                   (Spec, describe, it, shouldBe,
@@ -99,14 +98,6 @@ unitTests = do
 
             decodedCAddressTextNew `shouldSatisfy` isRight
             (toCAddress <$> decodedCAddressTextNew) `shouldSatisfy` isRight
-
-            -- TODO(ks): Uncomment this to see how it fails.
-            -- let decodedCAddressRaw :: Address
-            --     decodedCAddressRaw = case decodedCAddressTextNew of
-            --         Left _     -> error "Invalid address"
-            --         Right addr -> addr
-
-            -- (cAddrToAddr cAddress) `shouldBe` decodedCAddressRaw
 
 ----------------------------------------------------------------------------
 -- Quickcheck tests


### PR DESCRIPTION
https://issues.serokell.io/issue/CSE-231

So we need to merge another change suggested/found by @Pastafarianist  which allows RSCoin addresses to be used too - now we can use only Cardano addresses. My bad.
This PR contains the changes we need - https://github.com/input-output-hk/cardano-sl/pull/1644
It's almost identical to the one we merged but retains the checks for 32-byte addresses *in case of RSCoin addresses*.

So:
- RSCoin address == 32 bytes 
- Cardano address >= 34 bytes

@Pastafarianist comments - AFAIU base58 can be decoded as base64 as long as it has as many characters that `[num of characters]*6 % 8 == 0`.

@gromakovsky commented - Address contains: one hash (28 bytes), a tag (1 byte), attributes (it seems to me that attributes can take only 1 byte).
So it seems to me address can be 30 bytes long. But! There is also 4 bytes checksum, so it should be at least 34. Plus CBOR overhead.

Tested on `mainnet` using `./scripts/launch/connect-to-cluster/explorer-mainnet.sh`.

Going to `http://localhost:8100/api/addresses/summary/DdzFFzCqrhsqU7rLVY4rjYgmHidTDLLfNpLDQk85QwCBu8WQW8Snpmq4rEmeZ2ze96WzBrLEt8FjTWU4f7cG7bsymDrpfKpDC5Jknpda` returns:
```
{"Right":{"caAddress":"DdzFFzCqrhsqU7rLVY4rjYgmHidTDLLfNpLDQk85QwCBu8WQW8Snpmq4rEmeZ2ze96WzBrLEt8FjTWU4f7cG7bsymDrpfKpDC5Jknpda","caType":"CPubKeyAddress","caTxNum":2,"caBalance":{"getCoin":"0"},"caTxList":[{"ctbId":"ac439284933ba4a2bc81e5e8995c4a0c0a39256884d905e74ffcdf7ba9b257e7","ctbTimeIssued":1506329611,"ctbInputs":[["DdzFFzCqrhsqU7rLVY4rjYgmHidTDLLfNpLDQk85QwCBu8WQW8Snpmq4rEmeZ2ze96WzBrLEt8FjTWU4f7cG7bsymDrpfKpDC5Jknpda",{"getCoin":"1000000"}]],"ctbOutputs":[["DdzFFzCqrhsgHx6CUkwaLwABsZLtFZpuQsTbXpMkinerzLPCX9aNdpTVvj4P7uEmytxD8wW34y1A3f7awj1vGQMU3dBjv56619WXLjCo",{"getCoin":"329106"}],["DdzFFzCqrhsuXWViKNnvsC5NdWhT4NEw5FeDtzdm9WbzzDTTTrFSjRAPhiPhE258dt7hfHmQAHo6PNEkfzXZ7ZrF4WAiLYqPCmgUrc5G",{"getCoin":"500000"}]],"ctbInputSum":{"getCoin":"1000000"},"ctbOutputSum":{"getCoin":"829106"}},{"ctbId":"dbc87d198fc9f6067c8e65f89da60a944e1ef52f0c539d980ebbc95f3dc71b65","ctbTimeIssued":1506329391,"ctbInputs":[["Ae2tdPwUPEZ8fbeSrt7u4SfYF3GDCMBmqX4KaKygHjjcm8AjJH4R9Nbpp6u",{"getCoin":"1000000"}]],"ctbOutputs":[["DdzFFzCqrhsqU7rLVY4rjYgmHidTDLLfNpLDQk85QwCBu8WQW8Snpmq4rEmeZ2ze96WzBrLEt8FjTWU4f7cG7bsymDrpfKpDC5Jknpda",{"getCoin":"1000000"}]],"ctbInputSum":{"getCoin":"1000000"},"ctbOutputSum":{"getCoin":"1000000"}}]}}
```

Going to `http://localhost:8100/api/addresses/summary/AnB+vESuU7iUtyJ8Sq8G27LJYA2YJNODTdmgzD4UTPs=` returns:
```
{"Right":{"caAddress":"AnB+vESuU7iUtyJ8Sq8G27LJYA2YJNODTdmgzD4UTPs=","caType":"CRedeemAddress","caTxNum":0,"caBalance":{"getCoin":"0"},"caTxList":[]}}
```