### PR TITLE
Merge CSM-489 CSM-485 and CSM-491 to exchanges branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ test_script:
   - cd "%WORK_DIR%"
   - stack --verbosity warn setup --no-reinstall > nul
   # Install happy separately: https://github.com/commercialhaskell/stack/issues/3151#issuecomment-310642487. Also install cpphs because it's a build-tool and Stack can't figure out by itself that it should be installed
-  - stack --verbosity warn install happy cpphs
+  - scripts\ci\appveyor-retry call stack --verbosity warn install happy cpphs
       -j 2
       --no-terminal
       --local-bin-path %SYSTEMROOT%\system32

--- a/node/src/Pos/Client/Txp/History.hs
+++ b/node/src/Pos/Client/Txp/History.hs
@@ -27,6 +27,8 @@ module Pos.Client.Txp.History
        , getBlockHistoryDefault
        , getLocalHistoryDefault
        , saveTxDefault
+
+       , txHistoryListToMap
        ) where
 
 import           Universum
@@ -36,9 +38,7 @@ import           Control.Monad.Trans          (MonadTrans)
 import           Control.Monad.Trans.Control  (MonadBaseControl)
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Data.Coerce                  (coerce)
-import           Data.DList                   (DList)
-import qualified Data.DList                   as DL
-import qualified Data.Map.Strict              as M (lookup)
+import qualified Data.Map.Strict              as M (lookup, insert, fromList)
 import qualified Data.Text.Buildable
 import qualified Ether
 import           Formatting                   (bprint, build, (%))
@@ -100,7 +100,7 @@ data TxHistoryEntry = THEntry
     , _thInputs      :: ![TxOut]
     , _thOutputAddrs :: ![Address]
     , _thTimestamp   :: !(Maybe Timestamp)
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Generic, Ord)
 
 -- | Remained for compatibility
 _thInputAddrs :: TxHistoryEntry -> [Address]
@@ -126,11 +126,11 @@ getTxsByPredicate
     -> Maybe ChainDifficulty
     -> Maybe Timestamp
     -> [(WithHash Tx, TxWitness)]
-    -> m [TxHistoryEntry]
-getTxsByPredicate pr mDiff mTs txs = go txs []
+    -> m (Map TxId TxHistoryEntry)
+getTxsByPredicate pr mDiff mTs txs = go txs mempty
   where
-    go [] acc = return acc
-    go ((wh@(WithHash tx txId), _wit) : rest) acc = do
+    go [] !acc = return acc
+    go ((wh@(WithHash tx txId), _wit) : rest) !acc = do
         inputs <- getSenders tx
         let outgoings = toList $ txOutAddress <$> _txOutputs tx
         let incomings = map txOutAddress inputs
@@ -138,7 +138,7 @@ getTxsByPredicate pr mDiff mTs txs = go txs []
         applyTxToUtxo wh
 
         let acc' = if pr (incomings ++ outgoings)
-                   then (THEntry txId tx mDiff inputs outgoings mTs : acc)
+                   then M.insert txId (THEntry txId tx mDiff inputs outgoings mTs) acc
                    else acc
         go rest acc'
 
@@ -149,7 +149,7 @@ getRelatedTxsByAddrs
     -> Maybe ChainDifficulty
     -> Maybe Timestamp
     -> [(WithHash Tx, TxWitness)]
-    -> m [TxHistoryEntry]
+    -> m (Map TxId TxHistoryEntry)
 getRelatedTxsByAddrs addrs = getTxsByPredicate $ any (`elem` addrs)
 
 -- | Given a full blockchain, derive address history and Utxo
@@ -158,17 +158,17 @@ getRelatedTxsByAddrs addrs = getTxsByPredicate $ any (`elem` addrs)
 -- Tx will be required.
 deriveAddrHistory
     :: MonadUtxo m
-    => [Address] -> [Block ssc] -> m [TxHistoryEntry]
+    => [Address] -> [Block ssc] -> m (Map TxId TxHistoryEntry)
 deriveAddrHistory addrs chain =
-    DL.toList <$> foldrM (flip $ deriveAddrHistoryBlk addrs $ const Nothing) mempty chain
+    foldrM (flip $ deriveAddrHistoryBlk addrs $ const Nothing) mempty chain
 
 deriveAddrHistoryBlk
     :: MonadUtxo m
     => [Address]
     -> (MainBlock ssc -> Maybe Timestamp)
-    -> DList TxHistoryEntry
+    -> Map TxId TxHistoryEntry
     -> Block ssc
-    -> m (DList TxHistoryEntry)
+    -> m (Map TxId TxHistoryEntry)
 deriveAddrHistoryBlk _ _ hist (Left _) = pure hist
 deriveAddrHistoryBlk addrs getTs hist (Right blk) = do
     let mapper TxAux {..} = (withHash taTx, taWitness)
@@ -177,7 +177,7 @@ deriveAddrHistoryBlk addrs getTs hist (Right blk) = do
     txs <- getRelatedTxsByAddrs addrs (Just difficulty) mTimestamp $
            map mapper . flattenTxPayload $
            blk ^. mainBlockTxPayload
-    return $ DL.fromList txs <> hist
+    return $ txs <> hist -- TODO: Are we sure there is no intersection? OTherwise, the order might matter
 
 ----------------------------------------------------------------------------
 -- GenesisToil
@@ -205,19 +205,19 @@ instance (Monad m, HasConfiguration) =>
 class (Monad m, SscHelpersClass ssc) => MonadTxHistory ssc m | m -> ssc where
     getBlockHistory
         :: SscHelpersClass ssc
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getLocalHistory
-        :: [Address] -> m (DList TxHistoryEntry)
+        :: [Address] -> m (Map TxId TxHistoryEntry)
     saveTx :: (TxId, TxAux) -> m ()
 
     default getBlockHistory
         :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getBlockHistory = lift . getBlockHistory
 
     default getLocalHistory
         :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m)
-        => [Address] -> m (DList TxHistoryEntry)
+        => [Address] -> m (Map TxId TxHistoryEntry)
     getLocalHistory = lift . getLocalHistory
 
     default saveTx :: (MonadTrans t, MonadTxHistory ssc m', t m' ~ m) => (TxId, TxAux) -> m ()
