### PR TITLE
Change directory to workdir in CI so stack's cache can be retained

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -117,6 +117,7 @@ test_script:
   - ps: foreach ($x in @("cardano-launcher.exe", "cardano-node.exe")) { if (-NOT (Test-Path "$($env:WORK_DIR)\daedalus\$x")) { throw "ERROR... Missing $x" }}
 
 after_test:
+ - cd "%WORK_DIR%"
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%
  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
  - xcopy /q /s /e /r /k /i /v /h /y "%WORK_DIR%\daedalus" C:\projects\cardano-sl\daedalus


### PR DESCRIPTION
A quick explanation why this fix actually works.

`STACK_WORK`, as well as `CACHED_STACK_WORK` are relative directories, since stack doesn't support absolute ones.

Actual issue appears on this line:
```
IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
```
Because current directory was previously changed it simply can't find `STACK_WORK` and skips the copying.