### PR TITLE
[CSM-485] Calling api/txs/histories takes a lot of time

### DIFF
--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -47,11 +47,13 @@ module Pos.Wallet.Web.State.Acidic
        , SetWalletPassLU (..)
        , SetWalletSyncTip (..)
        , SetWalletTxMeta (..)
+       , AddOnlyNewTxMetas (..)
        , SetWalletTxHistory (..)
        , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
        , RemoveWallet (..)
-       , RemoveTxMetas (..)
+       , ClearWalletTxMetas (..)
+       , RemoveWalletTxMetas (..)
        , RemoveHistoryCache (..)
        , RemoveAccount (..)
        , RemoveWAddress (..)
@@ -144,11 +146,13 @@ makeAcidic ''WalletStorage
     , 'WS.setWalletPassLU
     , 'WS.setWalletSyncTip
     , 'WS.setWalletTxMeta
+    , 'WS.addOnlyNewTxMetas
     , 'WS.setWalletTxHistory
     , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta
     , 'WS.removeWallet
-    , 'WS.removeTxMetas
+    , 'WS.clearWalletTxMetas
+    , 'WS.removeWalletTxMetas
     , 'WS.removeHistoryCache
     , 'WS.removeAccount
     , 'WS.removeWAddress

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -54,10 +54,12 @@ module Pos.Wallet.Web.State.State
        , setWalletPassLU
        , setWalletSyncTip
        , setWalletTxMeta
+       , addOnlyNewTxMetas
        , setWalletTxHistory
        , addOnlyNewTxMeta
        , removeWallet
-       , removeTxMetas
+       , removeWalletTxMetas
+       , clearWalletTxMetas
        , removeHistoryCache
        , removeAccount
        , removeWAddress
@@ -228,6 +230,9 @@ setProfile = updateDisk . A.SetProfile
 setWalletTxMeta :: WebWalletModeDB ctx m => CId Wal -> CTxId -> CTxMeta -> m ()
 setWalletTxMeta cWalId cTxId = updateDisk . A.SetWalletTxMeta cWalId cTxId
 
+addOnlyNewTxMetas :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
+addOnlyNewTxMetas = updateDisk ... A.AddOnlyNewTxMetas
+
 setWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
 setWalletTxHistory cWalId = updateDisk . A.SetWalletTxHistory cWalId
 
@@ -243,8 +248,11 @@ addOnlyNewTxMeta cWalId cTxId = updateDisk . A.AddOnlyNewTxMeta cWalId cTxId
 removeWallet :: WebWalletModeDB ctx m => CId Wal -> m ()
 removeWallet = updateDisk . A.RemoveWallet
 
-removeTxMetas :: WebWalletModeDB ctx m => CId Wal -> m ()
-removeTxMetas = updateDisk . A.RemoveTxMetas
+clearWalletTxMetas :: WebWalletModeDB ctx m => CId Wal -> m ()
+clearWalletTxMetas = updateDisk . A.ClearWalletTxMetas
+
+removeWalletTxMetas :: WebWalletModeDB ctx m => CId Wal -> [CTxId] -> m ()
+removeWalletTxMetas = updateDisk ... A.RemoveWalletTxMetas
 
 removeHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m ()
 removeHistoryCache = updateDisk . A.RemoveHistoryCache

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -50,8 +50,10 @@ module Pos.Wallet.Web.State.Storage
        , setWalletUtxo
        , addOnlyNewTxMeta
        , setWalletTxMeta
+       , addOnlyNewTxMetas
        , removeWallet
-       , removeTxMetas
+       , removeWalletTxMetas
+       , clearWalletTxMetas
        , removeHistoryCache
        , removeAccount
        , removeWAddress
@@ -361,11 +363,18 @@ setWalletTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
 setWalletTxMeta cWalId cTxId cTxMeta =
     wsTxHistory . ix cWalId . at cTxId %= ($> cTxMeta)
 
