### PR TITLE
[CSM-491] Don't litter acid events log

### DIFF
--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -7,6 +7,7 @@ module Pos.Slotting.Util
        , getSlotStart
        , getSlotStartPure
        , getSlotStartEmpatically
+       , getCurrentEpochSlotDuration
        , getNextEpochSlotDuration
        , slotFromTimestamp
 
@@ -81,6 +82,13 @@ getSlotStartEmpatically
     -> m Timestamp
 getSlotStartEmpatically slot =
     getSlotStart slot >>= maybeThrow (SEUnknownSlotStart slot)
+
+-- | Get the previous before last known slot duration.
+getCurrentEpochSlotDuration
+    :: (MonadSlotsData ctx m)
+    => m Millisecond
+getCurrentEpochSlotDuration =
+    esdSlotDuration . fst <$> getCurrentNextEpochSlottingDataM
 
 -- | Get last known slot duration.
 getNextEpochSlotDuration

--- a/node/src/Pos/Client/Txp/History.hs
+++ b/node/src/Pos/Client/Txp/History.hs
@@ -27,6 +27,8 @@ module Pos.Client.Txp.History
        , getBlockHistoryDefault
        , getLocalHistoryDefault
        , saveTxDefault
+
+       , txHistoryListToMap
        ) where
 
 import           Universum
@@ -36,9 +38,7 @@ import           Control.Monad.Trans          (MonadTrans)
 import           Control.Monad.Trans.Control  (MonadBaseControl)
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Data.Coerce                  (coerce)
-import           Data.DList                   (DList)
-import qualified Data.DList                   as DL
-import qualified Data.Map.Strict              as M (lookup)
+import qualified Data.Map.Strict              as M (lookup, insert, fromList)
 import qualified Data.Text.Buildable
 import qualified Ether
 import           Formatting                   (bprint, build, (%))
@@ -100,7 +100,7 @@ data TxHistoryEntry = THEntry
     , _thInputs      :: ![TxOut]
     , _thOutputAddrs :: ![Address]
     , _thTimestamp   :: !(Maybe Timestamp)
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Generic, Ord)
 
 -- | Remained for compatibility
 _thInputAddrs :: TxHistoryEntry -> [Address]
@@ -126,11 +126,11 @@ getTxsByPredicate
     -> Maybe ChainDifficulty
     -> Maybe Timestamp
     -> [(WithHash Tx, TxWitness)]
-    -> m [TxHistoryEntry]
-getTxsByPredicate pr mDiff mTs txs = go txs []
+    -> m (Map TxId TxHistoryEntry)
+getTxsByPredicate pr mDiff mTs txs = go txs mempty
   where
-    go [] acc = return acc
-    go ((wh@(WithHash tx txId), _wit) : rest) acc = do
+    go [] !acc = return acc
+    go ((wh@(WithHash tx txId), _wit) : rest) !acc = do
         inputs <- getSenders tx
         let outgoings = toList $ txOutAddress <$> _txOutputs tx
         let incomings = map txOutAddress inputs
@@ -138,7 +138,7 @@ getTxsByPredicate pr mDiff mTs txs = go txs []
         applyTxToUtxo wh
 
         let acc' = if pr (incomings ++ outgoings)
-                   then (THEntry txId tx mDiff inputs outgoings mTs : acc)
+                   then M.insert txId (THEntry txId tx mDiff inputs outgoings mTs) acc
                    else acc
         go rest acc'
 
@@ -149,7 +149,7 @@ getRelatedTxsByAddrs
     -> Maybe ChainDifficulty
     -> Maybe Timestamp
     -> [(WithHash Tx, TxWitness)]
-    -> m [TxHistoryEntry]
+    -> m (Map TxId TxHistoryEntry)
 getRelatedTxsByAddrs addrs = getTxsByPredicate $ any (`elem` addrs)
 
 -- | Given a full blockchain, derive address history and Utxo
@@ -158,17 +158,17 @@ getRelatedTxsByAddrs addrs = getTxsByPredicate $ any (`elem` addrs)
 -- Tx will be required.
 deriveAddrHistory
     :: MonadUtxo m
-    => [Address] -> [Block ssc] -> m [TxHistoryEntry]
+    => [Address] -> [Block ssc] -> m (Map TxId TxHistoryEntry)
 deriveAddrHistory addrs chain =
