### PR TITLE
[CSM-494] `/api/wallets` (as well as `/api/accounts`) works for a long time

### DIFF
--- a/core/Pos/Util/Modifier.hs
+++ b/core/Pos/Util/Modifier.hs
@@ -25,6 +25,8 @@ module Pos.Util.Modifier
        , modifyHashMap
        , modifyMap
        , foldlMapModWKey'
+       , fromHashMap
+       , toHashMap
        ) where
 
 import           Universum                 hiding (filter, mapMaybe, toList)
@@ -202,3 +204,9 @@ foldlMapModWKey'
     -> MapModifier k v
     -> a
 foldlMapModWKey' f acc = HM.foldlWithKey' f acc . getMapModifier
+
+toHashMap :: MapModifier k v -> HashMap k (Maybe v)
+toHashMap = getMapModifier
+
+fromHashMap :: HashMap k (Maybe v) -> MapModifier k v
+fromHashMap = MapModifier

--- a/node/src/Pos/Client/Txp/Balances.hs
+++ b/node/src/Pos/Client/Txp/Balances.hs
@@ -59,9 +59,9 @@ getOwnUtxosDefault addrs = do
 
     updates <- getUtxoModifier
     commonUtxo <- if null commonAddrs then pure mempty
-                    else WS.getWalletUtxo
+                  else WS.getWalletUtxo
     redeemUtxo <- if null redeemAddrs then pure mempty
-                    else DB.getFilteredUtxo redeemAddrs
+                  else DB.getFilteredUtxo redeemAddrs
 
     let allUtxo = MM.modifyMap updates $ commonUtxo <> redeemUtxo
         addrsSet = HS.fromList addrs

--- a/node/src/Pos/SafeCopy.hs
+++ b/node/src/Pos/SafeCopy.hs
@@ -19,7 +19,6 @@ import           Serokell.Data.Memory.Units      (Byte, fromBytes, toBytes)
 import           Pos.Binary.Class                (Bi)
 import qualified Pos.Binary.Class                as Bi
 import           Pos.Block.Core
