### PR TITLE
[CSM-531] MERGE ONLY IN CASE OF EMERGENCY Revert "[CSM-491] Add timeout reports in blistener"

### DIFF
--- a/infra/Pos/Slotting/Util.hs
+++ b/infra/Pos/Slotting/Util.hs
@@ -7,7 +7,6 @@ module Pos.Slotting.Util
        , getSlotStart
        , getSlotStartPure
        , getSlotStartEmpatically
-       , getCurrentEpochSlotDuration
        , getNextEpochSlotDuration
        , slotFromTimestamp
 
@@ -79,13 +78,6 @@ getSlotStartEmpatically
     -> m Timestamp
 getSlotStartEmpatically slot =
     getSlotStart slot >>= maybeThrow (SEUnknownSlotStart slot)
-
--- | Get current slot duration.
-getCurrentEpochSlotDuration
-    :: (MonadSlotsData ctx m)
-    => m Millisecond
-getCurrentEpochSlotDuration =
-    esdSlotDuration . fst <$> getCurrentNextEpochSlottingDataM
 
 -- | Get last known slot duration.
 getNextEpochSlotDuration

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -15,7 +15,6 @@ import           Universum
 
 import           Control.Lens                     (to)
 import qualified Data.List.NonEmpty               as NE
-import           Data.Time.Units                  (convertUnit)
 import           Formatting                       (build, sformat, (%))
 import           Mockable                         (Async, Delay, Mockables)
 import           System.Wlog                      (HasLoggerName (modifyLoggerName),
@@ -33,13 +32,11 @@ import           Pos.DB.Class                     (MonadDBRead)
 import qualified Pos.GState                       as GS
 import           Pos.Reporting                    (MonadReporting, reportOrLogW)
 import           Pos.Slotting                     (MonadSlots, MonadSlotsData,
-                                                   getCurrentEpochSlotDuration,
                                                    getSlotStartPure, getSystemStartM)
 import           Pos.Txp.Core                     (TxAux (..), TxUndo, flattenTxPayload)
 import           Pos.Util.Chrono                  (NE, NewestFirst (..), OldestFirst (..))
-import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
-import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningWaitInf)
 
+import           Pos.Util.LogSafe                 (logInfoS, logWarningS)
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
 import qualified Pos.Wallet.Web.State             as WS
@@ -78,7 +75,7 @@ onApplyBlocksWebWallet
     , HasConfiguration
     )
     => OldestFirst NE Blund -> m SomeBatchOp
-onApplyBlocksWebWallet blunds = setLogger . reportTimeouts "apply" $ do
+onApplyBlocksWebWallet blunds = setLogger $ do
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
@@ -120,7 +117,7 @@ onRollbackBlocksWebWallet
     , HasConfiguration
     )
     => NewestFirst NE Blund -> m SomeBatchOp
-onRollbackBlocksWebWallet blunds = setLogger . reportTimeouts "rollback" $ do
+onRollbackBlocksWebWallet blunds = setLogger $ do
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
@@ -171,16 +168,6 @@ gbTxsWUndo (blk@(Right mb), undo) =
 
 setLogger :: HasLoggerName m => m a -> m a
 setLogger = modifyLoggerName (<> "wallet" <> "blistener")
-
-reportTimeouts
-    :: (MonadSlotsData ctx m, CanLogInParallel m)
-    => Text -> m a -> m a
-reportTimeouts desc action = do
-    slotDuration <- getCurrentEpochSlotDuration
-    let firstWarningTime = convertUnit slotDuration `div` 2
-    logWarningWaitInf firstWarningTime tag action
-  where
-    tag = "Wallet blistener " <> desc
 
 logMsg
     :: (MonadIO m, WithLogger m)


### PR DESCRIPTION
After addition of these logs we started to observe the issue, when after
new epoch start BListener application hang, mentioned logging emitted infinite
warnings about timeout.

Further investigation showed strange behaviour of `logWarningWaitInf`
function. It forks a thread via `withAsync` which periodically drops warnings
and this thread gets killed when primary action completes.
However, in our case, looks like `uninterruptibleCancel` hangs trying to kill
that forked thread, which in turn occurs to be on `delay` at that moment.
(And all these happens only upon a new epoch for some reason)

I hope someone explains me how could it be. Till that moment or some progress in investigation, I remove this logging-on-timeout.