### PR TITLE
[CSL-1519] Decrease waiting time in demo.sh to 15 sec

### DIFF
--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -62,7 +62,7 @@ fi
 # and start processing the first slot.
 if [ -z "$system_start" ]
   then
-    system_start=$((`date +%s` + 45))
+    system_start=$((`date +%s` + 15))
 fi
 
 echo "Using system start time "$system_start


### PR DESCRIPTION
I chose `15s` as minimal time which gives minimal number of error (from time-warp) in logs