### PR TITLE
[CSM-550] Group pagination parameters in one datatype

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2196,6 +2196,94 @@ self: {
           description = "Cardano SL - wallet";
           license = stdenv.lib.licenses.mit;
         }) {};
+      cardano-sl-wallet-new = callPackage ({ QuickCheck, aeson, aeson-pretty, base, bytestring, containers, data-default, formatting, hspec, http-api-data, http-client, http-types, insert-ordered-containers, lens, mkDerivation, mtl, neat-interpolation, network-uri, quickcheck-instances, serokell-util, servant, servant-client, servant-quickcheck, servant-server, servant-swagger, stdenv, string-conv, swagger2, text, text-format, transformers, universum, unordered-containers, wai, wai-cors, wai-extra, warp }:
+      mkDerivation {
+          pname = "cardano-sl-wallet-new";
+          version = "0.1.0.0";
+          src = ./../wallet-new;
+          isLibrary = true;
+          isExecutable = true;
+          libraryHaskellDepends = [
+            aeson
+            base
+            containers
+            data-default
+            formatting
+            http-api-data
+            http-client
+            http-types
+            mtl
+            network-uri
+            QuickCheck
+            serokell-util
+            servant
+            servant-client
+            servant-server
+            text
+            text-format
+            transformers
+            universum
+            warp
+          ];
+          executableHaskellDepends = [
+            aeson
+            aeson-pretty
+            base
+            bytestring
+            containers
+            data-default
+            formatting
+            http-api-data
+            http-types
+            insert-ordered-containers
+            lens
+            neat-interpolation
+            QuickCheck
+            servant
+            servant-server
+            servant-swagger
+            string-conv
+            swagger2
+            text
+            text-format
+            universum
+            unordered-containers
+            wai
+            wai-cors
+            wai-extra
+            warp
+          ];
+          testHaskellDepends = [
+            aeson
+            aeson-pretty
+            base
+            containers
+            data-default
+            formatting
+            hspec
+            http-client
+            http-types
+            insert-ordered-containers
+            lens
+            neat-interpolation
+            QuickCheck
+            quickcheck-instances
+            servant
+            servant-quickcheck
+            servant-server
+            servant-swagger
+            string-conv
+            swagger2
+            text
+            universum
+            unordered-containers
+          ];
+          doHaddock = false;
+          doCheck = true;
+          homepage = "https://github.com/swagger-api/swagger-codegen#readme";
+          description = "Auto-generated API bindings for cardano-sl-web-wallet";
+          license = stdenv.lib.licenses.unfree;
+        }) {};
       case-insensitive = callPackage ({ base, bytestring, deepseq, hashable, mkDerivation, stdenv, text }:
       mkDerivation {
           pname = "case-insensitive";
@@ -4940,8 +5028,8 @@ self: {
           pname = "natural-transformation";
           version = "0.4";
           sha256 = "aac28e2c1147ed77c1ec0f0eb607a577fa26d0fd67474293ba860ec124efc8af";
-          revision = "1";
-          editedCabalFile = "1scwm1gs07znkj4ahfyxpwrksj4rdl1pa81xflcqhkqfgcndvgl3";
+          revision = "2";
+          editedCabalFile = "1j90pd1zznr18966axskad5w0kx4dvqg62r65rmw1ihqwxm1ndix";
           libraryHaskellDepends = [
             base
           ];
@@ -6070,6 +6158,45 @@ self: {
           description = "Blaze-html support for servant";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      servant-client = callPackage ({ aeson, attoparsec, base, base-compat, base64-bytestring, bytestring, exceptions, generics-sop, http-api-data, http-client, http-client-tls, http-media, http-types, mkDerivation, monad-control, mtl, network-uri, safe, semigroupoids, servant, stdenv, string-conversions, text, transformers, transformers-base, transformers-compat }:
+      mkDerivation {
+          pname = "servant-client";
+          version = "0.10";
+          sha256 = "55e411ac7e38a5c1b77d8d3c2320369be36a7b7181e27bb5ac4fba308ef93eaa";
+          revision = "2";
+          editedCabalFile = "0j5ws3zjz748kmd7sn9vgdwp4mqdyzw26qnl46jdcf838b6klhl1";
+          libraryHaskellDepends = [
+            aeson
+            attoparsec
+            base
+            base-compat
+            base64-bytestring
+            bytestring
+            exceptions
+            generics-sop
+            http-api-data
+            http-client
+            http-client-tls
+            http-media
+            http-types
+            monad-control
+            mtl
+            network-uri
+            safe
+            semigroupoids
+            servant
+            string-conversions
+            text
+            transformers
+            transformers-base
+            transformers-compat
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "http://haskell-servant.readthedocs.org/";
+          description = "automatical derivation of querying functions for servant webservices";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
       servant-multipart = callPackage ({ base, bytestring, directory, http-client, http-media, mkDerivation, network, resourcet, servant, servant-server, stdenv, text, transformers, wai, wai-extra, warp }:
       mkDerivation {
           pname = "servant-multipart";
@@ -6105,6 +6232,42 @@ self: {
           doCheck = false;
           homepage = "https://github.com/haskell-servant/servant-multipart#readme";
           description = "multipart/form-data (e.g file upload) support for servant";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
+      servant-quickcheck = callPackage ({ QuickCheck, aeson, base, base-compat, bytestring, case-insensitive, clock, data-default-class, hspec, http-client, http-media, http-types, mkDerivation, mtl, pretty, process, servant, servant-client, servant-server, split, stdenv, string-conversions, temporary, text, time, warp }:
+      mkDerivation {
+          pname = "servant-quickcheck";
+          version = "0.0.3.1";
+          sha256 = "7a829420ac3d2d39dbd08ed233ff526073cefbb1ab053a0d44c09bd26fe0977a";
+          libraryHaskellDepends = [
+            aeson
+            base
+            base-compat
+            bytestring
+            case-insensitive
+            clock
+            data-default-class
+            hspec
+            http-client
+            http-media
+            http-types
+            mtl
+            pretty
+            process
+            QuickCheck
+            servant
+            servant-client
+            servant-server
+            split
+            string-conversions
+            temporary
+            text
+            time
+            warp
+          ];
+          doHaddock = false;
+          doCheck = false;
+          description = "QuickCheck entire APIs";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       servant-server = callPackage ({ Cabal, aeson, attoparsec, base, base-compat, base64-bytestring, bytestring, containers, directory, exceptions, filepath, http-api-data, http-types, mkDerivation, monad-control, mtl, network, network-uri, resourcet, safe, servant, split, stdenv, string-conversions, system-filepath, text, transformers, transformers-base, transformers-compat, wai, wai-app-static, warp, word8 }:
@@ -6445,6 +6608,22 @@ self: {
           homepage = "https://github.com/fpco/streaming-commons";
           description = "Common lower-level functions needed by various streaming data libraries";
           license = stdenv.lib.licenses.mit;
+        }) {};
+      string-conv = callPackage ({ base, bytestring, mkDerivation, stdenv, text }:
+      mkDerivation {
+          pname = "string-conv";
+          version = "0.1.2";
+          sha256 = "f259a03e6f296af19a71c07ab9a98a38661dfe40679f360f8e371334ea226039";
+          libraryHaskellDepends = [
+            base
+            bytestring
+            text
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/Soostone/string-conv";
+          description = "Standardized conversion between string types";
+          license = stdenv.lib.licenses.bsd3;
         }) {};
       string-conversions = callPackage ({ base, bytestring, mkDerivation, stdenv, text, utf8-string }:
       mkDerivation {

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -120,6 +120,8 @@ test-suite wallet-new-specs
                   , aeson-pretty
                   , cardano-sl-wallet-new
                   , containers
+                  , data-default
+                  , formatting
                   , hspec
                   , http-client
                   , http-types

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -40,6 +40,7 @@ library
                      , servant
                      , servant-client
                      , servant-server
+                     , servant-swagger
                      , text
                      , text-format
                      , transformers

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -40,7 +40,6 @@ library
                      , servant
                      , servant-client
                      , servant-server
-                     , servant-swagger
                      , text
                      , text-format
                      , transformers

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -30,6 +30,8 @@ library
                      , QuickCheck
                      , aeson
                      , containers
+                     , data-default
+                     , formatting
                      , http-api-data
                      , http-client
                      , http-types
@@ -39,6 +41,7 @@ library
                      , servant-client
                      , servant-server
                      , text
+                     , text-format
                      , transformers
                      , universum
                      , serokell-util
@@ -73,6 +76,8 @@ executable wallet-new-server
                      , bytestring
                      , cardano-sl-wallet-new
                      , containers
+                     , data-default
+                     , formatting
                      , http-api-data
                      , http-types
                      , lens
@@ -85,6 +90,7 @@ executable wallet-new-server
                      , string-conv
                      , swagger2
                      , text
+                     , text-format
                      , universum
                      , warp
                      , wai

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -38,13 +38,11 @@ deleteAccount _ _ = return NoContent
 getAccount :: WalletId -> AccountId -> Handler Account
 getAccount _ _ = liftIO $ generate arbitrary
 
-listAccounts :: Page
-             -> PerPage
-             -> ResponseType
+listAccounts :: PaginationParams
              -> Handler (OneOf [Account] (ExtendedResponse [Account]))
-listAccounts _ _ responseType = do
+listAccounts PaginationParams {..} = do
   example <- liftIO $ generate (resize 3 arbitrary)
-  case responseType of
+  case ppResponseType of
     Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -38,15 +38,14 @@ deleteAccount _ _ = return NoContent
 getAccount :: WalletId -> AccountId -> Handler Account
 getAccount _ _ = liftIO $ generate arbitrary
 
-listAccounts :: Maybe Page
-             -> Maybe PerPage
-             -> Maybe ResponseType
-             -> Maybe ResponseFormat
+listAccounts :: Page
+             -> PerPage
+             -> ResponseType
              -> Handler (OneOf [Account] (ExtendedResponse [Account]))
-listAccounts _ _ mbExtended _ = do
+listAccounts _ _ responseType = do
   example <- liftIO $ generate (resize 3 arbitrary)
-  case mbExtended of
-    Just Extended -> return $ OneOf $ Right $
+  case responseType of
+    Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -40,13 +40,13 @@ getAccount _ _ = liftIO $ generate arbitrary
 
 listAccounts :: Maybe Page
              -> Maybe PerPage
-             -> Maybe Bool
-             -> Maybe Text
+             -> Maybe ResponseType
+             -> Maybe ResponseFormat
              -> Handler (OneOf [Account] (ExtendedResponse [Account]))
 listAccounts _ _ mbExtended _ = do
   example <- liftIO $ generate (resize 3 arbitrary)
   case mbExtended of
-    Just True  -> return $ OneOf $ Right $
+    Just Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -15,12 +15,12 @@ handlers =  listAddresses
 
 listAddresses :: Maybe Page
               -> Maybe PerPage
-              -> Maybe Bool
-              -> Maybe Text
+              -> Maybe ResponseType
+              -> Maybe ResponseFormat
               -> Handler (OneOf [Address] (ExtendedResponse [Address]))
 listAddresses _ _ mbExtended _ =
   case mbExtended of
-    Just True  -> return $ OneOf $ Right $
+    Just Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = [Address "deadBeef", Address "123AABBCC"]
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -13,12 +13,10 @@ handlers :: Server Addresses.API
 handlers =  listAddresses
        :<|> newAddress
 
-listAddresses :: Page
-              -> PerPage
-              -> ResponseType
+listAddresses :: PaginationParams
               -> Handler (OneOf [Address] (ExtendedResponse [Address]))
-listAddresses _ _ responseType =
-  case responseType of
+listAddresses PaginationParams {..} =
+  case ppResponseType of
     Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = [Address "deadBeef", Address "123AABBCC"]

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -13,14 +13,13 @@ handlers :: Server Addresses.API
 handlers =  listAddresses
        :<|> newAddress
 
-listAddresses :: Maybe Page
-              -> Maybe PerPage
-              -> Maybe ResponseType
-              -> Maybe ResponseFormat
+listAddresses :: Page
+              -> PerPage
+              -> ResponseType
               -> Handler (OneOf [Address] (ExtendedResponse [Address]))
-listAddresses _ _ mbExtended _ =
-  case mbExtended of
-    Just Extended -> return $ OneOf $ Right $
+listAddresses _ _ responseType =
+  case responseType of
+    Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = [Address "deadBeef", Address "123AABBCC"]
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -24,15 +24,14 @@ newWallet :: NewWallet -> Handler Wallet
 newWallet _ = liftIO $ generate arbitrary
 
 
-listWallets :: Maybe Page
-            -> Maybe PerPage
-            -> Maybe ResponseType
-            -> Maybe ResponseFormat
+listWallets :: Page
+            -> PerPage
+            -> ResponseType
             -> Handler (OneOf [Wallet] (ExtendedResponse [Wallet]))
-listWallets _ _ mbExtended _ = do
+listWallets _ _ responseType = do
   example <- liftIO $ generate (resize 3 arbitrary)
-  case mbExtended of
-    Just Extended -> return $ OneOf $ Right $
+  case responseType of
+    Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -23,15 +23,16 @@ handlers =   newWallet
 newWallet :: NewWallet -> Handler Wallet
 newWallet _ = liftIO $ generate arbitrary
 
+
 listWallets :: Maybe Page
             -> Maybe PerPage
-            -> Maybe Bool
-            -> Maybe Text
+            -> Maybe ResponseType
+            -> Maybe ResponseFormat
             -> Handler (OneOf [Wallet] (ExtendedResponse [Wallet]))
 listWallets _ _ mbExtended _ = do
   example <- liftIO $ generate (resize 3 arbitrary)
   case mbExtended of
-    Just True  -> return $ OneOf $ Right $
+    Just Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example
       , extMeta = Metadata {

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -24,13 +24,11 @@ newWallet :: NewWallet -> Handler Wallet
 newWallet _ = liftIO $ generate arbitrary
 
 
-listWallets :: Page
-            -> PerPage
-            -> ResponseType
+listWallets :: PaginationParams
             -> Handler (OneOf [Wallet] (ExtendedResponse [Wallet]))
-listWallets _ _ responseType = do
+listWallets PaginationParams {..} = do
   example <- liftIO $ generate (resize 3 arbitrary)
-  case responseType of
+  case ppResponseType of
     Extended -> return $ OneOf $ Right $
       ExtendedResponse {
         extData = example

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Cardano.Wallet.API.V1.Swagger where
 
@@ -142,6 +144,14 @@ instance KnownSymbols ('[]) where
 instance (KnownSymbol a, KnownSymbols as) => KnownSymbols (a ': as) where
   symbolVals _ =
     symbolVal (Proxy :: Proxy a) : symbolVals (Proxy :: Proxy as)
+
+instance HasSwagger (apiType a :> res) =>
+         HasSwagger (WithDefaultApiArg apiType a :> res) where
+    toSwagger _ = toSwagger (Proxy @(apiType a :> res))
+
+instance HasSwagger (argA a :> argB a :> res) =>
+         HasSwagger (AlternativeApiArg argA argB a :> res) where
+    toSwagger _ = toSwagger (Proxy @(argA a :> argB a :> res))
 
 instance ( KnownSymbol summary , HasSwagger subApi) => HasSwagger (Summary summary :> subApi) where
     toSwagger _ =

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -223,8 +223,6 @@ instance ToParamSchema ResponseType where
         rtToText :: ResponseType -> Text
         rtToText = sformat build
 
-instance ToParamSchema ResponseFormat
-
 instance ToParamSchema WalletId
 
 instance ToDocs APIVersion where

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -657,9 +657,14 @@
                         "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
                         "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],
@@ -900,9 +905,14 @@
                         "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
                         "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],
@@ -1179,9 +1189,14 @@
                         "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
                         "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -609,7 +609,7 @@
                         "description": "`walletId` not found"
                     },
                     "400": {
-                        "description": "Invalid `Daedalus-Response-Format` or `extended` or `per_page` or `page`"
+                        "description": "Invalid `Daedalus-Response-Format` or `response_type` or `per_page` or `page`"
                     },
                     "200": {
                         "schema": {
@@ -646,16 +646,21 @@
                         "description": "The number of entries to display for each page. The minimum is **1**, whereas the maximum\nis **500**. If nothing is specified, **this value defaults to 10**.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "query",
-                        "name": "extended",
-                        "type": "boolean",
-                        "description": "Informs the backend that the fetched data should be wrapped in an `ExtendedResponse`\n(see the Models section). An `ExtendedResponse` includes useful metadata\nwhich can be used by clients to support pagination.\n"
+                        "name": "response_type",
+                        "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
+                        "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
-                        "description": "It has the same effect of setting `extended=true` in the URL as a query parameter.\nIf the header `Daedalus-Response-Format` is present in the HTTP request with a value set to\n`extended`, the fetched data will be wrapped in an `ExtendedResponse`.\n"
+                        "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],
                 "tags": [
@@ -853,7 +858,7 @@
                 "summary": "Returns all the available wallets.",
                 "responses": {
                     "400": {
-                        "description": "Invalid `Daedalus-Response-Format` or `extended` or `per_page` or `page`"
+                        "description": "Invalid `Daedalus-Response-Format` or `response_type` or `per_page` or `page`"
                     },
                     "200": {
                         "schema": {
@@ -884,16 +889,21 @@
                         "description": "The number of entries to display for each page. The minimum is **1**, whereas the maximum\nis **500**. If nothing is specified, **this value defaults to 10**.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "query",
-                        "name": "extended",
-                        "type": "boolean",
-                        "description": "Informs the backend that the fetched data should be wrapped in an `ExtendedResponse`\n(see the Models section). An `ExtendedResponse` includes useful metadata\nwhich can be used by clients to support pagination.\n"
+                        "name": "response_type",
+                        "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
+                        "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
-                        "description": "It has the same effect of setting `extended=true` in the URL as a query parameter.\nIf the header `Daedalus-Response-Format` is present in the HTTP request with a value set to\n`extended`, the fetched data will be wrapped in an `ExtendedResponse`.\n"
+                        "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],
                 "tags": [
@@ -1127,7 +1137,7 @@
                 "summary": "Returns all the addresses.",
                 "responses": {
                     "400": {
-                        "description": "Invalid `Daedalus-Response-Format` or `extended` or `per_page` or `page`"
+                        "description": "Invalid `Daedalus-Response-Format` or `response_type` or `per_page` or `page`"
                     },
                     "200": {
                         "schema": {
@@ -1158,16 +1168,21 @@
                         "description": "The number of entries to display for each page. The minimum is **1**, whereas the maximum\nis **500**. If nothing is specified, **this value defaults to 10**.\n"
                     },
                     {
+                        "default": "plain",
                         "in": "query",
-                        "name": "extended",
-                        "type": "boolean",
-                        "description": "Informs the backend that the fetched data should be wrapped in an `ExtendedResponse`\n(see the Models section). An `ExtendedResponse` includes useful metadata\nwhich can be used by clients to support pagination.\n"
+                        "name": "response_type",
+                        "type": "string",
+                        "enum": [
+                            "plain",
+                            "extended"
+                        ],
+                        "description": "Determines the response type. If set to `extended`, then fetched\ndata should be wrapped in an `ExtendedResponse` (see the Models section).\nAn `ExtendedResponse` includes useful metadata which can be used by clients\nto support pagination.\n"
                     },
                     {
                         "in": "header",
                         "name": "Daedalus-Response-Format",
                         "type": "string",
-                        "description": "It has the same effect of setting `extended=true` in the URL as a query parameter.\nIf the header `Daedalus-Response-Format` is present in the HTTP request with a value set to\n`extended`, the fetched data will be wrapped in an `ExtendedResponse`.\n"
+                        "description": "The same as URL parameter `response_type`. If the header `Daedalus-Response-Format`\nis present in the HTTP request with a value set to `extended`, the fetched data will\nbe wrapped in an `ExtendedResponse`.\n"
                     }
                 ],
                 "tags": [

--- a/wallet-new/src/Cardano/Wallet/API/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types.hs
@@ -23,7 +23,6 @@ import qualified Servant.Server.Internal as SI
 
 import           Servant
 import           Servant.API.Sub         ((:>))
-import           Servant.Swagger
 import           Test.QuickCheck
 
 --
@@ -114,10 +113,6 @@ instance ( HasServer (apiType a :> res) ctx
         inRouteServer @(apiType a :> res) route $
         \f a -> f $ fromMaybe def a
 
-instance HasSwagger (apiType a :> res) =>
-    HasSwagger (WithDefaultApiArg apiType a :> res) where
-    toSwagger _ = toSwagger (Proxy @(apiType a :> res))
-
 -- | Type aliases for query params and headers which have default values.
 type DQueryParam s a = WithDefaultApiArg (QueryParam s) a
 type DHeader s a = WithDefaultApiArg (Header s) a
@@ -150,10 +145,6 @@ instance ( HasServer (argA a :> argB a :> res) ctx
     route =
         inRouteServer @(argA a :> argB a :> res) route $
         \f a b -> f $ a <|> b
-
-instance HasSwagger (argA a :> argB a :> res) =>
-         HasSwagger (AlternativeApiArg argA argB a :> res) where
-    toSwagger _ = toSwagger (Proxy @(argA a :> argB a :> res))
 
 --
 -- Types

--- a/wallet-new/src/Cardano/Wallet/API/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types.hs
@@ -134,7 +134,6 @@ data AlternativeApiArg (argA :: * -> *) (argB :: * -> *) a
 
 instance ( ApiHasArgClass argA a
          , ApiHasArgClass argB a
-         , ApiArg argA a ~ Maybe b
          , ApiArg argA a ~ ApiArg argB a
          ) =>
          ApiHasArgClass (AlternativeApiArg argA argB) a where
@@ -142,7 +141,8 @@ instance ( ApiHasArgClass argA a
     apiArgName _ = apiArgName (Proxy @(argA a))
 
 instance ( HasServer (argA a :> argB a :> res) ctx
-         , Server (argA a :> argB a :> res) ~ (Maybe b -> Maybe b -> d)
+         , Server (argA a :> argB a :> res) ~ (t b -> t b -> d)
+         , Alternative t
          ) =>
          HasServer (AlternativeApiArg argA argB a :> res) ctx where
     type ServerT (AlternativeApiArg argA argB a :> res) m =

--- a/wallet-new/src/Cardano/Wallet/API/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types.hs
@@ -16,11 +16,144 @@ import           Universum
 
 import           Data.Aeson
 import           Data.Aeson.TH
-import qualified Data.Text       as T
+import           Data.Default            (Default (..))
+import qualified Data.Text               as T
 import           GHC.TypeLits
+import qualified Servant.Server.Internal as SI
+
 import           Servant
-import           Servant.API.Sub ((:>))
+import           Servant.API.Sub         ((:>))
+import           Servant.Swagger
 import           Test.QuickCheck
+
+--
+-- Utilities
+--
+-- NOTE: Many things here are stolen from `Pos.Util.Servant` of `cardano-sl` package.
+-- I didn't simply import it because I don't want to introduce `cardano-sl` as a dependency on
+-- stage of API prototyping, as it would slow down rebuilds of the prototype.
+-- In the future we should import this from `cardano-sl` or move `Pos.Util.Servant` module
+-- to `wallet-new` altogether.
+
+-- | `inRouteServer` is helper function used in order to transform one `HasServer`
+-- instance to another. It can be used to introduce custom request params type.
+-- See e. g. `WithDefaultApiArg` as an example of usage
+inRouteServer
+    :: forall api api' ctx env.
+       (Proxy api -> SI.Context ctx -> SI.Delayed env (Server api) -> SI.Router env)
+    -> (Server api' -> Server api)
+    -> (Proxy api' -> SI.Context ctx -> SI.Delayed env (Server api') -> SI.Router env)
+inRouteServer routing f = \_ ctx delayed -> routing Proxy ctx (fmap f delayed)
+
+-- | `ApiHasArg*` types help to reflect on names and types of arguments of API methods,
+-- specified by `Capture`s, `QueryParam`s, etc. These types are used to construct more
+-- complex useful types such as `WithDefaultApiArg`.
+class ApiHasArgClass apiType a where
+    -- | For arguments-specifiers of API, get argument type.
+    type ApiArg (apiType :: * -> *) a :: *
+    type ApiArg apiType a = a
+
+    -- | Name of argument.
+    -- E.g. name of argument specified by @Capture "nyan"@ is /nyan/.
+    apiArgName :: Proxy (apiType a) -> String
+    default apiArgName
+        :: forall n someApiType. (KnownSymbol n, someApiType n ~ apiType)
+        => Proxy (someApiType n a) -> String
+    apiArgName _ = symbolVal (Proxy @n)
+
+type ApiHasArgInvariant apiType a res =
+    Server (apiType a :> res) ~ (ApiArg apiType a -> Server res)
+
+type ApiHasArg apiType a res =
+    ( ApiHasArgClass apiType a
+    , ApiHasArgInvariant apiType a res
+    )
+
+instance KnownSymbol s => ApiHasArgClass (Capture s) a
+instance KnownSymbol s => ApiHasArgClass (QueryParam s) a where
+    type ApiArg (QueryParam s) a = Maybe a
+instance KnownSymbol s => ApiHasArgClass (QueryParams s) a where
+    type ApiArg (QueryParams s) a = [a]
+instance KnownSymbol s => ApiHasArgClass (Header s) a where
+    type ApiArg (Header s) a = Maybe a
+instance ApiHasArgClass (ReqBody ct) a where
+    apiArgName _ = "request body"
+
+-- | `Unmaybe` and `UnmaybeArg` type families are necessary to
+-- get `a` from `Maybe a` in a way which doesn't make GHC mad.
+-- Used in definition of `ApiHasArgClass` and `HasServer` instances for
+-- `WithDefaultApiArg`
+type family Unmaybe a where
+    Unmaybe (Maybe a) = a
+
+type family UnmaybeArg a where
+    UnmaybeArg (Maybe a -> b) = a -> b
+
+--
+-- Specifying API method parameters with default values
+--
+
+-- | `WithDefaultApiArg` type is used to specify API parameters,
+-- which are optional but have default values. It can be applied to every
+-- API specifier which yields `Maybe a` as argument type.
+data WithDefaultApiArg (argType :: * -> *) a
+
+instance (ApiHasArgClass apiType a, ApiArg apiType a ~ Maybe b) =>
+         ApiHasArgClass (WithDefaultApiArg apiType) a where
+    type ApiArg (WithDefaultApiArg apiType) a = Unmaybe (ApiArg apiType a)
+    apiArgName _ = apiArgName (Proxy @(apiType a))
+
+instance ( HasServer (apiType a :> res) ctx
+         , Server (apiType a :> res) ~ (Maybe c -> d)
+         , Default c
+         ) =>
+         HasServer (WithDefaultApiArg apiType a :> res) ctx where
+    type ServerT (WithDefaultApiArg apiType a :> res) m =
+        UnmaybeArg (ServerT (apiType a :> res) m)
+    route =
+        inRouteServer @(apiType a :> res) route $
+        \f a -> f $ fromMaybe def a
+
+instance HasSwagger (apiType a :> res) =>
+    HasSwagger (WithDefaultApiArg apiType a :> res) where
+    toSwagger _ = toSwagger (Proxy @(apiType a :> res))
+
+-- | Type aliases for query params and headers which have default values.
+type DQueryParam s a = WithDefaultApiArg (QueryParam s) a
+type DHeader s a = WithDefaultApiArg (Header s) a
+
+--
+-- Providing one argument via different methods
+--
+type family MergeArgs a where
+    MergeArgs (a -> a -> b) = a -> b
+
+-- | `AlternativeApiArg` is used when we want to provide a way
+-- to pass one argument via two ways, e. g. via request header or query parameter.
+data AlternativeApiArg (argA :: * -> *) (argB :: * -> *) a
+
+instance ( ApiHasArgClass argA a
+         , ApiHasArgClass argB a
+         , ApiArg argA a ~ Maybe b
+         , ApiArg argA a ~ ApiArg argB a
+         ) =>
+         ApiHasArgClass (AlternativeApiArg argA argB) a where
+    type ApiArg (AlternativeApiArg argA argB) a = ApiArg argA a
+    apiArgName _ = apiArgName (Proxy @(argA a))
+
+instance ( HasServer (argA a :> argB a :> res) ctx
+         , Server (argA a :> argB a :> res) ~ (Maybe b -> Maybe b -> d)
+         ) =>
+         HasServer (AlternativeApiArg argA argB a :> res) ctx where
+    type ServerT (AlternativeApiArg argA argB a :> res) m =
+        MergeArgs (ServerT (argA a :> argB a :> res) m)
+    route =
+        inRouteServer @(argA a :> argB a :> res) route $
+        \f a b -> f $ a <|> b
+
+instance HasSwagger (argA a :> argB a :> res) =>
+         HasSwagger (AlternativeApiArg argA argB a :> res) where
+    toSwagger _ = toSwagger (Proxy @(argA a :> argB a :> res))
 
 --
 -- Types

--- a/wallet-new/src/Cardano/Wallet/API/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types.hs
@@ -1,10 +1,15 @@
 {-- Types shared between different API versions. --}
+{-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DefaultSignatures     #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
 module Cardano.Wallet.API.Types where
 
 import           Universum

--- a/wallet-new/src/Cardano/Wallet/API/V1/Parameters.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Parameters.hs
@@ -1,36 +1,40 @@
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 module Cardano.Wallet.API.V1.Parameters where
 
 import           Universum
 
+import           Cardano.Wallet.API.Types    (DQueryParam)
 import           Cardano.Wallet.API.V1.Types
 
 import           Data.Text                   (Text)
 import           Servant
 
+
 type WalletRequestParams =
        QueryParam "page"     Page
     :> QueryParam "per_page" PerPage
-    :> QueryParam "extended" Bool
-    :> Header "Daedalus-Response-Format" Text
+    :> QueryParam "response_type"       ResponseType
+    :> Header "Daedalus-Response-Format" ResponseFormat
 
 type family WithWalletRequestParams c :: * where
-  WithWalletRequestParams c =  QueryParam "page"     Page
-                            :> QueryParam "per_page" PerPage
-                            :> QueryParam "extended" Bool
-                            :> Header "Daedalus-Response-Format" Text
-                            :> c
+  WithWalletRequestParams c = QueryParam "page"     Page
+                           :> QueryParam "per_page" PerPage
+                           :> QueryParam "response_type"       ResponseType
+                           :> Header "Daedalus-Response-Format" ResponseFormat
+                           :> c
 
 -- | Instance of `HasServer` which erases the `Tags` from its routing,
 -- as the latter is needed only for Swagger.
 instance (HasServer subApi context) => HasServer (WalletRequestParams :> subApi) context where
   type ServerT (WalletRequestParams :> subApi) m =
-      Maybe Page -> Maybe PerPage -> Maybe Bool -> Maybe Text -> ServerT subApi m
-  route _ = route (Proxy :: Proxy (WithWalletRequestParams subApi))
+      Maybe Page -> Maybe PerPage -> Maybe ResponseType -> Maybe ResponseFormat -> ServerT subApi m
+  route _ = route (Proxy @(WithWalletRequestParams subApi))

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -47,7 +47,7 @@ import           Data.Aeson.TH
 import           Data.Default           (Default (def))
 import           Data.Text              (Text)
 import qualified Data.Text.Buildable
-import           Formatting             (build, sformat, (%))
+import           Formatting             (build, sformat)
 import           GHC.Generics           (Generic)
 import qualified Serokell.Aeson.Options as Serokell
 import           Test.QuickCheck
@@ -164,6 +164,9 @@ instance ToHttpApiData ResponseType where
 
 instance Default ResponseType where
     def = Plain
+
+instance Arbitrary ResponseType where
+    arbitrary = oneof $ map pure [minBound..maxBound]
 
 -- | `PaginationParams` is datatype which combines request params related
 -- to pagination together

--- a/wallet-new/stack.yaml
+++ b/wallet-new/stack.yaml
@@ -15,3 +15,5 @@ extra-deps:
   - servant-server-0.10
   - servant-client-0.10
 
+nix:
+  shell-file: ../shell.nix

--- a/wallet-new/test/APISpec.hs
+++ b/wallet-new/test/APISpec.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module APISpec where
 
@@ -26,11 +28,19 @@ import           Cardano.Wallet.Server
 -- Instances to allow use of `servant-quickcheck`.
 --
 
+instance HasGenRequest (apiType a :> sub) =>
+         HasGenRequest (WithDefaultApiArg apiType a :> sub) where
+    genRequest _ = genRequest (Proxy @(apiType a :> sub))
+
+instance HasGenRequest (argA a :> argB a :> sub) =>
+         HasGenRequest (AlternativeApiArg argA argB a :> sub) where
+    genRequest _ = genRequest (Proxy @(argA a :> argB a :> sub))
+
 instance HasGenRequest sub => HasGenRequest (Tags tags :> sub) where
-    genRequest (Proxy :: Proxy (Tags tags :> sub)) = genRequest (Proxy :: Proxy sub)
+    genRequest _ = genRequest (Proxy :: Proxy sub)
 
 instance HasGenRequest sub => HasGenRequest (Summary sum :> sub) where
-    genRequest (Proxy :: Proxy (Summary sum :> sub)) = genRequest (Proxy :: Proxy sub)
+    genRequest _ = genRequest (Proxy :: Proxy sub)
 
 instance HasGenRequest sub => HasGenRequest (WalletRequestParams :> sub) where
     genRequest _ = genRequest (Proxy @(WithWalletRequestParams sub))

--- a/wallet-new/test/APISpec.hs
+++ b/wallet-new/test/APISpec.hs
@@ -33,7 +33,7 @@ instance HasGenRequest sub => HasGenRequest (Summary sum :> sub) where
     genRequest (Proxy :: Proxy (Summary sum :> sub)) = genRequest (Proxy :: Proxy sub)
 
 instance HasGenRequest sub => HasGenRequest (WalletRequestParams :> sub) where
-    genRequest _ = genRequest (Proxy :: Proxy (WithWalletRequestParams sub))
+    genRequest _ = genRequest (Proxy @(WithWalletRequestParams sub))
 
 --
 -- RESTful-abiding predicates


### PR DESCRIPTION
Investigation on whether or not pagination parameters can be grouped led to the following results:

1. Pagination parameters can indeed be grouped
2. Pagination parameters can have default values which are passed to API handlers automatically, which looks way more convenient than dealing with `Maybe`s in each handler.
3. As long as `extended` query parameter (which I dared to rename to `response_type`, because it seems more self-explanatory) and `Daedalus-Response-Format` header serve the same purpose, their values can be combined in single value, which is then passed to handlers.

Besides of that, I couldn't resist doing small refactorings here and there. 

These solutions are not final, but they clearly show that we can do interesting things with our API, keeping our handlers neat and tidy even if API specification isn't very convenient to implement.