### PR TITLE
[CSM-553] Create default address for each account during JSON wallet import

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17,8 +17,8 @@ self: {
           pname = "Cabal";
           version = "1.24.2.0";
           sha256 = "b7d0eb8e3503fbca460c0a6ca5c88352cecfe1b69e0bbc79827872134ed86340";
-          revision = "1";
-          editedCabalFile = "0jw809psa2ms9sy1mnirmbj9h7rs76wbmf24zgjqvhp4wq919z3m";
+          revision = "2";
+          editedCabalFile = "15ncrm7x2lg4hn0m5mhc8hy769bzhmajsm6l9i6536plfs2bbbdj";
           libraryHaskellDepends = [
             array
             base


### PR DESCRIPTION
Before default address was created only together with default account, if no accounts were specified in JSON backup. This PR introduces logic of creating default addresses for accounts which were specified in backup, but don't have any addresses in Utxo or transaction history.