### PR TITLE
[CSM-531] Revert "[CSM-491] Add timeout reports in blistener"

### DIFF
--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -7,7 +7,6 @@ module Pos.Slotting.Util
        , getSlotStart
        , getSlotStartPure
        , getSlotStartEmpatically
-       , getCurrentEpochSlotDuration
        , getNextEpochSlotDuration
        , slotFromTimestamp
 
@@ -80,13 +79,6 @@ getSlotStartEmpatically
     -> m Timestamp
 getSlotStartEmpatically slot =
     getSlotStart slot >>= maybeThrow (SEUnknownSlotStart slot)
-
--- | Get current slot duration.
-getCurrentEpochSlotDuration
-    :: (MonadSlotsData ctx m)
-    => m Millisecond
-getCurrentEpochSlotDuration =
-    esdSlotDuration . fst <$> getCurrentNextEpochSlottingDataM
 
 -- | Get last known slot duration.
 getNextEpochSlotDuration


### PR DESCRIPTION
New description (by @gromakovsky)

After addition of `logWarningWaitLinear` to wallet's BListener LRC hangs in wallet. That's because `applyBlocks` is called from `bracket` (`safe-exceptions` version) which applies `uninterruptibleMask` to given action. And `logWarningWaitLinear` uses `uninterruptibleCancel` to kill a thread which just hangs (due to `uninterruptibleMask` which is preserved when thread is forked).
We will fix it properly soon, for now the hotfix is to revert CSM-491. Note that this fix won't be necessary if #1772 is merged.

Old description (by @Martoon-00)

After addition of these logs we started to observe the issue, when after
new epoch start BListener application hang, mentioned logging emitted infinite
warnings about timeout.

Further investigation showed strange behaviour of `logWarningWaitInf`
function. It forks a thread via `withAsync` which periodically drops warnings
and this thread gets killed when primary action completes.
However, in our case, looks like `uninterruptibleCancel` hangs trying to kill
that forked thread, which in turn occurs to be on `delay` at that moment.
(And all these happens only upon a new epoch for some reason)

I hope someone explains me how could it be. Till that moment or some progress in investigation, I remove this logging-on-timeout.