### PR TITLE
also allow retrying when installing happy and cpphs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ test_script:
   - cd "%WORK_DIR%"
   - stack --verbosity warn setup --no-reinstall > nul
   # Install happy separately: https://github.com/commercialhaskell/stack/issues/3151#issuecomment-310642487. Also install cpphs because it's a build-tool and Stack can't figure out by itself that it should be installed
-  - stack --verbosity warn install happy cpphs
+  - scripts\ci\appveyor-retry call stack --verbosity warn install happy cpphs
       -j 2
       --no-terminal
       --local-bin-path %SYSTEMROOT%\system32


### PR DESCRIPTION
this solves the `C:\s\snapshots\6dde1a60\pkgdb\package.cache: openBinaryFile: permission denied (Permission denied)` error that happens when installing `happy` and `cpphs`

upstream issue: https://github.com/commercialhaskell/stack/issues/2617