@@ -253,7 +253,7 @@ type GenesisHistoryFetcher m = ToilT () (GenesisToil m)
 
 getBlockHistoryDefault
     :: forall ssc ctx m. (HasConfiguration, SscHelpersClass ssc, TxHistoryEnv' ssc ctx m)
-    => [Address] -> m (DList TxHistoryEntry)
+    => [Address] -> m (Map TxId TxHistoryEntry)
 getBlockHistoryDefault addrs = do
     let bot      = headerHash (genesisBlock0 @ssc)
     sd          <- GS.getSlottingData
@@ -265,7 +265,7 @@ getBlockHistoryDefault addrs = do
         getBlockTimestamp :: MainBlock ssc -> Maybe Timestamp
         getBlockTimestamp blk = getSlotStartPure systemStart (blk ^. mainBlockSlot) sd
 
-        blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (DList TxHistoryEntry)
+        blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (Map TxId TxHistoryEntry)
         blockFetcher start = GS.foldlUpWhileM fromBlund start (const $ const True)
             (deriveAddrHistoryBlk addrs getBlockTimestamp) mempty
 
@@ -273,7 +273,7 @@ getBlockHistoryDefault addrs = do
 
 getLocalHistoryDefault
     :: forall ctx m. TxHistoryEnv ctx m
-    => [Address] -> m (DList TxHistoryEntry)
+    => [Address] -> m (Map TxId TxHistoryEntry)
 getLocalHistoryDefault addrs = runDBToil . evalToilTEmpty $ do
     let mapper (txid, TxAux {..}) =
             (WithHash taTx txid, taWitness)
@@ -282,7 +282,7 @@ getLocalHistoryDefault addrs = runDBToil . evalToilTEmpty $ do
     ltxs <- lift $ map mapper <$> getLocalTxs
     txs <- getRelatedTxsByAddrs addrs Nothing Nothing =<<
            maybeThrow topsortErr (topsortTxs (view _1) ltxs)
-    return $ DL.fromList txs
+    return $ txs
 
 saveTxDefault :: TxHistoryEnv ctx m => (TxId, TxAux) -> m ()
 saveTxDefault txw = do
@@ -292,3 +292,6 @@ saveTxDefault txw = do
     res <- txProcessTransaction txw
 #endif
     eitherToThrow res
+
+txHistoryListToMap :: [TxHistoryEntry] -> Map TxId TxHistoryEntry
+txHistoryListToMap = M.fromList . map (\tx -> (_thTxId tx, tx))

--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -130,9 +130,9 @@ mkCTx
     -> TxHistoryEntry     -- ^ Tx history entry
     -> CTxMeta            -- ^ Transaction metadata
     -> CPtxCondition      -- ^ State of resubmission
-    -> [CWAddressMeta]    -- ^ Addresses of wallet
+    -> Set (CId Addr)     -- ^ Addresses of wallet
     -> Either Text CTx
-mkCTx diff THEntry {..} meta pc wAddrMetas = do
+mkCTx diff THEntry {..} meta pc wAddrsSet = do
     let isOurTxAddress = flip S.member wAddrsSet . addressToCId . txOutAddress
 
         ownInputs = filter isOurTxAddress inputs
@@ -166,7 +166,6 @@ mkCTx diff THEntry {..} meta pc wAddrMetas = do
     ctConfirmations = maybe 0 fromIntegral $ (diff -) <$> _thDifficulty
     ctMeta = meta
     ctCondition = pc
-    wAddrsSet = S.fromList $ map cwamId wAddrMetas
 
 addrMetaToAccount :: CWAddressMeta -> AccountId
 addrMetaToAccount CWAddressMeta{..} = AccountId

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -110,7 +110,7 @@ data AccountId = AccountId
       aiWId   :: CId Wal
     , -- | Derivation index of this wallet key
       aiIndex :: Word32
-    } deriving (Eq, Show, Generic, Typeable)
+    } deriving (Eq, Ord, Show, Generic, Typeable)
 
 instance Hashable AccountId
 

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -61,12 +61,14 @@ module Pos.Wallet.Web.State.Acidic
        , TotallyRemoveWAddress (..)
        , AddUpdate (..)
        , RemoveNextUpdate (..)
-       , UpdateHistoryCache (..)
+       , UpdateHistoryCache2 (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , FlushWalletStorage (..)
+       -- * No longer used, just here for migrations and backwards compatibility
+       , UpdateHistoryCache (..)
        ) where
 
 import           Universum
@@ -160,6 +162,7 @@ makeAcidic ''WalletStorage
     , 'WS.addUpdate
     , 'WS.removeNextUpdate
     , 'WS.updateHistoryCache
+    , 'WS.updateHistoryCache2
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -61,7 +61,8 @@ module Pos.Wallet.Web.State.Acidic
        , TotallyRemoveWAddress (..)
        , AddUpdate (..)
        , RemoveNextUpdate (..)
