### PR TITLE
[DEVOPS-441] display cardano rev in daedalus CI logs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,6 +109,8 @@ test_script:
   # Build the bridge
   - cd daedalus
   - Echo %APPVEYOR_BUILD_VERSION% > build-id
+  - Echo %APPVEYOR_REPO_COMMIT% > commit-id
+  - Echo https://ci.appveyor.com/project/%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%/build/%APPVEYOR_BUILD_VERSION% > ci-url
   - ps: Install-Product node 7
   - ..\scripts\ci\appveyor-retry call npm install
   - npm run build:prod

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -49,6 +49,7 @@ pushd daedalus
   nix-shell --run "npm install && npm run build:prod"
   echo $TRAVIS_BUILD_NUMBER > build-id
   echo $TRAVIS_COMMIT > commit-id
+  echo https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/$TRAVIS_JOB_ID > ci-url
   cp ../log-config-prod.yaml .
   cp ../lib/configuration.yaml .
   cp ../lib/*genesis*.json .


### PR DESCRIPTION
this ensures that both windows and darwin builds have a commit-id and also adds a ci-url, because the travis build id doesn't map directly to a url