### PR TITLE
[CSL-1732] Compress logs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,10 @@ before_test:
 - copy rocksdb.dll lib
 - copy rocksdb.dll wallet
 
+# Install liblzma/xz
+- ps: Start-FileDownload https://tukaani.org/xz/xz-5.2.3-windows.zip -Filename xz-5.2.3-windows.zip
+- 7z -oC:\xz_extracted x xz-5.2.3-windows.zip
+
 test_script:
   - cd "%WORK_DIR%"
   - stack --verbosity warn setup --no-reinstall > nul
@@ -81,6 +85,8 @@ test_script:
       --work-dir %STACK_WORK%
       --extra-include-dirs="C:\OpenSSL-Win64-v102\include"
       --extra-lib-dirs="C:\OpenSSL-Win64-v102"
+      --extra-include-dirs="C:\xz_extracted\include"
+      --extra-lib-dirs="C:\xz_extracted\bin_x86-64"
       --extra-include-dirs="%WORK_DIR%\rocksdb\include"
       --extra-lib-dirs="%WORK_DIR%"
 #   TODO: CSL-1133. To be reenabled.
@@ -100,6 +106,8 @@ test_script:
       --flag cardano-sl-wallet:for-installer
       --extra-include-dirs="C:\OpenSSL-Win64-v102\include"
       --extra-lib-dirs="C:\OpenSSL-Win64-v102"
+      --extra-include-dirs="C:\xz_extracted\include"
+      --extra-lib-dirs="C:\xz_extracted\bin_x86-64"
       --extra-include-dirs="%WORK_DIR%\rocksdb\include"
       --extra-lib-dirs="%WORK_DIR%"
   - stack exec --work-dir %STACK_WORK% -- cardano-wallet-hs2purs

--- a/core/Pos/Util/Util.hs
+++ b/core/Pos/Util/Util.hs
@@ -592,7 +592,9 @@ withSystemTempFile :: (MonadIO m, MC.MonadMask m) =>
                       String   -- ^ File name template
                    -> (FilePath -> Handle -> m a) -- ^ Callback that can use the file
                    -> m a
-withSystemTempFile template action = liftIO getCanonicalTemporaryDirectory >>= \tmpDir -> withTempFile tmpDir template action
+withSystemTempFile template action = do
+    tmpDir <- liftIO getCanonicalTemporaryDirectory
+    withTempFile tmpDir template action
 
 -- | Create, open, and use a temporary file in the given directory.
 --

--- a/infra/Pos/Reporting/Exceptions.hs
+++ b/infra/Pos/Reporting/Exceptions.hs
@@ -8,7 +8,7 @@ import           Universum
 
 import           Control.Exception (Exception (..))
 import qualified Data.Text.Buildable
-import           Formatting (bprint, string, (%))
+import           Formatting (bprint, stext, string, (%))
 import           Serokell.Util (listJson)
 
 import           Pos.Exception (cardanoExceptionFromException, cardanoExceptionToException)
@@ -17,6 +17,7 @@ data ReportingError
     = CantRetrieveLogs [FilePath]
     | SendingError !SomeException
     | NoPubFiles
+    | PackingError Text
     deriving Show
 
 instance Exception ReportingError where
@@ -39,3 +40,5 @@ instance Buildable ReportingError where
                 "can't find any .pub file in logconfig. " <>
                 "Most probably public logging is misconfigured. Either set reporting " <>
                 "servers to [] or include .pub files in log config"
+            PackingError t ->
+                bprint ("Couldn't pack log files, reason: "%stext) t

