### PR TITLE
[CSL-1869] MsgBlock extension/improvements

### DIFF
--- a/db/Pos/DB/Class.hs
+++ b/db/Pos/DB/Class.hs
@@ -130,7 +130,7 @@ instance {-# OVERLAPPABLE #-}
 type MonadBlockDBRead m = (MonadDBRead m, BlockchainHelpers MainBlockchain)
 
 getDeserialized
-    :: (MonadBlockDBRead m, Bi v)
+    :: (MonadThrow m, Bi v)
     => (x -> m (Maybe (Serialized tag))) -> x -> m (Maybe v)
 getDeserialized getter x = getter x >>= \case
     Nothing  -> pure Nothing

--- a/explorer/src/Pos/Explorer/Socket/Methods.hs
+++ b/explorer/src/Pos/Explorer/Socket/Methods.hs
@@ -54,10 +54,13 @@ import           Universum
 import           Control.Lens (at, ix, lens, non, (.=), _Just)
 import           Control.Monad.State (MonadState)
 import           Data.Aeson (ToJSON)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import           Formatting (sformat, shown, stext, (%))
 import           Network.EngineIO (SocketId)
 import           Network.SocketIO (Socket, socketId)
+import           System.Wlog (WithLogger, logDebug, logWarning, modifyLoggerName)
+
 import qualified Pos.Block.Logic as DB
 import           Pos.Block.Types (Blund)
 import           Pos.Core (Address, HeaderHash)
@@ -71,7 +74,6 @@ import qualified Pos.Explorer.DB as DB
 import qualified Pos.GState as DB
 import           Pos.Util (maybeThrow)
 import           Pos.Util.Chrono (getOldestFirst)
-import           System.Wlog (WithLogger, logDebug, logWarning, modifyLoggerName)
 
 import           Pos.Explorer.Aeson.ClientTypes ()
 import           Pos.Explorer.ExplorerMode (ExplorerMode)
@@ -81,12 +83,11 @@ import           Pos.Explorer.Socket.Holder (ClientContext, ConnectionsState, Ex
                                              csEpochsLastPageSubscribers, csTxsSubscribers,
                                              mkClientContext)
 import           Pos.Explorer.Socket.Util (EventName (..), emitTo)
-import           Pos.Explorer.Web.ClientTypes (CAddress, CTxBrief, CTxEntry (..),
-                                               EpochIndex (..), TxInternal (..),
-                                               fromCAddress, toTxBrief)
+import           Pos.Explorer.Web.ClientTypes (CAddress, CTxBrief, CTxEntry (..), EpochIndex (..),
+                                               TxInternal (..), fromCAddress, toTxBrief)
 import           Pos.Explorer.Web.Error (ExplorerError (..))
-import           Pos.Explorer.Web.Server (epochPageSearch, getBlocksLastPage,
-                                          getEpochPagesOrThrow, topsortTxsOrFail)
+import           Pos.Explorer.Web.Server (epochPageSearch, getBlocksLastPage, getEpochPagesOrThrow,
+                                          topsortTxsOrFail)
 
 -- * Event names
 
@@ -352,10 +353,11 @@ notifyEpochsLastPageSubscribers currentEpoch = do
 getBlundsFromTo
     :: forall ctx m . ExplorerMode ctx m
     => HeaderHash -> HeaderHash -> m (Maybe [Blund])
-getBlundsFromTo recentBlock oldBlock = do
-    mheaders <- DB.getHeadersFromToIncl oldBlock recentBlock
-    forM (getOldestFirst <$> mheaders) $ \(_ :| headers) ->
-        catMaybes <$> forM headers getBlund
+getBlundsFromTo recentBlock oldBlock =
+    DB.getHeadersRange oldBlock recentBlock >>= \case
+        Left _ -> pure Nothing
+        Right (getOldestFirst -> headers) ->
+            Just . catMaybes <$> forM (NE.tail headers) getBlund
 
 addrsTouchedByTx
     :: (MonadDBRead m, WithLogger m)

--- a/lib/src/Pos/Block/Network/Listeners.hs
+++ b/lib/src/Pos/Block/Network/Listeners.hs
@@ -20,7 +20,7 @@ import           Pos.Communication.Limits (recvLimited)
 import           Pos.Communication.Listener (listenerConv)
 import           Pos.Communication.Protocol (ConversationActions (..), ListenerSpec (..),
                                              MkListeners, OutSpecs, constantListeners)
-import qualified Pos.DB.Block as DB
+import qualified Pos.DB.Class as DB
 import           Pos.DB.Error (DBError (DBMalformed))
 import           Pos.Network.Types (Bucket, NodeId)
 import           Pos.Util.Chrono (NewestFirst (..))
@@ -70,12 +70,12 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
                      " blocks to "%build%" one-by-one: "%listJson)
                     (length hashes) nodeId hashes
                 for_ hashes $ \hHash ->
-                    DB.getBlock hHash >>= \case
+                    DB.dbGetSerBlock hHash >>= \case
                         Nothing -> do
                             send conv (MsgNoBlock $
                                        "Couldn't retrieve block with hash " <> pretty hHash)
                             failMalformed
-                        Just b -> send conv (MsgBlock b)
+                        Just (DB.Serialized bbs) -> send conv (MsgBlock bbs)
                 logDebug "handleGetBlocks: blocks sending done"
             _ -> logWarning $ "getBlocksByHeaders@retrieveHeaders returned Nothing"
   where