-       , UpdateHistoryCache2 (..)
+       , InsertIntoHistoryCache (..)
+       , RemoveFromHistoryCache (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
@@ -162,7 +163,8 @@ makeAcidic ''WalletStorage
     , 'WS.addUpdate
     , 'WS.removeNextUpdate
     , 'WS.updateHistoryCache
-    , 'WS.updateHistoryCache2
+    , 'WS.insertIntoHistoryCache
+    , 'WS.removeFromHistoryCache
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -67,7 +67,8 @@ module Pos.Wallet.Web.State.State
        , totallyRemoveWAddress
        , addUpdate
        , removeNextUpdate
-       , updateHistoryCache
+       , insertIntoHistoryCache
+       , removeFromHistoryCache
        , setWalletUtxo
        , setPtxCondition
        , casPtxCondition
@@ -284,8 +285,18 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 testReset :: WebWalletModeDB ctx m => m ()
 testReset = updateDisk A.TestReset
 
-updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId TxHistoryEntry -> m ()
-updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache2 cWalId
+insertIntoHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId TxHistoryEntry -> m ()
+insertIntoHistoryCache cWalId cTxs
+  | Map.null cTxs = return ()
+  | otherwise     = updateDisk (A.InsertIntoHistoryCache cWalId cTxs)
+
+removeFromHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId a -> m ()
+removeFromHistoryCache cWalId cTxs
+  | Map.null cTxs = return ()
+  | otherwise     = updateDisk (A.RemoveFromHistoryCache cWalId cTxs')
+  where
+    cTxs' :: Map TxId ()
+    cTxs' = Map.map (const ()) cTxs
 
 setPtxCondition
     :: WebWalletModeDB ctx m

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -78,6 +78,7 @@ module Pos.Wallet.Web.State.State
 
 import           Data.Acid                    (EventResult, EventState, QueryEvent,
                                                UpdateEvent)
+import qualified Data.Map                     as Map
 import           Ether.Internal               (HasLens (..))
 import           Mockable                     (MonadMockable)
 import           Universum
@@ -86,6 +87,7 @@ import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Txp                      (TxId, Utxo)
 import           Pos.Types                    (HeaderHash)
+import           Pos.Util.Servant             (encodeCType)
 import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
                                                CProfile, CTxId, CTxMeta, CUpdateInfo,
                                                CWAddressMeta, CWalletMeta, PassPhraseLU,
@@ -173,7 +175,7 @@ getUpdates = queryDisk A.GetUpdates
 getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
 getNextUpdate = queryDisk A.GetNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [TxHistoryEntry])
+getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache = queryDisk . A.GetHistoryCache
 
 getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]
@@ -230,8 +232,10 @@ setProfile = updateDisk . A.SetProfile
 setWalletTxMeta :: WebWalletModeDB ctx m => CId Wal -> CTxId -> CTxMeta -> m ()
 setWalletTxMeta cWalId cTxId = updateDisk . A.SetWalletTxMeta cWalId cTxId
 
-addOnlyNewTxMetas :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
-addOnlyNewTxMetas = updateDisk ... A.AddOnlyNewTxMetas
+addOnlyNewTxMetas :: WebWalletModeDB ctx m => CId Wal -> Map TxId CTxMeta -> m ()
+addOnlyNewTxMetas cWalId cTxMetas = updateDisk (A.AddOnlyNewTxMetas cWalId cTxMetaList)
+    where
+      cTxMetaList = [ (encodeCType txId, cTxMeta) | (txId, cTxMeta) <- Map.toList cTxMetas ]
 
 setWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
 setWalletTxHistory cWalId = updateDisk . A.SetWalletTxHistory cWalId
@@ -280,8 +284,8 @@ removeNextUpdate = updateDisk A.RemoveNextUpdate
 testReset :: WebWalletModeDB ctx m => m ()
 testReset = updateDisk A.TestReset
 
-updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> [TxHistoryEntry] -> m ()
-updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache cWalId
+updateHistoryCache :: WebWalletModeDB ctx m => CId Wal -> Map TxId TxHistoryEntry -> m ()
+updateHistoryCache cWalId = updateDisk . A.UpdateHistoryCache2 cWalId
 
 setPtxCondition
     :: WebWalletModeDB ctx m

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Rank2Types #-}
 
 -- @jens: this document is inspired by https://github.com/input-output-hk/rscoin-haskell/blob/master/src/RSCoin/Explorer/Storage.hs
@@ -62,6 +63,7 @@ module Pos.Wallet.Web.State.Storage
        , removeNextUpdate
        , testReset
        , updateHistoryCache
+       , updateHistoryCache2
        , setPtxCondition
        , casPtxCondition
        , ptxUpdateMeta
@@ -77,10 +79,10 @@ import           Control.Monad.State.Class      (put)
 import           Data.Default                   (Default, def)
 import qualified Data.HashMap.Strict            as HM
 import qualified Data.Map                       as M
-import           Data.SafeCopy                  (base, deriveSafeCopySimple)
+import           Data.SafeCopy                  (Migrate (..), extension, base, deriveSafeCopySimple)
 import           Data.Time.Clock.POSIX          (POSIXTime)
 
-import           Pos.Client.Txp.History         (TxHistoryEntry)
+import           Pos.Client.Txp.History         (TxHistoryEntry, txHistoryListToMap)
 import           Pos.Core.Configuration         (HasConfiguration)
 import           Pos.Core.Types                 (SlotId, Timestamp)
 import           Pos.Txp                        (TxAux, TxId, Utxo)
@@ -143,7 +145,7 @@ data WalletStorage = WalletStorage
     , _wsProfile         :: !CProfile
     , _wsReadyUpdates    :: [CUpdateInfo]
     , _wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
-    , _wsHistoryCache    :: !(HashMap (CId Wal) [TxHistoryEntry])
+    , _wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
     , _wsUtxo            :: !Utxo
     , _wsUsedAddresses   :: !CustomAddresses
     , _wsChangeAddresses :: !CustomAddresses
@@ -269,7 +271,7 @@ getUpdates = view wsReadyUpdates
 getNextUpdate :: Query (Maybe CUpdateInfo)
 getNextUpdate = preview (wsReadyUpdates . _head)
 
