### PR TITLE
[CSM-475] Sort transaction history to remove on tracked rollback

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
@@ -63,7 +63,7 @@ data CAccModifier = CAccModifier
     , camChange               :: !(VoidModifier (CId Addr, HeaderHash))
     , camUtxo                 :: !UtxoModifier
     , camAddedHistory         :: !(DList TxHistoryEntry)
-    , camDeletedHistory       :: !(DList TxId)
+    , camDeletedHistory       :: !(DList TxHistoryEntry)
     , camAddedPtxCandidates   :: !(DList (TxId, PtxBlockInfo))
     , camDeletedPtxCandidates :: !(DList (TxId, TxHistoryEntry))
     }


### PR DESCRIPTION
On block applying txs are sorted before being added to tx history.
On rollback we expect transactions to be removed from history in opposite
order, so transactions of rollbacked block should be sorted as well to
allow us properly drain them from the top of current history.