+clearWalletTxMetas :: CId Wal -> Update ()
+clearWalletTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
+
+addOnlyNewTxMetas :: CId Wal -> [(CTxId, CTxMeta)] -> Update ()
+addOnlyNewTxMetas = mapM_ . uncurry . addOnlyNewTxMeta
+
+removeWalletTxMetas :: CId Wal -> [CTxId] -> Update ()
+removeWalletTxMetas cWalId cTxs =
+    wsTxHistory . at cWalId . non' _Empty %= flip (foldr HM.delete) cTxs
+
 removeWallet :: CId Wal -> Update ()
 removeWallet cWalId = wsWalletInfos . at cWalId .= Nothing
-
-removeTxMetas :: CId Wal -> Update ()
-removeTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
 
 removeHistoryCache :: CId Wal -> Update ()
 removeHistoryCache cWalId = wsHistoryCache . at cWalId .= Nothing

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -54,13 +54,13 @@ import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
 import           Pos.Wallet.Web.State       (AddressLookupMode (Existing),
                                              CustomAddressType (ChangeAddr, UsedAddr),
-                                             addWAddress, createAccount, createWallet,
-                                             getAccountIds, getAccountMeta,
-                                             getWalletAddresses,
+                                             addWAddress, clearWalletTxMetas,
+                                             createAccount, createWallet, getAccountIds,
+                                             getAccountMeta, getWalletAddresses,
                                              getWalletMetaIncludeUnready, getWalletPassLU,
                                              isCustomAddress, removeAccount,
-                                             removeHistoryCache, removeTxMetas,
-                                             removeWallet, setAccountMeta, setWalletMeta,
+                                             removeHistoryCache, removeWallet,
+                                             setAccountMeta, setWalletMeta,
                                              setWalletPassLU, setWalletReady)
 import           Pos.Wallet.Web.Tracking    (CAccModifier (..), CachedCAccModifier,
                                              fixCachedAccModifierFor,
@@ -222,7 +222,7 @@ deleteWallet wid = do
     accounts <- getAccounts (Just wid)
     mapM_ (deleteAccount <=< decodeCTypeOrFail . caId) accounts
     removeWallet wid
-    removeTxMetas wid
+    clearWalletTxMetas wid
     removeHistoryCache wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -10,49 +10,49 @@ module Pos.Wallet.Web.Methods.Payment
 
 import           Universum
 
-import           Control.Monad.Except           (runExcept)
-import           Control.Exception              (throw)
-import           Formatting                     (sformat, (%))
-import qualified Formatting                     as F
-import           System.Wlog                    (logInfo)
+import           Control.Exception                (throw)
+import           Control.Monad.Except             (runExcept)
+import           Formatting                       (sformat, (%))
+import qualified Formatting                       as F
+import           System.Wlog                      (logInfo)
 
-import           Pos.Aeson.ClientTypes          ()
-import           Pos.Aeson.WalletBackup         ()
-import           Pos.Client.Txp.Addresses       (MonadAddresses (..))
-import           Pos.Client.Txp.Balances        (getOwnUtxos)
-import           Pos.Client.Txp.History         (TxHistoryEntry (..))
-import           Pos.Client.Txp.Util            (computeTxFee, runTxCreator)
-import           Pos.Communication              (SendActions (..), prepareMTx)
-import           Pos.Configuration              (HasNodeConfiguration)
-import           Pos.Core                       (Coin, HasConfiguration, addressF,
-                                                 getCurrentTimestamp)
-import           Pos.Crypto                     (PassPhrase, ShouldCheckPassphrase (..),
-                                                 checkPassMatches, hash,
-                                                 withSafeSignerUnsafe)
-import           Pos.Infra.Configuration        (HasInfraConfiguration)
+import           Pos.Aeson.ClientTypes            ()
+import           Pos.Aeson.WalletBackup           ()
+import           Pos.Client.Txp.Addresses         (MonadAddresses (..))
+import           Pos.Client.Txp.Balances          (getOwnUtxos)
+import           Pos.Client.Txp.History           (TxHistoryEntry (..))
+import           Pos.Client.Txp.Util              (computeTxFee, runTxCreator)
+import           Pos.Communication                (SendActions (..), prepareMTx)
+import           Pos.Configuration                (HasNodeConfiguration)
+import           Pos.Core                         (Coin, HasConfiguration, addressF,
+                                                   getCurrentTimestamp)
+import           Pos.Crypto                       (PassPhrase, ShouldCheckPassphrase (..),
+                                                   checkPassMatches, hash,
+                                                   withSafeSignerUnsafe)
+import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Txp                        (TxFee (..), Utxo, _txOutputs)
-import           Pos.Txp.Core                   (TxAux (..), TxOut (..))
-import           Pos.Util                       (eitherToThrow, maybeThrow)
-import           Pos.Update.Configuration       (HasUpdateConfiguration)
-import           Pos.Wallet.KeyStorage          (getSecretKeys)
-import           Pos.Wallet.Web.Account         (GenSeed (..), getSKByAddressPure,
-                                                 getSKById)
-import           Pos.Wallet.Web.ClientTypes     (AccountId (..), Addr, CAddress (..),
-                                                 CCoin, CId, CTx (..),
-                                                 CWAddressMeta (..), Wal,
-                                                 addrMetaToAccount, mkCCoin)
-import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx)
-import qualified Pos.Wallet.Web.Methods.Logic   as L
-import           Pos.Wallet.Web.Methods.Txp     (coinDistrToOutputs, rewrapTxError,
-                                                 submitAndSaveNewPtx)
-import           Pos.Wallet.Web.Mode            (MonadWalletWebMode, WalletWebMode)
-import           Pos.Wallet.Web.Pending         (mkPendingTx)
-import           Pos.Wallet.Web.State           (AddressLookupMode (Existing))
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail,
-                                                 getAccountAddrsOrThrow,
-                                                 getWalletAccountIds)
+import           Pos.Txp                          (TxFee (..), Utxo, _txOutputs)
+import           Pos.Txp.Core                     (TxAux (..), TxOut (..))
+import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util                         (eitherToThrow, maybeThrow)
+import           Pos.Wallet.KeyStorage            (getSecretKeys)
+import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAddressPure,
+                                                   getSKById)
+import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CAddress (..),
+                                                   CCoin, CId, CTx (..),
+                                                   CWAddressMeta (..), Wal,
+                                                   addrMetaToAccount, mkCCoin)
+import           Pos.Wallet.Web.Error             (WalletError (..))
+import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx)
+import qualified Pos.Wallet.Web.Methods.Logic     as L
+import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
+                                                   submitAndSaveNewPtx)
+import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
+import           Pos.Wallet.Web.Pending           (mkPendingTx)
+import           Pos.Wallet.Web.State             (AddressLookupMode (Existing))
+import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
+                                                   getAccountAddrsOrThrow,
+                                                   getWalletAccountIds)
 
 newPayment
     :: MonadWalletWebMode m
@@ -189,6 +189,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         dstAddrs
 
     addHistoryTx srcWallet th
+    constructCTx (srcWallet, Nothing) th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -29,7 +29,7 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId (..), CAccountId (..)
                                                  CPaperVendWalletRedeem (..), CTx (..),
                                                  CWalletRedeem (..))
 import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx)
+import           Pos.Wallet.Web.Methods.History (addHistoryTx, constructCTx)
 import qualified Pos.Wallet.Web.Methods.Logic   as L
 import           Pos.Wallet.Web.Methods.Txp     (rewrapTxError, submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
@@ -107,3 +107,4 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
 
     -- add redemption transaction to the history of new wallet
     addHistoryTx (aiWId accId) th
+    constructCTx (aiWId accId, Nothing) th


### PR DESCRIPTION
Call `addHistoryTx` only for mempool transactions, it should reduce number of writing to db, also do it as one acidic transaction. To save correctness we also set `CTxMeta` for blocks from blockchain in `BListener` callback.