### PR TITLE
[CSM-555] Switch from () to NoContent for endpoints with no result

### DIFF
--- a/wallet/src/Pos/Wallet/Aeson/ClientTypes.hs
+++ b/wallet/src/Pos/Wallet/Aeson/ClientTypes.hs
@@ -21,6 +21,7 @@ import           Pos.Wallet.Web.ClientTypes   (Addr, ApiVersion (..), CAccount,
                                                ClientInfo (..), SyncProgress, Wal)
 import           Pos.Wallet.Web.Error         (WalletError)
 import           Pos.Wallet.Web.Sockets.Types (NotifyEvent)
+import           Servant.API.ContentTypes     (NoContent (..))
 
 deriveJSON defaultOptions ''CAccountId
 deriveJSON defaultOptions ''CWAddressMeta
@@ -70,3 +71,6 @@ instance ToJSON ClientInfo where
             , "cabalVersion" .= showVersion ciCabalVersion
             , "apiVersion" .= ciApiVersion
             ]
+
+instance ToJSON NoContent where
+    toJSON NoContent = toJSON ()

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -76,7 +76,7 @@ import           Servant.API                ((:<|>), (:>), Capture, Delete, Get,
                                              ReqBody, Verb)
 import           Servant.Server             (HasServer (..))
 import           Servant.Swagger.UI         (SwaggerSchemaUI)
-import           Servant.API.ContentTypes   (OctetStream)
+import           Servant.API.ContentTypes   (OctetStream, NoContent)
 import           Universum
 
 import           Pos.Types                  (Coin, SoftwareVersion)
