### PR TITLE
[CSE-179] Do not discard log

### DIFF
--- a/lib/src/Pos/Explorer/Txp/Toil/Logic.hs
+++ b/lib/src/Pos/Explorer/Txp/Toil/Logic.hs
@@ -19,8 +19,7 @@ import qualified Data.HashSet                as HS
 import           Data.List                   (delete)
 import qualified Data.List.NonEmpty          as NE
 import           Formatting                  (build, sformat, (%))
-import           System.Wlog                 (WithLogger, logError, runNamedPureLog,
-                                              usingLoggerName)
+import           System.Wlog                 (WithLogger, logError)
 
 import           Pos.Core                    (Address, Coin, EpochIndex, HeaderHash,
                                               Timestamp, mkCoin, sumCoins, unsafeAddCoin,
@@ -106,9 +105,7 @@ eProcessTx curEpoch tx@(id, aux) extra = do
     undo <- Txp.processTx curEpoch tx
     putTxExtraWithHistory id extra $ getTxRelatedAddrs aux undo
     let balanceUpdate = getBalanceUpdate aux undo
-    -- TODO: [CSM-245] do not discard logged errors
-    fmap fst $ usingLoggerName "eProcessTx" $ runNamedPureLog $
-        updateAddrBalances balanceUpdate
+    updateAddrBalances balanceUpdate
     updateUtxoSumFromBalanceUpdate balanceUpdate
 
 -- | Get rid of invalid transactions.

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1933,7 +1933,7 @@ self: {
           description = "Cardano SL - Tools";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-txp = callPackage ({ QuickCheck, aeson, base, bytestring, cardano-sl-core, cardano-sl-db, cardano-sl-infra, conduit, containers, cpphs, data-default, ekg-core, ether, exceptions, fmt, formatting, generic-arbitrary, hashable, lens, lifted-base, log-warper, memory, mkDerivation, monad-control, mtl, neat-interpolation, node-sketch, plutus-prototype, resourcet, rocksdb-haskell, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, time-units, transformers, universum, unordered-containers, vector }:
+      cardano-sl-txp = callPackage ({ QuickCheck, aeson, base, bytestring, cardano-sl-core, cardano-sl-db, cardano-sl-infra, conduit, containers, cpphs, data-default, ekg-core, ether, exceptions, fmt, formatting, generic-arbitrary, hashable, lens, lifted-base, log-warper, memory, mkDerivation, mmorph, monad-control, mtl, neat-interpolation, node-sketch, plutus-prototype, resourcet, rocksdb-haskell, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, time-units, transformers, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "cardano-sl-txp";
           version = "1.0.2";
@@ -1959,6 +1959,7 @@ self: {
             lifted-base
             log-warper
             memory
+            mmorph
             monad-control
             mtl
             neat-interpolation

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -60,7 +60,8 @@ type GlobalVerifyToilMode m =
     ( MonadUtxo m
     , MonadStakes m
     , MonadGState m
-    , WithLogger m)
+    , WithLogger m
+    )
 
 -- CHECK: @verifyToil
 -- | Verify transactions correctness with respect to Utxo applying
@@ -102,6 +103,7 @@ type LocalToilMode m =
     ( MonadUtxo m
     , MonadGState m
     , MonadTxPool m
+    , WithLogger m
     , HasConfiguration
     )
 

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -82,6 +82,7 @@ library
                      , lifted-base
                      , log-warper
                      , memory
+                     , mmorph
                      , monad-control
                      , mtl
                      , neat-interpolation


### PR DESCRIPTION
Summary of changes:

1. `LocalToilMode` has `WithLogger`
2. `[E]ProcessTxMode` is over `NamedPureLogger Identity` instead of just `Identity`
3. `lib/src/Pos/Explorer/Txp/Toil/Logic.hs` no longer discards log from `updateAddrBalances`

AFAIK we don't need this in `cardano-sl-1.0`, it's not urgent.