-    DL.toList <$> foldrM (flip $ deriveAddrHistoryBlk addrs $ const Nothing) mempty chain
+    foldrM (flip $ deriveAddrHistoryBlk addrs $ const Nothing) mempty chain
 
 deriveAddrHistoryBlk
     :: MonadUtxo m
     => [Address]
     -> (MainBlock ssc -> Maybe Timestamp)
-    -> DList TxHistoryEntry
+    -> Map TxId TxHistoryEntry
     -> Block ssc
-    -> m (DList TxHistoryEntry)
+    -> m (Map TxId TxHistoryEntry)
 deriveAddrHistoryBlk _ _ hist (Left _) = pure hist
 deriveAddrHistoryBlk addrs getTs hist (Right blk) = do
     let mapper TxAux {..} = (withHash taTx, taWitness)
@@ -177,7 +177,7 @@ deriveAddrHistoryBlk addrs getTs hist (Right blk) = do
     txs <- getRelatedTxsByAddrs addrs (Just difficulty) mTimestamp $
            map mapper . flattenTxPayload $
            blk ^. mainBlockTxPayload
-    return $ DL.fromList txs <> hist
+    return $ txs <> hist -- TODO: Are we sure there is no intersection? OTherwise, the order might matter
 
 ----------------------------------------------------------------------------
 -- GenesisToil
@@ -205,19 +205,19 @@ instance (Monad m, HasConfiguration) =>
 class (Monad m, SscHelpersClass ssc) => MonadTxHistory ssc m | m -> ssc where
     getBlockHistory
         :: SscHelpersClass ssc
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getLocalHistory
-        :: [Address] -> m (DList TxHistoryEntry)
+        :: [Address] -> m (Map TxId TxHistoryEntry)
     saveTx :: (TxId, TxAux) -> m ()
 
     default getBlockHistory
         :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getBlockHistory = lift . getBlockHistory
 
     default getLocalHistory
         :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getLocalHistory = lift . getLocalHistory
 
     default saveTx :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m) => (TxId, TxAux) -> m ()
@@ -253,7 +253,7 @@ type GenesisHistoryFetcher m = ToilT () (GenesisToil m)
 
 getBlockHistoryDefault
     :: forall ssc ctx m. (HasConfiguration, SscHelpersClass ssc, TxHistoryEnv' ssc ctx m)
-    => [Address] -> m (DList TxHistoryEntry)
+    => [Address] -> m (Map TxId TxHistoryEntry)
 getBlockHistoryDefault addrs = do
     let bot      = headerHash (genesisBlock0 @ssc)
     sd          <- GS.getSlottingData
@@ -265,7 +265,7 @@ getBlockHistoryDefault addrs = do
         getBlockTimestamp :: MainBlock ssc -> Maybe Timestamp
         getBlockTimestamp blk = getSlotStartPure systemStart (blk ^. mainBlockSlot) sd
 
-        blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (DList TxHistoryEntry)
+        blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (Map TxId TxHistoryEntry)
         blockFetcher start = GS.foldlUpWhileM fromBlund start (const $ const True)
             (deriveAddrHistoryBlk addrs getBlockTimestamp) mempty
 
@@ -273,7 +273,7 @@ getBlockHistoryDefault addrs = do
 
 getLocalHistoryDefault
     :: forall ctx m. TxHistoryEnv ctx m
-    => [Address] -> m (DList TxHistoryEntry)
+    => [Address] -> m (Map TxId TxHistoryEntry)
 getLocalHistoryDefault addrs = runDBToil . evalToilTEmpty $ do
     let mapper (txid, TxAux {..}) =
             (WithHash taTx txid, taWitness)
@@ -282,7 +282,7 @@ getLocalHistoryDefault addrs = runDBToil . evalToilTEmpty $ do
     ltxs <- lift $ map mapper <$> getLocalTxs
     txs <- getRelatedTxsByAddrs addrs Nothing Nothing =<<
            maybeThrow topsortErr (topsortTxs (view _1) ltxs)
-    return $ DL.fromList txs
+    return $ txs
 
 saveTxDefault :: TxHistoryEnv ctx m => (TxId, TxAux) -> m ()
 saveTxDefault txw = do
@@ -292,3 +292,6 @@ saveTxDefault txw = do
     res <- txProcessTransaction txw
 #endif
     eitherToThrow res
+
+txHistoryListToMap :: [TxHistoryEntry] -> Map TxId TxHistoryEntry
+txHistoryListToMap = M.fromList . map (\tx -> (_thTxId tx, tx))

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -61,12 +61,14 @@ module Pos.Wallet.Web.State.Acidic
        , TotallyRemoveWAddress (..)
        , AddUpdate (..)
        , RemoveNextUpdate (..)
-       , UpdateHistoryCache (..)
+       , UpdateHistoryCache2 (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , FlushWalletStorage (..)
+       -- * No longer used, just here for migrations and backwards compatibility
+       , UpdateHistoryCache (..)
        ) where
 
 import           Universum
@@ -160,6 +162,7 @@ makeAcidic ''WalletStorage
     , 'WS.addUpdate
     , 'WS.removeNextUpdate
     , 'WS.updateHistoryCache
+    , 'WS.updateHistoryCache2
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -171,7 +171,7 @@ getUpdates = queryDisk A.GetUpdates
 getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
 getNextUpdate = queryDisk A.GetNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [TxHistoryEntry])
+getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache = queryDisk . A.GetHistoryCache
 
 getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]
@@ -272,7 +272,7 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 testReset :: WebWalletModeDB ctx m => m ()
 testReset = updateDisk A.TestReset
 
-updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> [TxHistoryEntry] -> m ()
+updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId TxHistoryEntry -> m ()
 updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache cWalId
 
 setPtxCondition

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -5,6 +5,7 @@ module Pos.Wallet.Web.State.State
        , MonadWalletWebDB
        , WalletTip (..)
        , PtxMetaUpdate (..)
+       , HistoryCacheUpdate (..)
        , getWalletWebState
        , WebWalletModeDB
        , openState
@@ -97,8 +98,10 @@ import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemS
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
 import           Pos.Wallet.Web.State.Storage (AddressLookupMode (..),
-                                               CustomAddressType (..), PtxMetaUpdate (..),
-                                               WalletStorage, WalletTip (..))
+                                               CustomAddressType (..),
+                                               HistoryCacheUpdate (..),
+                                               PtxMetaUpdate (..), WalletStorage,
+                                               WalletTip (..))
 
 -- | MonadWalletWebDB stands for monad which is able to get web wallet state
 type MonadWalletWebDB ctx m =
@@ -284,8 +287,8 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 testReset :: WebWalletModeDB ctx m => m ()
 testReset = updateDisk A.TestReset
 
-updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId TxHistoryEntry -> m ()
-updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache2 cWalId
+updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> HistoryCacheUpdate -> m ()
+updateHistoryCache = updateDisk ... A.UpdateHistoryCache2
 
 setPtxCondition
     :: WebWalletModeDB ctx m

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -141,7 +141,7 @@ data WalletStorage = WalletStorage
     , _wsProfile         :: !CProfile
     , _wsReadyUpdates    :: [CUpdateInfo]
     , _wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
-    , _wsHistoryCache    :: !(HashMap (CId Wal) [TxHistoryEntry])
+    , _wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
     , _wsUtxo            :: !Utxo
     , _wsUsedAddresses   :: !CustomAddresses
     , _wsChangeAddresses :: !CustomAddresses
@@ -267,7 +267,7 @@ getUpdates = view wsReadyUpdates
 getNextUpdate :: Query (Maybe CUpdateInfo)
 getNextUpdate = preview (wsReadyUpdates . _head)
 
