### PR TITLE
[CSM-485] Fasten history fetching more

### DIFF
--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -7,6 +7,7 @@ module Pos.Slotting.Util
        , getSlotStart
        , getSlotStartPure
        , getSlotStartEmpatically
+       , getCurrentEpochSlotDuration
        , getNextEpochSlotDuration
        , slotFromTimestamp
 
@@ -81,6 +82,13 @@ getSlotStartEmpatically
     -> m Timestamp
 getSlotStartEmpatically slot =
     getSlotStart slot >>= maybeThrow (SEUnknownSlotStart slot)
+
+-- | Get the previous before last known slot duration.
+getCurrentEpochSlotDuration
+    :: (MonadSlotsData ctx m)
+    => m Millisecond
+getCurrentEpochSlotDuration =
+    esdSlotDuration . fst <$> getCurrentNextEpochSlottingDataM
 
 -- | Get last known slot duration.
 getNextEpochSlotDuration

--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -12,6 +12,7 @@ module Pos.Wallet.Web.ClientTypes.Functions
       , toCUpdateInfo
       , addrMetaToAccount
       , isTxLocalAddress
+      , applyAddrTxFilter
       ) where
 
 import           Universum
@@ -39,7 +40,8 @@ import           Pos.Update.Core                  (BlockVersionData (..),
                                                    StakeholderVotes, UpdateProposal (..),
                                                    isPositiveVote)
 import           Pos.Update.Poll                  (ConfirmedProposalState (..))
-import           Pos.Wallet.Web.ClientTypes.Types (AccountId (..), Addr, CCoin (..),
+import           Pos.Wallet.Web.ClientTypes.Types (AccountId (..), Addr,
+                                                   AddrTxFilter (..), CCoin (..),
                                                    CHash (..), CId (..),
                                                    CPtxCondition (..), CTx (..),
                                                    CTxId (..), CTxMeta, CUpdateInfo (..),
@@ -201,3 +203,12 @@ toCUpdateInfo bvd ConfirmedProposalState {..} =
         cuiPositiveStake    = mkCCoin cpsPositiveStake
         cuiNegativeStake    = mkCCoin cpsNegativeStake
     in CUpdateInfo {..}
+
+applyAddrTxFilter :: AddrTxFilter -> [TxHistoryEntry] -> [TxHistoryEntry]
+applyAddrTxFilter (AddrTxFilter addrs) =
+    filter $ \THEntry{..} ->
+        let inps = map txOutAddress _thInputs
+            inpsNOuts = inps ++ _thOutputAddrs
+        in  any (`S.member` addrsSet) inpsNOuts
+  where
+    addrsSet = S.fromList addrs

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -36,6 +36,7 @@ module Pos.Wallet.Web.ClientTypes.Types
       , CElectronCrashReport (..)
       , Wal (..)
       , Addr (..)
+      , AddrTxFilter (..)
       ) where
 
 import           Universum
@@ -53,7 +54,7 @@ import qualified Prelude
 import           Servant.Multipart     (FileData)
 
 import           Pos.Aeson.Types       ()
-import           Pos.Core.Types        (ScriptVersion)
+import           Pos.Core.Types        (Address, ScriptVersion)
 import           Pos.Types             (BlockVersion, ChainDifficulty, SoftwareVersion)
 import           Pos.Util.BackupPhrase (BackupPhrase)
 
@@ -332,3 +333,6 @@ data CElectronCrashReport = CElectronCrashReport
     , cecCompanyName :: Text
     , cecUploadDump  :: FileData
     } deriving (Show, Generic)
+
+
+data AddrTxFilter = AddrTxFilter [Address]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -30,6 +30,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetNextUpdate (..)
        , TestReset (..)
        , GetHistoryCache (..)
+       , GetHistoryCachePart (..)
        , GetCustomAddresses (..)
        , GetCustomAddress (..)
        , GetPendingTxs (..)
@@ -126,6 +127,7 @@ makeAcidic ''WalletStorage
     , 'WS.getUpdates
     , 'WS.getNextUpdate
     , 'WS.getHistoryCache
+    , 'WS.getHistoryCachePart
     , 'WS.getCustomAddresses
     , 'WS.getCustomAddress
     , 'WS.getPendingTxs

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -5,6 +5,7 @@ module Pos.Wallet.Web.State.State
        , MonadWalletWebDB
        , WalletTip (..)
        , PtxMetaUpdate (..)
+       , HistoryCacheUpdate (..)
        , getWalletWebState
        , WebWalletModeDB
        , openState
@@ -32,6 +33,7 @@ module Pos.Wallet.Web.State.State
        , getUpdates
        , getNextUpdate
        , getHistoryCache
+       , getHistoryCachePart
        , getCustomAddresses
        , getCustomAddress
        , isCustomAddress
@@ -84,17 +86,19 @@ import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Txp                      (TxId, Utxo)
 import           Pos.Types                    (HeaderHash)
