### PR TITLE
[CSM-557] Fix `instance FromHttpApiData (CId w)`

### DIFF
--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -126,7 +126,7 @@ instance FromHttpApiData Address where
     parseUrlPiece = decodeTextAddress
 
 instance FromHttpApiData (CId w) where
-    parseUrlPiece = fmap encodeCType . decodeTextAddress
+    parseUrlPiece = pure . CId . CHash
 
 instance FromHttpApiData CAccountId where
     parseUrlPiece = fmap CAccountId . parseUrlPiece


### PR DESCRIPTION
We don't want to throw decoding error, just return `False` if address is invalid