### PR TITLE
[CSL-1772] more efficient header fetching

### DIFF
--- a/lib/src/Pos/Client/Txp/History.hs
+++ b/lib/src/Pos/Client/Txp/History.hs
@@ -54,7 +54,7 @@ import           Pos.Core                     (Address, ChainDifficulty, HasConf
                                                headerHash)
 import           Pos.Crypto                   (WithHash (..), withHash)
 import           Pos.DB                       (MonadDBRead, MonadGState)
-import           Pos.DB.Block                 (MonadBlockDB)
+import           Pos.DB.Block                 (MonadBlockDB, blkGetBlund)
 import qualified Pos.GState                   as GS
 import           Pos.KnownPeers               (MonadFormatPeers (..))
 import           Pos.Network.Types            (HasNodeType)
@@ -257,7 +257,7 @@ getBlockHistoryDefault addrs = do
         getBlockTimestamp blk = getSlotStartPure systemStart (blk ^. mainBlockSlot) sd
 
         blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (Map TxId TxHistoryEntry)
-        blockFetcher start = GS.foldlUpWhileM fromBlund start (const $ const True)
+        blockFetcher start = GS.foldlUpWhileM blkGetBlund fromBlund start (const $ const True)
             (deriveAddrHistoryBlk addrs getBlockTimestamp) mempty
 
     runGenesisToil . evalToilTEmpty $ blockFetcher bot

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -268,7 +268,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
                      -- We don't load blocks explicitly, because blockain can be long.
                      maybe (pure mempty)
                          (\wNextH ->
-                            foldlUpWhileM (applyBlock allAddresses) wNextH loadCond mappendR mempty)
+                            foldlUpWhileM DB.blkGetBlund (applyBlock allAddresses) wNextH loadCond mappendR mempty)
                          =<< resolveForwardLink wHeader
                | diff gstateH < diff wHeader -> do
                      -- This rollback can occur


### PR DESCRIPTION
Previously we'd always pull in the entire block and undo, even when
only the headers were needed (serving a get headers request).

Pulling in the block is quite expensive, because deserializing it
requires re-serializing the transactions it contains, as part of
deserializing the TxPayload, which re-builds a merkle tree. That's a
separate issue.