### PR TITLE
[CSM-485] Calling api/txs/histories takes a lot of time

### DIFF
--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -52,7 +52,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
        , RemoveWallet (..)
-       , ClearWalletTxMetas (..)
+       , RemoveTxMetas (..)
        , RemoveWalletTxMetas (..)
        , RemoveHistoryCache (..)
        , RemoveAccount (..)
@@ -151,7 +151,7 @@ makeAcidic ''WalletStorage
     , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta
     , 'WS.removeWallet
-    , 'WS.clearWalletTxMetas
+    , 'WS.removeTxMetas
     , 'WS.removeWalletTxMetas
     , 'WS.removeHistoryCache
     , 'WS.removeAccount

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -59,7 +59,7 @@ module Pos.Wallet.Web.State.State
        , addOnlyNewTxMeta
        , removeWallet
        , removeWalletTxMetas
-       , clearWalletTxMetas
+       , removeTxMetas
        , removeHistoryCache
        , removeAccount
        , removeWAddress
@@ -248,8 +248,8 @@ addOnlyNewTxMeta cWalId cTxId = updateDisk . A.AddOnlyNewTxMeta cWalId cTxId
 removeWallet :: WebWalletModeDB ctx m => CId Wal -> m ()
 removeWallet = updateDisk . A.RemoveWallet
 
-clearWalletTxMetas :: WebWalletModeDB ctx m => CId Wal -> m ()
-clearWalletTxMetas = updateDisk . A.ClearWalletTxMetas
+removeTxMetas :: WebWalletModeDB ctx m => CId Wal -> m ()
+removeTxMetas = updateDisk . A.RemoveTxMetas
 
 removeWalletTxMetas :: WebWalletModeDB ctx m => CId Wal -> [CTxId] -> m ()
 removeWalletTxMetas = updateDisk ... A.RemoveWalletTxMetas

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -53,7 +53,7 @@ module Pos.Wallet.Web.State.Storage
        , addOnlyNewTxMetas
        , removeWallet
        , removeWalletTxMetas
-       , clearWalletTxMetas
+       , removeTxMetas
        , removeHistoryCache
        , removeAccount
        , removeWAddress
@@ -363,8 +363,8 @@ setWalletTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
 setWalletTxMeta cWalId cTxId cTxMeta =
     wsTxHistory . ix cWalId . at cTxId %= ($> cTxMeta)
 
-clearWalletTxMetas :: CId Wal -> Update ()
-clearWalletTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
+removeTxMetas :: CId Wal -> Update ()
+removeTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
 
 addOnlyNewTxMetas :: CId Wal -> [(CTxId, CTxMeta)] -> Update ()
 addOnlyNewTxMetas = mapM_ . uncurry . addOnlyNewTxMeta

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -54,13 +54,13 @@ import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
 import           Pos.Wallet.Web.State       (AddressLookupMode (Existing),
                                              CustomAddressType (ChangeAddr, UsedAddr),
-                                             addWAddress, clearWalletTxMetas,
-                                             createAccount, createWallet, getAccountIds,
-                                             getAccountMeta, getWalletAddresses,
+                                             addWAddress, createAccount, createWallet,
+                                             getAccountIds, getAccountMeta,
+                                             getWalletAddresses,
                                              getWalletMetaIncludeUnready, getWalletPassLU,
                                              isCustomAddress, removeAccount,
-                                             removeHistoryCache, removeWallet,
-                                             setAccountMeta, setWalletMeta,
+                                             removeHistoryCache, removeTxMetas,
+                                             removeWallet, setAccountMeta, setWalletMeta,
                                              setWalletPassLU, setWalletReady)
 import           Pos.Wallet.Web.Tracking    (CAccModifier (..), CachedCAccModifier,
                                              fixCachedAccModifierFor,
@@ -222,7 +222,7 @@ deleteWallet wid = do
     accounts <- getAccounts (Just wid)
     mapM_ (deleteAccount <=< decodeCTypeOrFail . caId) accounts
     removeWallet wid
-    clearWalletTxMetas wid
+    removeTxMetas wid
     removeHistoryCache wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -446,8 +446,7 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
     oldCachedHist <- fromMaybe [] <$> WS.getHistoryCache wid
     let cMetas = map (bimap encodeCType (CTxMeta . timestampToPosix)) $
-                 catMaybes $
-                 map (\THEntry {..} -> (_thTxId, ) <$> _thTimestamp) $
+                 mapMaybe (\THEntry {..} -> (_thTxId, ) <$> _thTimestamp) $
                  DL.toList camAddedHistory
     WS.addOnlyNewTxMetas wid cMetas
     sortedAddedHistory <-


### PR DESCRIPTION
Rename db methods for backward compatibility.
One method in wallet-db was renamed in #1719 (`RemoveTxMetas`). It most likely breaks compatibility with old version of DB. This PR renames that method back.

Also fix probably bug with sorting in `Sync.hs`