--- a/infra/Pos/Reporting/Methods.hs
+++ b/infra/Pos/Reporting/Methods.hs
@@ -61,170 +61,9 @@ import           Pos.Reporting.MemState (HasLoggerConfig (..), HasReportServers 
 import           Pos.Util.CompileInfo (HasCompileInfo, compileInfo)
 import           Pos.Util.Util (maybeThrow, withSystemTempFile, (<//>))
 
-type MonadReporting ctx m =
-       ( MonadIO m
-       , MonadMask m
-       , MonadReader ctx m
-       , MonadFormatPeers m
-       , HasReportingContext ctx
-       , HasNodeType ctx
-       , WithLogger m
-       , HasConfiguration
-       , HasCompileInfo
-       )
 
 ----------------------------------------------------------------------------
--- Node-specific
-----------------------------------------------------------------------------
-
--- | Sends node's logs, taking 'LoggerConfig' from 'NodeContext',
--- retrieving all logger files from it. List of servers is also taken
--- from node's configuration.
-sendReportNode
-    :: (MonadReporting ctx m)
-    => ReportType -> m ()
-sendReportNode reportType = do
-    noServers <- null <$> view (reportingContext . reportServers)
-    if noServers
-        then onNoServers
-        else do
-            logConfig <- view (reportingContext . loggerConfig)
-            let allFiles = map snd $ retrieveLogFiles logConfig
-            logFile <-
-                maybeThrow
-                    NoPubFiles
-                    (head $ filter (".pub" `isSuffixOf`) allFiles)
-            logContent <-
-                takeGlobalSize charsConst <$>
-                retrieveLogContent logFile (Just 5000)
-            sendReportNodeImpl (reverse logContent) reportType
-  where
-    -- 2 megabytes, assuming we use chars which are ASCII mostly
-    charsConst :: Int
-    charsConst = 1024 * 1024 * 2
-    takeGlobalSize :: Int -> [Text] -> [Text]
-    takeGlobalSize _ [] = []
-    takeGlobalSize curLimit (t:xs) =
-        let delta = curLimit - length t
-        in bool [] (t : (takeGlobalSize delta xs)) (delta > 0)
-    onNoServers =
-        logInfo $
-        "sendReportNode: not sending report " <>
-        "because no reporting servers are specified"
-
--- | Same as 'sendReportNode', but doesn't attach any logs.
-sendReportNodeNologs :: (MonadReporting ctx m) => ReportType -> m ()
-sendReportNodeNologs = sendReportNodeImpl []
-
-sendReportNodeImpl
-    :: (MonadReporting ctx m)
-    => [Text] -> ReportType -> m ()
-sendReportNodeImpl rawLogs reportType = do
-    servers <- view (reportingContext . reportServers)
-    when (null servers) onNoServers
-    errors <- fmap lefts $ forM servers $ try .
-        sendReport [] rawLogs reportType "cardano-node" . toString
-    whenNotNull errors $ throwSE . NE.head
-  where
-    onNoServers =
-        logInfo $ "sendReportNodeImpl: not sending report " <>
-                  "because no reporting servers are specified"
-    throwSE (e :: SomeException) = throwM e
-
--- checks if ipv4 is from local range
-ipv4Local :: Word32 -> Bool
-ipv4Local w =
-    or [b1 == 10, b1 == 172 && b2 >= 16 && b2 <= 31, b1 == 192 && b2 == 168]
-  where
-    b1 = w .&. 0xff
-    b2 = (w `shiftR` 8) .&. 0xff
-
--- | Retrieves node info that we would like to know when analyzing
--- malicious behavior of node.
-getNodeInfo :: (MonadIO m, MonadFormatPeers m) => m Text
-getNodeInfo = do
-    peersText <- fromMaybe "unknown" <$> formatKnownPeers sformat
-    (ips :: [Text]) <-
-        map show . filter ipExternal . map ipv4 <$>
-        liftIO getNetworkInterfaces
-    pure $ sformat outputF (pretty $ listBuilderJSON ips) peersText
-  where
-    ipExternal (IPv4 w) =
-        not $ ipv4Local w || w == 0 || w == 16777343 -- the last is 127.0.0.1
-    outputF = ("{ nodeIps: '"%stext%"', peers: '"%stext%"' }")
-
-logReportType :: WithLogger m => ReportType -> m ()
-logReportType (RCrash i) = logError $ "Reporting crash with code " <> show i
-logReportType (RError reason) =
-    logError $ "Reporting error with reason \"" <> reason <> "\""
-logReportType (RMisbehavior True reason) =
-    logError $ "Reporting critical misbehavior with reason \"" <> reason <> "\""
-logReportType (RMisbehavior False reason) =
-    logWarning $ "Reporting non-critical misbehavior with reason \"" <> reason <> "\""
-logReportType (RInfo text) =
-    logInfo $ "Reporting info with text \"" <> text <> "\""
-
-extendRTDesc :: Text -> ReportType -> ReportType
-extendRTDesc text (RError reason)                  = RError $ reason <> text
-extendRTDesc text (RMisbehavior isCritical reason) = RMisbehavior isCritical $ reason <> text
-extendRTDesc text' (RInfo text)                    = RInfo $ text <> text'
-extendRTDesc _ x                                   = x
-
--- Note that we are catching all synchronous exceptions, but don't
--- catch async ones. If reporting is broken, we don't want it to
--- affect anything else.
-reportNode
-    :: forall ctx m . (MonadReporting ctx m)
-    => Bool -> Bool -> ReportType -> m ()
-reportNode sendLogs extendWithNodeInfo reportType =
-    reportNodeDo `catchAny` handler
-  where
-    send' = if sendLogs then sendReportNode else sendReportNodeNologs
-    reportNodeDo = do
-        logReportType reportType
-        if extendWithNodeInfo
-           then do
-              nodeInfo <- getNodeInfo
-              send' $ extendRTDesc (", nodeInfo: " <> nodeInfo) reportType
-           else send' reportType
-    handler :: SomeException -> m ()
-    handler e =
-        logError $
-        sformat ("Didn't manage to report "%shown%
-                 " because of exception '"%string%"' raised while sending")
-        reportType (displayException e)
-
--- | Report «misbehavior», i. e. a situation when something is globally
--- wrong, not only with our node. 'Bool' argument determines whether
--- misbehavior is critical and requires immediate response.
---
--- Misbehaviour is reported only by core nodes, because
--- a) core nodes usually have the most actual vision of the current state;
--- b) reporting misbehaviour from many nodes is redundant.
-reportMisbehaviour
-    :: forall ctx m . (MonadReporting ctx m)
-    => Bool -> Text -> m ()
-reportMisbehaviour isCritical message = do
-    nodeType <- getNodeType <$> ask
-    case nodeType of
-        NodeCore -> reportNode True True (RMisbehavior isCritical message)
-        _        -> pass
-
--- | Report some general information.
-reportInfo
-    :: forall ctx m . (MonadReporting ctx m)
-    => Bool -> Text -> m ()
-reportInfo sendLogs = reportNode sendLogs True . RInfo
-
--- | Report «error», i. e. a situation when something is wrong with our
--- node, e. g. an assertion failed.
-reportError
-    :: forall ctx m . (MonadReporting ctx m)
-    => Text -> m ()
-reportError = reportNode True True . RError
-
-----------------------------------------------------------------------------
--- General purpose
+-- General purpose/low level
 ----------------------------------------------------------------------------
 
 -- | Given logs files list and report type, sends reports to URI
@@ -297,6 +136,171 @@ retrieveLogFiles lconfig = fromLogTree $ lconfig ^. lcTree
         let curElems = map ([],) (lt ^.. ltFiles . each . hwFilePath)
             addFoo (part, node) = map (first (part :)) $ fromLogTree node
         in curElems ++ concatMap addFoo (lt ^. ltSubloggers . to HM.toList)
+
+----------------------------------------------------------------------------
+-- Node-specific
+----------------------------------------------------------------------------
+
+type MonadReporting ctx m =
+       ( MonadIO m
+       , MonadMask m
+       , MonadReader ctx m
+       , MonadFormatPeers m
+       , HasReportingContext ctx
+       , HasNodeType ctx
+       , WithLogger m
+       , HasConfiguration
+       , HasCompileInfo
+       )
+
+
+-- Common code across node sending: tries to send logs to at least one
+-- reporting server.
+sendReportNodeImpl
+    :: (MonadReporting ctx m)
+    => [Text] -> ReportType -> m ()
+sendReportNodeImpl rawLogs reportType = do
+    servers <- view (reportingContext . reportServers)
+    when (null servers) onNoServers
+    errors <- fmap lefts $ forM servers $ try .
+        sendReport [] rawLogs reportType "cardano-node" . toString
+    whenNotNull errors $ throwSE . NE.head
+  where
+    onNoServers =
+        logInfo $ "sendReportNodeImpl: not sending report " <>
+                  "because no reporting servers are specified"
+    throwSE (e :: SomeException) = throwM e
+
+-- | Sends node's logs, taking 'LoggerConfig' from 'NodeContext',
+-- retrieving all logger files from it. List of servers is also taken
+-- from node's configuration.
+sendReportNode
+    :: (MonadReporting ctx m)
+    => ReportType -> m ()
+sendReportNode reportType = do
+    noServers <- null <$> view (reportingContext . reportServers)
+    if noServers
+        then onNoServers
+        else do
+            logConfig <- view (reportingContext . loggerConfig)
+            let allFiles = map snd $ retrieveLogFiles logConfig
+            logFile <-
+                maybeThrow
+                    NoPubFiles
+                    (head $ filter (".pub" `isSuffixOf`) allFiles)
+            logContent <-
+                takeGlobalSize charsConst <$>
+                retrieveLogContent logFile (Just 5000)
+            sendReportNodeImpl (reverse logContent) reportType
+  where
+    -- 2 megabytes, assuming we use chars which are ASCII mostly
+    charsConst :: Int
+    charsConst = 1024 * 1024 * 2
+    takeGlobalSize :: Int -> [Text] -> [Text]
+    takeGlobalSize _ [] = []
+    takeGlobalSize curLimit (t:xs) =
+        let delta = curLimit - length t
+        in bool [] (t : (takeGlobalSize delta xs)) (delta > 0)
+    onNoServers =
+        logInfo $
+        "sendReportNode: not sending report " <>
+        "because no reporting servers are specified"
+
+-- | Same as 'sendReportNode', but doesn't attach any logs.
+sendReportNodeNologs :: (MonadReporting ctx m) => ReportType -> m ()
+sendReportNodeNologs = sendReportNodeImpl []
+
+-- Note that we are catching all synchronous exceptions, but don't
+-- catch async ones. If reporting is broken, we don't want it to
+-- affect anything else.
+reportNode
+    :: forall ctx m . (MonadReporting ctx m)
+    => Bool -> Bool -> ReportType -> m ()
+reportNode sendLogs extendWithNodeInfo reportType =
+    reportNodeDo `catchAny` handler
+  where
+    send' = if sendLogs then sendReportNode else sendReportNodeNologs
+    reportNodeDo = do
+        logReportType reportType
+        if extendWithNodeInfo
+           then do
+              nodeInfo <- getNodeInfo
+              send' $ extendRTDesc (", nodeInfo: " <> nodeInfo) reportType
+           else send' reportType
+    handler :: SomeException -> m ()
+    handler e =
+        logError $
+        sformat ("Didn't manage to report "%shown%
+                 " because of exception '"%string%"' raised while sending")
+        reportType (displayException e)
+
+    extendRTDesc :: Text -> ReportType -> ReportType
+    extendRTDesc text (RError reason)                  = RError $ reason <> text
+    extendRTDesc text (RMisbehavior isCritical reason) = RMisbehavior isCritical $ reason <> text
+    extendRTDesc text' (RInfo text)                    = RInfo $ text <> text'
+    extendRTDesc _ x                                   = x
+
+    logReportType :: WithLogger m => ReportType -> m ()
+    logReportType (RCrash i) = logError $ "Reporting crash with code " <> show i
+    logReportType (RError reason) =
+        logError $ "Reporting error with reason \"" <> reason <> "\""
+    logReportType (RMisbehavior True reason) =
+        logError $ "Reporting critical misbehavior with reason \"" <> reason <> "\""
+    logReportType (RMisbehavior False reason) =
+        logWarning $ "Reporting non-critical misbehavior with reason \"" <> reason <> "\""
+    logReportType (RInfo text) =
+        logInfo $ "Reporting info with text \"" <> text <> "\""
+
+    -- Retrieves node info that we would like to know when analyzing
+    -- malicious behavior of node.
+    getNodeInfo :: (MonadIO m, MonadFormatPeers m) => m Text
+    getNodeInfo = do
+        peersText <- fromMaybe "unknown" <$> formatKnownPeers sformat
+        (ips :: [Text]) <-
+            map show . filter ipExternal . map ipv4 <$>
+            liftIO getNetworkInterfaces
+        pure $ sformat outputF (pretty $ listBuilderJSON ips) peersText
+      where
+        ipExternal (IPv4 w) =
+            not $ ipv4Local w || w == 0 || w == 16777343 -- the last is 127.0.0.1
+        outputF = ("{ nodeIps: '"%stext%"', peers: '"%stext%"' }")
+
+    -- checks if ipv4 is from local range
+    ipv4Local :: Word32 -> Bool
+    ipv4Local w =
+        or [b1 == 10, b1 == 172 && b2 >= 16 && b2 <= 31, b1 == 192 && b2 == 168]
+      where
+        b1 = w .&. 0xff
+        b2 = (w `shiftR` 8) .&. 0xff
+
+-- | Report «misbehavior», i. e. a situation when something is globally
+-- wrong, not only with our node. 'Bool' argument determines whether
+-- misbehavior is critical and requires immediate response.
+--
+-- Misbehaviour is reported only by core nodes, because
+-- a) core nodes usually have the most actual vision of the current state;
+-- b) reporting misbehaviour from many nodes is redundant.
+reportMisbehaviour
+    :: forall ctx m . (MonadReporting ctx m)
+    => Bool -> Text -> m ()
+reportMisbehaviour isCritical message = do
+    nodeType <- getNodeType <$> ask
+    case nodeType of
+        NodeCore -> reportNode True True (RMisbehavior isCritical message)
+        _        -> pass
+
+-- | Report some general information.
+reportInfo
+    :: forall ctx m . (MonadReporting ctx m)
+    => Bool -> Text -> m ()
+reportInfo sendLogs = reportNode sendLogs True . RInfo
+
+-- | Report «error», i. e. a situation when something is wrong with our
+-- node, e. g. an assertion failed.
+reportError
+    :: forall ctx m . (MonadReporting ctx m)
+    => Text -> m ()
+reportError = reportNode True True . RError
 
 ----------------------------------------------------------------------------
 -- Exception handling

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -123,6 +123,7 @@ library
                       , cardano-sl-core
                       , cardano-sl-db
                       , cardano-report-server >= 0.3.0
