### PR TITLE
[CSM-485] Fastened history fetching more

### DIFF
--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -7,6 +7,7 @@ module Pos.Slotting.Util
        , getSlotStart
        , getSlotStartPure
        , getSlotStartEmpatically
+       , getCurrentEpochSlotDuration
        , getNextEpochSlotDuration
        , slotFromTimestamp
 
@@ -81,6 +82,13 @@ getSlotStartEmpatically
     -> m Timestamp
 getSlotStartEmpatically slot =
     getSlotStart slot >>= maybeThrow (SEUnknownSlotStart slot)
+
+-- | Get the previous before last known slot duration.
+getCurrentEpochSlotDuration
+    :: (MonadSlotsData ctx m)
+    => m Millisecond
+getCurrentEpochSlotDuration =
+    esdSlotDuration . fst <$> getCurrentNextEpochSlottingDataM
 
 -- | Get last known slot duration.
 getNextEpochSlotDuration

--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -12,6 +12,7 @@ module Pos.Wallet.Web.ClientTypes.Functions
       , toCUpdateInfo
       , addrMetaToAccount
       , isTxLocalAddress
+      , applyAddrTxFilter
       ) where
 
 import           Universum
@@ -39,7 +40,8 @@ import           Pos.Update.Core                  (BlockVersionData (..),
                                                    StakeholderVotes, UpdateProposal (..),
                                                    isPositiveVote)
 import           Pos.Update.Poll                  (ConfirmedProposalState (..))
-import           Pos.Wallet.Web.ClientTypes.Types (AccountId (..), Addr, CCoin (..),
+import           Pos.Wallet.Web.ClientTypes.Types (AccountId (..), Addr,
+                                                   AddrTxFilter (..), CCoin (..),
                                                    CHash (..), CId (..),
                                                    CPtxCondition (..), CTx (..),
                                                    CTxId (..), CTxMeta, CUpdateInfo (..),
@@ -201,3 +203,12 @@ toCUpdateInfo bvd ConfirmedProposalState {..} =
         cuiPositiveStake    = mkCCoin cpsPositiveStake
         cuiNegativeStake    = mkCCoin cpsNegativeStake
     in CUpdateInfo {..}
+
+applyAddrTxFilter :: AddrTxFilter -> [TxHistoryEntry] -> [TxHistoryEntry]
+applyAddrTxFilter (AddrTxFilter addrs) =
+    filter $ \THEntry{..} ->
+        let inps = map txOutAddress _thInputs
+            inpsNOuts = inps ++ _thOutputAddrs
+        in  any (`S.member` addrsSet) inpsNOuts
+  where
+    addrsSet = S.fromList addrs

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -36,6 +36,7 @@ module Pos.Wallet.Web.ClientTypes.Types
       , CElectronCrashReport (..)
       , Wal (..)
       , Addr (..)
+      , AddrTxFilter (..)
       ) where
 
 import           Universum
@@ -53,7 +54,7 @@ import qualified Prelude
 import           Servant.Multipart     (FileData)
 
 import           Pos.Aeson.Types       ()
-import           Pos.Core.Types        (ScriptVersion)
+import           Pos.Core.Types        (Address, ScriptVersion)
 import           Pos.Types             (BlockVersion, ChainDifficulty, SoftwareVersion)
 import           Pos.Util.BackupPhrase (BackupPhrase)
 
@@ -332,3 +333,6 @@ data CElectronCrashReport = CElectronCrashReport
     , cecCompanyName :: Text
     , cecUploadDump  :: FileData
     } deriving (Show, Generic)
+
+
+data AddrTxFilter = AddrTxFilter [Address]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -30,6 +30,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetNextUpdate (..)
        , TestReset (..)
        , GetHistoryCache (..)
+       , GetHistoryCachePart (..)
        , GetCustomAddresses (..)
        , GetCustomAddress (..)
        , GetPendingTxs (..)
@@ -125,6 +126,7 @@ makeAcidic ''WalletStorage
     , 'WS.getUpdates
     , 'WS.getNextUpdate
     , 'WS.getHistoryCache
+    , 'WS.getHistoryCachePart
     , 'WS.getCustomAddresses
     , 'WS.getCustomAddress
     , 'WS.getPendingTxs

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -21,9 +21,9 @@ import           System.Wlog                  (logDebug)
 import           Pos.Aeson.ClientTypes        ()
 import           Pos.Aeson.WalletBackup       ()
 import           Pos.Constants                (isDevelopment)
+import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.Crypto                   (EncryptedSecretKey, PassPhrase,
                                                emptyPassphrase, firstHardened)
