### PR TITLE
[CSM-500] Remember pending transaction from the very beginning

### DIFF
--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -109,6 +109,7 @@ type instance OriginType CPtxCondition = Maybe PtxCondition
 
 instance ToCType CPtxCondition where
     encodeCType = maybe CPtxNotTracked $ \case
+        PtxCreating{}       -> CPtxCreating
         PtxApplying{}       -> CPtxApplying
         PtxInNewestBlocks{} -> CPtxInBlocks
         PtxPersisted{}      -> CPtxInBlocks

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -430,7 +430,8 @@ instance Buildable (SecureLog CTxMeta) where
 -- @PtxInNewestBlocks@ and @PtxPersisted@ states are merged into one
 -- not to provide information which conflicts with 'ctConfirmations'.
 data CPtxCondition
-    = CPtxApplying
+    = CPtxCreating  -- not for displaying to frontend
+    | CPtxApplying
     | CPtxInBlocks
     | CPtxWontApply
     | CPtxNotTracked  -- ^ tx was made not in this life

--- a/wallet/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Acidic.hs
@@ -67,6 +67,7 @@ module Pos.Wallet.Web.State.Acidic
        , RemoveFromHistoryCache (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
+       , RemoveOnlyCreatingPtx (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , GetWalletStorage (..)
@@ -172,6 +173,7 @@ makeAcidic ''WalletStorage
     , 'WS.removeFromHistoryCache
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
+    , 'WS.removeOnlyCreatingPtx
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
     , 'WS.flushWalletStorage

--- a/wallet/src/Pos/Wallet/Web/State/State.hs
+++ b/wallet/src/Pos/Wallet/Web/State/State.hs
@@ -75,6 +75,7 @@ module Pos.Wallet.Web.State.State
        , setWalletUtxo
        , setPtxCondition
        , casPtxCondition
+       , removeOnlyCreatingPtx
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , getWalletStorage
@@ -324,6 +325,11 @@ casPtxCondition
     :: MonadWalletDB ctx m
     => CId Wal -> TxId -> PtxCondition -> PtxCondition -> m Bool
 casPtxCondition = updateDisk ... A.CasPtxCondition
+
+removeOnlyCreatingPtx
+    :: MonadWalletDB ctx m
+    => CId Wal -> TxId -> m Bool
+removeOnlyCreatingPtx = updateDisk ... A.RemoveOnlyCreatingPtx
 
 ptxUpdateMeta
     :: MonadWalletDB ctx m

--- a/wallet/src/Pos/Wallet/Web/State/Storage.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Storage.hs
@@ -74,22 +74,25 @@ module Pos.Wallet.Web.State.Storage
        , removeFromHistoryCache
        , setPtxCondition
        , casPtxCondition
+       , removeOnlyCreatingPtx
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        ) where
 
 import           Universum
 
-import           Control.Lens                 (at, ix, makeClassy, makeLenses, non', to,
-                                               toListOf, traversed, (%=), (+=), (.=),
-                                               (<<.=), (?=), _Empty, _head)
-import           Control.Monad.State.Class    (put)
+import           Control.Lens                 (at, has, ix, makeClassy, makeLenses, non',
+                                               to, toListOf, traversed, (%=), (+=), (.=),
+                                               (<<.=), (?=), _Empty, _Just, _head)
+import           Control.Monad.State.Class    (get, put)
+import qualified Control.Monad.State.Lazy     as LS
 import           Data.Default                 (Default, def)
 import qualified Data.HashMap.Strict          as HM
 import qualified Data.Map                     as M
 import           Data.SafeCopy                (Migrate (..), base, deriveSafeCopySimple,
                                                extension)
 import           Data.Time.Clock.POSIX        (POSIXTime)
+import           Serokell.Util                (zoom')
 
 import           Pos.Client.Txp.History       (TxHistoryEntry, txHistoryListToMap)
 import           Pos.Core.Configuration       (HasConfiguration)
@@ -107,7 +110,7 @@ import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CC
                                                PassPhraseLU, Wal, addrMetaToAccount)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition,
                                                PtxSubmitTiming (..), ptxCond,
-                                               ptxSubmitTiming)
+                                               ptxSubmitTiming, _PtxCreating)
 import           Pos.Wallet.Web.Pending.Util  (incPtxSubmitTimingPure, mkPtxSubmitTiming,
                                                ptxMarkAcknowledgedPure)
 
@@ -459,14 +462,29 @@ setPtxCondition :: CId Wal -> TxId -> PtxCondition -> Update ()
 setPtxCondition wid txId cond =
     wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond .= cond
 
+-- | Conditional modifier.
+-- Returns 'True' if pending transaction existed and modification was applied.
+checkAndSmthPtx
+    :: CId Wal
+    -> TxId
+    -> (Maybe PtxCondition -> Bool)
+    -> LS.State (Maybe PendingTx) ()
+    -> Update Bool
+checkAndSmthPtx wid txId whetherModify modifier =
+    fmap getAny $ zoom' (wsWalletInfos . ix wid . wsPendingTxs . at txId) $ do
+        matches <- whetherModify . fmap _ptxCond <$> get
+        when matches modifier
+        return (Any matches)
+
 -- | Compare-and-set version of 'setPtxCondition'.
--- Returns 'True' if transaction existed and modification was applied.
 casPtxCondition :: CId Wal -> TxId -> PtxCondition -> PtxCondition -> Update Bool
-casPtxCondition wid txId expectedCond newCond = do
-    oldCond <- preuse $ wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond
-    let success = oldCond == Just expectedCond
-    when success $ setPtxCondition wid txId newCond
-    return success
+casPtxCondition wid txId expectedCond newCond =
+    checkAndSmthPtx wid txId (== Just expectedCond) (_Just . ptxCond .= newCond)
+
+-- | Removes pending transaction, if its status is 'PtxCreating'.
+removeOnlyCreatingPtx :: CId Wal -> TxId -> Update Bool
+removeOnlyCreatingPtx wid txId =
+    checkAndSmthPtx wid txId (has (_Just . _PtxCreating)) (put Nothing)
 
 data PtxMetaUpdate
     = PtxIncSubmitTiming


### PR DESCRIPTION
This is important, because if we remember it once transaction creation is done,
then creation may complete only after the moment when transaction gets to
blocks and then gets detected by tracker, so effectively tracker misses the tx.

Solution is to add new pending transaction status, `PtxCreating`. which
is not to display to frontend, and such transaction may be removed if
full cycle of transaction creation finishes with fatal error (unlike
`PtxApplying`).
Transaction remembered with this status still caries all pending meta info,
so tracker can successfully update status of that transaction.

Tested on:

* Normal creation
* Slot-length artificial delay between transaction submission over network and local application (original issue case)
* Fatal and non-fatal failure scenarios
* Start with wallet-db before this PR