### PR TITLE
[CSL-1741] Ensure utxo size is big enough to create tx in payload.hs

### DIFF
--- a/core/Pos/Arbitrary/Core.hs
+++ b/core/Pos/Arbitrary/Core.hs
@@ -497,7 +497,9 @@ instance Arbitrary Fee.TxFeePolicy where
 
 instance HasGenesisBlockVersionData => Arbitrary G.TestnetBalanceOptions where
     arbitrary = do
-        tboPoors <- choose (0, 100)
+        -- We have at least 2 owned addresses in system so we can send
+        -- transactions in block-gen/tests.
+        tboPoors <- choose (1, 100)
         tboRichmen <- choose (1, 12)
         tboTotalBalance <- choose (1000, maxCoinVal)
         tboRichmenShare <- choose (0.55, 0.996)


### PR DESCRIPTION
Whenever utxo size is 1 we can't select tx outputs (since outputs must be different from inputs) and thus form transaction. This PR makes sure that we always have >=2 secret keys in `genesisSecrets`.