### PR TITLE
Use transformers-0.5.5.0 to fix space leak in Pos.Wallet.Web.Sockets.Notifier

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6828,8 +6828,8 @@ self: {
       transformers = callPackage ({ base, mkDerivation, stdenv }:
       mkDerivation {
           pname = "transformers";
-          version = "0.5.2.0";
-          sha256 = "6c408713a8ba7dd7a6573a4644e0c17fe11747f5bf259eab958421a7358a70e2";
+          version = "0.5.5.0";
+          sha256 = "b11eb8827cfd48a801516adec27e2de4091f424386e4c99846c587fc108b19a5";
           libraryHaskellDepends = [
             base
           ];

--- a/stack.yaml
+++ b/stack.yaml
@@ -96,6 +96,7 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
+- transformers-0.5.5.0            # https://hub.darcs.net/ross/transformers/issue/33#comment-20171004T152940
 - universum-0.6.1
 - serokell-util-0.5.0
 - pvss-0.2.0


### PR DESCRIPTION
Successor of #1723.