-getHistoryCache :: CId Wal -> Query (Maybe [TxHistoryEntry])
+getHistoryCache :: CId Wal -> Query (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache cWalId = view $ wsHistoryCache . at cWalId
 
 getCustomAddresses :: CustomAddressType -> Query [CId Addr]
@@ -409,7 +411,10 @@ testReset :: Update ()
 testReset = put def
 
 updateHistoryCache :: CId Wal -> [TxHistoryEntry] -> Update ()
-updateHistoryCache cWalId cTxs =
+updateHistoryCache cWalId = updateHistoryCache2 cWalId . txHistoryListToMap
+
+updateHistoryCache2 :: CId Wal -> Map TxId TxHistoryEntry -> Update ()
+updateHistoryCache2 cWalId cTxs =
     wsHistoryCache . at cWalId ?= cTxs
 
 -- This shouldn't be able to create new transaction.
@@ -495,4 +500,35 @@ deriveSafeCopySimple 0 'base ''AddressInfo
 deriveSafeCopySimple 0 'base ''AccountInfo
 deriveSafeCopySimple 0 'base ''WalletTip
 deriveSafeCopySimple 0 'base ''WalletInfo
-deriveSafeCopySimple 0 'base ''WalletStorage
+
+
+-- Legacy versions, for migrations
+
+data WalletStorage_v0 = WalletStorage_v0
+    { _v0_wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
+    , _v0_wsAccountInfos    :: !(HashMap AccountId AccountInfo)
+    , _v0_wsProfile         :: !CProfile
+    , _v0_wsReadyUpdates    :: [CUpdateInfo]
+    , _v0_wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
+    , _v0_wsHistoryCache    :: !(HashMap (CId Wal) [TxHistoryEntry])
+    , _v0_wsUtxo            :: !Utxo
+    , _v0_wsUsedAddresses   :: !CustomAddresses
+    , _v0_wsChangeAddresses :: !CustomAddresses
+    }
+
+deriveSafeCopySimple 0 'base ''WalletStorage_v0
+deriveSafeCopySimple 1 'extension ''WalletStorage
+
+instance Migrate WalletStorage where
+    type MigrateFrom WalletStorage = WalletStorage_v0
+    migrate WalletStorage_v0{..} = WalletStorage
+        { _wsWalletInfos     = _v0_wsWalletInfos
+        , _wsAccountInfos    = _v0_wsAccountInfos
+        , _wsProfile         = _v0_wsProfile
+        , _wsReadyUpdates    = _v0_wsReadyUpdates
+        , _wsTxHistory       = _v0_wsTxHistory
+        , _wsHistoryCache    = HM.map txHistoryListToMap _v0_wsHistoryCache
+        , _wsUtxo            = _v0_wsUtxo
+        , _wsUsedAddresses   = _v0_wsUsedAddresses
+        , _wsChangeAddresses = _v0_wsChangeAddresses
+        }

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -7,12 +7,14 @@ module Pos.Wallet.Web.Util
     , getAccountAddrsOrThrow
     , getWalletAddrMetas
     , getWalletAddrs
+    , getWalletAddrsSet
     , decodeCTypeOrFail
     , getWalletAssuredDepth
     ) where
 
 import           Universum
 
+import qualified Data.Set                   as S
 import           Formatting                 (build, sformat, (%))
 
 import           Pos.Core                   (BlockCount)
@@ -54,6 +56,12 @@ getWalletAddrs
     :: (WebWalletModeDB ctx m, MonadThrow m)
     => AddressLookupMode -> CId Wal -> m [CId Addr]
 getWalletAddrs = (cwamId <<$>>) ... getWalletAddrMetas
+
+getWalletAddrsSet
+    :: (WebWalletModeDB ctx m, MonadThrow m)
+    => AddressLookupMode -> CId Wal -> m (Set (CId Addr))
+getWalletAddrsSet lookupMode cWalId =
+    S.fromList . map cwamId <$> getWalletAddrMetas lookupMode cWalId
 
 decodeCTypeOrFail :: (MonadThrow m, FromCType c) => c -> m (OriginType c)
 decodeCTypeOrFail = either (throwM . DecodeError) pure . decodeCType

--- a/scripts/set_nixpath.sh
+++ b/scripts/set_nixpath.sh
@@ -4,9 +4,10 @@ update_NIX_PATH() {
     nix-build -o /tmp/iohk-utils '<nixpkgs>' -A coreutils
     export PATH=/tmp/iohk-utils/bin:$PATH
   esac
-  export PATH=$(nix-build '<nixpkgs>' -A jq --no-out-link)/bin/:$PATH
+  # workaround for https://github.com/NixOS/nixpkgs/issues/30070
+  export PATH=$(nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/9824ca6975fcbf5a2da9e6ba98dacafaa12bb1b3.tar.gz '<nixpkgs>' -A jq --no-out-link)/bin/:$PATH
   local scriptDir="$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
-  export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(nix-shell -p jq --run "jq .rev < \"${scriptDir}/../nixpkgs-src.json\" -r").tar.gz
+  export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(jq .rev < "${scriptDir}/../nixpkgs-src.json" -r).tar.gz
   # allows the nix expressions to detect that the path is already fixed
   export NIX_PATH_LOCKED=1
 }

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -65,7 +65,7 @@ getFullWalletHistory cWalId = do
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
     addHistoryTxs cWalId localHistory
-    cHistory <- forM fullHistory (constructCTx (cWalId, Just walAddrMetas))
+    cHistory <- forM fullHistory (constructCTx cWalId walAddrMetas)
     pure (cHistory, fromIntegral $ Map.size cHistory)
 
 getHistory
@@ -149,11 +149,11 @@ addHistoryTxs cWalId historyEntries = do
 
 constructCTx
     :: MonadWalletWebMode m
-    => (CId Wal, Maybe [CWAddressMeta])
+    => CId Wal
+    -> [CWAddressMeta]
     -> TxHistoryEntry
     -> m (CTx, POSIXTime)
-constructCTx (cWalId, walAddrMetasMB) wtx@THEntry{..} = do
-    walAddrMetas <- maybe (getWalletAddrMetas Ever cWalId) pure walAddrMetasMB
+constructCTx cWalId walAddrMetas wtx@THEntry{..} = do
     let cId = encodeCType _thTxId
     diff <- maybe localChainDifficulty pure =<< networkChainDifficulty
     meta <- maybe (CTxMeta <$> liftIO getPOSIXTime) -- It's impossible case but just in case

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -11,17 +11,18 @@ module Pos.Wallet.Web.Methods.History
 
 import           Universum
 
-import qualified Data.DList                 as DL
+import qualified Data.Map.Strict            as Map
 import qualified Data.Set                   as S
-import           Data.Time.Clock.POSIX      (getPOSIXTime)
+import           Data.Time.Clock.POSIX      (POSIXTime, getPOSIXTime)
 import           Formatting                 (build, sformat, stext, (%))
 import           Serokell.Util              (listJson)
