### PR TITLE
Use transformers-0.5.5.0 to fix space leak in Pos.Wallet.Web.Sockets.Notifier

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6760,8 +6760,8 @@ self: {
       transformers = callPackage ({ base, mkDerivation, stdenv }:
       mkDerivation {
           pname = "transformers";
-          version = "0.5.2.0";
-          sha256 = "1qkhi8ssf8c4jnmrw9dzym3igqbzq7h48iisaykdfzdsm09qfh3c";
+          version = "0.5.5.0";
+          sha256 = "198ric8gr1y58scckr468d11y2g45mzc5pkaa40shj7xgj1bh7mi";
           libraryHaskellDepends = [
             base
           ];

--- a/stack.yaml
+++ b/stack.yaml
@@ -96,6 +96,7 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
+- transformers-0.5.5.0
 - universum-0.6.1
 - serokell-util-0.5.0
 - pvss-0.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -96,7 +96,7 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
-- transformers-0.5.5.0
+- transformers-0.5.5.0            # https://hub.darcs.net/ross/transformers/issue/33#comment-20171004T152940
 - universum-0.6.1
 - serokell-util-0.5.0
 - pvss-0.2.0


### PR DESCRIPTION
`difficultyNotifier` uses `forever` in `Handler` monad which is `ExceptT` underneath and `forever` leaks space in `ExceptT` since it got changed in base-4.9.0.0. See https://hub.darcs.net/ross/transformers/issue/33#comment-20171004T152940 for more details. The fix went into transformers 0.5.5.0.