### PR TITLE
[CSL-1782] Restart wallet when node exits first

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17,8 +17,8 @@ self: {
           pname = "Cabal";
           version = "1.24.2.0";
           sha256 = "b7d0eb8e3503fbca460c0a6ca5c88352cecfe1b69e0bbc79827872134ed86340";
-          revision = "1";
-          editedCabalFile = "0jw809psa2ms9sy1mnirmbj9h7rs76wbmf24zgjqvhp4wq919z3m";
+          revision = "2";
+          editedCabalFile = "15ncrm7x2lg4hn0m5mhc8hy769bzhmajsm6l9i6536plfs2bbbdj";
           libraryHaskellDepends = [
             array
             base


### PR DESCRIPTION
The following was happening:

* Daedalus sends a shutdown signal to the node
* The node exits faster than Daedalus
* Launcher treats it as node crash and doesn't restart Daedalus