### PR TITLE
[CSL-1740] Ensure that fake change address is always long enough

### DIFF
--- a/core/Pos/Aeson/Genesis.hs
+++ b/core/Pos/Aeson/Genesis.hs
@@ -6,27 +6,27 @@ module Pos.Aeson.Genesis
 
 import           Universum
 
-import           Data.Aeson              (FromJSON (..), FromJSONKey (..),
-                                          FromJSONKeyFunction (..))
-import           Data.Aeson.TH           (deriveFromJSON)
-import           Serokell.Aeson.Options  (defaultOptions)
+import           Data.Aeson               (FromJSON (..), FromJSONKey (..),
+                                           FromJSONKeyFunction (..))
+import           Data.Aeson.TH            (deriveFromJSON)
+import           Serokell.Aeson.Options   (defaultOptions)
 
-import           Pos.Aeson.Core          ()
-import           Pos.Aeson.Crypto        ()
-import           Pos.Binary.Core.Address ()
-import           Pos.Core.Genesis.Types  (FakeAvvmOptions, GenesisAvvmBalances (..),
-                                          GenesisDelegation, GenesisInitializer,
-                                          GenesisNonAvvmBalances, GenesisSpec,
-                                          GenesisVssCertificatesMap (..),
-                                          GenesisWStakeholders (..), ProtocolConstants,
-                                          TestnetBalanceOptions, TestnetDistribution,
-                                          convertNonAvvmDataToBalances,
-                                          mkGenesisDelegation)
-import           Pos.Core.Types          (ProxySKHeavy, StakeholderId)
-import           Pos.Core.Vss            (VssCertificatesMap (..),
-                                          validateVssCertificatesMap)
-import           Pos.Crypto              (RedeemPublicKey, fromAvvmPk)
-import           Pos.Util.Util           (eitherToFail)
+import           Pos.Aeson.Core           ()
+import           Pos.Aeson.Crypto         ()
+import           Pos.Binary.Core.Address  ()
+import           Pos.Core.Genesis.Helpers (convertNonAvvmDataToBalances,
+                                           mkGenesisDelegation)
+import           Pos.Core.Genesis.Types   (FakeAvvmOptions, GenesisAvvmBalances (..),
+                                           GenesisDelegation, GenesisInitializer,
+                                           GenesisNonAvvmBalances, GenesisSpec,
+                                           GenesisVssCertificatesMap (..),
+                                           GenesisWStakeholders (..), ProtocolConstants,
+                                           TestnetBalanceOptions, TestnetDistribution)
+import           Pos.Core.Types           (ProxySKHeavy, StakeholderId)
+import           Pos.Core.Vss             (VssCertificatesMap (..),
+                                           validateVssCertificatesMap)
+import           Pos.Crypto               (RedeemPublicKey, fromAvvmPk)
+import           Pos.Util.Util            (eitherToFail)
 
 instance FromJSONKey RedeemPublicKey where
     fromJSONKey = FromJSONKeyTextParser fromAvvmPk

--- a/core/Pos/Binary/Core/Genesis.hs
+++ b/core/Pos/Binary/Core/Genesis.hs
@@ -4,13 +4,14 @@ module Pos.Binary.Core.Genesis () where
 
 import           Universum
 
-import           Pos.Binary.Class        (Bi (..))
-import           Pos.Binary.Core.Address ()
-import           Pos.Binary.Core.Types   ()
-import           Pos.Core.Address        ()
-import           Pos.Core.Genesis.Types  (GenesisDelegation, GenesisWStakeholders (..),
-                                          mkGenesisDelegation, unGenesisDelegation)
-import           Pos.Util.Util           (eitherToFail)
+import           Pos.Binary.Class         (Bi (..))
+import           Pos.Binary.Core.Address  ()
+import           Pos.Binary.Core.Types    ()
+import           Pos.Core.Address         ()
+import           Pos.Core.Genesis.Helpers (mkGenesisDelegation)
+import           Pos.Core.Genesis.Types   (GenesisDelegation, GenesisWStakeholders (..),
+                                           unGenesisDelegation)
+import           Pos.Util.Util            (eitherToFail)
 
 instance Bi GenesisWStakeholders where
     encode (GenesisWStakeholders m) = encode m