-getHistoryCache :: CId Wal -> Query (Maybe [TxHistoryEntry])
+getHistoryCache :: CId Wal -> Query (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache cWalId = view $ wsHistoryCache . at cWalId
 
 getCustomAddresses :: CustomAddressType -> Query [CId Addr]
@@ -399,7 +399,7 @@ removeNextUpdate = wsReadyUpdates %= drop 1
 testReset :: Update ()
 testReset = put def
 
-updateHistoryCache :: CId Wal -> [TxHistoryEntry] -> Update ()
+updateHistoryCache :: CId Wal -> Map TxId TxHistoryEntry -> Update ()
 updateHistoryCache cWalId cTxs =
     wsHistoryCache . at cWalId ?= cTxs
 

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -20,9 +20,9 @@ import           System.Wlog                (WithLogger, logInfo, logWarning)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
-import           Pos.Client.Txp.History     (txHistoryListToMap, TxHistoryEntry (..))
-import           Pos.Txp.Core.Types         (TxId)
+import           Pos.Client.Txp.History     (TxHistoryEntry (..), txHistoryListToMap)
 import           Pos.Core                   (timestampToPosix)
+import           Pos.Txp.Core.Types         (TxId)
 import           Pos.Util.Servant           (encodeCType)
 import           Pos.Wallet.WalletMode      (getLocalHistory, localChainDifficulty,
                                              networkChainDifficulty)

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -188,7 +188,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         (toList srcAddrs)
         dstAddrs
 
-    addHistoryTx srcWallet th
+    fst <$> addHistoryTx srcWallet th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -106,4 +106,4 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
         th <$ submitAndSaveNewPtx enqueueMsg ptx
 
     -- add redemption transaction to the history of new wallet
-    addHistoryTx (aiWId accId) th
+    fst <$> addHistoryTx (aiWId accId) th

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -73,7 +73,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId []
+    updateHistoryCache wId mempty
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -21,9 +21,9 @@ import           System.Wlog                  (logDebug)
 import           Pos.Aeson.ClientTypes        ()
 import           Pos.Aeson.WalletBackup       ()
 import           Pos.Constants                (isDevelopment)
+import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.Crypto                   (EncryptedSecretKey, PassPhrase,
                                                emptyPassphrase, firstHardened)
-import           Pos.Core.Configuration       (genesisHdwSecretKeys)
 import           Pos.StateLock                (Priority (..), withStateLockNoMetrics)
 import           Pos.Util                     (maybeThrow)
 import           Pos.Util.UserSecret          (UserSecretDecodingError (..),
@@ -41,7 +41,8 @@ import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
-import           Pos.Wallet.Web.State         (createAccount, setWalletSyncTip,
+import           Pos.Wallet.Web.State         (HistoryCacheUpdate (InitHistoryCache),
+                                               createAccount, setWalletSyncTip,
                                                updateHistoryCache)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
@@ -73,7 +74,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId mempty
+    updateHistoryCache wId InitHistoryCache
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -14,6 +14,7 @@ import           Universum
 
 import           Control.Lens                     (to)
 import qualified Data.List.NonEmpty               as NE
+import           Data.Time.Units                  (convertUnit)
 import           Formatting                       (build, sformat, (%))
 import           System.Wlog                      (HasLoggerName (modifyLoggerName),
                                                    WithLogger, logInfo, logWarning)
@@ -30,10 +31,12 @@ import           Pos.DB.Class                     (MonadDBRead)
 import qualified Pos.GState                       as GS
 import           Pos.Reporting                    (MonadReporting, reportOrLogW)
 import           Pos.Slotting                     (MonadSlots, MonadSlotsData,
+                                                   getCurrentEpochSlotDuration,
                                                    getSlotStartPure, getSystemStartM)
 import           Pos.Ssc.Class.Helpers            (SscHelpersClass)
 import           Pos.Txp.Core                     (TxAux (..), TxUndo, flattenTxPayload)
 import           Pos.Util.Chrono                  (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningWaitInf)
 
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
@@ -72,7 +75,7 @@ onApplyTracking
     , HasConfiguration
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
-onApplyTracking blunds = setLogger $ do
+onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
@@ -114,7 +117,7 @@ onRollbackTracking
     , HasConfiguration
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
-onRollbackTracking blunds = setLogger $ do
+onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
@@ -166,6 +169,16 @@ gbTxsWUndo (blk@(Right mb), undo) =
 
 setLogger :: HasLoggerName m => m a -> m a
 setLogger = modifyLoggerName (<> "wallet" <> "blistener")
+
+reportTimeouts
+    :: (MonadSlotsData ctx m, CanLogInParallel m)
+    => Text -> m a -> m a
+reportTimeouts desc action = do
+    slotDuration <- getCurrentEpochSlotDuration
+    let firstWarningTime = convertUnit slotDuration `div` 2
+    logWarningWaitInf firstWarningTime tag action
+  where
+    tag = "Wallet blistener " <> desc
 
 logMsg
     :: WithLogger m


### PR DESCRIPTION
Update tx history cache using atomic db modifier, not as `get` + `set`.
It's important as soon as history cache modification occurs on each slot, and history can be large.

Also some cosmetics:
1. Remove extra [] <-> DList conversions
2. DB now supposes that if there is no history cache for given wallet,
then it's actually empty, not absent (returns `mempty` instead of `Nothing`).
3. Add timeout logger on blistener actions

Now db size doesn't grow on itself over time, looks like we can forget about making checkpoints every several hours (8k transactions - `events-0000000000.log` stays of 8Mb size)