### PR TITLE
Bump version of cardano-sl-node

### DIFF
--- a/node/cardano-sl-node.cabal
+++ b/node/cardano-sl-node.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-node
-version:             1.0.1
+version:             1.0.2
 synopsis:            Cardano SL simple node executable
 description:         Please see README.md
 license:             MIT

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1773,7 +1773,7 @@ self: {
       cardano-sl-node = callPackage ({ base, binary, bytestring, cardano-sl, cardano-sl-core, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-update, containers, cpphs, data-default, directory, ether, filepath, formatting, lens, log-warper, mkDerivation, mtl, neat-interpolation, network-transport, network-transport-tcp, node-sketch, optparse-applicative, parsec, serokell-util, stdenv, stm-containers, time, time-units, universum }:
       mkDerivation {
           pname = "cardano-sl-node";
-          version = "1.0.1";
+          version = "1.0.2";
           src = ./../node;
           isLibrary = false;
           isExecutable = true;


### PR DESCRIPTION
To be the same as other packages' versions.