-import           System.Wlog                (WithLogger, logError, logInfo, logWarning)
+import           System.Wlog                (WithLogger, logInfo, logWarning)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
-import           Pos.Client.Txp.History     (TxHistoryEntry (..))
+import           Pos.Client.Txp.History     (txHistoryListToMap, TxHistoryEntry (..))
 import           Pos.Core                   (timestampToPosix)
+import           Pos.Txp.Core.Types         (TxId)
 import           Pos.Util.Servant           (encodeCType)
 import           Pos.Wallet.WalletMode      (getLocalHistory, localChainDifficulty,
                                              networkChainDifficulty)
@@ -35,76 +36,57 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNe
                                              getWalletPendingTxs, setWalletTxMeta)
 import           Pos.Wallet.Web.Util        (decodeCTypeOrFail, getAccountAddrsOrThrow,
                                              getWalletAccountIds, getWalletAddrMetas,
-                                             getWalletAddrs, getWalletThTime)
+                                             getWalletAddrs)
 
 
-getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m ([CTx], Word)
+getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
 getFullWalletHistory cWalId = do
     addrs <- mapM decodeCTypeOrFail =<< getWalletAddrs Ever cWalId
 
     unfilteredLocalHistory <- getLocalHistory addrs
 
     blockHistory <- getHistoryCache cWalId >>= \case
-        Just hist -> pure $ DL.fromList hist
+        Just hist -> pure hist
         Nothing -> do
             logWarning $
                 sformat ("getFullWalletHistory: history cache is empty for wallet #"%build)
                 cWalId
             pure mempty
 
-    let localHistory =
-            DL.fromList $ filterLocalTh
-                (DL.toList blockHistory)
-                (DL.toList unfilteredLocalHistory)
+    let localHistory = unfilteredLocalHistory `Map.difference` blockHistory
 
     logTxHistory "Block" blockHistory
     logTxHistory "Mempool" localHistory
 
-    fullHistory <- addRecentPtxHistory cWalId $ DL.toList $ localHistory <> blockHistory
+    fullHistory <- addRecentPtxHistory cWalId $ localHistory `Map.union` blockHistory
     walAddrMetas <- getWalletAddrMetas Ever cWalId
     -- TODO when we introduce some mechanism to react on new tx in mempool,
     -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
-    addHistoryTxs cWalId (DL.toList localHistory)
+    addHistoryTxs cWalId localHistory
     cHistory <- forM fullHistory (constructCTx (cWalId, Just walAddrMetas))
-    pure (cHistory, fromIntegral $ length cHistory)
-  where
-    filterLocalTh :: [TxHistoryEntry] -> [TxHistoryEntry] -> [TxHistoryEntry]
-    filterLocalTh blockH localH =
-        let blockTxIdsSet = S.fromList $ map _thTxId blockH
-        in  filter ((`S.notMember` blockTxIdsSet) . _thTxId) localH
+    pure (cHistory, fromIntegral $ Map.size cHistory)
 
 getHistory
     :: MonadWalletWebMode m
-    => Maybe (CId Wal)
-    -> Maybe AccountId
+    => CId Wal
+    -> [AccountId]
     -> Maybe (CId Addr)
-    -> m ([CTx], Word)
-getHistory mCWalId mAccountId mAddrId = do
+    -> m (Map TxId (CTx, POSIXTime), Word)
+getHistory cWalId accIds mAddrId = do
     -- FIXME: searching when only AddrId is provided is not supported yet.
