### PR TITLE
[CSL-1725] Report misbehavior from core nodes only

### DIFF
--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -47,6 +47,7 @@ import           Pos.DB.Class                     (MonadBlockDBGeneric (..),
 import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.KnownPeers                   (MonadFormatPeers (..),
                                                    MonadKnownPeers (..))
+import           Pos.Network.Types                (HasNodeType (..), NodeType (..))
 import           Pos.Reporting                    (HasReportingContext (..))
 import           Pos.Shutdown                     (HasShutdownContext (..))
 import           Pos.Slotting.Class               (MonadSlots (..))
@@ -119,6 +120,9 @@ instance HasNodeContext AuxxSscType AuxxContext where
 instance HasSlottingVar AuxxContext where
     slottingTimestamp = acRealModeContext_L . slottingTimestamp
     slottingVar = acRealModeContext_L . slottingVar
+
+instance HasNodeType AuxxContext where
+    getNodeType _ = NodeEdge
 
 instance {-# OVERLAPPABLE #-}
     HasLens tag (RealModeContext AuxxSscType) r =>

--- a/infra/Pos/Communication/Protocol.hs
+++ b/infra/Pos/Communication/Protocol.hs
@@ -42,9 +42,8 @@ import           Universum
 import           Pos.Communication.Types.Protocol
 import           Pos.Core.Configuration           (HasConfiguration)
 import           Pos.Core.Types                   (SlotId)
-import           Pos.KnownPeers                   (MonadFormatPeers)
 import           Pos.Recovery.Info                (MonadRecoveryInfo)
-import           Pos.Reporting                    (HasReportingContext)
+import           Pos.Reporting                    (MonadReporting)
 import           Pos.Shutdown                     (HasShutdownContext)
 import           Pos.Slotting                     (MonadSlots)
 import           Pos.Slotting.Util                (onNewSlot, onNewSlotImpl)
@@ -225,10 +224,9 @@ type LocalOnNewSlotComm ctx m =
     , MonadMask m
     , WithLogger m
     , Mockables m [Fork, Delay]
-    , HasReportingContext ctx
+    , MonadReporting ctx m
     , HasShutdownContext ctx
     , MonadRecoveryInfo m
-    , MonadFormatPeers m
     , HasConfiguration
     )
 

--- a/infra/Pos/DHT/Workers.hs
+++ b/infra/Pos/DHT/Workers.hs
@@ -21,10 +21,10 @@ import           Pos.Core.Slotting          (flattenSlotId)
 import           Pos.Core.Types             (slotIdF)
 import           Pos.DHT.Configuration      (kademliaDumpInterval)
 import           Pos.DHT.Real.Types         (KademliaDHTInstance (..))
-import           Pos.KnownPeers             (MonadFormatPeers, MonadKnownPeers)
 import           Pos.Infra.Configuration    (HasInfraConfiguration)
+import           Pos.KnownPeers             (MonadKnownPeers)
 import           Pos.Recovery.Info          (MonadRecoveryInfo, recoveryCommGuard)
-import           Pos.Reporting              (HasReportingContext)
+import           Pos.Reporting              (MonadReporting)
 import           Pos.Shutdown               (HasShutdownContext)
 import           Pos.Slotting.Class         (MonadSlots)
 
@@ -39,9 +39,8 @@ type DhtWorkMode ctx m =
     , Mockable Catch m
     , MonadRecoveryInfo m
     , MonadReader ctx m
+    , MonadReporting ctx m
     , MonadKnownPeers m
-    , MonadFormatPeers m
-    , HasReportingContext ctx
     , HasShutdownContext ctx
     , HasConfiguration
     , HasInfraConfiguration

--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -33,10 +33,8 @@ import           System.Wlog            (WithLogger, logDebug, logInfo, logNotic
 import           Pos.Core               (FlatSlotId, HasConfiguration, LocalSlotIndex,
                                          SlotId (..), Timestamp (..), flattenSlotId,
                                          slotIdF)
-import           Pos.KnownPeers         (MonadFormatPeers)
 import           Pos.Recovery.Info      (MonadRecoveryInfo (recoveryInProgress))
-import           Pos.Reporting.MemState (HasReportingContext)
-import           Pos.Reporting.Methods  (reportOrLogE)
+import           Pos.Reporting.Methods  (MonadReporting, reportOrLogE)
 import           Pos.Shutdown           (HasShutdownContext, runIfNotShutdown)
 import           Pos.Slotting.Class     (MonadSlots (..))
 import           Pos.Slotting.Error     (SlottingError (..))
@@ -98,10 +96,9 @@ type OnNewSlot ctx m =
     , WithLogger m
     , Mockable Fork m
     , Mockable Delay m
-    , HasReportingContext ctx
+    , MonadReporting ctx m
     , HasShutdownContext ctx
     , MonadRecoveryInfo m
-    , MonadFormatPeers m
     , HasConfiguration
     )
 

--- a/node/src/Pos/Client/Txp/History.hs
+++ b/node/src/Pos/Client/Txp/History.hs
@@ -57,8 +57,7 @@ import           Pos.Crypto                   (WithHash (..), withHash)
 import           Pos.DB                       (MonadDBRead, MonadGState, MonadRealDB)
 import           Pos.DB.Block                 (MonadBlockDB)
 import qualified Pos.GState                   as GS
-import           Pos.KnownPeers               (MonadFormatPeers)
-import           Pos.Reporting                (HasReportingContext)
+import           Pos.Reporting                (MonadReporting)
 import           Pos.Slotting                 (MonadSlots, getSlotStartPure,
                                                getSystemStartM)
 import           Pos.Ssc.Class                (SscHelpersClass)
@@ -240,8 +239,7 @@ type TxHistoryEnv ctx m =
     , HasLens' ctx StateLockMetrics
     , MonadBaseControl IO m
     , Mockable CurrentTime m
-    , MonadFormatPeers m
-    , HasReportingContext ctx
+    , MonadReporting ctx m
     )
 
 type TxHistoryEnv' ssc ctx m =

