### PR TITLE
[CSL-1708] Use latest version of log-warper

### DIFF
--- a/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
+++ b/godtossing/Pos/Ssc/GodTossing/Toss/Pure.hs
@@ -92,9 +92,9 @@ runPureToss
 runPureToss gs (PureToss act) = do
     seed <- Rand.drgNew
     let ((res, newGS), events) =
-            fst . Rand.withDRG seed $    -- run MonadRandom
-            runNamedPureLog  $           -- run NamedPureLogger
-            (flip runStateT gs) act      -- run State
+            fst . Rand.withDRG seed $ -- run MonadRandom
+            runNamedPureLog  $        -- run NamedPureLogger
+            (usingStateT gs) act      -- run State
     pure (res, newGS, events)
 
 runPureTossWithLogger

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4463,11 +4463,11 @@ self: {
           description = "ListT done right";
           license = stdenv.lib.licenses.mit;
         }) {};
-      log-warper = callPackage ({ aeson, ansi-terminal, base, containers, directory, dlist, errors, exceptions, extra, filepath, formatting, hashable, lens, mkDerivation, mmorph, monad-control, monad-loops, mtl, network, safecopy, stdenv, text, text-format, time, transformers, transformers-base, universum, unix, unordered-containers, yaml }:
+      log-warper = callPackage ({ aeson, ansi-terminal, base, containers, deepseq, directory, dlist, errors, exceptions, extra, filepath, formatting, hashable, lens, mkDerivation, mmorph, monad-control, monad-loops, mtl, network, safecopy, stdenv, text, text-format, time, transformers, transformers-base, universum, unix, unordered-containers, yaml }:
       mkDerivation {
           pname = "log-warper";
-          version = "1.2.2";
-          sha256 = "2b558bad636dc3b25383585667bcadda00251ef0f1a31da2267a9bfb8704bc43";
+          version = "1.2.3.1";
+          sha256 = "0fqn1a0zz8k281mbvqpifvcxrj0sg8k2khylv4khaa8969d0mpa7";
           isLibrary = true;
           isExecutable = true;
           libraryHaskellDepends = [
@@ -4475,6 +4475,7 @@ self: {
             ansi-terminal
             base
             containers
+            deepseq
             directory
             dlist
             errors

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4467,7 +4467,7 @@ self: {
       mkDerivation {
           pname = "log-warper";
           version = "1.2.3.1";
-          sha256 = "0fqn1a0zz8k281mbvqpifvcxrj0sg8k2khylv4khaa8969d0mpa7";
+          sha256 = "47dd0a5a3209290527d9d4c329267a1ac8dcd976f1e2bd6a4062a2ff810a163b";
           isLibrary = true;
           isExecutable = true;
           libraryHaskellDepends = [

--- a/stack.yaml
+++ b/stack.yaml
@@ -101,7 +101,7 @@ extra-deps:
 - serokell-util-0.5.0
 - pvss-0.2.0
 - base58-bytestring-0.1.0
-- log-warper-1.2.2
+- log-warper-1.2.3.1
 - concurrent-extra-0.7.0.10       # not yet on Stackage
 # - purescript-bridge-0.8.0.1
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8

--- a/update/Pos/Update/Poll/Pure.hs
+++ b/update/Pos/Update/Poll/Pure.hs
@@ -34,7 +34,7 @@ newtype PurePoll a = PurePoll
 
 runPurePollWithLogger :: Poll.PollState -> PurePoll a -> (a, Poll.PollState, [LogEvent])
 runPurePollWithLogger ps pp =
-    let innerMonad = flip runStateT ps . getPurePoll $ pp
+    let innerMonad = usingStateT ps . getPurePoll $ pp
     in  (\((a, finalState), logs) -> (a, finalState, logs)) . runIdentity . runNamedPureLog $ innerMonad
 
 evalPurePollWithLogger :: Poll.PollState -> PurePoll a -> a

--- a/update/Pos/Update/Poll/Pure.hs
+++ b/update/Pos/Update/Poll/Pure.hs
@@ -17,7 +17,7 @@ import           System.Wlog               (CanLog, HasLoggerName (..), LogEvent
                                             runNamedPureLog)
 
 import           Pos.Binary.Class          (Bi)
-import           Pos.Core                  (SoftwareVersion (..), HasConfiguration)
+import           Pos.Core                  (HasConfiguration, SoftwareVersion (..))
 import           Pos.Crypto                (hash)
 import           Pos.Update.Core           (UpdateProposal (..), applyBVM)
 import           Pos.Update.Poll.Class     (MonadPoll (..), MonadPollRead (..))
@@ -29,12 +29,13 @@ import           Pos.Update.Poll.Types     (BlockVersionState (..),
                                             psProposal)
 
 newtype PurePoll a = PurePoll
-    { getPurePoll :: NamedPureLogger (State Poll.PollState) a
-    } deriving (Functor, Applicative, Monad, CanLog, HasLoggerName)
+    { getPurePoll :: StateT Poll.PollState (NamedPureLogger Identity) a
+    } deriving (Functor, Applicative, Monad, CanLog, HasLoggerName, MonadState Poll.PollState)
 
 runPurePollWithLogger :: Poll.PollState -> PurePoll a -> (a, Poll.PollState, [LogEvent])
-runPurePollWithLogger ps =
-    (\((a, c), b) -> (a, b, c)) . flip runState ps . runNamedPureLog . getPurePoll
+runPurePollWithLogger ps pp =
+    let innerMonad = flip runStateT ps . getPurePoll $ pp
+    in  (\((a, finalState), logs) -> (a, finalState, logs)) . runIdentity . runNamedPureLog $ innerMonad
 
 evalPurePollWithLogger :: Poll.PollState -> PurePoll a -> a
 evalPurePollWithLogger r = view _1 . runPurePollWithLogger r


### PR DESCRIPTION
This PR upgrades the dependency stack to depend on the latest pre-3.x revision of `log-warper`, which includes @neongreen 's work on directories plus the memory improvements, which should result in a more stable and less heavy memory footprint.

The migration was almost painless, apart from a couple of places where I had to deal with the fact I have now removed the spurious constraints on a `PureLogger` inside `log-warper` (for which we were using `UndecidableInstances` before). This means I had to either reshuffle some monadic stack around (in a trivial way) or had to create trivial `newtype` wrappers (like in the explorer case).

Please let me know if any of what I have done looks fishy!