-import           Pos.Core.Vss                    (VssCertificate (..))
 import           Pos.Core.Fee                    (Coeff (..), TxFeePolicy (..),
                                                   TxSizeLinear (..))
 import           Pos.Core.Types                  (AddrAttributes (..),
@@ -35,8 +34,10 @@ import           Pos.Core.Types                  (AddrAttributes (..),
                                                   Script (..), SharedSeed (..),
                                                   SlotCount (..), SlotId (..),
                                                   SoftforkRule (..), SoftwareVersion (..))
+import           Pos.Core.Vss                    (VssCertificate (..))
 import           Pos.Crypto.Hashing              (AbstractHash (..))
 import           Pos.Crypto.HD                   (HDAddressPayload (..))
+import           Pos.Crypto.SecretSharing        (SecretProof)
 import           Pos.Crypto.Signing.Redeem       (RedeemPublicKey (..),
                                                   RedeemSecretKey (..),
                                                   RedeemSignature (..))
@@ -44,7 +45,6 @@ import           Pos.Crypto.Signing.Signing      (ProxyCert (..), ProxySecretKey
                                                   ProxySignature (..), PublicKey (..),
                                                   SecretKey (..), Signature (..),
                                                   Signed (..))
-import           Pos.Crypto.SecretSharing        (SecretProof)
 import           Pos.Data.Attributes             (Attributes (..), UnparsedFields)
 import           Pos.Delegation.Types            (DlgPayload (..))
 import           Pos.Merkle                      (MerkleNode (..), MerkleRoot (..),
@@ -60,6 +60,7 @@ import           Pos.Update.Core.Types           (BlockVersionModifier (..),
                                                   SystemTag (..), UpdateData (..),
                                                   UpdatePayload (..), UpdateProposal (..),
                                                   UpdateVote (..))
+import qualified Pos.Util.Modifier               as MM
 
 
 ----------------------------------------------------------------------------
@@ -349,3 +350,7 @@ instance Cereal.Serialize Byte where
     put = Cereal.put . toBytes
 
 instance SafeCopy Byte
+
+instance (SafeCopy k, SafeCopy v, Eq k, Hashable k) => SafeCopy (MM.MapModifier k v) where
+    getCopy = contain $ MM.fromHashMap <$> safeGet
+    putCopy mm = contain $ safePut (MM.toHashMap mm)

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -23,6 +23,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetWalletAddresses (..)
        , GetWalletUtxo (..)
        , GetWalletBalancesAndUtxo (..)
+       , UpdateWalletBalancesAndUtxo (..)
        , SetWalletUtxo (..)
        , GetAccountWAddresses (..)
        , DoesWAddressExist (..)
@@ -126,6 +127,7 @@ makeAcidic ''WalletStorage
     , 'WS.getWalletAddresses
     , 'WS.getWalletUtxo
     , 'WS.getWalletBalancesAndUtxo
+    , 'WS.updateWalletBalancesAndUtxo
     , 'WS.setWalletUtxo
     , 'WS.getAccountWAddresses
     , 'WS.doesWAddressExist

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -22,6 +22,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetWalletSyncTip (..)
        , GetWalletAddresses (..)
        , GetWalletUtxo (..)
+       , GetWalletBalancesAndUtxo (..)
        , SetWalletUtxo (..)
        , GetAccountWAddresses (..)
        , DoesWAddressExist (..)
@@ -124,6 +125,7 @@ makeAcidic ''WalletStorage
     , 'WS.getWalletSyncTip
     , 'WS.getWalletAddresses
     , 'WS.getWalletUtxo
+    , 'WS.getWalletBalancesAndUtxo
     , 'WS.setWalletUtxo
     , 'WS.getAccountWAddresses
     , 'WS.doesWAddressExist

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -36,6 +36,7 @@ module Pos.Wallet.Web.State.State
        , getCustomAddress
        , isCustomAddress
        , getWalletUtxo
+       , getWalletBalancesAndUtxo
        , getPendingTxs
        , getWalletPendingTxs
        , getPendingTx
@@ -99,7 +100,8 @@ import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemS
 import           Pos.Wallet.Web.State.Acidic  as A
 import           Pos.Wallet.Web.State.Storage (AddressLookupMode (..),
                                                CustomAddressType (..), PtxMetaUpdate (..),
-                                               WalletStorage, WalletTip (..))
+                                               WalletBalances, WalletStorage,
+                                               WalletTip (..))
 
 -- | MonadWalletWebDB stands for monad which is able to get web wallet state
 type MonadWalletWebDB ctx m =
@@ -243,6 +245,9 @@ setWalletTxHistory cWalId = updateDisk . A.SetWalletTxHistory cWalId
 
 getWalletUtxo :: WebWalletModeDB ctx m => m Utxo
 getWalletUtxo = queryDisk A.GetWalletUtxo
+
+getWalletBalancesAndUtxo :: WebWalletModeDB ctx m => m (WalletBalances, Utxo)
+getWalletBalancesAndUtxo = queryDisk A.GetWalletBalancesAndUtxo
 
 setWalletUtxo :: WebWalletModeDB ctx m => Utxo -> m ()
 setWalletUtxo = updateDisk . A.SetWalletUtxo

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -37,6 +37,7 @@ module Pos.Wallet.Web.State.State
        , isCustomAddress
        , getWalletUtxo
        , getWalletBalancesAndUtxo
+       , updateWalletBalancesAndUtxo
        , getPendingTxs
        , getWalletPendingTxs
        , getPendingTx
@@ -87,7 +88,7 @@ import           Universum
 
 import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core.Configuration       (HasConfiguration)
-import           Pos.Txp                      (TxId, Utxo)
+import           Pos.Txp                      (TxId, Utxo, UtxoModifier)
 import           Pos.Types                    (HeaderHash)
 import           Pos.Util.Servant             (encodeCType)
 import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
@@ -248,6 +249,9 @@ getWalletUtxo = queryDisk A.GetWalletUtxo
 
 getWalletBalancesAndUtxo :: WebWalletModeDB ctx m => m (WalletBalances, Utxo)
 getWalletBalancesAndUtxo = queryDisk A.GetWalletBalancesAndUtxo
+
+updateWalletBalancesAndUtxo :: WebWalletModeDB ctx m => UtxoModifier -> m ()
+updateWalletBalancesAndUtxo = updateDisk . A.UpdateWalletBalancesAndUtxo
 
 setWalletUtxo :: WebWalletModeDB ctx m => Utxo -> m ()
 setWalletUtxo = updateDisk . A.SetWalletUtxo

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE Rank2Types   #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE Rank2Types #-}
 
 -- @jens: this document is inspired by https://github.com/input-output-hk/rscoin-haskell/blob/master/src/RSCoin/Explorer/Storage.hs
 module Pos.Wallet.Web.State.Storage
@@ -7,6 +7,7 @@ module Pos.Wallet.Web.State.Storage
          WalletStorage (..)
        , AddressLookupMode (..)
        , CustomAddressType (..)
+       , WalletBalances
        , WalletTip (..)
        , PtxMetaUpdate (..)
        , Query
@@ -48,6 +49,7 @@ module Pos.Wallet.Web.State.Storage
        , setWalletTxHistory
        , getWalletTxHistory
        , getWalletUtxo
+       , getWalletBalancesAndUtxo
        , setWalletUtxo
        , addOnlyNewTxMeta
        , setWalletTxMeta
@@ -80,13 +82,15 @@ import           Control.Monad.State.Class      (put)
 import           Data.Default                   (Default, def)
 import qualified Data.HashMap.Strict            as HM
 import qualified Data.Map                       as M
-import           Data.SafeCopy                  (Migrate (..), extension, base, deriveSafeCopySimple)
+import           Data.SafeCopy                  (Migrate (..), base, deriveSafeCopySimple,
+                                                 extension)
 import           Data.Time.Clock.POSIX          (POSIXTime)
 
 import           Pos.Client.Txp.History         (TxHistoryEntry, txHistoryListToMap)
 import           Pos.Core.Configuration         (HasConfiguration)
 import           Pos.Core.Types                 (SlotId, Timestamp)
-import           Pos.Txp                        (TxAux, TxId, Utxo)
+import           Pos.Txp                        (AddrCoinMap, TxAux, TxId, Utxo,
+                                                 utxoToAddressCoinMap)
 import           Pos.Types                      (HeaderHash)
 import           Pos.Util.BackupPhrase          (BackupPhrase)
 import           Pos.Wallet.Web.ClientTypes     (AccountId, Addr, CAccountMeta, CCoin,
@@ -139,6 +143,7 @@ makeLenses ''WalletInfo
 
 -- | Maps addresses to their first occurrence in the blockchain
 type CustomAddresses = HashMap (CId Addr) HeaderHash
+type WalletBalances = AddrCoinMap
 
 data WalletStorage = WalletStorage
     { _wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
@@ -148,6 +153,9 @@ data WalletStorage = WalletStorage
     , _wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
     , _wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
     , _wsUtxo            :: !Utxo
+    -- @_wsBalances@ depends on @_wsUtxo@,
+    -- it's forbidden to update @_wsBalances@ without @_wsUtxo@
+    , _wsBalances        :: !WalletBalances
     , _wsUsedAddresses   :: !CustomAddresses
     , _wsChangeAddresses :: !CustomAddresses
     }
@@ -166,6 +174,7 @@ instance Default WalletStorage where
         , _wsUsedAddresses   = mempty
         , _wsChangeAddresses = mempty
         , _wsUtxo            = mempty
+        , _wsBalances        = mempty
         }
 
 type Query a = forall m. (MonadReader WalletStorage m) => m a
@@ -263,8 +272,13 @@ getWalletTxHistory cWalId = toList <<$>> preview (wsTxHistory . ix cWalId)
 getWalletUtxo :: Query Utxo
 getWalletUtxo = view wsUtxo
 
+getWalletBalancesAndUtxo :: Query (WalletBalances, Utxo)
+getWalletBalancesAndUtxo = (,) <$> view wsBalances <*> view wsUtxo
+
 setWalletUtxo :: Utxo -> Update ()
-setWalletUtxo utxo = wsUtxo .= utxo
+setWalletUtxo utxo = do
+    wsUtxo .= utxo
+    wsBalances .= utxoToAddressCoinMap utxo
 
 getUpdates :: Query [CUpdateInfo]
 getUpdates = view wsReadyUpdates
@@ -509,7 +523,6 @@ deriveSafeCopySimple 0 'base ''AccountInfo
 deriveSafeCopySimple 0 'base ''WalletTip
 deriveSafeCopySimple 0 'base ''WalletInfo
 
-
 -- Legacy versions, for migrations
 
 data WalletStorage_v0 = WalletStorage_v0
@@ -524,19 +537,47 @@ data WalletStorage_v0 = WalletStorage_v0
     , _v0_wsChangeAddresses :: !CustomAddresses
     }
 