--- a/core/Pos/Core/Address.hs
+++ b/core/Pos/Core/Address.hs
@@ -41,6 +41,14 @@ module Pos.Core.Address
        , createHDAddressNH
        , createHDAddressH
 
+       -- * Maximal sizes (needed for tx creation)
+       , largestPubKeyAddressBoot
+       , maxPubKeyAddressSizeBoot
+       , largestPubKeyAddressSingleKey
+       , maxPubKeyAddressSizeSingleKey
+       , largestHDAddressBoot
+       , maxHDAddressSizeBoot
+
          -- * Internals
        , AddressHash
        , addressHash
@@ -49,34 +57,38 @@ module Pos.Core.Address
 
 import           Universum
 
-import           Crypto.Hash              (Blake2b_224, Digest, SHA3_256)
-import qualified Crypto.Hash              as CryptoHash
-import           Data.ByteString.Base58   (Alphabet (..), bitcoinAlphabet, decodeBase58,
-                                           encodeBase58)
-import           Data.Hashable            (Hashable (..))
-import qualified Data.Text.Buildable      as Buildable
-import           Formatting               (Format, bprint, build, builder, int, later,
-                                           (%))
-import           Serokell.Util            (mapJson)
+import           Crypto.Hash                (Blake2b_224, Digest, SHA3_256)
+import qualified Crypto.Hash                as CryptoHash
+import qualified Data.ByteString            as BS
+import           Data.ByteString.Base58     (Alphabet (..), bitcoinAlphabet, decodeBase58,
+                                             encodeBase58)
+import           Data.Hashable              (Hashable (..))
+import qualified Data.Text.Buildable        as Buildable
+import           Formatting                 (Format, bprint, build, builder, int, later,
+                                             (%))
+import           Serokell.Data.Memory.Units (Byte)
+import           Serokell.Util              (mapJson)
 
-import           Pos.Binary.Class         (Bi)
-import qualified Pos.Binary.Class         as Bi
-import           Pos.Binary.Crypto        ()
-import           Pos.Core.Coin            ()
-import           Pos.Core.Constants       (accountGenesisIndex, wAddressGenesisIndex)
-import           Pos.Core.Types           (AddrAttributes (..), AddrSpendingData (..),
-                                           AddrStakeDistribution (..), AddrType (..),
-                                           Address (..), Address' (..), AddressHash,
-                                           Script, StakeholderId)
-import           Pos.Crypto.Hashing       (AbstractHash (AbstractHash), hashHexF,
-                                           shortHashF)
-import           Pos.Crypto.HD            (HDAddressPayload, HDPassphrase,
-                                           ShouldCheckPassphrase (..), deriveHDPassphrase,
-                                           deriveHDPublicKey, deriveHDSecretKey,
-                                           packHDAddressAttr)
-import           Pos.Crypto.Signing.Types (EncryptedSecretKey, PassPhrase, PublicKey,
-                                           RedeemPublicKey, encToPublic)
-import           Pos.Data.Attributes      (attrData, mkAttributes)
+import           Pos.Binary.Class           (Bi, biSize)
+import qualified Pos.Binary.Class           as Bi
+import           Pos.Binary.Crypto          ()
+import           Pos.Core.Coin              ()
+import           Pos.Core.Constants         (accountGenesisIndex, wAddressGenesisIndex)
+import           Pos.Core.Types             (AddrAttributes (..), AddrSpendingData (..),
+                                             AddrStakeDistribution (..), AddrType (..),
+                                             Address (..), Address' (..), AddressHash,
+                                             Script, StakeholderId)
+import           Pos.Crypto.Hashing         (AbstractHash (AbstractHash), hashHexF,
+                                             shortHashF)
+import           Pos.Crypto.HD              (HDAddressPayload, HDPassphrase,
+                                             ShouldCheckPassphrase (..),
+                                             deriveHDPassphrase, deriveHDPublicKey,
+                                             deriveHDSecretKey, packHDAddressAttr)
+import           Pos.Crypto.Signing         (EncryptedSecretKey, PassPhrase, PublicKey,
+                                             RedeemPublicKey, SecretKey,
+                                             deterministicKeyGen, emptyPassphrase,
+                                             encToPublic, noPassEncrypt)
+import           Pos.Data.Attributes        (attrData, mkAttributes)
 
 instance Bi Address => Hashable Address where
     hashWithSalt s = hashWithSalt s . Bi.serialize'
