### PR TITLE
temporary workaround for jq bug on darwin

### DIFF
--- a/scripts/set_nixpath.sh
+++ b/scripts/set_nixpath.sh
@@ -4,9 +4,10 @@ update_NIX_PATH() {
     nix-build -o /tmp/iohk-utils '<nixpkgs>' -A coreutils
     export PATH=/tmp/iohk-utils/bin:$PATH
   esac
-  export PATH=$(nix-build '<nixpkgs>' -A jq --no-out-link)/bin/:$PATH
+  # workaround for https://github.com/NixOS/nixpkgs/issues/30070
+  export PATH=$(nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/9824ca6975fcbf5a2da9e6ba98dacafaa12bb1b3.tar.gz '<nixpkgs>' -A jq --no-out-link)/bin/:$PATH
   local scriptDir="$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
-  export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(nix-shell -p jq --run "jq .rev < \"${scriptDir}/../nixpkgs-src.json\" -r").tar.gz
+  export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(jq .rev < "${scriptDir}/../nixpkgs-src.json" -r).tar.gz
   # allows the nix expressions to detect that the path is already fixed
   export NIX_PATH_LOCKED=1
 }


### PR DESCRIPTION
applying #1707 to the `cardano-sl-1.0` branch as well