-import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.StateLock                (Priority (..), withStateLockNoMetrics)
 import           Pos.Util                     (maybeThrow)
 import           Pos.Util.UserSecret          (UserSecretDecodingError (..),
@@ -41,7 +41,8 @@ import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
-import           Pos.Wallet.Web.State         (createAccount, setWalletSyncTip,
+import           Pos.Wallet.Web.State         (HistoryCacheUpdate (InitHistoryCache),
+                                               createAccount, setWalletSyncTip,
                                                updateHistoryCache)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
@@ -73,7 +74,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId []
+    _ <- updateHistoryCache wId InitHistoryCache
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -14,6 +14,7 @@ import           Universum
 
 import           Control.Lens                     (to)
 import qualified Data.List.NonEmpty               as NE
+import           Data.Time.Units                  (convertUnit)
 import           Formatting                       (build, sformat, (%))
 import           System.Wlog                      (HasLoggerName (modifyLoggerName),
                                                    WithLogger, logInfo, logWarning)
@@ -30,10 +31,12 @@ import           Pos.DB.Class                     (MonadDBRead)
 import qualified Pos.GState                       as GS
 import           Pos.Reporting                    (MonadReporting, reportOrLogW)
 import           Pos.Slotting                     (MonadSlots, MonadSlotsData,
+                                                   getCurrentEpochSlotDuration,
                                                    getSlotStartPure, getSystemStartM)
 import           Pos.Ssc.Class.Helpers            (SscHelpersClass)
 import           Pos.Txp.Core                     (TxAux (..), TxUndo, flattenTxPayload)
 import           Pos.Util.Chrono                  (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningWaitInf)
 
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
@@ -72,7 +75,7 @@ onApplyTracking
     , HasConfiguration
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
-onApplyTracking blunds = setLogger $ do
+onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
@@ -114,7 +117,7 @@ onRollbackTracking
     , HasConfiguration
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
-onRollbackTracking blunds = setLogger $ do
+onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
@@ -166,6 +169,16 @@ gbTxsWUndo (blk@(Right mb), undo) =
 
 setLogger :: HasLoggerName m => m a -> m a
 setLogger = modifyLoggerName (<> "wallet" <> "blistener")
+
+reportTimeouts
+    :: (MonadSlotsData ctx m, CanLogInParallel m)
+    => Text -> m a -> m a
+reportTimeouts desc action = do
+    slotDuration <- getCurrentEpochSlotDuration
+    let firstWarningTime = convertUnit slotDuration `div` 2
+    logWarningWaitInf firstWarningTime tag action
+  where
+    tag = "Wallet blistener " <> desc
 
 logMsg
     :: WithLogger m

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -442,18 +442,20 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     mapM_ (WS.addCustomAddress UsedAddr . fst) (MM.insertions camUsed)
     mapM_ (WS.addCustomAddress ChangeAddr . fst) (MM.insertions camChange)
     WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
-    oldCachedHist <- fromMaybe [] <$> WS.getHistoryCache wid
-    sortedAddedHistory <-
-        getNewestFirst <$> sortWalletThByTime wid (DL.toList camAddedHistory)
-    WS.updateHistoryCache wid $ sortedAddedHistory <> oldCachedHist
+    modifyTxHistory
     -- resubmitting worker can change ptx in db nonatomically, but
     -- tracker has priority over the resubmiter, thus do not use CAS here
     forM_ camAddedPtxCandidates $ \(txid, ptxBlkInfo) ->
         WS.setPtxCondition wid txid (PtxInNewestBlocks ptxBlkInfo)
     WS.setWalletSyncTip wid newTip
+  where
+    modifyTxHistory = do
+        sortedAddedHistory <-
+            getNewestFirst <$> sortWalletThByTime wid (DL.toList camAddedHistory)
+        void $ WS.updateHistoryCache wid $ WS.InsertToHistoryCache sortedAddedHistory
 
 rollbackModifierFromWallet
-    :: (WebWalletModeDB ctx m, MonadSlots ctx m)
+    :: (WebWalletModeDB ctx m, MonadSlots ctx m, WithLogger m)
     => CId Wal
     -> HeaderHash
     -> CAccModifier
@@ -468,23 +470,18 @@ rollbackModifierFromWallet wid newTip CAccModifier{..} = do
         curSlot <- getCurrentSlotInaccurate
         WS.ptxUpdateMeta wid txid (WS.PtxResetSubmitTiming curSlot)
         WS.setPtxCondition wid txid (PtxApplying poolInfo)
-    WS.getHistoryCache wid >>= \case
-        Nothing -> pure ()
-        Just oldCachedHist -> do
-            sortedDeletedHistory <-
-                getNewestFirst <$> sortWalletThByTime wid (DL.toList camDeletedHistory)
-            WS.updateHistoryCache wid $
-                removeFromHead sortedDeletedHistory oldCachedHist
+    modifyTxHistory
     WS.setWalletSyncTip wid newTip
   where
-    removeFromHead :: [TxHistoryEntry] -> [TxHistoryEntry] -> [TxHistoryEntry]
-    removeFromHead [] ths = ths
-    removeFromHead _ [] = []
-    removeFromHead (dTh : dThes) (th : thes) =
-        if _thTxId dTh == _thTxId th
-        then removeFromHead dThes thes
-        else error "rollbackModifierFromWallet: removeFromHead: \
-                   \rollbacked tx ID is not present in history cache!"
+    modifyTxHistory = do
+        sortedDeletedHistory <-
+            getNewestFirst <$> sortWalletThByTime wid (DL.toList camDeletedHistory)
+        success <-
+            WS.updateHistoryCache wid $
+            WS.RemoveFromHistoryCache sortedDeletedHistory
+        unless success $
+            logError "Failed to remove from head of history cache, \
+                     \wallet tracker is broken!"
 
 evalChange
     :: [CWAddressMeta] -- ^ All adresses


### PR DESCRIPTION
This includes:

1. Fetching limited history from database. Now time for history endpoint is approx. `min(totalTxsNum, limit) * 7` ms, which looks ok taking into account (if I understood it correctly) that passed limit is usually a number of 1-2 order of magnitude for bittrex and up to 1000 for daedalus.

2. History update is performed as single modifying db transaction, not as `get + set`

_Still need to test correctness of this_