@@ -372,3 +384,64 @@ isBootstrapEraDistrAddress (addrAttributesUnwrapped -> AddrAttributes {..}) =
     case aaStakeDistribution of
         BootstrapEraDistr -> True
         _                 -> False
+
+----------------------------------------------------------------------------
+-- Maximal size
+----------------------------------------------------------------------------
+
+-- | Largest (considering size of serialized data) PubKey address with
+-- BootstrapEra distribution. Actual size depends on CRC32 value which
+-- is serialized using var-length encoding.
+largestPubKeyAddressBoot :: Bi Address' => Address
+largestPubKeyAddressBoot = makePubKeyAddressBoot goodPk
+
+-- | Maximal size of PubKey address with BootstrapEra
+-- distribution (43).
+maxPubKeyAddressSizeBoot :: (Bi Address, Bi Address') => Byte
+maxPubKeyAddressSizeBoot = biSize largestPubKeyAddressBoot
+
+-- | Largest (considering size of serialized data) PubKey address with
+-- SingleKey distribution. Actual size depends on CRC32 value which
+-- is serialized using var-length encoding.
+largestPubKeyAddressSingleKey :: Bi Address' => Address
+largestPubKeyAddressSingleKey =
+    makePubKeyAddress (IsBootstrapEraAddr False) goodPk
+
+-- | Maximal size of PubKey address with SingleKey
+-- distribution (78).
+maxPubKeyAddressSizeSingleKey :: (Bi Address, Bi Address') => Byte
+maxPubKeyAddressSizeSingleKey = biSize largestPubKeyAddressSingleKey
+
+-- | Largest (considering size of serialized data) HD address with
+-- BootstrapEra distribution. Actual size depends on CRC32 value which
+-- is serialized using var-length encoding.
+largestHDAddressBoot :: Bi Address' => Address
+largestHDAddressBoot =
+    case deriveLvl2KeyPair
+             (IsBootstrapEraAddr True)
+             (ShouldCheckPassphrase False)
+             emptyPassphrase
+             encSK
+             maxBound
+             maxBound of
+        Nothing        -> error "largestHDAddressBoot failed"
+        Just (addr, _) -> addr
+  where
+    encSK = noPassEncrypt goodSk
+
+-- | Maximal size of HD address with BootstrapEra
+-- distribution (76).
+maxHDAddressSizeBoot :: (Bi Address, Bi Address') => Byte
+maxHDAddressSizeBoot = biSize largestHDAddressBoot
+
+-- Public key and secret key for which we know that they produce
+-- largest addresses in all cases we are interested in. It was checked
+-- manually.
+goodSkAndPk :: (PublicKey, SecretKey)
+goodSkAndPk = deterministicKeyGen $ BS.replicate 32 0
+
+goodPk :: PublicKey
+goodPk = fst goodSkAndPk
+
+goodSk :: SecretKey
+goodSk = snd goodSkAndPk

--- a/core/Pos/Core/Genesis.hs
+++ b/core/Pos/Core/Genesis.hs
@@ -1,11 +1,4 @@
-module Pos.Core.Genesis
-       (
-       -- * Re-exports
-         module Pos.Core.Genesis.Generate
-       , module Pos.Core.Genesis.Types
-       ) where
-
--- reexports
-import           Pos.Core.Genesis.Canonical ()
-import           Pos.Core.Genesis.Generate
-import           Pos.Core.Genesis.Types
+-- Pos.Core.Genesis
+{-# OPTIONS_GHC -F -pgmF autoexporter #-}
+{-# OPTIONS_GHC -Wno-unused-imports   #-}
+{-# OPTIONS_GHC -Wno-dodgy-exports    #-}

--- a/core/Pos/Core/Genesis/Canonical.hs
+++ b/core/Pos/Core/Genesis/Canonical.hs
@@ -28,12 +28,13 @@ import           Pos.Binary.Core.Address    ()
 import           Pos.Core.Address           (addressF, decodeTextAddress)
 import           Pos.Core.Fee               (Coeff (..), TxFeePolicy (..),
                                              TxSizeLinear (..))
+import           Pos.Core.Genesis.Helpers   (mkGenesisDelegation)
 import           Pos.Core.Genesis.Types     (GenesisAvvmBalances (..), GenesisData (..),
                                              GenesisDelegation (..),
                                              GenesisNonAvvmBalances (..),
                                              GenesisVssCertificatesMap (..),
                                              GenesisWStakeholders (..),
-                                             ProtocolConstants (..), mkGenesisDelegation)
+                                             ProtocolConstants (..))
 import           Pos.Core.Types             (Address, BlockVersionData (..), Coin,
                                              CoinPortion, EpochIndex (..),
                                              SharedSeed (..), SoftforkRule (..),

--- a/core/Pos/Core/Genesis/Helpers.hs
+++ b/core/Pos/Core/Genesis/Helpers.hs
@@ -1,0 +1,66 @@
+-- | Helper functions related to genesis types.
+
+module Pos.Core.Genesis.Helpers
+       ( mkGenesisDelegation
+       , convertNonAvvmDataToBalances
+       ) where
+
+import           Universum
+
+import           Control.Lens             (at)
+import           Control.Monad.Except     (MonadError (throwError))
+import qualified Data.HashMap.Strict      as HM
+import           Formatting               (build, sformat, (%))
+import           Serokell.Util            (allDistinct)
+
+import           Pos.Binary.Class         (Bi)
+import           Pos.Core.Address         (addressHash, decodeTextAddress)
+import           Pos.Core.Coin            (unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core.Genesis.Types   (GenesisDelegation (..),
+                                           GenesisNonAvvmBalances (..))
+import           Pos.Core.Types           (Address, Coin, ProxySKHeavy, StakeholderId)
+import           Pos.Crypto.Signing.Types (ProxySecretKey (..), isSelfSignedPsk)
+
+-- | Safe constructor of 'GenesisDelegation'.
+mkGenesisDelegation ::
+       MonadError Text m
+    => HashMap StakeholderId ProxySKHeavy
+    -> m GenesisDelegation
+mkGenesisDelegation pskM = do
+    forM_ (HM.toList pskM) $ \(k, ProxySecretKey{..}) ->
+        when (addressHash pskIssuerPk /= k) $
+            throwError $ sformat
+                ("wrong issuerPk set as key for delegation map: "%
+                 "issuer id = "%build%", cert id = "%build)
+                k (addressHash pskIssuerPk)
+    unless (allDistinct $ pskIssuerPk <$> psks) $
+        throwError "all issuers must be distinct"
+    when (any isSelfSignedPsk psks) $
+        throwError "there is a self-signed (revocation) psk"
+    let resPairs =
+            psks <&> \psk@ProxySecretKey {..} -> (addressHash pskIssuerPk, psk)
+    let resMap = HM.fromList resPairs
+    let isIssuer ProxySecretKey {..} =
+            isJust $ resMap ^. at (addressHash pskDelegatePk)
+    when (any isIssuer psks) $
+        throwError "one of the delegates is also an issuer, don't do it"
+    return $ UnsafeGenesisDelegation resMap
+  where
+    psks = toList pskM
+
+-- | Generate genesis address distribution out of avvm
+-- parameters. Txdistr of the utxo is all empty. Redelegate it in
+-- calling funciton.
+convertNonAvvmDataToBalances
+    :: forall m .
+       ( MonadFail m, Bi Address )
+    => HashMap Text Integer
+    -> m GenesisNonAvvmBalances
+convertNonAvvmDataToBalances balances = GenesisNonAvvmBalances <$> balances'
+  where
+    balances' :: m (HashMap Address Coin)
+    balances' = HM.fromListWith unsafeAddCoin <$> traverse convert (HM.toList balances)
+    convert :: (Text, Integer) -> m (Address, Coin)
+    convert (txt, i) = case decodeTextAddress txt of
+        Left err   -> fail (toString err)
+        Right addr -> return (addr, unsafeIntegerToCoin i)

--- a/core/Pos/Util/Arbitrary.hs
+++ b/core/Pos/Util/Arbitrary.hs
@@ -11,6 +11,8 @@ module Pos.Util.Arbitrary
        , runGen
        ) where
 
+import           Universum
+
 import qualified Crypto.Random          as Rand
 import           Data.ByteString        (pack)
 import qualified Data.ByteString.Lazy   as BL (ByteString, pack)
@@ -21,9 +23,9 @@ import           Test.QuickCheck        (Arbitrary (..), Gen, listOf, scale, shu
                                          vector)
 import           Test.QuickCheck.Gen    (unGen)
 import           Test.QuickCheck.Random (mkQCGen)
-import           Universum
 
 import           Pos.Crypto.Random      (randomNumberInRange)
+import           Pos.Util.Util          ()
 
 makeSmall :: Gen a -> Gen a
 makeSmall = scale f

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -57,6 +57,7 @@ library
                        Pos.Core.Genesis
                        Pos.Core.Genesis.Canonical
                        Pos.Core.Genesis.Generate
+                       Pos.Core.Genesis.Helpers
                        Pos.Core.Genesis.Types
 
                        Pos.Crypto

--- a/lib/src/Pos/Client/Txp/Addresses.hs
+++ b/lib/src/Pos/Client/Txp/Addresses.hs
@@ -15,3 +15,8 @@ class Monad m => MonadAddresses m where
     -- | Generate new address using given 'AddrData' (e.g. password +
     -- account id).
     getNewAddress :: AddrData m -> m Address
+
+    -- | Generate a “fake” change address. Its size must be greater
+    -- than or equal to the maximal possible size of address generated
+    -- by 'getNewAddress'.
+    getFakeChangeAddress :: m Address

--- a/lib/src/Pos/Generator/Block/Mode.hs
+++ b/lib/src/Pos/Generator/Block/Mode.hs
@@ -42,7 +42,8 @@ import           Pos.Configuration                (HasNodeConfiguration)
 import           Pos.Core                         (Address, GenesisWStakeholders (..),
                                                    HasConfiguration, HasPrimaryKey (..),
                                                    IsHeader, SlotId (..), Timestamp,
-                                                   epochOrSlotToSlot, getEpochOrSlot)
+                                                   epochOrSlotToSlot, getEpochOrSlot,
+                                                   largestPubKeyAddressBoot)
 import           Pos.Crypto                       (SecretKey)
 import           Pos.DB                           (DBSum, MonadBlockDBGeneric (..),
                                                    MonadBlockDBGenericWrite (..), MonadDB,
@@ -373,6 +374,12 @@ instance MonadBlockGenBase m => MonadBListener (BlockGenMode ext m) where
 instance Monad m => MonadAddresses (BlockGenMode ext m) where
     type AddrData (BlockGenMode ext m) = Address
     getNewAddress = pure
+    -- It must be consistent with the way we construct address in
+    -- block-gen. If it's changed, tests will fail, so we will notice
+    -- it.
+    -- N.B. Currently block-gen uses only PubKey addresses with BootstrapEra
+    -- distribution.
+    getFakeChangeAddress = pure largestPubKeyAddressBoot
 
 type instance MempoolExt (BlockGenMode ext m) = ext
 

--- a/lib/test/Test/Pos/Client/Txp/Mode.hs
+++ b/lib/test/Test/Pos/Client/Txp/Mode.hs
@@ -25,8 +25,8 @@ import           Pos.Block.Types                  (Undo)
 import           Pos.Client.Txp.Addresses         (MonadAddresses (..))
 import           Pos.Client.Txp.Util              (TxCreateMode)
 import           Pos.Configuration                (HasNodeConfiguration)
-import           Pos.Core                         (HasConfiguration, IsHeader, SlotId,
-                                                   Timestamp (..))
+import           Pos.Core                         (Address, HasConfiguration, IsHeader,
+                                                   SlotId, Timestamp (..))
 import           Pos.DB                           (MonadGState (..))
 import qualified Pos.DB                           as DB
 import qualified Pos.DB.Block                     as DB
@@ -237,11 +237,15 @@ instance HasTxpConfigurations => DB.MonadDB TxpTestMode where
 
 instance HasTxpConfigurations => MonadAddresses TxpTestMode where
     type AddrData TxpTestMode = ()
-    getNewAddress _ = pure address
-      where
-        -- seed for address generation is a ByteString with 32 255's
-        seed = BS.replicate seedSize (255 :: Word8)
-        (_, address) = generateAddressWithKey seed
+    getNewAddress _ = pure fakeAddressForMonadAddresses
+    getFakeChangeAddress = pure fakeAddressForMonadAddresses
+
+fakeAddressForMonadAddresses :: Address
+fakeAddressForMonadAddresses = address
+  where
+    -- seed for address generation is a ByteString with 32 255's
+    seed = BS.replicate seedSize (255 :: Word8)
+    (_, address) = generateAddressWithKey seed
 
 
 ----------------------------------------------------------------------------
@@ -255,6 +259,7 @@ type TxpTestProperty = PropertyM TxpTestMode
 instance HasTxpConfigurations => MonadAddresses TxpTestProperty where
     type AddrData TxpTestProperty = AddrData TxpTestMode
     getNewAddress = lift . getNewAddress
+    getFakeChangeAddress = lift getFakeChangeAddress
 
 txCreatePropertyToProperty
     :: HasTxpConfigurations

--- a/lib/test/Test/Pos/Core/AddressSpec.hs
+++ b/lib/test/Test/Pos/Core/AddressSpec.hs
@@ -6,22 +6,91 @@ module Test.Pos.Core.AddressSpec
 
 import           Universum
 
-import           Test.Hspec            (Spec, describe)
-import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import qualified Data.ByteString            as BS
+import           Formatting                 (formatToString, int, (%))
+import           Serokell.Data.Memory.Units (Byte, memory)
+import           Test.Hspec                 (Spec, describe, it, shouldBe)
+import           Test.Hspec.QuickCheck      (modifyMaxSuccess, prop)
+import           Test.QuickCheck            (Gen, arbitrary, counterexample, forAll,
+                                             frequency, vectorOf)
 
-import           Pos.Arbitrary.Core    ()
-import           Pos.Core              (IsBootstrapEraAddr (..), makePubKeyAddress,
-                                        makePubKeyHdwAddress)
-import           Pos.Crypto            (PublicKey)
-import           Pos.Crypto.HD         (HDAddressPayload (..))
+import           Pos.Arbitrary.Core         ()
+import           Pos.Binary.Class           (biSize)
+import           Pos.Core                   (Address, IsBootstrapEraAddr (..),
+                                             deriveLvl2KeyPair, largestHDAddressBoot,
+                                             largestPubKeyAddressBoot,
+                                             largestPubKeyAddressSingleKey,
+                                             makePubKeyAddress, makePubKeyAddressBoot,
+                                             makePubKeyHdwAddress)
+import           Pos.Crypto                 (EncryptedSecretKey, PassPhrase, PublicKey,
+                                             SecretKey (..), ShouldCheckPassphrase (..),
+                                             deterministicKeyGen, emptyPassphrase,
+                                             mkEncSecret, noPassEncrypt, toPublic)
+import           Pos.Crypto.HD              (HDAddressPayload (..))
 
 spec :: Spec
-spec = describe "Address" $ modifyMaxSuccess (min 10) $ do
-    prop "PK and HDW addresses with same public key are shown differently"
-         pkAndHdwAreShownDifferently
+spec = describe "Address" $ do
+    modifyMaxSuccess (min 10) $ do
+        prop "PK and HDW addresses with same public key are shown differently"
+            pkAndHdwAreShownDifferently
+
+    describe "Largest addresses" $ do
+        let genPubKeyAddrBoot = pure . makePubKeyAddressBoot . toPublic
+        largestAddressProp "PubKey address with BootstrapEra distribution"
+            genPubKeyAddrBoot largestPubKeyAddressBoot 43
+
+        let genPubKeyAddrSingleKey = pure . makePubKeyAddress
+                (IsBootstrapEraAddr False) . toPublic
+        largestAddressProp "PubKey address with SingleKey distribution"
+            genPubKeyAddrSingleKey largestPubKeyAddressSingleKey 78
+
+        let genHDAddrBoot :: SecretKey -> Gen Address
+            genHDAddrBoot sk = frequency
+                [ (1, genHDAddrBootEmptyPass sk)
+                , (5, genHDAddrBootSomePass sk)
+                ]
+
+            genHDAddrBoot' :: PassPhrase -> EncryptedSecretKey -> Word32 -> Word32 -> Address
+            genHDAddrBoot' passphrase esk accIdx addrIdx =
+                case deriveLvl2KeyPair
+                            (IsBootstrapEraAddr True)
+                            (ShouldCheckPassphrase False)
+                            passphrase
+                            esk
+                            accIdx
+                            addrIdx of
+                    Nothing        -> error "genHDAddrBoot' failed in tests"
+                    Just (addr, _) -> addr
+
+            genHDAddrBootEmptyPass sk =
+                genHDAddrBoot' emptyPassphrase (noPassEncrypt sk) <$>
+                arbitrary <*> arbitrary
+
+            genHDAddrBootSomePass (SecretKey sk) = do
+                passphrase <- arbitrary
+                esk <- mkEncSecret passphrase sk
+                genHDAddrBoot' passphrase esk <$> arbitrary <*> arbitrary
+
+        largestAddressProp "HD address with BootstrapEra distribution"
+            genHDAddrBoot largestHDAddressBoot 76
 
 pkAndHdwAreShownDifferently :: Bool -> PublicKey -> Bool
 pkAndHdwAreShownDifferently isBootstrap pk =
     show (makePubKeyAddress (IsBootstrapEraAddr isBootstrap) pk) /=
     (show @_ @Text (makePubKeyHdwAddress (IsBootstrapEraAddr isBootstrap)
                     (HDAddressPayload "pataq") pk))
+
+largestAddressProp :: Text -> (SecretKey -> Gen Address) -> Address -> Byte -> Spec
+largestAddressProp addressDescription genAddress largestAddress expectedLargestSize = do
+    describe (toString addressDescription) $ do
+
+        it (formatToString ("has the size we expect: "%memory) expectedLargestSize) $ do
+            biSize largestAddress `shouldBe` expectedLargestSize
+
+        prop "is indeed the largest address" $ do
+            forAll (deterministicKeyGen . BS.pack <$> vectorOf 32 arbitrary) $ \(_, sk) ->
+                forAll (genAddress sk) $ \address ->
+                    let generatedSize = biSize address
+                    in counterexample
+                           (formatToString (int % " > " %int) generatedSize expectedLargestSize)
+                           (generatedSize <= expectedLargestSize)

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -23,7 +23,8 @@ import           Pos.Client.Txp.Util              (computeTxFee, runTxCreator)
 import           Pos.Communication                (SendActions (..), prepareMTx)
 import           Pos.Configuration                (HasNodeConfiguration)
 import           Pos.Core                         (Coin, HasConfiguration, addressF,
-                                                   getCurrentTimestamp)
+                                                   getCurrentTimestamp,
+                                                   largestHDAddressBoot)
 import           Pos.Crypto                       (PassPhrase, ShouldCheckPassphrase (..),
                                                    checkPassMatches, hash,
                                                    withSafeSignerUnsafe)
@@ -135,6 +136,9 @@ instance
     getNewAddress (accId, passphrase) = do
         clientAddress <- L.newAddress RandomSeed passphrase accId
         decodeCTypeOrFail (cadId clientAddress)
+    -- We rely on the fact that Daedalus always uses HD addresses with
+    -- BootstrapEra distribution.
+    getFakeChangeAddress = pure largestHDAddressBoot
 
 sendMoney
     :: MonadWalletWebMode m


### PR DESCRIPTION
Previous implementation was using one of output addresses as a fake
change address. But it can happen that 'getNewAddress' generates an address
which is longer than the fake change address, which in turn will lead to
tx fee being too small and invalid tx will be created.
Note that this problem is quite important already, even though we can only
create bootstrap era addresses with HD payload. For more details about it
please see my comment in CSL-1740.

The solution is a bit hacky, but it seems there is no better way to resolve
problem. 'getFakeChangeAddress' was added to 'MonadAddresses' which must
create an address with size greater than or equal to maximal possible size of
address generated by 'getNewAddress'. An address generated by
'getFakeChangeAddress' is used to create a fake transaction to compute fee.
In rare cases fee can be slightly greater than limit (by about 1-3 bytes
multiplied by ratio), but it's quite negligible.
Unfortunately we can't generate a real change address before computing fee,
because it requires a passphrase, but we don't want to require passphrase to
compute fee.