+data WalletStorage_v1 = WalletStorage_v1
+    { _v1_wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
+    , _v1_wsAccountInfos    :: !(HashMap AccountId AccountInfo)
+    , _v1_wsProfile         :: !CProfile
+    , _v1_wsReadyUpdates    :: [CUpdateInfo]
+    , _v1_wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
+    , _v1_wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
+    , _v1_wsUtxo            :: !Utxo
+    , _v1_wsUsedAddresses   :: !CustomAddresses
+    , _v1_wsChangeAddresses :: !CustomAddresses
+    }
+
 deriveSafeCopySimple 0 'base ''WalletStorage_v0
-deriveSafeCopySimple 1 'extension ''WalletStorage
+deriveSafeCopySimple 1 'extension ''WalletStorage_v1
+deriveSafeCopySimple 2 'extension ''WalletStorage
+
+instance Migrate WalletStorage_v1 where
+    type MigrateFrom WalletStorage_v1 = WalletStorage_v0
+    migrate WalletStorage_v0{..} = WalletStorage_v1
+        { _v1_wsWalletInfos     = _v0_wsWalletInfos
+        , _v1_wsAccountInfos    = _v0_wsAccountInfos
+        , _v1_wsProfile         = _v0_wsProfile
+        , _v1_wsReadyUpdates    = _v0_wsReadyUpdates
+        , _v1_wsTxHistory       = _v0_wsTxHistory
+        , _v1_wsHistoryCache    = HM.map txHistoryListToMap _v0_wsHistoryCache
+        , _v1_wsUtxo            = _v0_wsUtxo
+        , _v1_wsUsedAddresses   = _v0_wsUsedAddresses
+        , _v1_wsChangeAddresses = _v0_wsChangeAddresses
+        }
 
 instance Migrate WalletStorage where