-    (cWalId, accIds) <- case (mCWalId, mAccountId) of
-        (Nothing, Nothing)      -> throwM errorSpecifySomething
-        (Just _, Just _)        -> throwM errorDontSpecifyBoth
-        (Just cWalId', Nothing) -> do
-            accIds' <- getWalletAccountIds cWalId'
-            pure (cWalId', accIds')
-        (Nothing, Just accId)   -> pure (aiWId accId, [accId])
     accAddrs <- map cwamId <$> concatMapM (getAccountAddrsOrThrow Ever) accIds
     addrs <- case mAddrId of
         Nothing -> pure accAddrs
         Just addr ->
             if addr `elem` accAddrs then pure [addr] else throwM errorBadAddress
-    first (filter (fits $ S.fromList addrs)) <$> getFullWalletHistory cWalId
+    first (Map.filter (fits (S.fromList addrs) . fst)) <$> getFullWalletHistory cWalId
   where
     fits :: S.Set (CId Addr) -> CTx -> Bool
     fits addrs CTx{..} =
         let inpsNOuts = map fst (ctInputs ++ ctOutputs)
         in  any (`S.member` addrs) inpsNOuts
-    errorSpecifySomething = RequestError $
-        "Please specify either walletId or accountId"
-    errorDontSpecifyBoth = RequestError $
-        "Please do not specify both walletId and accountId at the same time"
     errorBadAddress = RequestError $
         "Specified wallet/account does not contain specified address"
 
@@ -116,33 +98,50 @@ getHistoryLimited
     -> Maybe Word
     -> Maybe Word
     -> m ([CTx], Word)
-getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit =
-    first applySkipLimit <$> getHistory mCWalId mAccId mAddrId
+getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit = do
+    (cWalId, accIds) <- case (mCWalId, mAccId) of
+        (Nothing, Nothing)      -> throwM errorSpecifySomething
+        (Just _, Just _)        -> throwM errorDontSpecifyBoth
+        (Just cWalId', Nothing) -> do
+            accIds' <- getWalletAccountIds cWalId'
+            pure (cWalId', accIds')
+        (Nothing, Just accId)   -> pure (aiWId accId, [accId])
+    (unsortedThs, n) <- getHistory cWalId accIds mAddrId
+    let sortedTxh = sortByTime (Map.elems unsortedThs)
+    pure (applySkipLimit sortedTxh, n)
   where
+    sortByTime :: [(CTx, POSIXTime)] -> [CTx]
+    sortByTime thsWTime =
+        -- TODO: if we use a (lazy) heap sort here, we can get the
+        -- first n values of the m sorted elements in O(m + n log m)
+        map fst $ sortWith (Down . snd) thsWTime
     applySkipLimit = take limit . drop skip
     limit = (fromIntegral $ fromMaybe defaultLimit mLimit)
     skip = (fromIntegral $ fromMaybe defaultSkip mSkip)
     defaultLimit = 100
     defaultSkip = 0
+    errorSpecifySomething = RequestError $
+        "Please specify either walletId or accountId"
+    errorDontSpecifyBoth = RequestError $
+        "Please do not specify both walletId and accountId at the same time"
 
 addHistoryTx
     :: MonadWalletWebMode m
     => CId Wal
     -> TxHistoryEntry
     -> m ()
-addHistoryTx cWalId = addHistoryTxs cWalId . one
+addHistoryTx cWalId = addHistoryTxs cWalId . txHistoryListToMap . one
 
 -- This functions is helper to do @addHistoryTx@ for
 -- all txs from mempool as one Acidic transaction.
 addHistoryTxs
     :: MonadWalletWebMode m
     => CId Wal
-    -> [TxHistoryEntry]
+    -> Map TxId TxHistoryEntry
     -> m ()
 addHistoryTxs cWalId historyEntries = do
     metas <- mapM toMeta historyEntries
-    let cIds = map (encodeCType . _thTxId) historyEntries
-    addOnlyNewTxMetas cWalId (zip cIds metas)
+    addOnlyNewTxMetas cWalId metas
   where
     toMeta THEntry {..} = CTxMeta <$> case _thTimestamp of
         Nothing -> liftIO getPOSIXTime
@@ -152,7 +151,7 @@ constructCTx
     :: MonadWalletWebMode m
     => (CId Wal, Maybe [CWAddressMeta])
     -> TxHistoryEntry
-    -> m CTx
+    -> m (CTx, POSIXTime)
 constructCTx (cWalId, walAddrMetasMB) wtx@THEntry{..} = do
     walAddrMetas <- maybe (getWalletAddrMetas Ever cWalId) pure walAddrMetasMB
     let cId = encodeCType _thTxId
@@ -160,7 +159,7 @@ constructCTx (cWalId, walAddrMetasMB) wtx@THEntry{..} = do
     meta <- maybe (CTxMeta <$> liftIO getPOSIXTime) -- It's impossible case but just in case
             pure =<< getTxMeta cWalId cId
     ptxCond <- encodeCType . fmap _ptxCond <$> getPendingTx cWalId _thTxId
-    either (throwM . InternalError) pure $
+    either (throwM . InternalError) (pure . (, ctmDate meta)) $
         mkCTx diff wtx meta ptxCond walAddrMetas
 
 updateTransaction :: MonadWalletWebMode m => AccountId -> CTxId -> CTxMeta -> m ()
@@ -169,35 +168,17 @@ updateTransaction accId txId txMeta = do
 
 addRecentPtxHistory
     :: MonadWalletWebMode m
-    => CId Wal -> [TxHistoryEntry] -> m [TxHistoryEntry]
+    => CId Wal -> Map TxId TxHistoryEntry -> m (Map TxId TxHistoryEntry)
 addRecentPtxHistory wid currentHistory = do
-    candidates <- sortWith (Down . _thTimestamp) <$> getCandidates
+    pendingTxs <- getWalletPendingTxs wid
+    let candidates = toCandidates pendingTxs
     logTxHistory "Pending" candidates
-    merge currentHistory candidates
+    return $ Map.union currentHistory candidates
   where
-    getCandidates =
-        mapMaybe (ptxPoolInfo . _ptxCond) . fromMaybe [] <$>
-        getWalletPendingTxs wid
-
-    merge [] recent     = return recent
-    merge current []    = return current
-    merge (c:cs) (r:rs) = do
-        if _thTxId c == _thTxId r
-            then (c:) <$> merge cs rs
-            else do
-                mctime <- getWalletThTime wid c
-                let mrtime = timestampToPosix <$> _thTimestamp r
-                when (isNothing mrtime) $ reportNoTimestamp r
-                if mctime <= mrtime
-                    then (r:) <$> merge (c:cs) rs
-                    else (c:) <$> merge cs (r:rs)
-
-    -- pending transactions are made by us, always have timestamp set
-    reportNoTimestamp th =
-        logError $
-        sformat ("Pending transaction "%build%" has no timestamp set")
-                (_thTxId th)
-
+    toCandidates =
+            txHistoryListToMap
+        .   mapMaybe (ptxPoolInfo . _ptxCond)
+        .   fromMaybe []
 
 logTxHistory
     :: (Container t, Element t ~ TxHistoryEntry, WithLogger m)

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -6,6 +6,7 @@ module Pos.Wallet.Web.Methods.History
        ( getHistoryLimited
        , addHistoryTx
        , constructCTx
+       , getCurChainDifficulty
        , updateTransaction
        ) where
 
@@ -21,7 +22,7 @@ import           System.Wlog                (WithLogger, logInfo, logWarning)
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
 import           Pos.Client.Txp.History     (txHistoryListToMap, TxHistoryEntry (..))
-import           Pos.Core                   (timestampToPosix)
+import           Pos.Core                   (ChainDifficulty, timestampToPosix)
 import           Pos.Txp.Core.Types         (TxId)
 import           Pos.Util.Servant           (encodeCType)
 import           Pos.Wallet.WalletMode      (getLocalHistory, localChainDifficulty,
@@ -60,12 +61,13 @@ getFullWalletHistory cWalId = do
 
     fullHistory <- addRecentPtxHistory cWalId $ localHistory `Map.union` blockHistory
     walAddrs    <- getWalletAddrsSet Ever cWalId
+    diff        <- getCurChainDifficulty
     -- TODO when we introduce some mechanism to react on new tx in mempool,
     -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
     addHistoryTxs cWalId localHistory
-    cHistory <- forM fullHistory (constructCTx cWalId walAddrs)
+    cHistory <- forM fullHistory (constructCTx cWalId walAddrs diff)
     pure (cHistory, fromIntegral $ Map.size cHistory)
 
 getHistory
@@ -151,16 +153,19 @@ constructCTx
     :: MonadWalletWebMode m
     => CId Wal
     -> Set (CId Addr)
+    -> ChainDifficulty
     -> TxHistoryEntry
     -> m (CTx, POSIXTime)
-constructCTx cWalId walAddrsSet wtx@THEntry{..} = do
+constructCTx cWalId walAddrsSet diff wtx@THEntry{..} = do
     let cId = encodeCType _thTxId
-    diff <- maybe localChainDifficulty pure =<< networkChainDifficulty
     meta <- maybe (CTxMeta <$> liftIO getPOSIXTime) -- It's impossible case but just in case
             pure =<< getTxMeta cWalId cId
     ptxCond <- encodeCType . fmap _ptxCond <$> getPendingTx cWalId _thTxId
     either (throwM . InternalError) (pure . (, ctmDate meta)) $
         mkCTx diff wtx meta ptxCond walAddrsSet
+
+getCurChainDifficulty :: MonadWalletWebMode m => m ChainDifficulty
+getCurChainDifficulty = maybe localChainDifficulty pure =<< networkChainDifficulty
 
 updateTransaction :: MonadWalletWebMode m => AccountId -> CTxId -> CTxMeta -> m ()
 updateTransaction accId txId txMeta = do

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -189,7 +189,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         dstAddrs
 
     addHistoryTx srcWallet th
-    constructCTx (srcWallet, Nothing) th
+    fst <$> constructCTx (srcWallet, Nothing) th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -49,10 +49,11 @@ import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxE
                                                    submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
-import           Pos.Wallet.Web.State             (AddressLookupMode (Existing))
+import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing))
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
                                                    getAccountAddrsOrThrow,
-                                                   getWalletAccountIds)
+                                                   getWalletAccountIds,
+                                                   getWalletAddrMetas)
 
 newPayment
     :: MonadWalletWebMode m
