### PR TITLE
[CSL-1676] Send keep-alive like packets after relay subscription

### DIFF
--- a/infra/Pos/Communication/Types/Protocol.hs
+++ b/infra/Pos/Communication/Types/Protocol.hs
@@ -306,8 +306,18 @@ instance Monad m => Monoid (MkListeners m) where
 -- This is used by behind-NAT nodes, who join the network by sending a
 -- MsgSubscribe to a relay nodes.
 --
+-- Note that after node A subscribes, it doesn't send anything to node B
+-- anymore. Therefore it might happen that due to problems within the network
+-- (e.g. router failures, see
+-- https://blog.stephencleary.com/2009/05/detection-of-half-open-dropped.html
+-- for more detailed information) node B closes the subscription channel after
+-- it tries to send data to node A and fails, whereas node A will be oblivious
+-- to that event and won't try to reestablish the channel. To remedy that node A
+-- needs to periodically send keep-alive like data to node B in order to ensure
+-- that the connection is valid.
+--
 -- Kademia nodes might also use this if they want a guarantee that they receive
 -- messages from their peers (without subscription we rely on luck for some
 -- nodes to decide to add us to their list of known peers).
-data MsgSubscribe = MsgSubscribe
+data MsgSubscribe = MsgSubscribe | MsgSubscribeKeepAlive
     deriving (Generic, Show, Eq)

--- a/infra/Pos/Util/Timer.hs
+++ b/infra/Pos/Util/Timer.hs
@@ -1,0 +1,53 @@
+-- | Restartable, STM-based timer for waiting a given number of microseconds.
+--
+-- Consider the following code:
+-- @
+--   main :: IO ()
+--   main = do
+--     delay <- newTimer $ 5 * 1000000
+--     tid <- forkIO . forever $ do
+--       startTimer delay
+--       atomically $ waitTimer delay
+--       putStrLn $ "Timer ended"
+--     (`finally` killThread tid) . forever $ do
+--       _ <- getLine
+--       startTimer delay
+-- @
+--
+-- It will print "Timer ended" every 5 seconds after there was no input for 5
+-- seconds.
+module Pos.Util.Timer
+    ( Timer
+    , newTimer
+    , waitTimer
+    , startTimer
+    ) where
+
+import Universum
+import Control.Concurrent.STM (newTVar, readTVar, retry, registerDelay)
+
+data Timer = Timer
+  { delayDuration  :: !Int
+  , delaySemaphore :: !(TVar (TVar Bool))
+  }
+
+-- | Create a new, inactive Timer given the number of microseconds. In order to
+-- activate it 'startTimer' needs to be called.
+newTimer :: MonadIO m => Int -> m Timer
+newTimer n
+    | n < 0     = error "newTimer: negative duration"
+    | otherwise = Timer n <$> atomically (newTVar True >>= newTVar)
+
+-- | Wait for the duration associated with the Timer that passed since the last
+-- time 'startTimer' was called.
+waitTimer :: Timer -> STM ()
+waitTimer Timer{..} = do
+  done <- readTVar =<< readTVar delaySemaphore
+  unless done retry
+
+-- Start the timer. If the function is called before @t + n@, where @t@ is the
+-- time startTimer was called for the last time and @n@ is the number of
+-- microseconds associated with the Timer, the timer is restarted.
+startTimer :: MonadIO m => Timer -> m ()
+startTimer Timer{..} = liftIO (registerDelay delayDuration)
+    >>= atomically . writeTVar delaySemaphore

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -110,6 +110,7 @@ library
                         Pos.Util.LogSafe
                         Pos.Util.TimeLimit
                         Pos.Util.TimeWarp
+                        Pos.Util.Timer
 
   other-modules:        Paths_cardano_sl_infra
 

--- a/lib/src/Pos/Binary/Communication.hs
+++ b/lib/src/Pos/Binary/Communication.hs
@@ -66,11 +66,13 @@ instance HasConfiguration => Bi MsgBlock where
 -- "fake" deriving as per `MempoolMsg`.
 -- TODO: Shall we encode this as `CBOR` TkNull?
 instance Bi MsgSubscribe where
-  encode MsgSubscribe = encode (42 :: Word8)
-  decode = do
-    x <- decode @Word8
-    when (x /= 42) $ fail "wrong byte"
-    pure MsgSubscribe
+    encode = \case
+        MsgSubscribe          -> encode (42 :: Word8)
+        MsgSubscribeKeepAlive -> encode (43 :: Word8)
+    decode = decode @Word8 >>= \case
+        42 -> pure MsgSubscribe
+        43 -> pure MsgSubscribeKeepAlive
+        n  -> fail $ "MsgSubscribe wrong byte: " <> show n
 
 ----------------------------------------------------------------------------
 -- Protocol version info and related

