### PR TITLE
[CSM-477] Hide wallet/account names from logs

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -63,8 +63,8 @@ instance Buildable CWalletAssurance where
 
 instance Buildable CWalletMeta where
     build CWalletMeta{..} =
-        bprint ("'"%build%"' ("%build%"/"%build%")")
-               cwName cwAssurance cwUnit
+        bprint ("("%build%"/"%build%")")
+               cwAssurance cwUnit
 
 instance Buildable CWalletInit where
     build CWalletInit{..} =
@@ -88,8 +88,7 @@ instance Buildable CWallet where
         cwPassphraseLU
 
 instance Buildable CAccountMeta where
-    build CAccountMeta{..} =
-        bprint ("'"%build%"'") caName
+    build CAccountMeta{..} = "<meta>"
 
 instance Buildable CAccountInit where
     build CAccountInit{..} =


### PR DESCRIPTION
... till the day we allow unicode symbols in logging library.

I assume that there is no need to hide redeeming seed because if user passes invalid key with unicode chars endpoint will just throw a strange error