### PR TITLE
[DEVOPS-157] naturalise cardano-keygen:  number generated key files from 0, instead of 1

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5955,8 +5955,8 @@ self: {
           pname = "servant-blaze";
           version = "0.7.1";
           sha256 = "90ed1c7a22b83bee344ef3896203f3699b7633bf986ffa064752c3596c072646";
-          revision = "5";
-          editedCabalFile = "05zz0kvnmai230palf44f72gm1vadqyssk9hl4h0qq5263frbsli";
+          revision = "6";
+          editedCabalFile = "051m44rqmxkl30n96qcbz1xwwsw2n7l7laflnc0xydc40ws0bj96";
           libraryHaskellDepends = [
             base
             blaze-html

--- a/tools/src/keygen/Dump.hs
+++ b/tools/src/keygen/Dump.hs
@@ -52,9 +52,9 @@ dumpKeyfiles (dir, pat) TestnetBalanceOptions{..} secrets = do
     let totalStakeholders = tboRichmen + tboPoors
     let (richmen, poors) = splitAt (fromIntegral tboRichmen) secrets
 
-    forM_ (zip richmen [1 .. tboRichmen]) $ \(sk, i) ->
+    forM_ (zip richmen [0 .. (tboRichmen - 1)]) $ \(sk, i) ->
         dumpKeyfile True (richDir </> applyPattern pat i) sk
-    forM_ (zip poors [1 .. tboPoors]) $ \(sk, i) ->
+    forM_ (zip poors [0 .. (tboPoors - 1)]) $ \(sk, i) ->
         dumpKeyfile False (poorDir </> applyPattern pat i) sk
 
     logInfo $ show totalStakeholders <> " keyfiles are generated"


### PR DESCRIPTION
This caught people off-guard numerous times.

Seems like humans are better trained to deal with natural numbers.