### PR TITLE
[CSL-1767] fix block generator leak

### DIFF
--- a/auxx/src/Command/BlockGen.hs
+++ b/auxx/src/Command/BlockGen.hs
@@ -43,7 +43,7 @@ generateBlocks GenBlocksParams{..} = do
                 , _bgpSkipNoKey       = True
                 , _bgpTxpGlobalSettings = txpGlobalSettings
                 }
-    withCompileInfo def $ void $ evalRandT (genBlocks bgenParams) (mkStdGen seed)
+    withCompileInfo def $ evalRandT (genBlocks bgenParams (const ())) (mkStdGen seed)
     -- We print it twice because there can be a ton of logs and
     -- you don't notice the first message.
     logInfo $ "Generated with seed " <> show seed

--- a/lib/src/Pos/Generator/Block/Logic.hs
+++ b/lib/src/Pos/Generator/Block/Logic.hs
@@ -41,7 +41,6 @@ import           Pos.Lrc.Context             (lrcActionOnEpochReason)
 import qualified Pos.Lrc.DB                  as LrcDB
 import           Pos.Txp                     (MempoolExt, MonadTxpLocal,
                                               TxpGlobalSettings)
-import           Pos.Util.Chrono             (OldestFirst (..))
 import           Pos.Util.CompileInfo        (HasCompileInfo, withCompileInfo)
 import           Pos.Util.Util               (HasLens', maybeThrow, _neHead)
 
@@ -60,22 +59,32 @@ type BlockTxpGenMode g ctx m =
 -- | Generate an arbitrary sequence of valid blocks. The blocks are
 -- valid with respect to the global state right before this function
 -- call.
+-- The blocks themselves can be combined and retained according to some monoid.
+-- Intermediate results will be forced. Blocks can be generated, written to
+-- disk, then collected by using '()' as the monoid and 'const ()' as the
+-- injector, for example.
 genBlocks ::
-       forall g ctx m . BlockTxpGenMode g ctx m
+       forall g ctx m t . (BlockTxpGenMode g ctx m, Monoid t)
     => BlockGenParams
-    -> RandT g m (OldestFirst [] Blund)
-genBlocks params = do
+    -> (Maybe Blund -> t)
+    -> RandT g m t
+genBlocks params inj = do
     ctx <- lift $ mkBlockGenContext @(MempoolExt m) params
     mapRandT (`runReaderT` ctx) genBlocksDo
   where
-    genBlocksDo =
-        OldestFirst <$> do
-            let numberOfBlocks = params ^. bgpBlockCount
-            tipEOS <- getEpochOrSlot <$> lift getTipHeader
-            let startEOS = succ tipEOS
-            let finishEOS =
-                    toEnum $ fromEnum tipEOS + fromIntegral numberOfBlocks
-            catMaybes <$> mapM genBlock [startEOS .. finishEOS]
+    genBlocksDo = do
+        let numberOfBlocks = params ^. bgpBlockCount
+        tipEOS <- getEpochOrSlot <$> lift getTipHeader
+        let startEOS = succ tipEOS
+        let finishEOS = toEnum $ fromEnum tipEOS + fromIntegral numberOfBlocks
+        foldM' genOneBlock mempty [startEOS .. finishEOS]
+
+    genOneBlock t eos = ((t <>) . inj) <$> genBlock eos
+
+    foldM' _ !base [] = return base
+    foldM' combine !base (x : xs) = do
+      it <- combine base x
+      foldM' combine it xs
 
 -- Generate a valid 'Block' for the given epoch or slot (genesis block
 -- in the former case and main block the latter case) and apply it.

--- a/lib/src/Pos/Generator/Block/Logic.hs
+++ b/lib/src/Pos/Generator/Block/Logic.hs
@@ -81,10 +81,10 @@ genBlocks params inj = do
 
     genOneBlock t eos = ((t <>) . inj) <$> genBlock eos
 
-    foldM' _ !base [] = return base
-    foldM' combine !base (x : xs) = do
-      it <- combine base x
-      foldM' combine it xs
+    foldM' combine = go
+      where
+      go !base [] = return base
+      go !base (x:xs) = combine base x >>= flip go xs
 
 -- Generate a valid 'Block' for the given epoch or slot (genesis block
 -- in the former case and main block the latter case) and apply it.

--- a/lib/src/Pos/Generator/BlockEvent.hs
+++ b/lib/src/Pos/Generator/BlockEvent.hs
@@ -189,9 +189,7 @@ genBlocksInTree secrets bootStakeholders blockchainTree = do
             , _bgpSkipNoKey       = False
             , _bgpTxpGlobalSettings = txpSettings
             }
-    -- Partial pattern-matching is safe because we specify
-    -- blockCount = 1 in the generation parameters.
-    OldestFirst [block] <- genBlocks blockGenParams
+    [block] <- genBlocks blockGenParams maybeToList
     forestBlocks <- genBlocksInForest secrets bootStakeholders blockchainForest
     return $ BlockchainTree block forestBlocks
 

--- a/lib/src/Test/Pos/Block/Logic/Util.hs
+++ b/lib/src/Test/Pos/Block/Logic/Util.hs
@@ -92,7 +92,7 @@ bpGenBlocks
 bpGenBlocks blkCnt enableTxPayload inplaceDB = do
     params <- genBlockGenParams blkCnt enableTxPayload inplaceDB
     g <- pick $ MkGen $ \qc _ -> qc
-    lift $ evalRandT (genBlocks params) g
+    lift $ OldestFirst <$> evalRandT (genBlocks params maybeToList) g
 
 -- | A version of 'bpGenBlocks' which generates exactly one
 -- block. Allows one to avoid unsafe functions sometimes.

--- a/wallet/test/Test/Pos/Wallet/Web/Util.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Util.hs
@@ -74,7 +74,7 @@ wpGenBlocks blkCnt enTxPayload inplaceDB = do
     params <- genBlockGenParams blkCnt enTxPayload inplaceDB
     g <- pick $ MkGen $ \qc _ -> qc
     lift $ modifyStateLock HighPriority "wpGenBlocks" $ \prevTip -> do
-        blunds <- evalRandT (genBlocks params) g
+        blunds <- OldestFirst <$> evalRandT (genBlocks params maybeToList) g
         case nonEmpty $ getOldestFirst blunds of
             Just nonEmptyBlunds -> do
                 let tipBlockHeader = nonEmptyBlunds ^. _neLast . _1 . blockHeader


### PR DESCRIPTION
`catMaybes <$> mapM genBlock [startEOS .. finishEOS]` caused the entire list of blocks to be retained.

Instead of constructing the list of blocks, some value of a monoid `t` is strictly constructed according to some injector `Maybe (Blund SscGodTossing) -> t`. Using `const ()` means the blocks will never be retained. `genBlock` writes them out to disk, which is all we want for the block generator application.