--- a/lib/src/Pos/Block/Worker.hs
+++ b/lib/src/Pos/Block/Worker.hs
@@ -65,6 +65,7 @@ import           Pos.Util.Chrono             (OldestFirst (..))
 import           Pos.Util.JsonLog            (jlCreatedBlock)
 import           Pos.Util.LogSafe            (logDebugS, logInfoS, logWarningS)
 import           Pos.Util.TimeWarp           (CanJsonLog (..))
+import           Pos.Util.Timer              (Timer)
 import           Pos.WorkMode.Class          (WorkMode)
 
 ----------------------------------------------------------------------------
@@ -74,11 +75,11 @@ import           Pos.WorkMode.Class          (WorkMode)
 -- | All workers specific to block processing.
 blkWorkers
     :: WorkMode ctx m
-    => ([WorkerSpec m], OutSpecs)
-blkWorkers =
+    => Timer -> ([WorkerSpec m], OutSpecs)
+blkWorkers keepAliveTimer =
     merge $ [ blkCreatorWorker
             , blkMetricCheckerWorker
-            , retrievalWorker
+            , retrievalWorker keepAliveTimer
             ]
   where
     merge = mconcatPair . map (first pure)

--- a/lib/src/Pos/Context/Context.hs
+++ b/lib/src/Pos/Context/Context.hs
@@ -55,6 +55,7 @@ import           Pos.Ssc.Types            (HasSscContext (..), SscContext)
 import           Pos.StateLock            (StateLock, StateLockMetrics)
 import           Pos.Txp.Settings         (TxpGlobalSettings)
 import           Pos.Update.Context       (UpdateContext)
+import           Pos.Util.Timer           (Timer)
 import           Pos.Util.UserSecret      (HasUserSecret (..), UserSecret)
 import           Pos.Util.Util            (postfixLFields)
 
@@ -134,6 +135,9 @@ data NodeContext = NodeContext
     , ncConnectedPeers      :: !ConnectedPeers
     -- ^ Set of peers that we're connected to.
     , ncNetworkConfig       :: !(NetworkConfig KademliaDHTInstance)
+    -- ^ Timer for delaying sending keep-alive like packets to relay nodes until
+    -- a specific duration after the last time a block was received has passed.
+    , ncSubscriptionKeepAliveTimer :: !Timer
     }
 
 makeLensesWith postfixLFields ''NodeContext

--- a/lib/src/Pos/Launcher/Resource.hs
+++ b/lib/src/Pos/Launcher/Resource.hs
@@ -79,6 +79,7 @@ import           Pos.Launcher.Mode                (InitMode, InitModeContext (..
 import           Pos.Update.Context               (mkUpdateContext)
 import qualified Pos.Update.DB                    as GState
 import           Pos.Util                         (newInitFuture)
+import           Pos.Util.Timer                   (newTimer)
 
 import qualified System.Wlog                      as Logger
 
@@ -297,6 +298,7 @@ allocateNodeContext ancd txpSettings = do
     -- TODO synchronize the NodeContext peers var with whatever system
     -- populates it.
     peersVar <- newTVarIO mempty
+    ncSubscriptionKeepAliveTimer <- newTimer $ 30 * 1000000 -- TODO: use slot duration
     let ctx =
             NodeContext
             { ncConnectedPeers = ConnectedPeers peersVar

--- a/lib/src/Pos/Worker.hs
+++ b/lib/src/Pos/Worker.hs
@@ -46,14 +46,15 @@ allWorkers NodeResources {..} = mconcatPair
     , wrap' "us"         $ usWorkers
 
       -- Have custom loggers
-    , wrap' "block"      $ blkWorkers
+    , wrap' "block"      $ blkWorkers ncSubscriptionKeepAliveTimer
     , wrap' "txp"        $ txpWorkers
     , wrap' "delegation" $ dlgWorkers
     , wrap' "slotting"   $ (properSlottingWorkers, mempty)
 
     , wrap' "subscription" $ case topologySubscriptionWorker (ncTopology ncNetworkConfig) of
         Just (SubscriptionWorkerBehindNAT dnsDomains) ->
-          subscriptionWorker (dnsSubscriptionWorker ncNetworkConfig dnsDomains)
+          subscriptionWorker (dnsSubscriptionWorker ncNetworkConfig dnsDomains
+                                                    ncSubscriptionKeepAliveTimer)
         Just (SubscriptionWorkerKademlia kinst nodeType valency fallbacks) ->
           subscriptionWorker (dhtSubscriptionWorker kinst nodeType valency fallbacks)
         Nothing ->


### PR DESCRIPTION
That should take care of [CSL-1676](https://issues.serokell.io/issue/CSL-1676).

The only issue is that I'm not sure how to test that change  - running `demo.sh` doesn't trigger subscription worker on any of the nodes.
