### PR TITLE
[CSE-236] Disable epoch search

### DIFF
--- a/explorer/frontend/src/Explorer/Update.purs
+++ b/explorer/frontend/src/Explorer/Update.purs
@@ -518,10 +518,12 @@ update (GlobalSearchTime event) state =
                     in
                     pure <<< Just $ Navigate (toUrl epochSlotUrl) event
                 Tuple (Just epoch) Nothing ->
-                    let epochIndex = mkEpochIndex epoch
-                        epochUrl   = Epoch $ epochIndex
-                    in
-                    pure <<< Just $ Navigate (toUrl epochUrl) event
+                    -- [CSE-236] Disable epoch search
+                    -- let epochIndex = mkEpochIndex epoch
+                    --     epochUrl   = Epoch $ epochIndex
+                    -- in
+                    -- pure <<< Just $ Navigate (toUrl epochUrl) event
+                    pure Nothing
 
                 _ -> pure Nothing -- TODO (ks) maybe put up a message?
         ]
@@ -909,7 +911,9 @@ update (UpdateView r@(Epoch epochIndex)) state =
     , effects:
         [ pure $ Just ScrollTop
         , pure $ Just ClearWaypoints
-        , pure <<< Just $ RequestSearchBlocks epochIndex Nothing
+        -- [CSE-236] Disable epoch search and redirect to 404 page
+        -- , pure <<< Just $ RequestSearchBlocks epochIndex Nothing
+        , pure <<< Just $ UpdateView NotFound
         ]
     }
 

--- a/explorer/frontend/src/Explorer/Util/Time.Test.purs
+++ b/explorer/frontend/src/Explorer/Util/Time.Test.purs
@@ -19,25 +19,25 @@ testPrettyDuration =
             describe "short durations" do
                 it "a milisecond should return less than a minute" do
                   let result = prettyDuration English (Milliseconds 1.0)
-                      expected = "< 1 Minutes"
+                      expected = "< 1 minutes"
                   result `shouldEqual` expected
                 it "a second should return less than a minute" do
                   let result = prettyDuration English (Seconds 1.0)
-                      expected = "< 1 Minutes"
+                      expected = "< 1 minutes"
                   result `shouldEqual` expected
                 it "59 seconds should return less than a minute" do
                   let result = prettyDuration English (Seconds 59.0)
-                      expected = "< 1 Minutes"
+                      expected = "< 1 minutes"
                   result `shouldEqual` expected
             describe "durations" do
                 it "30 minutes should return 30 minutes" do
                     let result = prettyDuration English (Minutes 30.0)
-                        expected = "30 Minutes"
+                        expected = "30 minutes"
                     result `shouldEqual` expected
             describe "longer durations" do
               it "5 days should return 5 days" do
                   let result = prettyDuration English (Days 5.0)
-                      expected = "5 Days"
+                      expected = "5 days"
                   result `shouldEqual` expected
         describe "prettyDate" do
               it "format date of DD.MM.YYYY HH:mm,ss" do

--- a/explorer/frontend/src/Explorer/View/Blocks.purs
+++ b/explorer/frontend/src/Explorer/View/Blocks.purs
@@ -113,7 +113,9 @@ blockRow state (CBlockEntry entry) =
     S.div ! S.className CSS.blocksBodyRow
           ! P.key ((show $ entry ^. cbeEpoch) <> "-" <> (show $ entry ^. cbeSlot)) $ do
           blockColumn { label: show $ entry ^. cbeEpoch
-                      , mRoute: Just <<< Epoch <<< mkEpochIndex $ entry ^. cbeEpoch
+                      -- [CSE-236] Disable epoch search
+                      -- , mRoute: Just <<< Epoch <<< mkEpochIndex $ entry ^. cbeEpoch
+                      , mRoute: Nothing
                       , clazz: CSS.blocksColumnEpoch
                       , mCurrency: Nothing
                       }

--- a/explorer/frontend/src/Explorer/View/Transaction.purs
+++ b/explorer/frontend/src/Explorer/View/Transaction.purs
@@ -95,12 +95,14 @@ summaryRowEpochSlot (CTxSummary ctxSummary) lang =
         case ctxSummary ^. ctsBlockEpoch of
             Just epoch ->
                 let epochLabel = translate (I18nL.common <<< I18nL.cEpoch) lang
-                    epochRoute = Epoch $ mkEpochIndex epoch
+                    -- [CSE-236] Disable epoch search
+                    -- epochRoute = Epoch $ mkEpochIndex epoch
                 in
-                S.a ! S.href (toUrl epochRoute)
-                    #! P.onClick (Navigate $ toUrl epochRoute)
-                    ! S.className "link"
-                    $ S.text (epochLabel <> " " <> show epoch)
+                -- [CSE-236] Disable epoch search
+                -- S.a ! S.href (toUrl epochRoute)
+                --     #! P.onClick (Navigate $ toUrl epochRoute)
+                --     ! S.className "link"
+                S.span $ S.text (epochLabel <> " " <> show epoch)
             Nothing ->
                 S.span $ S.text noData
         S.text " / "

--- a/explorer/frontend/src/Explorer/View/blocks.css
+++ b/explorer/frontend/src/Explorer/View/blocks.css
@@ -40,8 +40,9 @@
 
   &__epoch {
     lost-column: 3/12;
-    button: standard-button;
-    button-color: var(--color8) var(--color5) var(--color5);
+    /* [CSE-236] Disable epoch search */
+    /*button: standard-button;
+    button-color: var(--color8) var(--color5) var(--color5);*/
   }
   &__slot {
     lost-column: 3/12;

--- a/explorer/src/Pos/Explorer/Web/Server.hs
+++ b/explorer/src/Pos/Explorer/Web/Server.hs
@@ -576,6 +576,11 @@ epochSlotSearch
     -> m [CBlockEntry]
 epochSlotSearch epochIndex slotIndex = do
 
+    -- [CSE-236] Disable search for epoch only
+    -- TODO: Remove restriction if epoch search will be optimized
+    when (isNothing slotIndex) $
+        throwM $ Internal "We currently do not support searching for epochs only."
+
     -- Get pages from the database
     -- TODO: Fix this Int / Integer thing once we merge repositories
     epochBlocksHH   <- getPageHHsOrThrow epochIndex


### PR DESCRIPTION
These changes are temporary until `CSE-236` will be fixed: https://issues.serokell.io/issue/CSE-236

Note: Because `scripts/launch/explorer-with-nodes.sh` does not work with branch `cardano-sl-1.0` locally I had have to test UI changes with mock server. And without a running `scripts/launch/explorer-with-nodes.sh` I could not test disabled endpoint of `api/search/epoch/{n}`.  

PS.: This PR includes a cherry pick of 2caa8f2652be81e6d38f8150967a9cba26f2f57a to have all front-end tests green :green_apple: 