### PR TITLE
[CSM-485] Fasten tx history endpoint

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -88,11 +88,12 @@ getHistory mCWalId mAccountId mAddrId = do
         Nothing -> pure accAddrs
         Just addr ->
             if addr `elem` accAddrs then pure [addr] else throwM errorBadAddress
-    first (filter (fits addrs)) <$> getFullWalletHistory cWalId
+    first (filter (fits $ S.fromList addrs)) <$> getFullWalletHistory cWalId
   where
-    fits :: [CId Addr] -> CTx -> Bool
-    fits addrs ctx = any (relatesToAddr ctx) addrs
-    relatesToAddr CTx {..} = (`elem` (map fst $ ctInputs ++ ctOutputs))
+    fits :: S.Set (CId Addr) -> CTx -> Bool
+    fits addrs CTx{..} =
+        let inpsNOuts = map fst (ctInputs ++ ctOutputs)
+        in  any (`S.member` addrs) inpsNOuts
     errorSpecifySomething = RequestError $
         "Please specify either walletId or accountId"
     errorDontSpecifyBoth = RequestError $


### PR DESCRIPTION
It occurred that tx history fetching time linearly depends on number of addresses.

Measurements:
Before
3000 transactions + 5 addresses -> 7 sec
3000 transactions + 1000 addresses -> 40 sec

Now
3000 transactions + 5 addresses -> 7 sec
3000 transactions + 1000 addresses -> 12 sec

Current estimated duration for bittrex is 32 sec.

As it was noticed, there is a space for optimizing related request to database, but for now it doesn't play significant role. We will perform this work in master