+                      , conduit
                       , containers
                       , data-default
                       , directory
@@ -134,6 +135,7 @@ library
                       , filepath
                       , formatting
                       , generic-arbitrary
+                      , lzma-conduit
                       , hashable
                       , http-client
                       , http-client-tls
@@ -154,6 +156,7 @@ library
                       , serokell-util >= 0.1.3.4
                       , stm
                       , tagged
+                      , tar
                       , text
                       , template-haskell
                       , text-format

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -863,6 +863,20 @@ self: {
           description = "Binary serialisation for Haskell values using lazy ByteStrings";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      bindings-DSL = callPackage ({ base, mkDerivation, stdenv }:
+      mkDerivation {
+          pname = "bindings-DSL";
+          version = "1.0.23";
+          sha256 = "eb6c76448eeb2a9a17135b08eec0dd09e1917a9f6ab702cea0b2070bd19c10e7";
+          libraryHaskellDepends = [
+            base
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/jwiegley/bindings-dsl/wiki";
+          description = "FFI domain specific language, on top of hsc2hs";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
       blaze-builder = callPackage ({ base, bytestring, deepseq, mkDerivation, stdenv, text }:
       mkDerivation {
           pname = "blaze-builder";
@@ -1696,7 +1710,7 @@ self: {
           description = "Cardano explorer";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-infra = callPackage ({ QuickCheck, aeson, base, base64-bytestring, binary, bytestring, cardano-report-server, cardano-sl-core, cardano-sl-db, containers, cpphs, data-default, directory, dns, either, ekg-core, ether, exceptions, filepath, formatting, generic-arbitrary, hashable, http-client, http-client-tls, iproute, kademlia, lens, list-t, log-warper, mkDerivation, mmorph, monad-control, mtl, network-info, network-transport, network-transport-tcp, node-sketch, optparse-applicative, parsec, reflection, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers, yaml }:
+      cardano-sl-infra = callPackage ({ QuickCheck, aeson, base, base64-bytestring, binary, bytestring, cardano-report-server, cardano-sl-core, cardano-sl-db, conduit, containers, cpphs, data-default, directory, dns, either, ekg-core, ether, exceptions, filepath, formatting, generic-arbitrary, hashable, http-client, http-client-tls, iproute, kademlia, lens, list-t, log-warper, lzma-conduit, mkDerivation, mmorph, monad-control, mtl, network-info, network-transport, network-transport-tcp, node-sketch, optparse-applicative, parsec, reflection, serokell-util, stdenv, stm, tagged, tar, template-haskell, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unix, unordered-containers, yaml }:
       mkDerivation {
           pname = "cardano-sl-infra";
           version = "1.0.3";
@@ -1710,6 +1724,7 @@ self: {
             cardano-report-server
             cardano-sl-core
             cardano-sl-db
+            conduit
             containers
             data-default
             directory
@@ -1729,6 +1744,7 @@ self: {
             lens
             list-t
             log-warper
+            lzma-conduit
             mmorph
             monad-control
             mtl
@@ -1743,6 +1759,7 @@ self: {
             serokell-util
             stm
             tagged
+            tar
             template-haskell
             text
             text-format
@@ -4766,6 +4783,26 @@ self: {
           description = "a simple, pure LRU cache";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      lzma-conduit = callPackage ({ base, bindings-DSL, bytestring, conduit, lzma, mkDerivation, resourcet, stdenv, transformers }:
+      mkDerivation {
+          pname = "lzma-conduit";
+          version = "1.1.3.3";
+          sha256 = "17cc0669639891a86fdae101b785f614fbd8560c170b4f8a88929134f2936da5";
+          libraryHaskellDepends = [
+            base
+            bindings-DSL
+            bytestring
+            conduit
+            resourcet
+            transformers
+          ];
+          librarySystemDepends = [ lzma ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "http://github.com/alphaHeavy/lzma-conduit";
+          description = "Conduit interface for lzma/xz compression";
+          license = stdenv.lib.licenses.bsd3;
+        }) { lzma = pkgs.lzma; };
       math-functions = callPackage ({ base, deepseq, mkDerivation, primitive, stdenv, vector, vector-th-unbox }:
       mkDerivation {
           pname = "math-functions";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17,8 +17,8 @@ self: {
           pname = "Cabal";
           version = "1.24.2.0";
           sha256 = "b7d0eb8e3503fbca460c0a6ca5c88352cecfe1b69e0bbc79827872134ed86340";
-          revision = "1";
-          editedCabalFile = "0jw809psa2ms9sy1mnirmbj9h7rs76wbmf24zgjqvhp4wq919z3m";
+          revision = "2";
+          editedCabalFile = "15ncrm7x2lg4hn0m5mhc8hy769bzhmajsm6l9i6536plfs2bbbdj";
           libraryHaskellDepends = [
             array
             base

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ in
      buildInputs = [
        zlib openssh autoreconfHook openssl
        gmp rocksdb git bsdiff ncurses
-       hsPkgs.happy hsPkgs.cpphs
+       hsPkgs.happy hsPkgs.cpphs lzma
      # cabal-install and stack pull in lots of dependencies on OSX so skip them
      # See https://github.com/NixOS/nixpkgs/issues/21200
      ] ++ (lib.optionals stdenv.isLinux [ cabal-install stack ])

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -487,7 +487,8 @@ reportNodeCrash exitCode logConfPath reportServ logPath = liftIO $ do
     let ec = case exitCode of
             ExitSuccess   -> 0
             ExitFailure n -> n
-    sendReport (normalise logPath:logFiles) [] (RCrash ec) "cardano-node" reportServ
+    -- TODO CSL-1732 Compress with tgz
+    sendReport (normalise logPath:logFiles) (RCrash ec) "cardano-node" reportServ
 
 -- Taken from the 'turtle' library and modified
 system'

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -486,9 +486,8 @@ reportNodeCrash exitCode logConfPath reportServ = liftIO $ do
     let ec = case exitCode of
             ExitSuccess   -> 0
             ExitFailure n -> n
-    txz <- compressLogs logFiles
-    sendReport [txz] (RCrash ec) "cardano-node" reportServ
-    removeFile txz
+    bracket (compressLogs logFiles) removeFile $ \txz ->
+        sendReport [txz] (RCrash ec) "cardano-node" reportServ
 
 -- Taken from the 'turtle' library and modified
 system'

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -55,7 +55,7 @@ import           Pos.Client.CLI (configurationOptionsParser, readLoggerConfig)
 import           Pos.Core (Timestamp (..))
 import           Pos.Launcher (HasConfigurations, withConfigurations)
 import           Pos.Launcher.Configuration (ConfigurationOptions (..))
-import           Pos.Reporting.Methods (retrieveLogFiles, sendReport)
+import           Pos.Reporting.Methods (compressLogs, retrieveLogFiles, sendReport)
 import           Pos.ReportServer.Report (ReportType (..))
 import           Pos.Util (directory, sleep)
 import           Pos.Util.CompileInfo (HasCompileInfo, retrieveCompileTimeInfo, withCompileInfo)
@@ -487,8 +487,9 @@ reportNodeCrash exitCode logConfPath reportServ logPath = liftIO $ do
     let ec = case exitCode of
             ExitSuccess   -> 0
             ExitFailure n -> n
-    -- TODO CSL-1732 Compress with tgz
-    sendReport (normalise logPath:logFiles) (RCrash ec) "cardano-node" reportServ
+    txz <- compressLogs $ normalise logPath:logFiles
+    sendReport [txz] (RCrash ec) "cardano-node" reportServ
+    removeFile txz
 
 -- Taken from the 'turtle' library and modified
 system'


### PR DESCRIPTION
This PR introduces support for sending `tar.lzma` archives to reporting server.
Changes that were made:
* Report server can now accept binary files: https://github.com/input-output-hk/cardano-report-server/pull/7
* Reporting `Methods` was restructured to support this change.
* Before sending memory logs (from the node itself), we write it to file and tar.lzma this single file. After it's send, archive is deleted. Compression level is maximum.
* When node fails from launcher point of view, we do the same, though logs number is more than one (that's where tar is being actually used).