### PR TITLE
[CSL-1713] time-warp ack timeout configurable

### DIFF
--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -114,6 +114,7 @@ dev: &dev
     recoveryHeadersMessage: 20 # should be greater than k
     messageCacheTimeout: 30
     networkConnectionTimeout: 2000
+    conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds

--- a/node/src/Pos/Configuration.hs
+++ b/node/src/Pos/Configuration.hs
@@ -71,7 +71,7 @@ data NodeConfiguration = NodeConfiguration
       -- support caching
     , ccNetworkConnectionTimeout     :: !Int
       -- ^ Network connection timeout in milliseconds
-    , ccConversationEstablishTimeout :: !(Maybe Int)
+    , ccConversationEstablishTimeout :: !Int
       -- ^ Conversation acknowledgement timeout in milliseconds.
       -- Default 30 seconds.
     , ccBlockRetrievalQueueSize      :: !Int
@@ -103,8 +103,7 @@ networkConnectionTimeout = ms . fromIntegral . ccNetworkConnectionTimeout $ node
 
 -- | Default is 30 seconds.
 conversationEstablishTimeout :: HasNodeConfiguration => Microsecond
-conversationEstablishTimeout =
-    ms . fromIntegral . fromMaybe 30000 . ccConversationEstablishTimeout $ nodeConfiguration
+conversationEstablishTimeout = ms . fromIntegral . ccConversationEstablishTimeout $ nodeConfiguration
 
 blockRetrievalQueueSize :: (HasNodeConfiguration, Integral a) => a
 blockRetrievalQueueSize =

--- a/node/src/Pos/Configuration.hs
+++ b/node/src/Pos/Configuration.hs
@@ -13,6 +13,7 @@ module Pos.Configuration
 
        -- * Other constants
        , networkConnectionTimeout
+       , conversationEstablishTimeout
        , blockRetrievalQueueSize
        , propagationQueueSize
        , defaultPeers
@@ -52,29 +53,32 @@ withNodeConfiguration = give
 -- | Compile time configuration. See example in /constants.yaml/ file.
 data NodeConfiguration = NodeConfiguration
     {
-      ccNetworkDiameter             :: !Int
+      ccNetworkDiameter              :: !Int
       -- ^ Estimated time for broadcasting messages
-    , ccDefaultPeers                :: ![Text]
+    , ccDefaultPeers                 :: ![Text]
       -- ^ List of default peers
-    , ccMdNoBlocksSlotThreshold     :: !Int
+    , ccMdNoBlocksSlotThreshold      :: !Int
       -- ^ Threshold of slots for malicious activity detection
-    , ccLightDlgConfirmationTimeout :: !Int
+    , ccLightDlgConfirmationTimeout  :: !Int
       -- ^ Timeout for holding light psks confirmations
-    , ccDlgCacheParam               :: !Int
+    , ccDlgCacheParam                :: !Int
       -- ^ This value parameterizes size of cache used in Delegation.
       -- Not bytes, but number of elements.
-    , ccRecoveryHeadersMessage      :: !Int
+    , ccRecoveryHeadersMessage       :: !Int
       -- ^ Numbers of headers put in message in recovery mode.
-    , ccMessageCacheTimeout         :: !Int
+    , ccMessageCacheTimeout          :: !Int
       -- ^ Interval we ignore cached messages in components that
       -- support caching
-    , ccNetworkConnectionTimeout    :: !Int
+    , ccNetworkConnectionTimeout     :: !Int
       -- ^ Network connection timeout in milliseconds
-    , ccBlockRetrievalQueueSize     :: !Int
+    , ccConversationEstablishTimeout :: !(Maybe Int)
+      -- ^ Conversation acknowledgement timeout in milliseconds.
+      -- Default 30 seconds.
+    , ccBlockRetrievalQueueSize      :: !Int
       -- ^ Block retrieval queue capacity
-    , ccPropagationQueueSize        :: !Int
+    , ccPropagationQueueSize         :: !Int
       -- ^ InvMsg propagation queue capacity
-    , ccPendingTxResubmissionPeriod :: !Int
+    , ccPendingTxResubmissionPeriod  :: !Int
       -- ^ Minimal delay between pending transactions resubmission
     } deriving (Show, Generic)
 
@@ -96,6 +100,11 @@ networkDiameter = sec . ccNetworkDiameter $ nodeConfiguration
 
 networkConnectionTimeout :: HasNodeConfiguration => Microsecond
 networkConnectionTimeout = ms . fromIntegral . ccNetworkConnectionTimeout $ nodeConfiguration
+
+-- | Default is 30 seconds.
+conversationEstablishTimeout :: HasNodeConfiguration => Microsecond
+conversationEstablishTimeout =
+    ms . fromIntegral . fromMaybe 30000 . ccConversationEstablishTimeout $ nodeConfiguration
 
 blockRetrievalQueueSize :: (HasNodeConfiguration, Integral a) => a
 blockRetrievalQueueSize =


### PR DESCRIPTION
Optional `conversationEstablishTimeout` key in the node section of configuration. Default is 30 seconds. It's in milliseconds like the network connection timeout.

Really this belongs in the infra configuration, and so does the network connection timeout, but I kept the two in the same area rather than doing that refactor.