@@ -144,7 +144,7 @@ type WRes verbType a = WalletVerb (verbType '[JSON] a)
 type TestReset =
        "test"
     :> "reset"
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 type TestState =
        "test"
@@ -187,7 +187,7 @@ type RestoreWallet =
 type DeleteWallet =
        "wallets"
     :> Capture "walletId" (CId Wal)
-    :> WRes Delete ()
+    :> WRes Delete NoContent
 
 type ImportWallet =
        "wallets"
@@ -202,7 +202,7 @@ type ChangeWalletPassphrase =
     :> Capture "walletId" (CId Wal)
     :> DCQueryParam "old" CPassPhrase
     :> DCQueryParam "new" CPassPhrase
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 -------------------------------------------------------------------------
 -- Accounts
@@ -233,7 +233,7 @@ type NewAccount =
 type DeleteAccount =
        "accounts"
     :> CCapture "accountId" CAccountId
-    :> WRes Delete ()
+    :> WRes Delete NoContent
 
 -------------------------------------------------------------------------
 -- Wallet addresses
@@ -294,7 +294,7 @@ type UpdateTx =
     :> CCapture "address" CAccountId
     :> Capture "transaction" CTxId
     :> ReqBody '[JSON] CTxMeta
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 type GetHistory =
        "txs"
@@ -317,12 +317,12 @@ type NextUpdate =
 type PostponeUpdate =
        "update"
     :> "postpone"
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 type ApplyUpdate =
        "update"
     :> "apply"
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 -------------------------------------------------------------------------
 -- Redemptions
@@ -351,7 +351,7 @@ type ReportingInitialized =
        "reporting"
     :> "initialized"
     :> ReqBody '[JSON] CInitialized
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 -------------------------------------------------------------------------
 -- Settings
@@ -395,7 +395,7 @@ type ExportBackupJSON =
     :> "export"
     :> Capture "walletId" (CId Wal)
     :> ReqBody '[JSON] CFilePath
-    :> WRes Post ()
+    :> WRes Post NoContent
 
 -------------------------------------------------------------------------
 -- Settings

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -27,6 +27,7 @@ import           Pos.Wallet.Web.Error         (WalletError (..))
 import qualified Pos.Wallet.Web.Methods.Logic as L
 import           Pos.Wallet.Web.State         (createAccount, getWalletMeta)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
+import           Servant.API.ContentTypes     (NoContent (..))
 
 import           Pos.Crypto                   (emptyPassphrase, firstHardened)
 
@@ -79,7 +80,8 @@ importWalletJSON (CFilePath (toString -> fp)) = do
         sformat ("Error while reading JSON backup file: "%stext) $
         toText err
 
-exportWalletJSON :: MonadWalletBackup ctx m => CId Wal -> CFilePath -> m ()
+exportWalletJSON :: MonadWalletBackup ctx m => CId Wal -> CFilePath -> m NoContent
 exportWalletJSON wid (CFilePath (toString -> fp)) = do
     wBackup <- TotalBackup <$> getWalletBackup wid
     liftIO $ BSL.writeFile fp $ A.encode wBackup
+    return NoContent

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -213,7 +213,9 @@ addRecentPtxHistory wid currentHistory = do
 
 logTxHistory
     :: (Container t, Element t ~ TxHistoryEntry, WithLogger m, MonadIO m)
-    => Text -> t -> m NoContent
-logTxHistory desc t = do
-    logInfoS . sformat (stext%" transactions history: "%listJson) desc . map _thTxId . toList $ t
-    return NoContent
+    => Text -> t -> m ()
+logTxHistory desc = do
+    logInfoS
+        . sformat (stext%" transactions history: "%listJson) desc
+        . map _thTxId
+        . toList

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -260,7 +260,7 @@ deleteWallet wid = do
     return NoContent
 
 deleteAccount :: MonadWalletLogic ctx m => AccountId -> m NoContent
-deleteAccount aid = removeAccount aid >> return NoContent
+deleteAccount aid = removeAccount aid $> NoContent
 
 ----------------------------------------------------------------------------
 -- Modifiers

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -32,6 +32,7 @@ import qualified Data.HashMap.Strict        as HM
 import           Data.List                  (findIndex)
 import           Data.Time.Clock.POSIX      (getPOSIXTime)
 import           Formatting                 (build, sformat, (%))
+import           Servant.API.ContentTypes   (NoContent (..))
 import           System.Wlog                (WithLogger)
 
 import           Pos.Client.KeyStorage      (MonadKeys (..), MonadKeysRead, addSecretKey,
@@ -234,10 +235,11 @@ createWalletSafe cid wsMeta isReady = do
 
 markWalletReady
   :: MonadWalletLogic ctx m
-  => CId Wal -> Bool -> m ()
+  => CId Wal -> Bool -> m NoContent
 markWalletReady cid isReady = do
     _ <- getWalletMetaIncludeUnready True cid >>= maybeThrow noWallet
     setWalletReady cid isReady
+    return NoContent
   where
     noWallet = RequestError $
         sformat ("No wallet with that id "%build%" found") cid
@@ -247,7 +249,7 @@ markWalletReady cid isReady = do
 -- Deleters
 ----------------------------------------------------------------------------
 
-deleteWallet :: MonadWalletLogic ctx m => CId Wal -> m ()
+deleteWallet :: MonadWalletLogic ctx m => CId Wal -> m NoContent
 deleteWallet wid = do
     accounts <- getAccounts (Just wid)
     mapM_ (deleteAccount <=< decodeCTypeOrFail . caId) accounts
@@ -255,9 +257,10 @@ deleteWallet wid = do
     removeTxMetas wid
     removeHistoryCache wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
+    return NoContent
 
-deleteAccount :: MonadWalletLogic ctx m => AccountId -> m ()
-deleteAccount = removeAccount
+deleteAccount :: MonadWalletLogic ctx m => AccountId -> m NoContent
+deleteAccount aid = removeAccount aid >> return NoContent
 
 ----------------------------------------------------------------------------
 -- Modifiers
@@ -275,7 +278,7 @@ updateAccount accId wMeta = do
 
 changeWalletPassphrase
     :: MonadWalletLogic ctx m
-    => CId Wal -> PassPhrase -> PassPhrase -> m ()
+    => CId Wal -> PassPhrase -> PassPhrase -> m NoContent
 changeWalletPassphrase wid oldPass newPass = do
     oldSK <- getSKById wid
 
@@ -284,6 +287,7 @@ changeWalletPassphrase wid oldPass newPass = do
         deleteSK oldPass
         addSecretKey newSK
         setWalletPassLU wid =<< liftIO getPOSIXTime
+    return NoContent
   where
     badPass = RequestError "Invalid old passphrase given"
     deleteSK passphrase = do

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -29,7 +29,8 @@ import           Mockable                     (MonadMockable)
 import           Pos.Core                     (SoftwareVersion (..))
 import           Pos.Update.Configuration     (HasUpdateConfiguration, curSoftwareVersion)
 import           Pos.Util                     (maybeThrow)
-import           Servant.API.ContentTypes     (MimeRender (..), OctetStream)
+import           Servant.API.ContentTypes     (MimeRender (..), NoContent (..),
+                                               OctetStream)
 
 import           Pos.Client.KeyStorage        (MonadKeys, deleteSecretKey, getSecretKeys)
 import           Pos.NtpCheck                 (NtpCheckMonad, NtpStatus (..),
@@ -86,12 +87,12 @@ nextUpdate = do
     noUpdates = RequestError "No updates available"
 
 -- | Postpone next update after restart
-postponeUpdate :: MonadWalletDB ctx m => m ()
-postponeUpdate = removeNextUpdate
+postponeUpdate :: MonadWalletDB ctx m => m NoContent
+postponeUpdate = removeNextUpdate >> return NoContent
 
 -- | Delete next update info and restart immediately
-applyUpdate :: (MonadWalletDB ctx m, MonadUpdates m) => m ()
-applyUpdate = removeNextUpdate >> applyLastUpdate
+applyUpdate :: (MonadWalletDB ctx m, MonadUpdates m) => m NoContent
+applyUpdate = removeNextUpdate >> applyLastUpdate >> return NoContent
 
 ----------------------------------------------------------------------------
 -- Sync progress
@@ -123,8 +124,8 @@ localTimeDifference =
 -- Reset
 ----------------------------------------------------------------------------
 
-testResetAll :: (MonadWalletDB ctx m, MonadKeys m) => m ()
-testResetAll = deleteAllKeys >> testReset
+testResetAll :: (MonadWalletDB ctx m, MonadKeys m) => m NoContent
+testResetAll = deleteAllKeys >> testReset >> return NoContent
   where
     deleteAllKeys :: MonadKeys m => m ()
     deleteAllKeys = do

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -167,7 +167,7 @@ sendMoney passphrase moneySource dstDistr = do
 
     -- We add TxHistoryEntry's meta created by us in advance
     -- to make TxHistoryEntry in CTx consistent with entry in history.
-    addHistoryTxMeta srcWallet th
+    _ <- addHistoryTxMeta srcWallet th
     srcWalletAddrs <- getWalletAddrsSet Ever srcWallet
     diff <- getCurChainDifficulty
     fst <$> constructCTx srcWallet srcWalletAddrs diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -106,7 +106,7 @@ redeemAdaInternal passphrase cAccId seedBs = do
     let cWalId = aiWId accId
     -- We add TxHistoryEntry's meta created by us in advance
     -- to make TxHistoryEntry in CTx consistent with entry in history.
-    addHistoryTxMeta cWalId th
+    _ <- addHistoryTxMeta cWalId th
     cWalAddrs <- getWalletAddrsSet Ever cWalId
     diff <- getCurChainDifficulty
     fst <$> constructCTx cWalId cWalAddrs diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Reporting.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Reporting.hs
@@ -10,7 +10,10 @@ import           Universum
 
 import           Pos.Reporting.Methods      (MonadReporting, reportInfo)
 import           Pos.Wallet.Web.ClientTypes (CInitialized)
+import           Servant.API.ContentTypes   (NoContent (..))
 
 -- REPORT:INFO Time to initialize Daedalus info (from start to main screen, from start to network connection established)
-reportingInitialized :: MonadReporting ctx m => CInitialized -> m ()
-reportingInitialized cinit = reportInfo False (show cinit)
+reportingInitialized :: MonadReporting ctx m => CInitialized -> m NoContent
+reportingInitialized cinit = do
+    reportInfo False (show cinit)
+    return NoContent

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -111,7 +111,7 @@ importWalletDo
     -> m CWallet
 importWalletDo passphrase wSecret = do
     wId <- cwId <$> importWalletSecret emptyPassphrase wSecret
-    L.changeWalletPassphrase wId emptyPassphrase passphrase
+    _ <- L.changeWalletPassphrase wId emptyPassphrase passphrase
     L.getWallet wId
 
 importWalletSecret

--- a/wallet/src/Pos/Wallet/Web/Swagger/Spec.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Spec.hs
@@ -7,15 +7,21 @@ module Pos.Wallet.Web.Swagger.Spec
 
 import           Universum
 
-import           Control.Lens                           ((?~))
-import qualified Paths_cardano_sl                       as CSL
-import           Data.Swagger                           (Swagger, description, info, title, version)
-import           Data.Version                           (showVersion)
+import           Control.Lens                         ((?~))
+import           Data.Swagger                         (Swagger, description, info, title,
+                                                       version)
+import           Data.Text.Buildable                  (build)
+import           Data.Version                         (showVersion)
+import qualified Paths_cardano_sl                     as CSL
 
-import           Pos.Wallet.Web.Api                     (walletApi)
-import           Pos.Wallet.Web.Swagger.CustomSwagger   (toCustomSwagger)
-import           Pos.Wallet.Web.Swagger.Description     ()
+import           Pos.Wallet.Web.Api                   (walletApi)
+import           Pos.Wallet.Web.Swagger.CustomSwagger (toCustomSwagger)
+import           Pos.Wallet.Web.Swagger.Description   ()
+import           Servant.API.ContentTypes             (NoContent (..))
 
+
+instance Buildable NoContent where
+    build NoContent = build ()
 
 -- | Build Swagger-specification from 'walletApi'.
 swaggerSpecForWalletApi :: Swagger


### PR DESCRIPTION
This slightly-invasive PR switch from `()` to `NoContent` for endpoints which do not return a result. This was necessary to avoid `servant-swagger` generating invalid specs.

Prior to this PR, it was not possible to validate the spec generated:

![screen shot 2017-11-06 at 09 45 17](https://user-images.githubusercontent.com/29383371/32449307-7a4729de-c311-11e7-89cb-903426ec0aa3.png)

After this PR, we can:

![screen shot 2017-11-06 at 16 25 27](https://user-images.githubusercontent.com/29383371/32449319-8306cdd6-c311-11e7-8fa5-8b46f3ebd8f3.png)

`NoContent` is a type defined in `Servant.API.ContentTypes` which is then erased by response bodies but at the same time ensures our Swagger spec validates correctly.

If you guys can think of a less-invasive way to support this, I'm all ears (one possibility would be to `fmap NoContent` each unit-returning endpoint inside `servantHandlers`, but if feels conceptually cleaner to give each handler a proper return type directly in its definition). 