### PR TITLE
Rework grep.sh

### DIFF
--- a/scripts/grep.sh
+++ b/scripts/grep.sh
@@ -1,5 +1,7 @@
-# This utility script is written by @gromak and is provided "as is".
-# The author doesn't guarantee anything about it. It might work.
+# This utility script searchs prints lines matching a pattern in
+# Haskell source code.
+# N.B. If you want to find something in all files in the repostiory,
+# consider using `git grep'.
 
-grep --color=auto -r "$@" lib/src lib/test lib/bench core/Pos update/Pos db/Pos lrc/Pos infra/Pos ssc/Pos tools/src txp/Pos auxx/src auxx/*.hs wallet node/*hs explorer/*.hs --exclude-dir='.stack-work'
-# grep -r --exclude-dir={.stack-work,.git} "$@" .
+# grep --color=auto -r "$@" lib/src lib/test lib/bench core/Pos update/Pos db/Pos lrc/Pos infra/Pos ssc/Pos tools/src txp/Pos auxx/src auxx/*.hs wallet node/*hs explorer/src --exclude-dir='.stack-work'
+grep --color=auto -r --exclude-dir={.stack-work,.git} --include \*.hs "$@" *


### PR DESCRIPTION
I noticed that `grep.sh' didn't work correctly for explorer source code and
decided that it's better to use version which doesn't require enumerating all
folders.
Initially it was proposed by @sectore and I slightly modified it.