### PR TITLE
[CSL-1738] Wallet rollback fix

### DIFF
--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -64,6 +64,7 @@ module Pos.Wallet.Web.State.Acidic
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
+       , FlushWalletStorage (..)
        ) where
 
 import           Universum
@@ -159,4 +160,5 @@ makeAcidic ''WalletStorage
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
+    , 'WS.flushWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -71,6 +71,7 @@ module Pos.Wallet.Web.State.State
        , casPtxCondition
        , ptxUpdateMeta
        , addOnlyNewPendingTx
+       , flushWalletStorage
        ) where
 
 import           Data.Acid                    (EventResult, EventState, QueryEvent,
@@ -291,3 +292,6 @@ ptxUpdateMeta = updateDisk ... A.PtxUpdateMeta
 
 addOnlyNewPendingTx :: WebWalletModeDB ctx m => PendingTx -> m ()
 addOnlyNewPendingTx = updateDisk ... A.AddOnlyNewPendingTx
+
+flushWalletStorage :: WebWalletModeDB ctx m => m ()
+flushWalletStorage = updateDisk A.FlushWalletStorage

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -310,9 +310,12 @@ addWAddress :: CWAddressMeta -> Update ()
 addWAddress addrMeta@CWAddressMeta{..} = do
     let accInfo :: Traversal' WalletStorage AccountInfo
         accInfo = wsAccountInfos . ix (addrMetaToAccount addrMeta)
-    whenJustM (preuse (accInfo . aiUnusedKey)) $ \key -> do
-        accInfo . aiUnusedKey += 1
-        accInfo . aiAddresses . at cwamId ?= AddressInfo addrMeta key
+    whenJustM (preuse accInfo) $ \info -> do
+        let mAddr = info ^. aiAddresses . at cwamId
+        when (isNothing mAddr) $ do
+            accInfo . aiUnusedKey += 1
+            let key = info ^. aiUnusedKey
+            accInfo . aiAddresses . at cwamId ?= AddressInfo addrMeta key
 
 -- see also 'removeWAddress'
 addRemovedAccount :: CWAddressMeta -> Update ()

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -446,11 +446,12 @@ addOnlyNewPendingTx ptx =
 flushWalletStorage :: Update ()
 flushWalletStorage = modify flushDo
   where
-    flushDo ws = def
+    flushDo ws = ws
         { _wsWalletInfos = flushWalletInfo <$> _wsWalletInfos ws
-        , _wsAccountInfos = _wsAccountInfos ws
-        , _wsProfile = _wsProfile ws
-        , _wsTxHistory = _wsTxHistory ws
+        , _wsHistoryCache = HM.empty
+        , _wsUtxo = M.empty
+        , _wsUsedAddresses = HM.empty
+        , _wsChangeAddresses = HM.empty
         }
     flushWalletInfo wi = wi { _wiSyncTip = NotSynced
                             , _wiIsReady = False

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -74,6 +74,7 @@ import           Control.Lens                   (at, ix, makeClassy, makeLenses,
 import           Control.Monad.State.Class      (put)
 import           Data.Default                   (Default, def)
 import qualified Data.HashMap.Strict            as HM
+import qualified Data.Map                       as M
 import           Data.SafeCopy                  (base, deriveSafeCopySimple)
 import           Data.Time.Clock.POSIX          (POSIXTime)
 

--- a/scripts/launch/connect-to-cluster/mainnet-exchange.sh
+++ b/scripts/launch/connect-to-cluster/mainnet-exchange.sh
@@ -5,7 +5,7 @@ readonly CLUSTER=mainnet
 
 flush_wallet=""
 
-if [[ "$1" == "-c" ]]; then
+if [[ "$1" == "-l" ]]; then
   shift
   flush_wallet="--flush-wallet-db"
 fi
@@ -13,10 +13,20 @@ fi
 echo "Launch a single node and connect it to '${CLUSTER}' cluster..."
 
 readonly TMP_TOPOLOGY_YAML=/tmp/topology.yaml
-printf "wallet:
-    relays: [[{ host: relays.cardano-mainnet.iohk.io }]]
-    valency: 1
-    fallbacks: 7" > "${TMP_TOPOLOGY_YAML}"
+printf 'wallet:
+ relays: [ [ {"host": "cardano-node-0.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-1.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-6.cardano-mainnet.iohk.io"}
+           ]
+         , [ {"host": "cardano-node-2.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-3.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-6.cardano-mainnet.iohk.io"}
+           ]
+         , [ {"host": "cardano-node-4.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-5.cardano-mainnet.iohk.io"}
+           , {"host": "cardano-node-6.cardano-mainnet.iohk.io"}
+           ]
+         ]' > "${TMP_TOPOLOGY_YAML}"
 
 stack exec -- cardano-node                                  \
     --tlscert ./scripts/tls-files/server.crt                \
@@ -29,5 +39,6 @@ stack exec -- cardano-node                                  \
     --db-path db-${CLUSTER}                                 \
     --wallet-db-path wdb-${CLUSTER}                         \
     --keyfile secret-$CLUSTER.key                           \
+    --wallet-acid-cleanup-interval=180                      \
     --configuration-file node/configuration.yaml    \
     --configuration-key mainnet_full $flush_wallet

--- a/scripts/launch/connect-to-cluster/mainnet-exchange.sh
+++ b/scripts/launch/connect-to-cluster/mainnet-exchange.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+readonly CLUSTER=mainnet
+
+flush_wallet=""
+
+if [[ "$1" == "-c" ]]; then
+  shift
+  flush_wallet="--flush-wallet-db"
+fi
+
+echo "Launch a single node and connect it to '${CLUSTER}' cluster..."
+
+readonly TMP_TOPOLOGY_YAML=/tmp/topology.yaml
+printf "wallet:
+    relays: [[{ host: relays.cardano-mainnet.iohk.io }]]
+    valency: 1
+    fallbacks: 7" > "${TMP_TOPOLOGY_YAML}"
+
+stack exec -- cardano-node                                  \
+    --tlscert ./scripts/tls-files/server.crt                \
+    --tlskey ./scripts/tls-files/server.key                 \
+    --tlsca ./scripts/tls-files/ca.crt                      \
+    --no-ntp                                                \
+    --topology "${TMP_TOPOLOGY_YAML}"                       \
+    --log-config scripts/log-templates/log-config-qa.yaml   \
+    --logs-prefix "logs/${CLUSTER}"                         \
+    --db-path db-${CLUSTER}                                 \
+    --wallet-db-path wdb-${CLUSTER}                         \
+    --keyfile secret-$CLUSTER.key                           \
+    --configuration-file node/configuration.yaml    \
+    --configuration-key mainnet_full $flush_wallet

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -51,6 +51,12 @@ if [[ "$NUM_TXS" == "" ]]; then
   NUM_TXS=3000
 fi
 
+wallet_flush=""
+# Argument for testing wallet db flushing
+if [[ "$WALLET_FLUSH" != "" ]]; then
+  wallet_flush="--flush-wallet-db"
+fi
+
 # System start time in seconds (time since epoch).
 # An extra second is added so that the nodes have extra time to start up
 # and start processing the first slot.
@@ -83,7 +89,7 @@ while [[ $i -lt $panesCnt ]]; do
   exec_name='cardano-node-simple'
   if [[ $WALLET_TEST != "" ]]; then
       if (( $i == $n - 1 )); then
-          wallet_args=" --tlscert $base/../tls-files/server.crt --tlskey $base/../tls-files/server.key --tlsca $base/../tls-files/ca.crt " # --wallet-rebuild-db'
+          wallet_args=" --tlscert $base/../tls-files/server.crt --tlskey $base/../tls-files/server.key --tlsca $base/../tls-files/ca.crt $wallet_flush" # --wallet-rebuild-db'
           exec_name='cardano-node'
           if [[ $WALLET_DEBUG != "" ]]; then
               wallet_args="$wallet_args --wallet-debug"

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -28,9 +28,12 @@ import           Pos.Launcher         (HasConfigurations, NodeParams (..),
 import           Pos.Ssc.Class        (SscParams)
 import           Pos.Ssc.GodTossing   (SscGodTossing)
 import           Pos.Util.UserSecret  (usVss)
+import           Pos.Wallet.SscType   (WalletSscType)
 import           Pos.Wallet.Web       (WalletWebMode, bracketWalletWS, bracketWalletWebDB,
-                                       runWRealMode, walletServeWebFull, walletServerOuts)
-import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage)
+                                       getSKById, runWRealMode, syncWalletsWithGState,
+                                       walletServeWebFull, walletServerOuts)
+import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage,
+                                       getWalletAddresses)
 import           Pos.Web              (serveWebGT)
 import           Pos.WorkMode         (WorkMode)
 
@@ -53,10 +56,16 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
         when (walletFlushDb) $ do
             putText "Flushing wallet db..."
             flushWalletStorage
+            putText "Resyncing wallets with blockchain..."
+            syncWallets
     runNodeWithInit init nr =
         let (ActionSpec f, outs) = runNode @SscGodTossing nr plugins
          in (ActionSpec $ \v s -> init >> f v s, outs)
     convPlugins = (, mempty) . map (\act -> ActionSpec $ \__vI __sA -> act)
+    syncWallets :: WalletWebMode ()
+    syncWallets = do
+        sks <- getWalletAddresses >>= mapM getSKById
+        syncWalletsWithGState @WalletSscType sks
     plugins :: HasConfigurations => ([WorkerSpec WalletWebMode], OutSpecs)
     plugins = mconcat [ convPlugins (pluginsGT wArgs)
                       , walletProd wArgs

--- a/wallet/node/NodeOptions.hs
+++ b/wallet/node/NodeOptions.hs
@@ -35,6 +35,7 @@ data WalletArgs = WalletArgs
     , walletRebuildDb    :: !Bool
     , walletAcidInterval :: !Minute
     , walletDebug        :: !Bool
+    , walletFlushDb      :: !Bool
     } deriving Show
 
 walletArgsParser :: Parser WalletNodeArgs
@@ -65,6 +66,10 @@ walletArgsParser = do
         long "wallet-debug" <>
         help "Run wallet with debug params (e.g. include \
              \all the genesis keys in the set of secret keys)."
+    walletFlushDb <- switch $
+        long "flush-wallet-db" <>
+        help "Flushes all blockchain-recoverable data from DB \
+              \(everything excluding wallets/accounts/addresses, metadata)"
 
     pure $ WalletNodeArgs commonNodeArgs WalletArgs{..}
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -38,7 +38,7 @@ import           Control.Lens                     (to)
 import           Control.Monad.Catch              (handleAll)
 import qualified Data.DList                       as DL
 import qualified Data.HashMap.Strict              as HM
-import           Data.List                        ((!!))
+import           Data.List                        (deleteBy, (!!))
 import qualified Data.List.NonEmpty               as NE
 import qualified Data.Map                         as M
 import           Ether.Internal                   (HasLens (..))
@@ -480,11 +480,8 @@ rollbackModifierFromWallet wid newTip CAccModifier{..} = do
     removeFromHead :: [TxHistoryEntry] -> [TxHistoryEntry] -> [TxHistoryEntry]
     removeFromHead [] ths = ths
     removeFromHead _ [] = []
-    removeFromHead (dTh : dThes) (th : thes) =
-        if _thTxId dTh == _thTxId th
-        then removeFromHead dThes thes
-        else error "rollbackModifierFromWallet: removeFromHead: \
-                   \rollbacked tx ID is not present in history cache!"
+    removeFromHead (dTh : dThes) thes =
+        removeFromHead dThes $! deleteBy ((==) `on` _thTxId) dTh thes
 
 evalChange
     :: [CWAddressMeta] -- ^ All adresses


### PR DESCRIPTION
1) This provides a mechanism for restoring corrupted history and UTXO cache from blockchain
2) A fix which prevents error leading to db corruption from arising is introduced

Wallet flush and restore is tested on environment with 1000 addresses and 1000 transisactions. `getAccounts` and `getHistory` endpoints return identical data before and after flush & restore.

_Should be tested via simulated rollback_