### PR TITLE
[DEVOPS-392] Fix debugging symbols for cryptonite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ with pkgs.haskell.lib;
 
 let
   addConfigureFlags = flags: drv: overrideCabal drv (drv: {
-    configureFlags = flags;
+    configureFlags = (drv.configureFlags or []) ++ flags;
   });
   cardanoPkgs = ((import ./pkgs { inherit pkgs; }).override {
     overrides = self: super: {


### PR DESCRIPTION
addConfigureFlags override previous configure flags while
setting new ones. Now we just append them.