-    type MigrateFrom WalletStorage = WalletStorage_v0
-    migrate WalletStorage_v0{..} = WalletStorage
-        { _wsWalletInfos     = _v0_wsWalletInfos
-        , _wsAccountInfos    = _v0_wsAccountInfos
-        , _wsProfile         = _v0_wsProfile
-        , _wsReadyUpdates    = _v0_wsReadyUpdates
-        , _wsTxHistory       = _v0_wsTxHistory
-        , _wsHistoryCache    = HM.map txHistoryListToMap _v0_wsHistoryCache
-        , _wsUtxo            = _v0_wsUtxo
-        , _wsUsedAddresses   = _v0_wsUsedAddresses
-        , _wsChangeAddresses = _v0_wsChangeAddresses
+    type MigrateFrom WalletStorage = WalletStorage_v1
+    migrate WalletStorage_v1{..} = WalletStorage
+        { _wsWalletInfos     = _v1_wsWalletInfos
+        , _wsAccountInfos    = _v1_wsAccountInfos
+        , _wsProfile         = _v1_wsProfile
+        , _wsReadyUpdates    = _v1_wsReadyUpdates
+        , _wsTxHistory       = _v1_wsTxHistory
+        , _wsHistoryCache    = _v1_wsHistoryCache
+        , _wsUtxo            = _v1_wsUtxo
+        , _wsBalances        = utxoToAddressCoinMap _v1_wsUtxo
+        , _wsUsedAddresses   = _v1_wsUsedAddresses
+        , _wsChangeAddresses = _v1_wsChangeAddresses
         }

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -4,7 +4,7 @@
 -- @jens: this document is inspired by https://github.com/input-output-hk/rscoin-haskell/blob/master/src/RSCoin/Explorer/Storage.hs
 module Pos.Wallet.Web.State.Storage
        (
-         WalletStorage (..)
+         WalletStorage
        , AddressLookupMode (..)
        , CustomAddressType (..)
        , WalletBalances

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3447,6 +3447,8 @@ self: {
           pname = "foldl";
           version = "1.2.5";
           sha256 = "aa2d5c3cfb8641163dcdd489e9e0fe481301e94c0e3940fc9e234f8e1b00ec4b";
+          revision = "1";
+          editedCabalFile = "02lk5838594mi15bylz2kpcm1c4akbsswj73i7k8xw4ns66iaq04";
           libraryHaskellDepends = [
             base
             bytestring
@@ -3706,10 +3708,8 @@ self: {
       happy = callPackage ({ Cabal, array, base, containers, directory, filepath, mkDerivation, mtl, stdenv }:
       mkDerivation {
           pname = "happy";
-          version = "1.19.7";
-          sha256 = "bb312a9e63d5295cca3e94ebe32d7c094216d7d9dafee3edb45c847b45126f9b";
-          revision = "1";
-          editedCabalFile = "1w0sm3qn1icxiiif6355pr6cwd9bqfh56g8qc5hycagcnms8hip1";
+          version = "1.19.8";
+          sha256 = "4df739965d559e48a9b0044fa6140241c07e8f3c794c6c0a6323024fd7f0d3a0";
           isLibrary = false;
           isExecutable = true;
           setupHaskellDepends = [
@@ -6024,6 +6024,8 @@ self: {
           pname = "servant-swagger";
           version = "1.1.3.1";
           sha256 = "e8d85d05f4251b7bdbd7c5f215d90a22eb55a46812bc82469d94d2f07adebb58";
+          revision = "1";
+          editedCabalFile = "1bx68rcz4whjw3pqm40aiqpfigcgg9dkgjdlggry2iv81s0415xf";
           setupHaskellDepends = [
             base
             Cabal
@@ -6054,6 +6056,8 @@ self: {
           pname = "servant-swagger-ui";
           version = "0.2.4.3.0.20";
           sha256 = "b603d7da9141714a5eab226d015ffe566294671840c84d9bf94c4ea0114817a3";
+          revision = "1";
+          editedCabalFile = "1wsbb9zaq5qv39hrymy1cma581337rbvqlm7y24jwfvk4vafs3fp";
           libraryHaskellDepends = [
             base
             blaze-markup

--- a/txp/Pos/Txp/Toil/Utxo/Util.hs
+++ b/txp/Pos/Txp/Toil/Utxo/Util.hs
@@ -6,6 +6,7 @@ module Pos.Txp.Toil.Utxo.Util
        , getTotalCoinsInUtxo
        , utxoToStakes
        , utxoToAddressCoinPairs
+       , utxoToAddressCoinMap
        ) where
 
 import qualified Data.HashMap.Strict as HM
@@ -44,9 +45,12 @@ utxoToAddressCoinPairs utxo = combineWith unsafeAddCoin txOuts
 
     txOuts :: [(Address, Coin)]
     txOuts = map processTxOutAux utxoElems
-      where
-        processTxOutAux :: TxOutAux -> (Address, Coin)
-        processTxOutAux txOutAux = view _TxOut . toaOut $ txOutAux
 
-        utxoElems :: [TxOutAux]
-        utxoElems = M.elems utxo
+    utxoElems :: [TxOutAux]
+    utxoElems = M.elems utxo
+
+    processTxOutAux :: TxOutAux -> (Address, Coin)
+    processTxOutAux = view _TxOut . toaOut
+
+utxoToAddressCoinMap :: Utxo -> HashMap Address Coin
+utxoToAddressCoinMap = HM.fromList . utxoToAddressCoinPairs

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -8,16 +8,16 @@ module Pos.Wallet.Web.Server.Handlers
 
 import           Universum
 
-import           Pos.Communication       (SendActions (..))
+import           Pos.Communication        (SendActions (..))
 import           Pos.Update.Configuration (curSoftwareVersion)
-import           Pos.Wallet.WalletMode   (blockchainSlotDuration)
-import           Pos.Wallet.Web.Account  (GenSeed (RandomSeed))
-import           Pos.Wallet.Web.Api      (WalletApi)
-import qualified Pos.Wallet.Web.Methods  as M
-import           Pos.Wallet.Web.Mode     (MonadWalletWebMode)
-import           Pos.Wallet.Web.Tracking (fixingCachedAccModifier)
-import           Servant.API             ((:<|>) ((:<|>)))
-import           Servant.Server          (ServerT)
+import           Pos.Wallet.WalletMode    (blockchainSlotDuration)
+import           Pos.Wallet.Web.Account   (GenSeed (RandomSeed))
+import           Pos.Wallet.Web.Api       (WalletApi)
+import qualified Pos.Wallet.Web.Methods   as M
+import           Pos.Wallet.Web.Mode      (MonadWalletWebMode)
+import           Pos.Wallet.Web.Tracking  (fixingCachedAccModifier)
+import           Servant.API              ((:<|>) ((:<|>)))
+import           Servant.Server           (ServerT)
 
 servantHandlers
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -143,7 +143,7 @@ txMempoolToModifier encSK = do
     tipH <- DB.getTipHeader @WalletSscType
     allAddresses <- getWalletAddrMetas Ever wId
     case topsortTxs wHash txsWUndo of
-        Nothing -> mempty <$ logWarning "txMempoolToModifier: couldn't topsort mempool txs"
+        Nothing      -> mempty <$ logWarning "txMempoolToModifier: couldn't topsort mempool txs"
         Just ordered -> pure $
             trackingApplyTxs @WalletSscType encSK allAddresses getDiff getTs getPtxBlkInfo $
             map (\(_, tx, undo) -> (tx, undo, tipH)) ordered
@@ -278,7 +278,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
     whenNothing_ wTipHeader $ do
         let encInfo = getEncInfo encSK
             ownGenesisData =
-                selectOwnAccounts encInfo (txOutAddress . toaOut . snd) $
+                selectOwnAddresses encInfo (txOutAddress . toaOut . snd) $
                 M.toList $ unGenesisUtxo genesisUtxo
             ownGenesisUtxo = M.fromList $ map fst ownGenesisData
             ownGenesisAddrs = map snd ownGenesisData
@@ -299,15 +299,6 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
     firstGenesisHeader = resolveForwardLink (genesisHash @BlockHeaderStub) >>=
         maybe (error "Unexpected state: genesisHash doesn't have forward link")
             (maybe (error "No genesis block corresponding to header hash") pure <=< DB.blkGetHeader)
-
--- TODO: @pva701: maybe it would be needed, dunno
--- runWithWalletUtxo
---     :: (MonadReader ctx m, HasLens GenesisUtxo ctx GenesisUtxo, WebWalletModeDB ctx m)
---     => ToilT () (DBToil m) a
---     -> m a
--- runWithWalletUtxo action = do
---     walletUtxo <- WS.getWalletUtxo
---     runDBToil $ fst <$> runToilTLocal (fromUtxo walletUtxo) def mempty action
 
 -- Process transactions on block application,
 -- decrypt our addresses, and add/delete them to/from wallet-db.
@@ -340,9 +331,8 @@ trackingApplyTxs (getEncInfo -> encInfo) allAddresses getDiff getTs getPtxBlkInf
             txOutgoings = map txOutAddress outs
             txInputs = map (toaOut . snd) resolvedInputs
 
-            ownInputs = selectOwnAccounts encInfo (txOutAddress . toaOut . snd) resolvedInputs
-            ownOutputs = selectOwnAccounts encInfo (txOutAddress . snd) $
-                enumerate outs
+            ownInputs = selectOwnAddresses encInfo (txOutAddress . toaOut . snd) resolvedInputs
+            ownOutputs = selectOwnAddresses encInfo (txOutAddress . snd) $ enumerate outs
             ownInpAddrMetas = map snd ownInputs
             ownOutAddrMetas = map snd ownOutputs
             ownTxIns = map (fst . fst) ownInputs
@@ -374,7 +364,7 @@ trackingApplyTxs (getEncInfo -> encInfo) allAddresses getDiff getTs getPtxBlkInf
             camDeletedPtxCandidates
 
 -- Process transactions on block rollback.
--- Like @trackingApplyTx@, but vise versa.
+-- Like @trackingApplyTxs@, but vise versa.
 trackingRollbackTxs
     :: forall ssc . (HasConfiguration, SscHelpersClass ssc)
     => EncryptedSecretKey -- ^ Wallet's secret key
@@ -399,8 +389,8 @@ trackingRollbackTxs (getEncInfo -> encInfo) allAddress getDiff getTs txs =
             txOutgoings = map txOutAddress outs
             txInputs = map (toaOut . snd) resolvedInputs
 
-            ownInputs = selectOwnAccounts encInfo (txOutAddress . toaOut) undoL'
-            ownOutputs = selectOwnAccounts encInfo txOutAddress $ outs
+            ownInputs = selectOwnAddresses encInfo (txOutAddress . toaOut) undoL'
+            ownOutputs = selectOwnAddresses encInfo txOutAddress $ outs
             ownInputMetas = map snd ownInputs
             ownOutputMetas = map snd ownOutputs
             ownInputAddrs = map cwamId ownInputMetas
@@ -494,19 +484,19 @@ getEncInfo encSK = do
     let wCId = addressToCId $ makeRootPubKeyAddress pubKey
     (hdPass, wCId)
 
-selectOwnAccounts
+selectOwnAddresses
     :: (HDPassphrase, CId Wal)
     -> (a -> Address)
     -> [a]
     -> [(a, CWAddressMeta)]
-selectOwnAccounts encInfo getAddr =
-    mapMaybe (\a -> (a,) <$> decryptAccount encInfo (getAddr a))
+selectOwnAddresses encInfo getAddr =
+    mapMaybe (\a -> (a,) <$> decryptAddress encInfo (getAddr a))
 
 setLogger :: HasLoggerName m => m a -> m a
 setLogger = modifyLoggerName (<> "wallet" <> "sync")
 
-decryptAccount :: (HDPassphrase, CId Wal) -> Address -> Maybe CWAddressMeta
-decryptAccount (hdPass, wCId) addr = do
+decryptAddress :: (HDPassphrase, CId Wal) -> Address -> Maybe CWAddressMeta
+decryptAddress (hdPass, wCId) addr = do
     hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
     derPath <- unpackHDAddressAttr hdPass hdPayload
     guard $ length derPath == 2

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -50,7 +50,8 @@ import           System.Wlog                      (HasLoggerName, WithLogger, lo
 import           Pos.Block.Core                   (BlockHeader, getBlockHeader,
                                                    mainBlockTxPayload)
 import           Pos.Block.Types                  (Blund, undoTx)
-import           Pos.Client.Txp.History           (TxHistoryEntry (..), txHistoryListToMap)
+import           Pos.Client.Txp.History           (TxHistoryEntry (..),
+                                                   txHistoryListToMap)
 import           Pos.Core                         (Address (..), BlockHeaderStub,
                                                    ChainDifficulty, HasConfiguration,
                                                    HasDifficulty (..), HeaderHash,
@@ -76,7 +77,8 @@ import           Pos.StateLock                    (Priority (..), StateLock,
 import           Pos.Txp                          (GenesisUtxo (..), Tx (..), TxAux (..),
                                                    TxIn (..), TxOutAux (..), TxUndo,
                                                    flattenTxPayload, genesisUtxo, toaOut,
-                                                   topsortTxs, txOutAddress)
+                                                   topsortTxs, txOutAddress,
+                                                   utxoToModifier)
 import           Pos.Txp.MemState.Class           (MonadTxpMem, getLocalTxsNUndo)
 import           Pos.Util.Chrono                  (getNewestFirst)
 import qualified Pos.Util.Modifier                as MM
@@ -283,7 +285,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
             ownGenesisUtxo = M.fromList $ map fst ownGenesisData
             ownGenesisAddrs = map snd ownGenesisData
         mapM_ WS.addWAddress ownGenesisAddrs
-        WS.getWalletUtxo >>= WS.setWalletUtxo . (ownGenesisUtxo <>)
+        WS.updateWalletBalancesAndUtxo (utxoToModifier ownGenesisUtxo)
 
     startFromH <- maybe firstGenesisHeader pure wTipHeader
     mapModifier@CAccModifier{..} <- computeAccModifier startFromH
@@ -434,7 +436,7 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     mapM_ WS.addWAddress (sortedInsertions camAddresses)
     mapM_ (WS.addCustomAddress UsedAddr . fst) (MM.insertions camUsed)
     mapM_ (WS.addCustomAddress ChangeAddr . fst) (MM.insertions camChange)
-    WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
+    WS.updateWalletBalancesAndUtxo camUtxo
     let cMetas = M.fromList
                $ mapMaybe (\THEntry {..} -> (\mts -> (_thTxId, CTxMeta . timestampToPosix $ mts)) <$> _thTimestamp)
                $ DL.toList camAddedHistory
@@ -458,7 +460,7 @@ rollbackModifierFromWallet wid newTip CAccModifier{..} = do
     mapM_ WS.removeWAddress (indexedDeletions camAddresses)
     mapM_ (WS.removeCustomAddress UsedAddr) (MM.deletions camUsed)
     mapM_ (WS.removeCustomAddress ChangeAddr) (MM.deletions camChange)
-    WS.getWalletUtxo >>= WS.setWalletUtxo . MM.modifyMap camUtxo
+    WS.updateWalletBalancesAndUtxo camUtxo
     forM_ camDeletedPtxCandidates $ \(txid, poolInfo) -> do
         curSlot <- getCurrentSlotInaccurate
         WS.ptxUpdateMeta wid txid (WS.PtxResetSubmitTiming curSlot)


### PR DESCRIPTION
At least one problem was we computed balance for an address via iterating over utxo. Now we store hashmap `Address -> Coin` corresponding to wallet utxo.

I tested on old database, migration works. A number of addresses and transactions = 500, time was reduced from 6sec to 0.2sec. Result JSONs for `/api/wallets` and `/api/accounts/` before and after fix are same.

Tested with n = 3000, ~2 secs.
There is still what can be optimized, but I suppose it's enough for now and we should get a response from Richie for the current version.

**UPD**: tested on both version of wallet-db: initial and version in `cardano-sl-1.0-exchange`