### PR TITLE
Link daedalus bridge module in daedalus-bridge.sh

### DIFF
--- a/scripts/build/daedalus-bridge.sh
+++ b/scripts/build/daedalus-bridge.sh
@@ -20,3 +20,6 @@ echo "3. Building Bridge..."
 cd daedalus
 npm install
 npm run build:prod
+
+echo "4. Linking Bridge..."
+npm link


### PR DESCRIPTION
According to the documentation https://cardanodocs.com/for-contributors/building-from-source/ you should be able to install the daedalus-client-api module after running daedalus-bridge.sh. I found that I had to explicitly run `npm link` to get it to work. So lets add it to the script.