### PR TITLE
[CSL-1734] Add a command to auxx for sending an update proposal

### DIFF
--- a/auxx/src/Command/Run.hs
+++ b/auxx/src/Command/Run.hs
@@ -26,6 +26,7 @@ import           Pos.Core.Types             (AddrAttributes (..), AddrSpendingDa
 import           Pos.Crypto                 (emptyPassphrase, encToPublic,
                                              fullPublicKeyHexF, hashHexF, noPassEncrypt,
                                              safeCreatePsk, withSafeSigner)
+import           Pos.DB.Class               (MonadGState (..))
 import           Pos.Launcher.Configuration (HasConfigurations)
 import           Pos.Util.CompileInfo       (HasCompileInfo)
 import           Pos.Util.UserSecret        (readUserSecret, usKeys)
@@ -51,9 +52,14 @@ Avaliable commands:
                                      "round-robin", and "send-random".
    vote <N> <decision> <upid>     -- send vote with given hash of proposal id (in base16) and
                                      decision, from own address #N
-   propose-update <N> <block ver> <script ver> <slot duration> <max block size> <software ver> <propose_file>?
+   propose-update <N> <block ver> <software ver> <script ver> <slot duration> <max block size> <propose_file>?
                                   -- propose an update with given versions and other data
                                      with one positive vote for it, from own address #N
+
+   propose-unlock-stake-epoch <N> <block ver> <software ver> <epoch>
+                                  -- propose an update with the specified unlock stake epoch,
+                                  -- with one positive vote for it, from our own address #N
+
    listaddr                       -- list own addresses
    delegate-light <N> <M> <eStart> <eEnd>?
                                   -- delegate secret key #N to pk <M> light version (M is encoded in base58),
@@ -91,6 +97,7 @@ runCmd
 runCmd _ (Balance addr) =
     getBalance addr >>=
     putText . sformat ("Current balance: "%coinF)
+runCmd _ PrintBlockVersionData = putText . pretty =<< gsAdoptedBVData
 runCmd sendActions (Send idx outputs) = Tx.send sendActions idx outputs
 runCmd sendActions (SendToAllGenesis stagp) =
     Tx.sendToAllGenesis sendActions stagp

--- a/auxx/src/Command/Types.hs
+++ b/auxx/src/Command/Types.hs
@@ -10,14 +10,11 @@ module Command.Types
 
 import           Universum
 
-import           Serokell.Data.Memory.Units (Byte)
-
-import           Pos.Core.Types             (ScriptVersion)
-import           Pos.Crypto                 (PublicKey)
-import           Pos.Txp                    (TxOut)
-import           Pos.Types                  (AddrStakeDistribution, Address, BlockVersion,
-                                             EpochIndex, SoftwareVersion)
-import           Pos.Update                 (SystemTag, UpId)
+import           Pos.Crypto (PublicKey)
+import           Pos.Txp    (TxOut)
+import           Pos.Types  (AddrStakeDistribution, Address, BlockVersion, EpochIndex,
+                             SoftwareVersion)
+import           Pos.Update (BlockVersionModifier, SystemTag, UpId)
 
 -- | Specify how transactions are sent to the network during
 -- benchmarks using 'SendToAllGenesis'.
@@ -38,13 +35,11 @@ data SendToAllGenesisParams = SendToAllGenesisParams
 
 -- | Parameters for 'ProposeUpdate' command.
 data ProposeUpdateParams = ProposeUpdateParams
-    { puIdx             :: Int -- TODO: what is this? rename
-    , puBlockVersion    :: BlockVersion
-    , puScriptVersion   :: ScriptVersion
-    , puSlotDurationSec :: Int
-    , puMaxBlockSize    :: Byte
-    , puSoftwareVersion :: SoftwareVersion
-    , puUpdates         :: [ProposeUpdateSystem]
+    { puSecretKeyIdx         :: !Int -- the node that creates/signs the proposal
+    , puBlockVersion         :: !BlockVersion
+    , puSoftwareVersion      :: !SoftwareVersion
+    , puBlockVersionModifier :: !BlockVersionModifier
+    , puUpdates              :: ![ProposeUpdateSystem]
     } deriving (Show)
 
 data Command
@@ -65,6 +60,7 @@ data Command
     | AddrDistr !PublicKey !AddrStakeDistribution
     | Rollback !Word !FilePath
     | SendTxsFromFile !FilePath
+    | PrintBlockVersionData
     | Quit
     deriving Show
 

--- a/auxx/src/Command/Update.hs
+++ b/auxx/src/Command/Update.hs
@@ -10,27 +10,23 @@ module Command.Update
 import           Universum
 
 import qualified Data.ByteString          as BS
+import           Data.Default             (def)
 import qualified Data.HashMap.Strict      as HM
 import           Data.List                ((!!))
-import           Data.Time.Units          (convertUnit)
 import           Formatting               (sformat, string, (%))
-import           Serokell.Util            (sec)
 import           System.Wlog              (logDebug)
 
 import           Pos.Binary               (Raw)
 import           Pos.Communication        (SendActions, immediateConcurrentConversations,
                                            submitUpdateProposal, submitVote)
 import           Pos.Configuration        (HasNodeConfiguration)
-import           Pos.Core.Configuration   (HasConfiguration, genesisBlockVersionData)
+import           Pos.Core.Configuration   (HasConfiguration)
 import           Pos.Crypto               (Hash, SignTag (SignUSVote), emptyPassphrase,
                                            encToPublic, hash, hashHexF, safeSign,
                                            unsafeHash, withSafeSigner)
-import           Pos.Data.Attributes      (mkAttributes)
 import           Pos.Infra.Configuration  (HasInfraConfiguration)
-import           Pos.Update               (BlockVersionData (..),
-                                           BlockVersionModifier (..), SystemTag, UpId,
-                                           UpdateData (..), UpdateVote (..),
-                                           mkUpdateProposalWSign)
+import           Pos.Update               (SystemTag, UpId, UpdateData (..),
+                                           UpdateVote (..), mkUpdateProposalWSign)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Util.CompileInfo     (HasCompileInfo)
 import           Pos.Wallet               (getSecretKeys)
@@ -93,25 +89,7 @@ propose
 propose sendActions ProposeUpdateParams{..} = do
     CmdCtx{ccPeers} <- getCmdCtx
     logDebug "Proposing update..."
-    skey <- (!! puIdx) <$> getSecretKeys
-    let BlockVersionData {..} = genesisBlockVersionData
-    let bvm =
-            BlockVersionModifier
-            { bvmScriptVersion     = Just puScriptVersion
-            , bvmSlotDuration      = Just $ convertUnit (sec puSlotDurationSec)
-            , bvmMaxBlockSize      = Just puMaxBlockSize
-            , bvmMaxHeaderSize     = Just bvdMaxHeaderSize
-            , bvmMaxTxSize         = Just bvdMaxTxSize
-            , bvmMaxProposalSize   = Just bvdMaxProposalSize
-            , bvmMpcThd            = Just bvdMpcThd
-            , bvmHeavyDelThd       = Just bvdHeavyDelThd
-            , bvmUpdateVoteThd     = Just bvdUpdateVoteThd
-            , bvmUpdateProposalThd = Just bvdUpdateProposalThd
-            , bvmUpdateImplicit    = Just bvdUpdateImplicit
-            , bvmSoftforkRule      = Nothing
-            , bvmTxFeePolicy       = Nothing
-            , bvmUnlockStakeEpoch  = Nothing
-            }
+    skey <- (!! puSecretKeyIdx) <$> getSecretKeys
     updateData <- mapM updateDataElement puUpdates
     let udata = HM.fromList updateData
     let whenCantCreate = error . mappend "Failed to create update proposal: "
@@ -121,18 +99,17 @@ propose sendActions ProposeUpdateParams{..} = do
             let updateProposal = either whenCantCreate identity $
                     mkUpdateProposalWSign
                         puBlockVersion
-                        bvm
+                        puBlockVersionModifier
                         puSoftwareVersion
                         udata
-                        (mkAttributes ())
+                        def
                         ss
             if null ccPeers
                 then putText "Error: no addresses specified"
                 else do
                     submitUpdateProposal (immediateConcurrentConversations sendActions ccPeers) ss updateProposal
                     let id = hash updateProposal
-                    putText $
-                      sformat ("Update proposal submitted, upId: "%hashHexF) id
+                    putText $ sformat ("Update proposal submitted, upId: "%hashHexF) id
 
 updateDataElement :: MonadIO m => ProposeUpdateSystem -> m (SystemTag, UpdateData)
 updateDataElement ProposeUpdateSystem{..} = do

--- a/update/Pos/Update/Core/Types.hs
+++ b/update/Pos/Update/Core/Types.hs
@@ -65,9 +65,9 @@ import           Pos.Binary.Class           (Bi, Raw)
 import           Pos.Binary.Crypto          ()
 import           Pos.Core                   (BlockVersion, BlockVersionData (..),
                                              CoinPortion, EpochIndex, FlatSlotId,
-                                             IsGenesisHeader, IsMainHeader, ScriptVersion,
-                                             SoftforkRule, SoftwareVersion, TxFeePolicy,
-                                             addressHash, HasConfiguration)
+                                             HasConfiguration, IsGenesisHeader,
+                                             IsMainHeader, ScriptVersion, SoftforkRule,
+                                             SoftwareVersion, TxFeePolicy, addressHash)
 import           Pos.Crypto                 (Hash, PublicKey, SafeSigner,
                                              SignTag (SignUSProposal), Signature,
                                              checkSig, hash, safeSign, safeToPublic,
@@ -100,6 +100,24 @@ data BlockVersionModifier = BlockVersionModifier
 
 instance NFData BlockVersionModifier
 instance Hashable BlockVersionModifier
+
+instance Default BlockVersionModifier where
+    def = BlockVersionModifier
+        { bvmScriptVersion     = Nothing
+        , bvmSlotDuration      = Nothing
+        , bvmMaxBlockSize      = Nothing
+        , bvmMaxHeaderSize     = Nothing
+        , bvmMaxTxSize         = Nothing
+        , bvmMaxProposalSize   = Nothing
+        , bvmMpcThd            = Nothing
+        , bvmHeavyDelThd       = Nothing
+        , bvmUpdateVoteThd     = Nothing
+        , bvmUpdateProposalThd = Nothing
+        , bvmUpdateImplicit    = Nothing
+        , bvmSoftforkRule      = Nothing
+        , bvmTxFeePolicy       = Nothing
+        , bvmUnlockStakeEpoch  = Nothing
+        }
 
 instance Buildable BlockVersionModifier where
     build BlockVersionModifier {..} =


### PR DESCRIPTION
* added a propose-unlock-stake-epoch command to auxx that sends an update proposal with a new value of unlockStakeEpoch
* added a print-bvd command auxx in order to monitor the current BlockVersionData
* fixed the name of puIdx (there was a TODO about it)