--- a/node/src/Pos/Explorer/Txp/Local.hs
+++ b/node/src/Pos/Explorer/Txp/Local.hs
@@ -24,8 +24,7 @@ import           Pos.Core.Configuration (HasConfiguration)
 import           Pos.DB.Class           (MonadDBRead, MonadGState (..))
 import qualified Pos.Explorer.DB        as ExDB
 import qualified Pos.GState             as GS
-import           Pos.KnownPeers         (MonadFormatPeers)
-import           Pos.Reporting          (HasReportingContext, reportError)
+import           Pos.Reporting          (MonadReporting, reportError)
 import           Pos.Slotting           (MonadSlots (getCurrentSlot), getSlotStart)
 import           Pos.StateLock          (Priority (..), StateLock, StateLockMetrics,
                                          withStateLock)
@@ -56,8 +55,7 @@ type ETxpLocalWorkMode ctx m =
     , MonadSlots ctx m
     , Mockable CurrentTime m
     , MonadMask m
-    , MonadFormatPeers m
-    , HasReportingContext ctx
+    , MonadReporting ctx m
     )
 
 type ETxpLocalDataPure = GenericTxpLocalDataPure ExplorerExtra

--- a/node/src/Pos/Generator/Block/Mode.hs
+++ b/node/src/Pos/Generator/Block/Mode.hs
@@ -55,6 +55,7 @@ import qualified Pos.GState                  as GS
 import           Pos.Infra.Configuration     (HasInfraConfiguration)
 import           Pos.KnownPeers              (MonadFormatPeers)
 import           Pos.Lrc                     (LrcContext (..))
