### PR TITLE
[CSL-1744] Remove mpc threshold checks from 'genTestnetDistribution'

### DIFF
--- a/core/Pos/Arbitrary/Core.hs
+++ b/core/Pos/Arbitrary/Core.hs
@@ -39,11 +39,9 @@ import           Pos.Binary.Class                  (FixedSizeInt (..), SignedVar
 import           Pos.Binary.Core                   ()
 import           Pos.Binary.Crypto                 ()
 import           Pos.Core.Address                  (addressHash, makeAddress)
-import           Pos.Core.Coin                     (coinPortionToDouble, coinToInteger,
-                                                    divCoin, unsafeSubCoin)
+import           Pos.Core.Coin                     (coinToInteger, divCoin, unsafeSubCoin)
 import           Pos.Core.Configuration            (HasGenesisBlockVersionData,
-                                                    HasProtocolConstants, epochSlots,
-                                                    genesisBlockVersionData)
+                                                    HasProtocolConstants, epochSlots)
 import           Pos.Core.Constants                (sharedSeedLength)
 import qualified Pos.Core.Fee                      as Fee
 import qualified Pos.Core.Genesis                  as G
@@ -502,13 +500,7 @@ instance HasGenesisBlockVersionData => Arbitrary G.TestnetBalanceOptions where
         tboPoors <- choose (0, 100)
         tboRichmen <- choose (1, 12)
         tboTotalBalance <- choose (1000, maxCoinVal)
-        -- This threshold is considered by genesis generation
-        -- function. It fails if a poor stakeholder has stake greater
-        -- than this value.
-        let genesisThd =
-                coinPortionToDouble $ bvdMpcThd genesisBlockVersionData
-        let minRichmenShare = min 1 (1.01 - genesisThd * fromIntegral tboPoors)
-        tboRichmenShare <- choose (minRichmenShare, 0.996)
+        tboRichmenShare <- choose (0.55, 0.996)
         let tboUseHDAddresses = False
         return G.TestnetBalanceOptions {..}
 

--- a/core/Pos/Core/Genesis/Generate.hs
+++ b/core/Pos/Core/Genesis/Generate.hs
@@ -22,10 +22,8 @@ import           Pos.Core.Address                        (Address,
                                                           IsBootstrapEraAddr (..),
                                                           addressHash, deriveLvl2KeyPair,
                                                           makePubKeyAddressBoot)
-import           Pos.Core.Coin                           (coinPortionToDouble, mkCoin,
-                                                          unsafeIntegerToCoin)
-import           Pos.Core.Configuration.BlockVersionData (HasGenesisBlockVersionData,
-                                                          genesisBlockVersionData)
+import           Pos.Core.Coin                           (mkCoin, unsafeIntegerToCoin)
+import           Pos.Core.Configuration.BlockVersionData (HasGenesisBlockVersionData)
 import           Pos.Core.Configuration.Protocol         (HasProtocolConstants, vssMaxTTL,
                                                           vssMinTTL)
 import qualified Pos.Core.Genesis.Constants              as Const
@@ -37,8 +35,7 @@ import           Pos.Core.Genesis.Types                  (FakeAvvmOptions (..),
                                                           GenesisWStakeholders (..),
                                                           TestnetBalanceOptions (..),
                                                           TestnetDistribution (..))
-import           Pos.Core.Types                          (BlockVersionData (bvdMpcThd),
-                                                          Coin)
+import           Pos.Core.Types                          (Coin)
 import           Pos.Core.Vss                            (VssCertificate,
                                                           mkVssCertificate,
                                                           mkVssCertificatesMap)
@@ -216,8 +213,6 @@ genTestnetDistribution TestnetBalanceOptions{..} testBalance =
     onePoorBalance = if poors == 0 then 0 else poorsBalance `div` poors
     realPoorBalance = onePoorBalance * poors
 
-    mpcBalance = getShare (coinPortionToDouble $ bvdMpcThd genesisBlockVersionData) testBalance
-
     richBalances = replicate (fromInteger richs) (unsafeIntegerToCoin oneRichmanBalance)
     poorBalances = replicate (fromInteger poors) (unsafeIntegerToCoin onePoorBalance)
 
@@ -226,12 +221,6 @@ genTestnetDistribution TestnetBalanceOptions{..} testBalance =
     everythingIsConsistent =
         [ ( realRichBalance + realPoorBalance <= testBalance
           , "Real rich + poor balance is more than desired."
-          )
-        , ( oneRichmanBalance >= mpcBalance
-          , "Richman's balance is less than MPC threshold"
-          )
-        , ( onePoorBalance < mpcBalance
-          , "Poor's balance is more than MPC threshold"
           )
         ]
 


### PR DESCRIPTION
These checks aren't useful at all nowadays, because mpc threshold considers
stakes, while this function generates balances.
And they are a bit annoying when one needs to generate proper inititializer.
This changed allowed me to simplify 'TestnetBalanceOptions' generation and
fix rarely failing tests.