-import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
-                                               CProfile, CTxId, CTxMeta, CUpdateInfo,
-                                               CWAddressMeta, CWalletMeta, PassPhraseLU,
-                                               Wal)
+import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, AddrTxFilter,
+                                               CAccountMeta, CId, CProfile, CTxId,
+                                               CTxMeta, CUpdateInfo, CWAddressMeta,
+                                               CWalletMeta, PassPhraseLU, Wal)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition)
 import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
 import           Pos.Wallet.Web.State.Storage (AddressLookupMode (..),
-                                               CustomAddressType (..), PtxMetaUpdate (..),
-                                               WalletStorage, WalletTip (..))
+                                               CustomAddressType (..),
+                                               HistoryCacheUpdate (..),
+                                               PtxMetaUpdate (..), WalletStorage,
+                                               WalletTip (..))
 
 -- | MonadWalletWebDB stands for monad which is able to get web wallet state
 type MonadWalletWebDB ctx m =
@@ -171,8 +175,13 @@ getUpdates = queryDisk A.GetUpdates
 getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
 getNextUpdate = queryDisk A.GetNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [TxHistoryEntry])
+getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m [TxHistoryEntry]
 getHistoryCache = queryDisk . A.GetHistoryCache
+
+getHistoryCachePart
+    :: WebWalletModeDB ctx m
+    => AddrTxFilter -> Int -> CId Wal -> m [TxHistoryEntry]
+getHistoryCachePart = queryDisk ... A.GetHistoryCachePart
 
 getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]
 getCustomAddresses = queryDisk ... A.GetCustomAddresses
@@ -272,8 +281,10 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 testReset :: WebWalletModeDB ctx m => m ()
 testReset = updateDisk A.TestReset
 
-updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> [TxHistoryEntry] -> m ()
-updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache cWalId
+updateHistoryCache
+    :: WebWalletModeDB ctx m
+    => CId Wal -> HistoryCacheUpdate -> m ()
+updateHistoryCache = updateDisk ... A.UpdateHistoryCache
 
 setPtxCondition
     :: WebWalletModeDB ctx m

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -21,9 +21,9 @@ import           System.Wlog                  (logDebug)
 import           Pos.Aeson.ClientTypes        ()
 import           Pos.Aeson.WalletBackup       ()
 import           Pos.Constants                (isDevelopment)
+import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.Crypto                   (EncryptedSecretKey, PassPhrase,
                                                emptyPassphrase, firstHardened)
-import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.StateLock                (Priority (..), withStateLockNoMetrics)
 import           Pos.Util                     (maybeThrow)
 import           Pos.Util.UserSecret          (UserSecretDecodingError (..),
@@ -41,7 +41,8 @@ import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
-import           Pos.Wallet.Web.State         (createAccount, setWalletSyncTip,
+import           Pos.Wallet.Web.State         (HistoryCacheUpdate (InitHistoryCache),
+                                               createAccount, setWalletSyncTip,
                                                updateHistoryCache)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
@@ -73,7 +74,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId []
+    updateHistoryCache wId InitHistoryCache
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -14,6 +14,7 @@ import           Universum
 
 import           Control.Lens                     (to)
 import qualified Data.List.NonEmpty               as NE
+import           Data.Time.Units                  (convertUnit)
 import           Formatting                       (build, sformat, (%))
 import           System.Wlog                      (HasLoggerName (modifyLoggerName),
                                                    WithLogger, logInfo, logWarning)
@@ -30,10 +31,12 @@ import           Pos.DB.Class                     (MonadDBRead)
 import qualified Pos.GState                       as GS
 import           Pos.Reporting                    (MonadReporting, reportOrLogW)
 import           Pos.Slotting                     (MonadSlots, MonadSlotsData,
+                                                   getCurrentEpochSlotDuration,
                                                    getSlotStartPure, getSystemStartM)
 import           Pos.Ssc.Class.Helpers            (SscHelpersClass)
 import           Pos.Txp.Core                     (TxAux (..), TxUndo, flattenTxPayload)
 import           Pos.Util.Chrono                  (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningWaitInf)
 
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
@@ -72,7 +75,7 @@ onApplyTracking
     , HasConfiguration
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
-onApplyTracking blunds = setLogger $ do
+onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
@@ -114,7 +117,7 @@ onRollbackTracking
     , HasConfiguration
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
-onRollbackTracking blunds = setLogger $ do
+onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
@@ -166,6 +169,16 @@ gbTxsWUndo (blk@(Right mb), undo) =
 
 setLogger :: HasLoggerName m => m a -> m a
 setLogger = modifyLoggerName (<> "wallet" <> "blistener")
+
+reportTimeouts
+    :: (MonadSlotsData ctx m, CanLogInParallel m)
+    => Text -> m a -> m a
+reportTimeouts desc action = do
+    slotDuration <- getCurrentEpochSlotDuration
+    let firstWarningTime = convertUnit slotDuration `div` 2
+    logWarningWaitInf firstWarningTime tag action
+  where
+    tag = "Wallet blistener " <> desc
 
 logMsg
     :: WithLogger m


### PR DESCRIPTION
This includes:

1. Fetching limited history from database. Now time for history endpoint is approx. `min(totalTxsNum, limit) * 7` ms, which looks ok taking into account (if I understood it correctly) that passed limit is usually a number of 1-2 order of magnitude for bittrex and up to 1000 for daedalus.

2. History update is performed as single modifying db transaction, not as `get + set`.
In fact, I thought that the latter works for `O(|whole modified structure|)`, but guys made it clear to me that actually it's `O(|modified part|)`. And accidentally I amended this part to point 1, so it will take an effort to revert - but I'll do if anyone ask me to.
Note that we do not benefit from atomicity in this case, because `updateHistoryCache` is in fact always called under lock

_Still need to test correctness of this_