--- a/lib/src/Pos/Block/Network/Listeners.hs
+++ b/lib/src/Pos/Block/Network/Listeners.hs
@@ -11,7 +11,7 @@ import           System.Wlog (logDebug, logWarning)
 import           Universum
 
 import           Pos.Binary.Communication ()
-import           Pos.Block.Logic (getHeadersFromToIncl)
+import           Pos.Block.Logic (getHeadersRange)
 import           Pos.Block.Network.Announce (handleHeadersCommunication)
 import           Pos.Block.Network.Logic (handleUnsolicitedHeaders)
 import           Pos.Block.Network.Types (MsgBlock (..), MsgGetBlocks (..), MsgGetHeaders,
@@ -62,26 +62,27 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
     whenJust mbMsg $ \mgb@MsgGetBlocks{..} -> do
         logDebug $ sformat ("handleGetBlocks: got request "%build%" from "%build)
             mgb nodeId
-        mHashes <- getHeadersFromToIncl mgbFrom mgbTo
-        case mHashes of
-            Just hashes -> do
+        getHeadersRange mgbFrom mgbTo >>= \case
+            Right hashes -> do
                 logDebug $ sformat
                     ("handleGetBlocks: started sending "%int%
                      " blocks to "%build%" one-by-one: "%listJson)
                     (length hashes) nodeId hashes
-                for_ hashes $ \hHash ->
-                    DB.dbGetSerBlock hHash >>= \case
-                        Nothing -> do
-                            send conv (MsgNoBlock $
-                                       "Couldn't retrieve block with hash " <> pretty hHash)
-                            failMalformed
-                        Just (DB.Serialized bbs) -> send conv (MsgBlock bbs)
+                for_ hashes $ \hHash -> DB.dbGetSerBlock hHash >>= \case
+                    Nothing -> do
+                        send conv (MsgNoBlock $
+                                   "Couldn't retrieve block with hash " <> pretty hHash)
+                        failMalformed
+                    Just (DB.Serialized bbs) -> send conv (MsgBlock bbs)
                 logDebug "handleGetBlocks: blocks sending done"
-            _ -> logWarning $ "getBlocksByHeaders@retrieveHeaders returned Nothing"
+            Left e -> do
+                let e' = "getBlocksByHeaders@retrieveHeaders returned error: " <> e
+                logWarning e'
+                send conv (MsgNoBlock e')
   where
     failMalformed =
         throwM $ DBMalformed $
-        "hadleGetBlocks: getHeadersFromToIncl returned header that doesn't " <>
+        "handleGetBlocks: getHeadersRange returned header that doesn't " <>
         "have corresponding block in storage."
 
 ----------------------------------------------------------------------------

--- a/lib/src/Pos/Block/Network/Types.hs
+++ b/lib/src/Pos/Block/Network/Types.hs
@@ -68,6 +68,7 @@ data MsgHeaders
 
 -- | 'Block' message (see protocol specification).
 data MsgBlock
-    = MsgBlock Block
-    | MsgNoBlock Text
+    = MsgBlock ByteString  -- ^ Raw block representation.
+    | MsgBlockDirect Block -- ^ Compatibility option. Use 'MsgBlock' if possible, it's faster.
+    | MsgNoBlock Text      -- ^ Couldn't retrieve block that was requested.
     deriving (Eq, Show, Generic)

--- a/lib/src/Pos/Communication/Limits.hs
+++ b/lib/src/Pos/Communication/Limits.hs
@@ -273,7 +273,7 @@ instance MessageLimited Block where
 instance MessageLimited MsgBlock where
     getMsgLenLimit _ = do
         blkLimit <- getMsgLenLimit (Proxy @Block)
-        return $ MsgBlock <$> blkLimit
+        return $ MsgBlockDirect <$> blkLimit
 
 instance HasConfiguration => MessageLimitedPure MsgGetHeaders where
     msgLenLimit = MsgGetHeaders <$> vector maxGetHeadersNum <+> msgLenLimit

--- a/lib/src/Pos/GState/BlockExtra.hs
+++ b/lib/src/Pos/GState/BlockExtra.hs
@@ -11,6 +11,7 @@ module Pos.GState.BlockExtra
        , getFirstGenesisBlockHash
        , BlockExtraOp (..)
        , foldlUpWhileM
+       , loadHashesUpWhile
        , loadHeadersUpWhile
        , loadBlocksUpWhile
        , initGStateBlockExtra
@@ -153,6 +154,15 @@ loadUpWhile getDatum morph start condition = OldestFirst . reverse <$>
         (\b h -> condition (snd b) h)
         (\l e -> pure (e : l))
         []
+
+-- | Bottom-top hashes traversal, basically iterating forward links
+-- with condition.
+loadHashesUpWhile :: (MonadBlockDBRead m, HasHeaderHash a)
+    => a
+    -> (HeaderHash -> Int -> Bool)
+    -> m (OldestFirst [] HeaderHash)
+loadHashesUpWhile start condition =
+    loadUpWhile (pure . Just) identity start condition
 
 -- | Returns headers loaded up.
 loadHeadersUpWhile


### PR DESCRIPTION
This PR introduces two changes:
1. I've implemented new type of `MsgBlock` that sends raw bytestring over the network. Listener logic is now replying with new message type only, though in recovery code old reply (`MsgBlockDirect`) is still supported. 
2. I improved performance of `getHeadersFromToIncl` (which is now called `getHeadersRange`) -- it now uses forward links and doesn't query `O(n)` headers, operating only on header hashes level. It should speed up responding to `MsgBlock`.