### PR TITLE
[CSM-523] Get rid of nonatomic deletions in key storage

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4044,8 +4044,8 @@ self: {
       hscolour = callPackage ({ base, containers, mkDerivation, stdenv }:
       mkDerivation {
           pname = "hscolour";
-          version = "1.24.1";
-          sha256 = "e46fe3de8ed6f96e2216b94b7608d01919bc86b15dd8d0ec7e71c0e7e5bf79c8";
+          version = "1.24.2";
+          sha256 = "55fb86bafdcad9613c25910b1cbca4b071c1ddc6365538c3b3d4e350cb30cf22";
           isLibrary = true;
           isExecutable = true;
           enableSeparateDataOutput = true;

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -2,7 +2,6 @@
 
 module Pos.Wallet.Web.Account
        ( myRootAddresses
-       , getAddrIdx
        , getSKById
        , getSKByAddress
        , getSKByAddressPure
@@ -19,7 +18,6 @@ module Pos.Wallet.Web.Account
        ) where
 
 import           Control.Monad.Except (MonadError (throwError), runExceptT)
-import           Data.List (elemIndex)
 import           Formatting (build, sformat, (%))
 import           System.Random (randomIO)
 import           System.Wlog (WithLogger)
@@ -29,7 +27,7 @@ import           Pos.Client.KeyStorage (AllUserSecrets (..), MonadKeys, MonadKey
                                         getSecretKeys, getSecretKeysPlain)
 import           Pos.Core (Address (..), IsBootstrapEraAddr (..), deriveLvl2KeyPair)
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..), isHardened)
-import           Pos.Util (eitherToThrow, maybeThrow)
+import           Pos.Util (eitherToThrow)
 import           Pos.Util.BackupPhrase (BackupPhrase, safeKeysFromPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
                                              addrMetaToAccount, addressToCId, encToCId)
@@ -46,12 +44,6 @@ type AccountMode ctx m =
 
 myRootAddresses :: MonadKeysRead m => m [CId Wal]
 myRootAddresses = encToCId <<$>> getSecretKeysPlain
-
-getAddrIdx :: AccountMode ctx m => CId Wal -> m Int
-getAddrIdx addr = elemIndex addr <$> myRootAddresses >>= maybeThrow notFound
-  where
-    notFound =
-        RequestError $ sformat ("No wallet with address "%build%" found") addr
 
 getSKById
     :: AccountMode ctx m

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -31,7 +31,7 @@ import           Pos.Update.Configuration (HasUpdateConfiguration, curSoftwareVe
 import           Pos.Util (maybeThrow)
 import           Servant.API.ContentTypes (MimeRender (..), NoContent (..), OctetStream)
 
-import           Pos.Client.KeyStorage (MonadKeys, deleteSecretKey, getSecretKeys)
+import           Pos.Client.KeyStorage (MonadKeys, deleteAllSecretKeys)
 import           Pos.NtpCheck (NtpCheckMonad, NtpStatus (..), mkNtpStatusVar)
 import           Pos.Wallet.Aeson.ClientTypes ()
 import           Pos.Wallet.Aeson.Storage ()
@@ -120,12 +120,7 @@ localTimeDifference =
 ----------------------------------------------------------------------------
 
 testResetAll :: (MonadWalletDB ctx m, MonadKeys m) => m NoContent
-testResetAll = deleteAllKeys >> testReset >> return NoContent
-  where
-    deleteAllKeys :: MonadKeys m => m ()
-    deleteAllKeys = do
-        keyNum <- length <$> getSecretKeys
-        replicateM_ keyNum $ deleteSecretKey 0
+testResetAll = deleteAllSecretKeys >> testReset >> return NoContent
 
 ----------------------------------------------------------------------------
 -- Print wallet state


### PR DESCRIPTION
I actually wanted to modify our wallet creating endpoints so that, instead of
`makeWallet emptyPassphrase >> changePassphrase emptyPassphrase userPassphrase`
they do the same in one hope (for security purposes).
But then I saw that only `importWallet` endpoint suffers from that, so just an other little change is here