### PR TITLE
[DEVOPS-157] Fix devnet configuration

### DIFF
--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -14983,6 +14983,15 @@ devnet: &devnet
               testnetRichmenStakeDistr: []
             seed: 0
 
+  update:
+    applicationName: cardano-sl
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 0
+      bvAlt: 0
+    systemTag: none
+
   node:
     <<: *mainnet_base_node
     networkDiameter: 18 # should be slightly less than slot duration


### PR DESCRIPTION
`Devnet` configuration didn't have explicit `update` part and was reusing one from
mainnet_base, which corresponds to real mainnet and has `lastKnownBlockVersion`
set to 0.1.0. Because of that, nodes didn't create blocks (in devnet).