+import           Pos.Network.Types           (HasNodeType (..), NodeType (..))
 import           Pos.Reporting               (HasReportingContext (..), ReportingContext,
                                               emptyReportingContext)
 import           Pos.Slotting                (HasSlottingVar (..), MonadSlots (..),
@@ -307,6 +308,12 @@ instance HasLens TxpGlobalSettings BlockGenContext TxpGlobalSettings where
 
 instance HasReportingContext BlockGenContext where
     reportingContext = bgcReportingContext_L
+
+-- Let's assume that block-gen is core node, though it shouldn't
+-- really matter (needed for reporting, which is not used in block-gen
+-- anyway).
+instance HasNodeType BlockGenContext where
+    getNodeType _ = NodeCore
 
 instance MonadBlockGenBase m => MonadDBRead (BlockGenMode m) where
     dbGet = DB.dbGetSumDefault

--- a/node/src/Pos/WorkMode.hs
+++ b/node/src/Pos/WorkMode.hs
@@ -41,6 +41,8 @@ import           Pos.DB.Block           (dbGetBlockDefault, dbGetBlockSscDefault
 import           Pos.DB.Class           (MonadBlockDBGeneric (..),
                                          MonadBlockDBGenericWrite (..), MonadDB (..),
                                          MonadDBRead (..))
+import           Pos.DHT.Real.Types     (KademliaDHTInstance)
+import           Pos.Network.Types      (HasNodeType (..), getNodeTypeDefault)
 import           Pos.DB.DB              (gsAdoptedBVDataDefault)
 import           Pos.DB.Rocks           (dbDeleteDefault, dbGetDefault,
                                          dbIterSourceDefault, dbPutDefault,
@@ -98,6 +100,9 @@ instance HasLens TxpHolderTag (RealModeContext ssc) (GenericTxpLocalData TxpExtr
 
 instance HasLens DelegationVar (RealModeContext ssc) DelegationVar where
     lensOf = rmcDelegationVar_L
+
+instance HasNodeType (RealModeContext ssc) where
+    getNodeType = getNodeTypeDefault @KademliaDHTInstance
 
 instance {-# OVERLAPPABLE #-}
     HasLens tag (NodeContext ssc) r =>

--- a/node/src/Pos/WorkMode/Class.hs
+++ b/node/src/Pos/WorkMode/Class.hs
@@ -39,7 +39,7 @@ import           Pos.Configuration           (HasNodeConfiguration)
 import           Pos.Core                    (HasConfiguration, HasPrimaryKey)
 import           Pos.Infra.Configuration     (HasInfraConfiguration)
 import           Pos.KnownPeers              (MonadFormatPeers, MonadKnownPeers)
-import           Pos.Network.Types           (NetworkConfig)
+import           Pos.Network.Types           (HasNodeType, NetworkConfig)
 import           Pos.Recovery.Info           (MonadRecoveryInfo)
 import           Pos.Reporting               (HasReportingContext)
 import           Pos.Security.Params         (SecurityParams)
@@ -109,6 +109,7 @@ type WorkMode ssc ctx m
       , HasShutdownContext ctx
       , HasSlogContext ctx
       , HasSlogGState ctx
+      , HasNodeType ctx
       )
 
 -- | More relaxed version of 'WorkMode'.

--- a/node/test/Test/Pos/Block/Logic/Mode.hs
+++ b/node/test/Test/Pos/Block/Logic/Mode.hs
@@ -63,6 +63,7 @@ import qualified Pos.GState                       as GS
 import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.KnownPeers                   (MonadFormatPeers (..))
 import           Pos.Lrc                          (LrcContext (..), mkLrcSyncData)
+import           Pos.Network.Types                (HasNodeType (..), NodeType (..))
 import           Pos.Reporting                    (HasReportingContext (..),
                                                    ReportingContext,
                                                    emptyReportingContext)
@@ -403,6 +404,9 @@ instance HasLens TxpHolderTag BlockTestContext (GenericTxpLocalData TxpExtra_TMP
 
 instance HasLoggerName' BlockTestContext where
     loggerName = lensOf @LoggerName
+
+instance HasNodeType BlockTestContext where
+    getNodeType _ = NodeCore -- doesn't really matter, it's for reporting
 
 instance {-# OVERLAPPING #-} HasLoggerName BlockTestMode where
     getLoggerName = getLoggerNameDefault

--- a/ssc/Pos/Ssc/Mode.hs
+++ b/ssc/Pos/Ssc/Mode.hs
@@ -14,10 +14,9 @@ import           System.Wlog         (WithLogger)
 
 import           Pos.Core            (HasConfiguration, HasPrimaryKey)
 import           Pos.DB.Class        (MonadDB, MonadGState)
-import           Pos.KnownPeers      (MonadFormatPeers)
 import           Pos.Lrc.Context     (LrcContext)
 import           Pos.Recovery.Info   (MonadRecoveryInfo)
-import           Pos.Reporting       (HasReportingContext)
+import           Pos.Reporting       (MonadReporting)
 import           Pos.Security.Params (SecurityParams)
 import           Pos.Shutdown        (HasShutdownContext)
 import           Pos.Slotting        (MonadSlots)
@@ -36,13 +35,12 @@ type SscMode ssc ctx m
       , MonadSlots ctx m
       , MonadGState m
       , MonadDB m
-      , MonadFormatPeers m
       , MonadSscMem ssc ctx m
       , MonadRecoveryInfo m
       , HasShutdownContext ctx
       , MonadReader ctx m
       , HasSscContext ssc ctx
-      , HasReportingContext ctx
+      , MonadReporting ctx m
       , HasPrimaryKey ctx
       , HasLens SecurityParams ctx SecurityParams
       , HasLens LrcContext ctx LrcContext

--- a/txp/Pos/Txp/Logic/Local.hs
+++ b/txp/Pos/Txp/Logic/Local.hs
@@ -27,8 +27,7 @@ import           Pos.Core             (BlockVersionData, EpochIndex, HasConfigur
 import           Pos.Crypto           (WithHash (..))
 import           Pos.DB.Class         (MonadDBRead, MonadGState (..))
 import qualified Pos.DB.GState.Common as GS
-import           Pos.KnownPeers       (MonadFormatPeers)
-import           Pos.Reporting        (HasReportingContext, reportError)
+import           Pos.Reporting        (MonadReporting, reportError)
 import           Pos.Slotting         (MonadSlots (..))
 import           Pos.StateLock        (Priority (..), StateLock, StateLockMetrics,
                                        withStateLock)
@@ -52,8 +51,7 @@ type TxpLocalWorkMode ctx m =
     , WithLogger m
     , Mockable CurrentTime m
     , MonadMask m
-    , MonadFormatPeers m
-    , HasReportingContext ctx
+    , MonadReporting ctx m
     , HasConfiguration
     )
 

--- a/update/Pos/Update/Logic/Local.hs
+++ b/update/Pos/Update/Logic/Local.hs
@@ -39,9 +39,8 @@ import           Pos.Core               (BlockVersionData (bvdMaxBlockSize),
 import           Pos.Crypto             (PublicKey, shortHashF)
 import           Pos.DB.Class           (MonadDBRead)
 import qualified Pos.DB.GState.Common   as DB
-import           Pos.KnownPeers         (MonadFormatPeers)
 import           Pos.Lrc.Context        (LrcContext)
-import           Pos.Reporting          (HasReportingContext)
+import           Pos.Reporting          (MonadReporting)
 import           Pos.StateLock          (StateLock)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Update.Context     (UpdateContext (..))
@@ -124,8 +123,7 @@ modifyMemState action = do
 
 processSkeleton ::
        ( USLocalLogicModeWithLock ctx m
-       , MonadFormatPeers m
-       , HasReportingContext ctx
+       , MonadReporting ctx m
        )
     => UpdatePayload
     -> m (Either PollVerFailure ())
@@ -215,8 +213,7 @@ getLocalProposalNVotes id = do
 -- sender could be sure that error would happen.
 processProposal
     :: ( USLocalLogicModeWithLock ctx m
-       , MonadFormatPeers m
-       , HasReportingContext ctx
+       , MonadReporting ctx m
        )
     => UpdateProposal -> m (Either PollVerFailure ())
 processProposal proposal = processSkeleton $ UpdatePayload (Just proposal) []
@@ -267,8 +264,7 @@ getLocalVote propId pk decision = do
 -- sender could be sure that error would happen.
 processVote
     :: ( USLocalLogicModeWithLock ctx m
-       , MonadFormatPeers m
-       , HasReportingContext ctx
+       , MonadReporting ctx m
        )
     => UpdateVote -> m (Either PollVerFailure ())
 processVote vote = processSkeleton $ UpdatePayload Nothing [vote]

--- a/update/Pos/Update/Mode.hs
+++ b/update/Pos/Update/Mode.hs
@@ -11,9 +11,8 @@ import           System.Wlog         (WithLogger)
 
 import           Pos.Core.Configuration (HasConfiguration)
 import           Pos.DB.Class        (MonadDB, MonadGState)
-import           Pos.KnownPeers      (MonadFormatPeers)
 import           Pos.Lrc.Context     (LrcContext)
-import           Pos.Reporting       (HasReportingContext)
+import           Pos.Reporting       (MonadReporting)
 import           Pos.StateLock       (StateLock)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Update.Context  (UpdateContext)
@@ -33,6 +32,5 @@ type UpdateMode ctx m
       , HasLens StateLock ctx StateLock
       , HasConfiguration
       , HasUpdateConfiguration
-      , HasReportingContext ctx
-      , MonadFormatPeers m
+      , MonadReporting ctx m
       )

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -46,6 +46,7 @@ import           Pos.Infra.Configuration        (HasInfraConfiguration)
 import           Pos.KnownPeers                 (MonadFormatPeers (..),
                                                  MonadKnownPeers (..))
 import           Pos.Reporting                  (HasReportingContext (..))
+import           Pos.Network.Types              (HasNodeType (..))
 import           Pos.Shutdown                   (HasShutdownContext (..))
 import           Pos.Slotting.Class             (MonadSlots (..))
 import           Pos.Slotting.Impl.Sum          (currentTimeSlottingSum,
@@ -136,6 +137,9 @@ instance HasSlogGState WalletWebModeContext where
 
 instance HasJsonLogConfig WalletWebModeContext where
     jsonLogConfig = wwmcRealModeContext_L . jsonLogConfig
+
+instance HasNodeType WalletWebModeContext where
+    getNodeType = getNodeType . wwmcRealModeContext
 
 data WalletWebModeContextTag
 


### PR DESCRIPTION
I introduced 'HasNodeType' class which allows the node to know its type.
The type is determined by network config for normal node and is hardcoded for
tests, block-gen, etc.
The essential change is in 'reportMisbehaviour', other changes are related to
new type class, propagating proper constraints and defining instances.

P. S. I believe it should go to 1.0 branch to decrease load on reporting server.