@@ -189,7 +190,8 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         dstAddrs
 
     addHistoryTx srcWallet th
-    fst <$> constructCTx (srcWallet, Nothing) th
+    srcWalletAddrMetas <- getWalletAddrMetas Ever srcWallet
+    fst <$> constructCTx srcWallet srcWalletAddrMetas th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -43,7 +43,8 @@ import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CAddres
                                                    CWAddressMeta (..), Wal,
                                                    addrMetaToAccount, mkCCoin)
 import           Pos.Wallet.Web.Error             (WalletError (..))
-import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx)
+import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
+                                                   getCurChainDifficulty)
 import qualified Pos.Wallet.Web.Methods.Logic     as L
 import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
                                                    submitAndSaveNewPtx)
@@ -191,7 +192,8 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
 
     addHistoryTx srcWallet th
     srcWalletAddrs <- getWalletAddrsSet Ever srcWallet
-    fst <$> constructCTx srcWallet srcWalletAddrs th
+    diff <- getCurChainDifficulty
+    fst <$> constructCTx srcWallet srcWalletAddrs diff th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -53,7 +53,7 @@ import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Exis
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
                                                    getAccountAddrsOrThrow,
                                                    getWalletAccountIds,
-                                                   getWalletAddrMetas)
+                                                   getWalletAddrsSet)
 
 newPayment
     :: MonadWalletWebMode m
@@ -190,8 +190,8 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         dstAddrs
 
     addHistoryTx srcWallet th
-    srcWalletAddrMetas <- getWalletAddrMetas Ever srcWallet
-    fst <$> constructCTx srcWallet srcWalletAddrMetas th
+    srcWalletAddrs <- getWalletAddrsSet Ever srcWallet
+    fst <$> constructCTx srcWallet srcWalletAddrs th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -36,7 +36,7 @@ import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending         (mkPendingTx)
 import           Pos.Wallet.Web.State           (AddressLookupMode (Ever))
 import           Pos.Wallet.Web.Tracking        (fixingCachedAccModifier)
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail, getWalletAddrMetas)
+import           Pos.Wallet.Web.Util            (decodeCTypeOrFail, getWalletAddrsSet)
 
 
 redeemAda
@@ -109,5 +109,5 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     -- add redemption transaction to the history of new wallet
     let cWalId = aiWId accId
     addHistoryTx cWalId th
-    cWalAddrMetas <- getWalletAddrMetas Ever cWalId
-    fst <$> constructCTx cWalId cWalAddrMetas th
+    cWalAddrs <- getWalletAddrsSet Ever cWalId
+    fst <$> constructCTx cWalId cWalAddrs th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -107,4 +107,4 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
 
     -- add redemption transaction to the history of new wallet
     addHistoryTx (aiWId accId) th
-    constructCTx (aiWId accId, Nothing) th
+    fst <$> constructCTx (aiWId accId, Nothing) th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -34,8 +34,9 @@ import qualified Pos.Wallet.Web.Methods.Logic   as L
 import           Pos.Wallet.Web.Methods.Txp     (rewrapTxError, submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending         (mkPendingTx)
+import           Pos.Wallet.Web.State           (AddressLookupMode (Ever))
 import           Pos.Wallet.Web.Tracking        (fixingCachedAccModifier)
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail)
+import           Pos.Wallet.Web.Util            (decodeCTypeOrFail, getWalletAddrMetas)
 
 
 redeemAda
@@ -106,5 +107,7 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
         th <$ submitAndSaveNewPtx enqueueMsg ptx
 
     -- add redemption transaction to the history of new wallet
-    addHistoryTx (aiWId accId) th
-    fst <$> constructCTx (aiWId accId, Nothing) th
+    let cWalId = aiWId accId
+    addHistoryTx cWalId th
+    cWalAddrMetas <- getWalletAddrMetas Ever cWalId
+    fst <$> constructCTx cWalId cWalAddrMetas th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -29,7 +29,8 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId (..), CAccountId (..)
                                                  CPaperVendWalletRedeem (..), CTx (..),
                                                  CWalletRedeem (..))
 import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx, constructCTx)
+import           Pos.Wallet.Web.Methods.History (addHistoryTx, constructCTx,
+                                                 getCurChainDifficulty)
 import qualified Pos.Wallet.Web.Methods.Logic   as L
 import           Pos.Wallet.Web.Methods.Txp     (rewrapTxError, submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
@@ -110,4 +111,5 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     let cWalId = aiWId accId
     addHistoryTx cWalId th
     cWalAddrs <- getWalletAddrsSet Ever cWalId
-    fst <$> constructCTx cWalId cWalAddrs th
+    diff <- getCurChainDifficulty
+    fst <$> constructCTx cWalId cWalAddrs diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -42,7 +42,7 @@ import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
 import           Pos.Wallet.Web.State         (createAccount, setWalletSyncTip,
-                                               updateHistoryCache)
+                                               removeHistoryCache)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
 
