### PR TITLE
[CSM-500] Remember pending transaction from the very beginning

### DIFF
--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -107,6 +107,7 @@ type instance OriginType CPtxCondition = Maybe PtxCondition
 
 instance ToCType CPtxCondition where
     encodeCType = maybe CPtxNotTracked $ \case
+        PtxCreating{}       -> CPtxInvisible
         PtxApplying{}       -> CPtxApplying
         PtxInNewestBlocks{} -> CPtxInBlocks
         PtxPersisted{}      -> CPtxInBlocks

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -364,7 +364,8 @@ instance Buildable CTxMeta where
 -- @PtxInNewestBlocks@ and @PtxPersisted@ states are merged into one
 -- not to provide information which conflicts with 'ctConfirmations'.
 data CPtxCondition
-    = CPtxApplying
+    = CPtxInvisible  -- tx is not for displaying to frontend
+    | CPtxApplying
     | CPtxInBlocks
     | CPtxWontApply
     | CPtxNotTracked  -- ^ tx was made not in this life

--- a/wallet/src/Pos/Wallet/Web/Pending/Functions.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Functions.hs
@@ -5,6 +5,7 @@
 
 module Pos.Wallet.Web.Pending.Functions
     ( ptxPoolInfo
+    , isPtxActive
     , isPtxInBlocks
     , mkPendingTx
     , isReclaimableFailure
@@ -28,9 +29,16 @@ import           Pos.Wallet.Web.Pending.Util  (mkPtxSubmitTiming)
 import           Pos.Wallet.Web.State         (getWalletMeta)
 
 ptxPoolInfo :: PtxCondition -> Maybe PtxPoolInfo
-ptxPoolInfo (PtxApplying i)    = Just i
-ptxPoolInfo (PtxWontApply _ i) = Just i
-ptxPoolInfo _                  = Nothing
+ptxPoolInfo (PtxCreating i)     = Just i
+ptxPoolInfo (PtxApplying i)     = Just i
+ptxPoolInfo (PtxWontApply _ i)  = Just i
+ptxPoolInfo PtxInNewestBlocks{} = Nothing
+ptxPoolInfo PtxPersisted{}      = Nothing
+
+-- | Whether transaction is claimed to be once created.
+isPtxActive :: PtxCondition -> Bool
+isPtxActive PtxCreating{} = False
+isPtxActive _             = True
 
 isPtxInBlocks :: PtxCondition -> Bool
 isPtxInBlocks = isNothing . ptxPoolInfo
@@ -43,7 +51,7 @@ mkPendingTx wid _ptxTxId _ptxTxAux th = do
 
     _ptxCreationSlot <- getCurrentSlotInaccurate
     return PendingTx
-        { _ptxCond = PtxApplying th
+        { _ptxCond = PtxCreating th
         , _ptxWallet = wid
         , _ptxPeerAck = False
         , _ptxSubmitTiming = mkPtxSubmitTiming _ptxCreationSlot

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -13,20 +13,23 @@ module Pos.Wallet.Web.Pending.Submission
 
 import           Universum
 
-import           Control.Monad.Catch              (Handler (..), catches)
+import           Control.Monad.Catch              (Handler (..), catches, onException)
 import           Formatting                       (build, sformat, shown, stext, (%))
 import           System.Wlog                      (WithLogger, logInfo)
 
 import           Pos.Client.Txp.History           (saveTx)
 import           Pos.Communication                (EnqueueMsg, submitTxRaw)
 import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
+import           Pos.Util.Util                    (maybeThrow)
+import           Pos.Wallet.Web.Error             (WalletError (InternalError))
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode)
-import           Pos.Wallet.Web.Pending.Functions (isReclaimableFailure)
+import           Pos.Wallet.Web.Pending.Functions (isReclaimableFailure, ptxPoolInfo,
+                                                   usingPtxCoords)
 import           Pos.Wallet.Web.Pending.Types     (PendingTx (..), PtxCondition (..),
                                                    PtxPoolInfo)
 import           Pos.Wallet.Web.State             (PtxMetaUpdate (PtxMarkAcknowledged),
                                                    addOnlyNewPendingTx, casPtxCondition,
-                                                   ptxUpdateMeta)
+                                                   ptxUpdateMeta, removeOnlyCreatingPtx)
 
 -- | Handers used for to procees various pending transaction submission
 -- errors.
@@ -110,9 +113,14 @@ submitAndSavePtx
     :: MonadWalletWebMode m
     => PtxSubmissionHandlers m -> EnqueueMsg m -> PendingTx -> m ()
 submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
-    ack <- submitTxRaw enqueue _ptxTxAux
-    saveTx (_ptxTxId, _ptxTxAux) `catches` handlers ack
     addOnlyNewPendingTx ptx
+    ack <- submitTxRaw enqueue _ptxTxAux
+    (saveTx (_ptxTxId, _ptxTxAux)
+        `catches` handlers ack)
+        `onException` creationFailedHandler
+
+    poolInfo <- badInitPtxCondition `maybeThrow` ptxPoolInfo _ptxCond
+    _ <- usingPtxCoords casPtxCondition ptx _ptxCond (PtxApplying poolInfo)
     when ack $ ptxUpdateMeta _ptxWallet _ptxTxId PtxMarkAcknowledged
   where
     handlers accepted =
@@ -126,15 +134,21 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
             -- but it's better to try with tx again than to regret, right?
             minorError "unknown error" e
         ]
