### PR TITLE
[CSM-495] Change the default path to tls files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ before_test:
 - IF EXIST %CACHED_STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_ROOT% %STACK_ROOT%
 - IF EXIST %CACHED_STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_WORK% %STACK_WORK%
 # Install OpenSSL 1.0.2 (see https://github.com/appveyor/ci/issues/1665)
-- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2L.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
+- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2m.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
 - ps: cmd /c start /wait "$($env:USERPROFILE)\Win64OpenSSL.exe" /silent /verysilent /sp- /suppressmsgboxes /DIR=C:\OpenSSL-Win64-v102
 - ps: Install-Product node 6
 # Install stack

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5031,8 +5031,8 @@ self: {
           pname = "natural-transformation";
           version = "0.4";
           sha256 = "aac28e2c1147ed77c1ec0f0eb607a577fa26d0fd67474293ba860ec124efc8af";
-          revision = "1";
-          editedCabalFile = "1scwm1gs07znkj4ahfyxpwrksj4rdl1pa81xflcqhkqfgcndvgl3";
+          revision = "2";
+          editedCabalFile = "1j90pd1zznr18966axskad5w0kx4dvqg62r65rmw1ihqwxm1ndix";
           libraryHaskellDepends = [
             base
           ];

--- a/wallet/node/NodeOptions.hs
+++ b/wallet/node/NodeOptions.hs
@@ -99,19 +99,19 @@ tlsParamsOption = do
                 "tlscert"
                 "FILEPATH"
                 "Path to file with TLS certificate"
-                <> Opt.value "server.crt"
+                <> Opt.value "./scripts/tls-files/server.crt"
     tpKeyPath <-
         Opt.strOption $
             CLI.templateParser
                 "tlskey"
                 "FILEPATH"
                 "Path to file with TLS key"
-                <> Opt.value "server.key"
+                <> Opt.value "./scripts/tls-files/server.key"
     tpCaPath <-
         Opt.strOption $
             CLI.templateParser
                 "tlsca"
                 "FILEPATH"
                 "Path to file with TLS certificate authority"
-                <> Opt.value "ca.crt"
+                <> Opt.value "./scripts/tls-files/ca.crt"
     return TlsParams{..}


### PR DESCRIPTION
Default paths for wallet tls files are wrong
If we run demo scripts and ommit to add some of
the tls param filepaths default ones get used.
Problem was that default settings search for files
in the root folder while they are actually in the
/scripts/tls-files