### PR TITLE
[CSM-516] React to mempool changes via `MonadTxpListener`

### DIFF
--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -91,6 +91,7 @@ library
 
                       Pos.Wallet.Web.Tracking
                       Pos.Wallet.Web.Tracking.BListener
+                      Pos.Wallet.Web.Tracking.Decrypt
                       Pos.Wallet.Web.Tracking.Sync
                       Pos.Wallet.Web.Tracking.Modifier
 

--- a/wallet/src/Pos/Wallet/Redirect.hs
+++ b/wallet/src/Pos/Wallet/Redirect.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
--- | This module contains various monadic redirects used by wallet.
+-- | This module contains various default definitions
+-- of some monads used by wallet.
 
 module Pos.Wallet.Redirect
        ( MonadBlockchainInfo(..)
@@ -13,26 +14,48 @@ module Pos.Wallet.Redirect
        , MonadUpdates(..)
        , waitForUpdateWebWallet
        , applyLastUpdateWebWallet
+       , MonadTxpLocal (..)
+       , txpProcessTxWebWallet
+       , txpNormalizeWebWallet
        ) where
 
 import           Universum
 
-import           Control.Lens          (views)
-import           Data.Time.Units       (Millisecond)
-import           Ether.Internal        (HasLens (..))
-import           System.Wlog           (WithLogger)
+import           Control.Lens                   (views)
+import qualified Data.HashMap.Strict            as HM
+import           Data.Time.Units                (Millisecond)
+import           Ether.Internal                 (HasLens (..))
+import           System.Wlog                    (WithLogger, logWarning)
 
-import           Pos.Block.Core        (BlockHeader)
-import qualified Pos.Context           as PC
-import           Pos.Core              (ChainDifficulty, HasConfiguration, difficultyL)
-import           Pos.DB.Block          (MonadBlockDB)
-import           Pos.DB.DB             (getTipHeader)
-import qualified Pos.GState            as GS
-import           Pos.Shutdown          (HasShutdownContext, triggerShutdown)
-import           Pos.Slotting          (MonadSlots (..), getNextEpochSlotDuration)
-import           Pos.Update.Context    (UpdateContext (ucDownloadedUpdate))
-import           Pos.Update.Poll.Types (ConfirmedProposalState)
-import           Pos.Wallet.WalletMode (MonadBlockchainInfo (..), MonadUpdates (..))
+import           Pos.Block.Core                 (BlockHeader)
+import qualified Pos.Context                    as PC
+import           Pos.Core                       (ChainDifficulty, HasConfiguration,
+                                                 Timestamp, difficultyL,
+                                                 getCurrentTimestamp)
+import           Pos.Crypto                     (WithHash (..))
+import           Pos.DB.Block                   (MonadBlockDB)
+import           Pos.DB.DB                      (getTipHeader)
+import qualified Pos.GState                     as GS
+import           Pos.Shutdown                   (HasShutdownContext, triggerShutdown)
+import           Pos.Slotting                   (MonadSlots (..),
+                                                 getNextEpochSlotDuration)
+import           Pos.Txp                        (MonadTxpLocal (..), ToilVerFailure, Tx,
+                                                 TxAux (..), TxId, TxUndo,
+                                                 TxpNormalizeMempoolMode,
+                                                 TxpProcessTransactionMode,
+                                                 getLocalTxsNUndo, txNormalize,
+                                                 txProcessTransaction)
+import           Pos.Update.Context             (UpdateContext (ucDownloadedUpdate))
+import           Pos.Update.Poll.Types          (ConfirmedProposalState)
+import           Pos.Wallet.WalletMode          (MonadBlockchainInfo (..),
+                                                 MonadUpdates (..))
+import           Pos.Wallet.Web.Account         (AccountMode, getSKById)
+import           Pos.Wallet.Web.ClientTypes     (CId, Wal)
+import           Pos.Wallet.Web.Methods.History (addHistoryTxMeta)
+import qualified Pos.Wallet.Web.State           as WS
+import           Pos.Wallet.Web.Tracking        (THEntryExtra, buildTHEntryExtra,
+                                                 eskToWalletDecrCredentials,
+                                                 isTxEntryInteresting)
 
 ----------------------------------------------------------------------------
 -- BlockchainInfo