-
     minorError desc e = do
         reportError desc e ", but was given another chance"
         pshOnMinor e
     nonReclaimableError accepted e = do
         reportError "fatal" e ""
         pshOnNonReclaimable accepted e
-
     reportError desc e outcome =
         logInfoS $
         sformat ("Transaction #"%build%" application failed ("%shown%" - "
                 %stext%")"%stext) _ptxTxId e desc outcome
+
+    creationFailedHandler =
+        -- tx creation shouldn't fail if any of peers accepted our tx, but still,
+        -- if transaction was detected in blocks and its state got updated by tracker
+        -- while transaction creation failed, due to protocol error or bug,
+        -- then we better not remove this pending transaction
+        void $ usingPtxCoords removeOnlyCreatingPtx ptx
+    badInitPtxCondition = InternalError "Expected PtxCreating as initial pending condition"

--- a/wallet/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Acidic.hs
@@ -65,6 +65,7 @@ module Pos.Wallet.Web.State.Acidic
        , RemoveFromHistoryCache (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
+       , RemoveOnlyCreatingPtx (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , FlushWalletStorage (..)
@@ -167,6 +168,7 @@ makeAcidic ''WalletStorage
     , 'WS.removeFromHistoryCache
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
+    , 'WS.removeOnlyCreatingPtx
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
     , 'WS.flushWalletStorage

--- a/wallet/src/Pos/Wallet/Web/State/State.hs
+++ b/wallet/src/Pos/Wallet/Web/State/State.hs
@@ -72,6 +72,7 @@ module Pos.Wallet.Web.State.State
        , setWalletUtxo
        , setPtxCondition
        , casPtxCondition
+       , removeOnlyCreatingPtx
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , flushWalletStorage
@@ -307,6 +308,11 @@ casPtxCondition
     :: WebWalletModeDB ctx m
     => CId Wal -> TxId -> PtxCondition -> PtxCondition -> m Bool
 casPtxCondition = updateDisk ... A.CasPtxCondition
+
+removeOnlyCreatingPtx
+    :: WebWalletModeDB ctx m
+    => CId Wal -> TxId -> m Bool
+removeOnlyCreatingPtx = updateDisk ... A.RemoveOnlyCreatingPtx
 
 ptxUpdateMeta
     :: WebWalletModeDB ctx m


### PR DESCRIPTION
This is important, because if we remember it once transaction creation is done,
then creation may complete only after the moment when transaction gets to
blocks and then gets detected by tracker, so effectively tracker misses the tx.

Solution is to add new pending transaction status, `PtxCreating`. which
is not to display to frontend, and such transaction may be removed if
full cycle of transaction creation finishes with fatal error (unlike
`PtxApplying`).
Transaction remembered with this status still caries all pending meta info,
so tracker can successfully update status of that transaction.

Tested on:
* Normal creation
* Slot-length artificial delay between transaction submission over network and local application (original issue case)
* Fatal and non-fatal failure scenarios