@@ -73,7 +73,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId mempty
+    removeHistoryCache wId
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -73,7 +73,7 @@ newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
-    updateHistoryCache wId []
+    updateHistoryCache wId mempty
     -- BListener checks current syncTip before applying update,
     -- thus setting it up to date manually here
     withStateLockNoMetrics HighPriority $ \tip -> setWalletSyncTip wId tip

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -38,7 +38,7 @@ import           Control.Lens                     (to)
 import           Control.Monad.Catch              (handleAll)
 import qualified Data.DList                       as DL
 import qualified Data.HashMap.Strict              as HM
-import           Data.List                        (deleteBy, (!!))
+import           Data.List                        ((!!))
 import qualified Data.List.NonEmpty               as NE
 import qualified Data.Map                         as M
 import           Ether.Internal                   (HasLens (..))
@@ -50,7 +50,7 @@ import           System.Wlog                      (HasLoggerName, WithLogger, lo
 import           Pos.Block.Core                   (BlockHeader, getBlockHeader,
                                                    mainBlockTxPayload)
 import           Pos.Block.Types                  (Blund, undoTx)
-import           Pos.Client.Txp.History           (TxHistoryEntry (..))
+import           Pos.Client.Txp.History           (TxHistoryEntry (..), txHistoryListToMap)
 import           Pos.Core                         (Address (..), BlockHeaderStub,
                                                    ChainDifficulty, HasConfiguration,
                                                    HasDifficulty (..), HeaderHash,
@@ -98,7 +98,7 @@ import           Pos.Wallet.Web.Tracking.Modifier (CAccModifier (..), CachedCAcc
                                                    deleteAndInsertIMM, deleteAndInsertMM,
                                                    deleteAndInsertVM, indexedDeletions,
                                                    sortedInsertions)
-import           Pos.Wallet.Web.Util              (getWalletAddrMetas, sortWalletThByTime)
+import           Pos.Wallet.Web.Util              (getWalletAddrMetas)
 
 
 type BlockLockMode ssc ctx m =
@@ -444,14 +444,13 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     mapM_ (WS.addCustomAddress UsedAddr . fst) (MM.insertions camUsed)
     mapM_ (WS.addCustomAddress ChangeAddr . fst) (MM.insertions camChange)
     WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
-    oldCachedHist <- fromMaybe [] <$> WS.getHistoryCache wid
-    let cMetas = map (bimap encodeCType (CTxMeta . timestampToPosix)) $
-                 mapMaybe (\THEntry {..} -> (_thTxId, ) <$> _thTimestamp) $
-                 DL.toList camAddedHistory
+    oldCachedHist <- fromMaybe mempty <$> WS.getHistoryCache wid
+    let cMetas = M.fromList
+               $ mapMaybe (\THEntry {..} -> (\mts -> (_thTxId, CTxMeta . timestampToPosix $ mts)) <$> _thTimestamp)
+               $ DL.toList camAddedHistory
     WS.addOnlyNewTxMetas wid cMetas
-    sortedAddedHistory <-
-        getNewestFirst <$> sortWalletThByTime wid (DL.toList camAddedHistory)
-    WS.updateHistoryCache wid $ sortedAddedHistory <> oldCachedHist
+    let addedHistory = txHistoryListToMap $ DL.toList camAddedHistory
+    WS.updateHistoryCache wid $ addedHistory <> oldCachedHist -- TODO: check that there are no intersections
     -- resubmitting worker can change ptx in db nonatomically, but
     -- tracker has priority over the resubmiter, thus do not use CAS here
     forM_ camAddedPtxCandidates $ \(txid, ptxBlkInfo) ->
@@ -477,18 +476,11 @@ rollbackModifierFromWallet wid newTip CAccModifier{..} = do
     WS.getHistoryCache wid >>= \case
         Nothing -> pure ()
         Just oldCachedHist -> do
-            sortedDeletedHistory <-
-                getNewestFirst <$> sortWalletThByTime wid (DL.toList camDeletedHistory)
+            let deletedHistory = txHistoryListToMap (DL.toList camDeletedHistory)
             WS.updateHistoryCache wid $
-                removeFromHead sortedDeletedHistory oldCachedHist
-            WS.removeWalletTxMetas wid (map (encodeCType . _thTxId) sortedDeletedHistory)
+                oldCachedHist `M.difference` deletedHistory
+            WS.removeWalletTxMetas wid (map encodeCType $ M.keys deletedHistory)
     WS.setWalletSyncTip wid newTip
-  where
-    removeFromHead :: [TxHistoryEntry] -> [TxHistoryEntry] -> [TxHistoryEntry]
-    removeFromHead [] ths = ths
-    removeFromHead _ [] = []
-    removeFromHead (dTh : dThes) thes =
-        removeFromHead dThes $! deleteBy ((==) `on` _thTxId) dTh thes
 
 evalChange
     :: [CWAddressMeta] -- ^ All adresses


### PR DESCRIPTION
Branch (& PR) to combine and test the following fixes:

 * [X] CSM-489 / PR #1729 keep the history cache as a map
 * [x] CSM-491 / PR #1722 smaller acid-state DB tx logs
 * [x] CSM-485 / PR #1726 further improvements to getHistory

These existing PRs need to be rebased on this branch (so on top of the history cache representation change). My recommendation is to merge in the order above. In particular #1722 also changes the DB transactions and that could be simplified slightly by merging next.

Then we need:

 * [x] test DB migration works, ie test with a non-empty DB and non-empty DB tx log.
 * [ ] test that the epoch boundary bug is solved (ie CSM-489)
 * [x] check overall getHistory performance improvements
 * [ ] test to make sure timestamps of transactions are stable, needed by deadalus UI and perhaps could be confusing for exchanges if this were off.

We can test between merging #1722 and #1726 or just at the end.