### PR TITLE
[CSL-1836] Fix unsafeArbitrary instances of sk/pk

### DIFF
--- a/core/Pos/Arbitrary/Crypto/Unsafe.hs
+++ b/core/Pos/Arbitrary/Crypto/Unsafe.hs
@@ -4,29 +4,25 @@ module Pos.Arbitrary.Crypto.Unsafe () where
 
 import           Universum
 
-import           Test.QuickCheck           (Arbitrary (..), choose)
-import           Test.QuickCheck.Instances ()
+import           Test.QuickCheck                 (Arbitrary (..), choose)
+import           Test.QuickCheck.Instances       ()
 
-import           Pos.Binary.Class          (Bi)
-import qualified Pos.Binary.Class          as Bi
+import           Pos.Binary.Class                (Bi)
+import qualified Pos.Binary.Class                as Bi
 import           Pos.Core.Configuration.Protocol (HasProtocolConstants)
-import           Pos.Crypto.Hashing        (AbstractHash, HashAlgorithm,
-                                            unsafeAbstractHash)
-import           Pos.Crypto.SecretSharing  (VssKeyPair, VssPublicKey,
-                                            deterministicVssKeyGen, toVssPublicKey)
-import           Pos.Crypto.Signing        (PublicKey, SecretKey, Signature, Signed,
-                                            mkSigned)
-import           Pos.Crypto.Signing.Types.Tag (SignTag)
-import           Pos.Util.Arbitrary        (ArbitraryUnsafe (..), arbitrarySizedS)
+import           Pos.Crypto.Hashing              (AbstractHash, HashAlgorithm,
+                                                  unsafeAbstractHash)
+import           Pos.Crypto.SecretSharing        (VssKeyPair, VssPublicKey,
+                                                  deterministicVssKeyGen, toVssPublicKey)
+import           Pos.Crypto.Signing              (PublicKey, SecretKey, Signed, mkSigned)
+import           Pos.Crypto.Signing.Types.Tag    (SignTag)
+import           Pos.Util.Arbitrary              (ArbitraryUnsafe (..), arbitrarySizedS)
 
 instance Bi PublicKey => ArbitraryUnsafe PublicKey where
-    arbitraryUnsafe = Bi.unsafeDeserialize' <$> arbitrarySizedS 32
+    arbitraryUnsafe = Bi.unsafeDeserialize' . Bi.serialize' <$> arbitrarySizedS 64
 
 instance Bi SecretKey => ArbitraryUnsafe SecretKey where
-    arbitraryUnsafe = Bi.unsafeDeserialize' <$> arbitrarySizedS 64
-
-instance Bi (Signature a) => ArbitraryUnsafe (Signature a) where
-    arbitraryUnsafe = Bi.unsafeDeserialize' <$> arbitrarySizedS 64
+    arbitraryUnsafe = Bi.unsafeDeserialize' . Bi.serialize' <$> arbitrarySizedS 128
 
 -- Generating invalid `Signed` objects doesn't make sense even in
 -- benchmarks

--- a/core/Pos/Crypto/Signing/Signing.hs
+++ b/core/Pos/Crypto/Signing/Signing.hs
@@ -29,21 +29,21 @@ module Pos.Crypto.Signing.Signing
        , module Pos.Crypto.Signing.Types.Signing
        ) where
 
-import qualified Cardano.Crypto.Wallet  as CC
-import           Crypto.Random          (MonadRandom, getRandomBytes)
-import           Data.ByteArray         (ScrubbedBytes)
-import qualified Data.ByteString        as BS
-import           Data.Coerce            (coerce)
-import           Formatting             (Format, build, later, sformat, (%))
-import qualified Serokell.Util.Base16   as B16
-import           Universum              hiding (show)
+import qualified Cardano.Crypto.Wallet            as CC
+import           Crypto.Random                    (MonadRandom, getRandomBytes)
+import           Data.ByteArray                   (ScrubbedBytes)
+import qualified Data.ByteString                  as BS
+import           Data.Coerce                      (coerce)
+import           Formatting                       (Format, build, later, sformat, (%))
+import qualified Serokell.Util.Base16             as B16
+import           Universum                        hiding (show)
 
-import           Pos.Binary.Class       (Bi, Raw)
-import qualified Pos.Binary.Class       as Bi
-import           Pos.Core.Configuration.Protocol (HasProtocolConstants)
-import           Pos.Crypto.Signing.Types.Tag (SignTag (SignProxySK))
-import           Pos.Crypto.Signing.Tag (signTag)
+import           Pos.Binary.Class                 (Bi, Raw)
+import qualified Pos.Binary.Class                 as Bi
+import           Pos.Core.Configuration.Protocol  (HasProtocolConstants)
+import           Pos.Crypto.Signing.Tag           (signTag)
 import           Pos.Crypto.Signing.Types.Signing
+import           Pos.Crypto.Signing.Types.Tag     (SignTag (SignProxySK))
 
 ----------------------------------------------------------------------------
 -- Keys, key generation & printing & decoding


### PR DESCRIPTION
Sk/pk instances were using wrong arbitrary string sizes, which led to failure in benches. I've also removed `unsafeArbitrary` instance for `Signature` because it wasn't used anywhere #noweeds. 