### PR TITLE
[CSL-1771] Get rid of with-wallet flag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,7 +92,6 @@ test_script:
       --test
       --no-haddock-deps
       --work-dir %STACK_WORK%
-      --flag cardano-sl:with-wallet
       --flag cardano-sl-core:-asserts
       --flag cardano-sl-tools:for-installer
       --flag cardano-sl-wallet:for-installer

--- a/explorer/scripts/build/cardano-sl.sh
+++ b/explorer/scripts/build/cardano-sl.sh
@@ -50,7 +50,6 @@ spec_prj=''
 
 no_nix=false
 ram=false
-wallet=true
 explorer=false
 no_code=false
 werror=false
@@ -89,9 +88,6 @@ do
   # -Werror = compile with -Werror
   elif [[ $var == "-Werror" ]]; then
     werror=true
-  # --no-wallet = don't build in wallet mode
-  elif [[ $var == "--no-wallet" ]]; then
-    wallet=false
   # --explorer = build with Explorer support
   elif [[ $var == "--explorer" ]]; then
     explorer=true
@@ -134,10 +130,6 @@ fi
 
 if [[ $for_installer == true ]]; then
   commonargs="$commonargs --flag cardano-sl-tools:for-installer"
-fi
-
-if [[ $wallet == false ]]; then
-  commonargs="$commonargs --flag cardano-sl:-with-wallet"
 fi
 
 if [[ $no_fast == true ]];
@@ -191,7 +183,7 @@ fi
 echo "Going to build: $to_build"
 
 for prj in $to_build; do
- 
+
   echo -e "Building $prj\n"
   sbuild="stack build --ghc-options=\"$ghc_opts\" $commonargs $norun --dependencies-only $args $prj"
   echo -e "$sbuild\n\n"

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -12,12 +12,6 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
-Flag with-wallet
-  default:     False
-  manual:      True
-
-  description: Build with wallet
-
 Flag with-explorer
   default:     True
   manual:      True
@@ -445,12 +439,6 @@ library
   ghc-options:         -Wall
                        -fno-warn-orphans
                        -O2
-
-  -- linker speed up for linux
-  -- for explorer / wallet linking see https://ghc.haskell.org/trac/ghc/ticket/13810
-  if os(linux) && !flag(with-explorer) && !flag(with-wallet)
-    ghc-options:       -optl-fuse-ld=gold
-    ld-options:        -fuse-ld=gold
 
   default-extensions:   DeriveDataTypeable
                         DeriveGeneric

--- a/scripts/build/cardano-sl.sh
+++ b/scripts/build/cardano-sl.sh
@@ -53,7 +53,6 @@ spec_prj=''
 no_nix=false
 ram=false
 prodMode=
-wallet=true
 explorer=true
 no_code=false
 werror=false
@@ -97,9 +96,6 @@ do
   # -Werror = compile with -Werror
   elif [[ $var == "-Werror" ]]; then
     werror=true
-  # --no-wallet = don't build in wallet mode
-  elif [[ $var == "--no-wallet" ]]; then
-    wallet=false
   # --no-explorer = build without Explorer (support)
   elif [[ $var == "--no-explorer" ]]; then
     explorer=false
@@ -169,10 +165,6 @@ fi
 
 if [[ $explorer == false ]]; then
   commonargs="$commonargs --flag cardano-sl:-with-explorer"
-fi
-
-if [[ $wallet == true ]]; then
-  commonargs="$commonargs --flag cardano-sl:with-wallet"
 fi
 
 if [[ $for_installer == true ]]; then
@@ -254,12 +246,6 @@ else
   to_build="cardano-sl-$spec_prj"
 fi
 
-# A warning for invalid flag usage when building wallet. This should not happen.
-if [[ $to_build == *"wallet"* && $wallet == false ]]; then
-  echo "You can't build output with wallet and not use wallet! Invalid flag '--no-wallet'."
-  exit
-fi
-
 # A warning for invalid flag usage when building explorer. This should not happen.
 if [[ $to_build == *"explorer"* && $explorer == false ]]; then
   echo "You can't build output with explorer and not use explorer! Invalid flag '--no-explorer'."
@@ -271,7 +257,6 @@ if [[ $to_build == "" ]]; then
 else
   echo "Going to build: $to_build"
 fi
-echo "'wallet' flag: $wallet"
 echo "'explorer' flag: $explorer"
 
 for prj in $to_build; do


### PR DESCRIPTION
It was used only to disable gold linker options in cardano-sl library.
I think it only adds unnecessary mess, because we almost always build with
wallet and/or explorer flags (they are default).