### PR TITLE
[CSL-1794] Update versions in configuration

### DIFF
--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -279,10 +279,10 @@ mainnet_base: &mainnet_base
 
   update: &mainnet_base_update
     applicationName: cardano-sl
-    applicationVersion: 2
+    applicationVersion: 0
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 0
+      bvMinor: 1
       bvAlt: 0
     systemTag: none
 
@@ -14803,15 +14803,25 @@ mainnet_full: &mainnet_full
 mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
-    <<: *mainnet_base_update
+    <<:
     applicationName: csl-daedalus
+    applicationVersion: 3
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
     systemTag: win64
 
 mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
-    <<: *mainnet_base_update
+    <<:
     applicationName: csl-daedalus
+    applicationVersion: 3
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
     systemTag: macos64
 
 ##############################################################################
@@ -14832,15 +14842,25 @@ mainnet_dryrun_full: &mainnet_dryrun_full
 mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
-    <<: *mainnet_base_update
+    <<:
     applicationName: csl-daedalus
+    applicationVersion: 3
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
     systemTag: win64
 
 mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
-    <<: *mainnet_base_update
+    <<:
     applicationName: csl-daedalus
+    applicationVersion: 3
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
     systemTag: macos64
 
 ##############################################################################


### PR DESCRIPTION
We are going to propose and vote for an update to block version 0.1.0.
We will also need to set application version to 3 for csl-daedalus.
Previosuly cardano-sl software was launched with version 2, but it was by
mistake, because last confirmed version was 0. This mistake didn't have any
impact though. I changed it to 0 to be correct.
Wallet configs now don't reuse `mainnet_base_update`, but instead define
all versions explicitly, because the previous solution was error-prone.