@@ -104,3 +127,38 @@ waitForUpdateWebWallet =
 
 applyLastUpdateWebWallet :: UpdatesEnv ctx m => m ()
 applyLastUpdateWebWallet = triggerShutdown
+
+----------------------------------------------------------------------------
+-- Txp Local
+----------------------------------------------------------------------------
+
+txpProcessTxWebWallet
+    :: forall ctx m .
+    ( TxpProcessTransactionMode ctx m
+    , AccountMode ctx m
+    , WS.MonadWalletDB ctx m
+    )
+    => (TxId, TxAux) -> m (Either ToilVerFailure ())
+txpProcessTxWebWallet tx@(txId, txAux) = txProcessTransaction tx >>= traverse (const addTxToWallets)
+  where
+    addTxToWallets :: m ()
+    addTxToWallets = do
+        (_, txUndos) <- getLocalTxsNUndo
+        case HM.lookup txId txUndos of
+            Nothing ->
+                logWarning "Node processed a tx but corresponding tx undo not found"
+            Just txUndo -> do
+                ts <- getCurrentTimestamp
+                let txWithUndo = (WithHash (taTx txAux) txId, txUndo)
+                thees <- mapM (toThee txWithUndo ts) =<< WS.getWalletAddresses
+                let interestingThees = mapMaybe (\ (id, t) -> (id,) <$> isTxEntryInteresting t) thees
+                mapM_ (uncurry addHistoryTxMeta) interestingThees
+
+    toThee :: (WithHash Tx, TxUndo) -> Timestamp -> CId Wal -> m (CId Wal, THEntryExtra)
+    toThee txWithUndo ts wId = do
+        wdc <- eskToWalletDecrCredentials <$> getSKById wId
+        pure (wId, buildTHEntryExtra wdc txWithUndo (Nothing, Just ts))
+
+txpNormalizeWebWallet
+    :: TxpNormalizeMempoolMode ctx m => m ()
+txpNormalizeWebWallet = txNormalize

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -5,7 +5,7 @@
 module Pos.Wallet.Web.Methods.History
        ( MonadWalletHistory
        , getHistoryLimited
-       , addHistoryTx
+       , addHistoryTxMeta
        , constructCTx
        , getCurChainDifficulty
        , updateTransaction
@@ -32,7 +32,7 @@ import           Pos.Wallet.Web.ClientTypes   (AccountId (..), Addr, CId, CTx (.
                                                CTxMeta (..), CWAddressMeta (..),
                                                ScrollLimit, ScrollOffset, Wal, mkCTx)
 import           Pos.Wallet.Web.Error         (WalletError (..))
-import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogic)
+import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogicRead)
 import           Pos.Wallet.Web.Pending       (PendingTx (..), ptxPoolInfo)
 import           Pos.Wallet.Web.State         (AddressLookupMode (Ever), MonadWalletDB,
                                                MonadWalletDBRead, addOnlyNewTxMetas,
@@ -44,7 +44,7 @@ import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, getAccountAddr
 
 
 type MonadWalletHistory ctx m =
-    ( MonadWalletLogic ctx m
+    ( MonadWalletLogicRead ctx m
     , MonadBlockchainInfo m
     , MonadTxHistory m
     )
@@ -73,11 +73,6 @@ getFullWalletHistory cWalId = do
     fullHistory <- addRecentPtxHistory cWalId $ localHistory `Map.union` blockHistory
     walAddrs    <- getWalletAddrsSet Ever cWalId
     diff        <- getCurChainDifficulty
-    -- TODO when we introduce some mechanism to react on new tx in mempool,
-    -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
-    -- We call @addHistoryTxs@ only for mempool transactions because for
-    -- transactions from block and resubmitting timestamp is already known.
-    addHistoryTxs cWalId localHistory
     cHistory <- forM fullHistory (constructCTx cWalId walAddrs diff)
     pure (cHistory, fromIntegral $ Map.size cHistory)
 
@@ -153,21 +148,21 @@ getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit = do
     errorDontSpecifyBoth = RequestError $
         "Please do not specify both walletId and accountId at the same time"
 
-addHistoryTx
+addHistoryTxMeta
     :: MonadWalletDB ctx m
     => CId Wal
     -> TxHistoryEntry
     -> m ()
-addHistoryTx cWalId = addHistoryTxs cWalId . txHistoryListToMap . one
+addHistoryTxMeta cWalId = addHistoryTxsMeta cWalId . txHistoryListToMap . one
 
 -- This functions is helper to do @addHistoryTx@ for
 -- all txs from mempool as one Acidic transaction.
-addHistoryTxs
+addHistoryTxsMeta
     :: MonadWalletDB ctx m
     => CId Wal
     -> Map TxId TxHistoryEntry
     -> m ()
-addHistoryTxs cWalId historyEntries = do
+addHistoryTxsMeta cWalId historyEntries = do
     metas <- mapM toMeta historyEntries
     addOnlyNewTxMetas cWalId metas
   where
@@ -198,7 +193,7 @@ updateTransaction accId txId txMeta = do
     setWalletTxMeta (aiWId accId) txId txMeta
 
 addRecentPtxHistory
-    :: (WithLogger m, MonadWalletDB ctx m)
+    :: (WithLogger m, MonadWalletDBRead ctx m)
     => CId Wal -> Map TxId TxHistoryEntry -> m (Map TxId TxHistoryEntry)
 addRecentPtxHistory wid currentHistory = do
     pendingTxs <- getWalletPendingTxs wid

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -4,6 +4,7 @@
 
 module Pos.Wallet.Web.Methods.Logic
        ( MonadWalletLogic
+       , MonadWalletLogicRead
 
        , getWallet
        , getWallets

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -35,7 +35,7 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId (..), Addr, CCoin, CI
                                                  CTx (..), CWAddressMeta (..), Wal,
                                                  addrMetaToAccount)
 import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx, constructCTx,
+import           Pos.Wallet.Web.Methods.History (addHistoryTxMeta, constructCTx,
                                                  getCurChainDifficulty)
 import           Pos.Wallet.Web.Methods.Txp     (MonadWalletTxFull, coinDistrToOutputs,
                                                  rewrapTxError, submitAndSaveNewPtx)
@@ -165,7 +165,9 @@ sendMoney passphrase moneySource dstDistr = do
 
         th <$ submitAndSaveNewPtx ptx
 
-    addHistoryTx srcWallet th
+    -- We add TxHistoryEntry's meta created by us in advance
+    -- to make TxHistoryEntry in CTx consistent with entry in history.
+    addHistoryTxMeta srcWallet th
     srcWalletAddrs <- getWalletAddrsSet Ever srcWallet
     diff <- getCurChainDifficulty
     fst <$> constructCTx srcWallet srcWalletAddrs diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -26,7 +26,7 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId (..), CAccountId (..)
                                                  CPaperVendWalletRedeem (..), CTx (..),
                                                  CWalletRedeem (..))
 import           Pos.Wallet.Web.Error           (WalletError (..))
-import           Pos.Wallet.Web.Methods.History (addHistoryTx, constructCTx,
+import           Pos.Wallet.Web.Methods.History (addHistoryTxMeta, constructCTx,
                                                  getCurChainDifficulty)
 import qualified Pos.Wallet.Web.Methods.Logic   as L
 import           Pos.Wallet.Web.Methods.Txp     (MonadWalletTxFull, rewrapTxError,
@@ -104,7 +104,9 @@ redeemAdaInternal passphrase cAccId seedBs = do
 
     -- add redemption transaction to the history of new wallet
     let cWalId = aiWId accId
-    addHistoryTx cWalId th
+    -- We add TxHistoryEntry's meta created by us in advance
+    -- to make TxHistoryEntry in CTx consistent with entry in history.
+    addHistoryTxMeta cWalId th
     cWalAddrs <- getWalletAddrsSet Ever cWalId
     diff <- getCurChainDifficulty
     fst <$> constructCTx cWalId cWalAddrs diff th

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -85,8 +85,7 @@ import           Pos.StateLock                     (StateLock)
 import           Pos.Txp                           (MempoolExt, MonadTxpLocal (..),
                                                     MonadTxpMem, Utxo, addrBelongsToSet,
                                                     applyUtxoModToAddrCoinMap,
-                                                    getUtxoModifier, txNormalize,
-                                                    txProcessTransaction)
+                                                    getUtxoModifier, getUtxoModifier)
 import qualified Pos.Txp.DB                        as DB
 import           Pos.Util                          (Some (..))
 import           Pos.Util.CompileInfo              (HasCompileInfo)
@@ -110,6 +109,8 @@ import           Pos.Wallet.Redirect               (MonadBlockchainInfo (..),
                                                     connectedPeersWebWallet,
                                                     localChainDifficultyWebWallet,
                                                     networkChainDifficultyWebWallet,
+                                                    txpNormalizeWebWallet,
+                                                    txpProcessTxWebWallet,
                                                     waitForUpdateWebWallet)
 import           Pos.Wallet.WalletMode             (WalletMempoolExt)
 import           Pos.Wallet.Web.Account            (AccountMode, GenSeed (RandomSeed))
@@ -349,8 +350,8 @@ type instance MempoolExt WalletWebMode = WalletMempoolExt
 
 instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) =>
          MonadTxpLocal WalletWebMode where
-    txpNormalize = txNormalize
-    txpProcessTx = txProcessTransaction
+    txpNormalize = txpNormalizeWebWallet
+    txpProcessTx = txpProcessTxWebWallet
 
 instance MonadKeysRead WalletWebMode where
     getSecret = getSecretDefault

--- a/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
@@ -1,0 +1,98 @@
+-- | Contains some utils to decrypt HD payload of addresses.
+-- Also utils to create THEntryExtra which based on
+-- decrypting of HDPayload.
+
+module Pos.Wallet.Web.Tracking.Decrypt
+       ( THEntryExtra (..)
+       , isTxEntryInteresting
+       , buildTHEntryExtra
+
+       , WalletDecrCredentials
+       , eskToWalletDecrCredentials
+       , selectOwnAddresses
+       ) where
+
+import           Universum
+
+import           Data.List                  ((!!))
+import qualified Data.List.NonEmpty         as NE
+import           Serokell.Util              (enumerate)
+
+import           Pos.Client.Txp.History     (TxHistoryEntry (..))
+import           Pos.Core                   (Address (..), ChainDifficulty, Timestamp,
+                                             aaPkDerivationPath, addrAttributesUnwrapped,
+                                             makeRootPubKeyAddress)
+import           Pos.Crypto                 (EncryptedSecretKey, HDPassphrase,
+                                             WithHash (..), deriveHDPassphrase,
+                                             encToPublic, unpackHDAddressAttr)
+import           Pos.Txp                    (Tx (..), TxIn (..), TxOut, TxOutAux (..),
+                                             TxUndo, toaOut, txOutAddress)
+import           Pos.Util.Servant           (encodeCType)
+
+import           Pos.Wallet.Web.ClientTypes (CId, CWAddressMeta (..), Wal)
+
+type OwnTxInOuts = [((TxIn, TxOutAux), CWAddressMeta)]
+
+-- | Auxiliary datatype which holds TxIns and TxOuts
+-- belonging to some wallet.
+data THEntryExtra = THEntryExtra
+    { theeInputs  :: OwnTxInOuts
+    -- ^ Inputs and corresponding outputs of tx
+    -- which belong to wallet
+    , theeOutputs :: OwnTxInOuts
+    -- ^ Outputs and corresponding inputs of tx
+    -- which belong to wallet
+    , theeTxEntry :: TxHistoryEntry
+    -- ^ Tx entry for history, likely it's not our entry
+    }
+
+isTxEntryInteresting :: THEntryExtra -> Maybe TxHistoryEntry
+isTxEntryInteresting THEntryExtra{..} =
+    if (not $ null theeInputs) || (not $ null theeOutputs) then Just theeTxEntry
+    else Nothing
+
+buildTHEntryExtra
+    :: WalletDecrCredentials
+    -> (WithHash Tx, TxUndo)
+    -> (Maybe ChainDifficulty, Maybe Timestamp)
+    -> THEntryExtra
+buildTHEntryExtra wdc (WithHash tx txId, NE.toList -> undoL) (mDiff, mTs) =
+    let (UnsafeTx (NE.toList -> inps) (NE.toList -> outs) _) = tx
+        toTxInOut (idx, out) = (TxInUtxo txId idx, TxOutAux out)
+
+        resolvedInputs :: [(TxIn, TxOutAux)]
+        resolvedInputs = catMaybes (zipWith (fmap . (,)) inps undoL)
+        txOutgoings = map txOutAddress outs
+        txInputs = map (toaOut . snd) resolvedInputs
+
+        theeInputs :: [((TxIn, TxOutAux), CWAddressMeta)]
+        theeInputs = selectOwnAddresses wdc (txOutAddress . toaOut . snd) resolvedInputs
+        theeOutputsRaw :: [((Word32, TxOut), CWAddressMeta)]
+        theeOutputsRaw = selectOwnAddresses wdc (txOutAddress . snd) (enumerate outs)
+        theeOutputs = map (first toTxInOut) theeOutputsRaw
+        theeTxEntry = THEntry txId tx mDiff txInputs txOutgoings mTs in
+    THEntryExtra {..}
+
+type WalletDecrCredentials = (HDPassphrase, CId Wal)
+
+eskToWalletDecrCredentials :: EncryptedSecretKey -> WalletDecrCredentials
+eskToWalletDecrCredentials encSK = do
+    let pubKey = encToPublic encSK
+    let hdPass = deriveHDPassphrase pubKey
+    let wCId = encodeCType $ makeRootPubKeyAddress pubKey
+    (hdPass, wCId)
+
+selectOwnAddresses
+    :: WalletDecrCredentials
+    -> (a -> Address)
+    -> [a]
+    -> [(a, CWAddressMeta)]
+selectOwnAddresses wdc getAddr =
+    mapMaybe (\a -> (a,) <$> decryptAddress wdc (getAddr a))
+
+decryptAddress :: WalletDecrCredentials -> Address -> Maybe CWAddressMeta
+decryptAddress (hdPass, wCId) addr = do
+    hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
+    derPath <- unpackHDAddressAttr hdPass hdPayload
+    guard $ length derPath == 2
+    pure $ CWAddressMeta wCId (derPath !! 0) (derPath !! 1) (encodeCType addr)

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -102,6 +102,8 @@ import           Pos.Wallet.Redirect               (applyLastUpdateWebWallet,
                                                     connectedPeersWebWallet,
                                                     localChainDifficultyWebWallet,
                                                     networkChainDifficultyWebWallet,
+                                                    txpNormalizeWebWallet,
+                                                    txpProcessTxWebWallet,
                                                     waitForUpdateWebWallet)
 import           Pos.Wallet.Web.Networking         (MonadWalletSendActions (..))
 
@@ -445,8 +447,8 @@ instance (HasCompileInfo, HasConfigurations)
 
 
 instance (HasCompileInfo, HasConfigurations) => MonadTxpLocal WalletTestMode where
-    txpNormalize = txNormalize
-    txpProcessTx = txProcessTransactionNoLock
+    txpNormalize = txpNormalizeWebWallet
+    txpProcessTx = txpProcessTxWebWallet
 
 instance MonadWalletSendActions WalletTestMode where
     sendTxToNetwork txAux = True <$ (asks wtcSentTxs >>= atomically . flip STM.modifyTVar (txAux:))


### PR DESCRIPTION
First steps to modify wallet state when new tx received.
In this PR wallet does update tx meta when tx received instead of when tx history requested.

**UPD**: I decided to write test for this change (now we CAN do it).