### PR TITLE
[CSL-1819] Update `push-update-on-mainnet.md`

### DIFF
--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -8,6 +8,7 @@ module Command.Proc
 import           Universum
 
 import           Data.Constraint (Dict (..))
+import           Data.Default (def)
 import           Data.List ((!!))
 import qualified Data.Map as Map
 import           Formatting (build, int, sformat, stext, (%))
@@ -322,7 +323,7 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
         puVoteAll <- getArg tyBool "vote-all"
         puBlockVersion <- getArg tyBlockVersion "block-version"
         puSoftwareVersion <- getArg tySoftwareVersion "software-version"
-        puBlockVersionModifier <- getArg tyBlockVersionModifier "bvm"
+        puBlockVersionModifier <- fromMaybe def <$> getArgOpt tyBlockVersionModifier "bvm"
         puUpdates <- getArgMany tyProposeUpdateSystem "update"
         pure ProposeUpdateParams{..}
     , cpExec = \params ->

--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -68,7 +68,7 @@ NOTE: the various other Cardano components can be obtained through other attribu
 -  `cardano-report-server-static`:
    - `cardano-report-server`
 -  `cardano-sl-auxx`:
-   - `cardano-hash-installer`, `cardano-auxx`
+   - `cardano-auxx`
 -  `cardano-sl-explorer-static`:
    - `cardano-explorer`, `cardano-explorer-hs2purs`, `cardano-explorer-swagger`, `cardano-explorer-mock`
 -  `cardano-sl-tools-static`:

--- a/docs/how-to/push-update-on-mainnet.md
+++ b/docs/how-to/push-update-on-mainnet.md
@@ -249,7 +249,7 @@ These hashes are Blake2b_256 hashes of CBOR-encoded contents of the files.
 There is a simple command to calculate the hash of an installer:
 
 ```
-stack exec -- cardano-auxx cmd --commands "hash-installer <FILEPATH>"
+./scripts/hash-installer.sh <FILEPATH>
 ```
 
 Note:

--- a/docs/how-to/push-update-on-mainnet.md
+++ b/docs/how-to/push-update-on-mainnet.md
@@ -137,7 +137,7 @@ The following variables will be used in all following commands:
 CONFIG_KEY=mainnet_dryrun_full  # Should be the same as on the running nodes!
 RELAY_PEER=<IP>:3000            # A host of any relay node.
 
-COMMONOPTS="--system-start 0 --configuration-file ../cardano-sl/node/configuration.yaml --configuration-key ${CONFIG_KEY}"
+COMMONOPTS="--system-start 0 --configuration-file ../cardano-sl/lib/configuration.yaml --configuration-key ${CONFIG_KEY} --mode=with-config"
 
 AUXXOPTS="--log-config ../cardano-sl/scripts/log-templates/log-config-qa.yaml --logs-prefix logs/aux-update.1.0.1 --db-path aux-update-1.0.1 --peer ${RELAY_PEER}"
 ```
@@ -148,7 +148,7 @@ to desired locations.
 Sending an update proposal
 ------------------
 
-Let's say that you want to push an update with the following Windows/macOS installers (note: it's important that the installers must be in current directory, i.e. there must be no slashes):
+Let's say that you want to push an update with the following Windows/macOS installers (note: the file path must start with either `/` or `./` and only alphanumeric characters and `.`, `-`, `_`, `/` are allowed):
 
 ```
 WIN64_INSTALLER=daedalus-win64-1.0.3350.0-installer.exe
@@ -164,7 +164,7 @@ It's assumed that you are doing everything from scratch and don't have
 `secret.key` file before using the command below.
 
 ```
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "add-key key0.sk primary, add-key key1.sk primary, add-key key2.sk primary, add-key key3.sk primary, listaddr"
+stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "add-key ./key0.sk primary:true; add-key ./key1.sk primary:true; add-key ./key2.sk primary:true; add-key ./key3.sk primary:true; listaddr"
 ```
 
 Flag `primary` indicates that signing secret key will be added.
@@ -174,7 +174,7 @@ If the `listaddr` command hasn't printed the addresses belonging to the four key
 To create and send an update proposal with votes from all imported secret keys, you need to run this command:
 
 ```
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all 0.1.0 65536 70000 <software-version> [win64 ${WIN64_INSTALLER} none macos64 ${DARWIN_INSTALLER} none]"
+stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all:true 0.1.0 ~software~<software-version> (upd-bin \"win64\" ${WIN64_INSTALLER}) (upd-bin \"macos64\" ${DARWIN_INSTALLER})"
 ```
 
 Notice that the last part of this command is optional, its presence
@@ -183,30 +183,27 @@ depends on whether you want to update `cardano-sl` or `csl-daedalus`.
 Examples:
 
 ```
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all 0.1.0 65536 70000 csl-daedalus:1 win64 ${WIN64_INSTALLER} none macos64 ${DARWIN_INSTALLER} none"
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all 0.1.0 65536 70000 cardano-sl:1"
+stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all:true 0.1.0 ~software~csl-daedalus:1 (upd-bin \"win64\" ${WIN64_INSTALLER}) (upd-bin \"macos64\" ${DARWIN_INSTALLER})"
+stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "propose-update 0 vote-all:true 0.1.0 ~software~cardano-sl:1"
 ```
 
 You also can combine importing keys and sending an update proposal in
 one command for your convenience. Example:
 
 ```
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "add-key key0.sk primary, add-key key1.sk primary, add-key key2.sk primary, add-key key3.sk primary, propose-update 0 vote-all 0.1.0 65536 70000 csl-daedalus:1 win64 ${WIN64_INSTALLER} none macos64 ${DARWIN_INSTALLER} none"
+stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "add-key ./key0.sk primary:true; add-key ./key1.sk primary:true; add-key ./key2.sk primary:true; add-key ./key3.sk primary:true; propose-update 0 vote-all:true 0.1.0 bvm ~software~csl-daedalus:1 (upd-bin "win64" ${WIN64_INSTALLER}) (upd-bin "macos64" ${DARWIN_INSTALLER})"
 ```
 
 Let's break down the invocation of `propose-update`. First come arguments that you almost certainly won't need to modify:
 
 * `0` is the index of key that will be used to sign the update.
-* `vote-all` flag means that update proposal will be submitted along
+* `vote-all:true` flag means that update proposal will be submitted along
   with votes from all our keys.
 * `0.1.0` is block version to be used after the
   update. See [Prerequisites](#prerequisites), you should know it in
   advance. `0.1.0` is used as an example.
-* `65536` is maximal tx size. Should be set to this value (`65536`) in `0.1.0`.
-* `70000` is maximal size of update proposal. Should be set to this
-  value (`70000`) in `0.1.0`.
 
-The next argument (`<software-version>`, e. g. `csl-daedalus:1`) is
+The next argument (`~software~<software-version>`, e. g. `~software~csl-daedalus:1`) is
 software version description. You should substitute `1` (version) with
 the integer provided along with installers (see *Prerequisites*
 section). Recall that currently we are maintaining two softwares:
@@ -214,13 +211,14 @@ section). Recall that currently we are maintaining two softwares:
 by wallets).
 
 Further arguments are optional, should be provided in `csl-daedalus`
-case and omitted in `cardano-sl` case. Those arguments are an arbitrary number
-of _triples_ (two in `csl-daedalus` case, one for Windows and one for
-macOS). Each triple is `<system tag> <installer filename> none`. Once
-again, those are filenames in the current dir, not arbitrary
-paths. `none` stands for binary diff (this feature is not used for
-now). System tags should corresponds to `systemTag` values in
-configuration file.
+case and omitted in `cardano-sl` case. Those arguments are update proposals
+for a system. You can specify an arbitary amount of them
+(two in `csl-daedalus` case, one for Windows and one for macOS).
+They're constructed with `upd-bin` function, which takes two arguments:
+a system tag and the installer filename. Once again, they must start
+with either `/` or `./` and only alphanumeric characters and `-`, `_`, `.`
+and `/` are allowed in the file path. System tags should corresponds to
+`systemTag` values in configuration file.
 
 Successfull command output looks like this:
 
@@ -251,7 +249,7 @@ These hashes are Blake2b_256 hashes of CBOR-encoded contents of the files.
 There is a simple command to calculate the hash of an installer:
 
 ```
-stack exec -- cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "hash-installer <FILEPATH>"
+stack exec -- cardano-auxx cmd --commands "hash-installer <FILEPATH>"
 ```
 
 Note:

--- a/docs/how-to/test-update-system.md
+++ b/docs/how-to/test-update-system.md
@@ -53,10 +53,10 @@ Then you will appear in `repl` mode and would need to perform few actions:
 #### Import secret keys
 
 ```
-add-key nodes2/testnet1.key primary
-add-key nodes2/testnet2.key primary
-add-key nodes2/testnet3.key primary
-add-key nodes2/testnet4.key primary
+add-key ./nodes2/testnet1.key true
+add-key ./nodes2/testnet2.key true
+add-key ./nodes2/testnet3.key true
+add-key ./nodes2/testnet4.key true
 ```
 
 Then if you execute
@@ -70,16 +70,28 @@ You should see something like:
 ```
 > listaddr
 Available addresses:
-    #0:   1feg76nzCcJrhwX4Z9NXc9iwNwo1UxUdkaF3XwdyFhtDdst (PK: eMrhrnbwqmRmeHNQW6kyrD9gs4sMtUyGRqPuLsiZaaTLhHY4uojgp7imLNX6tsECechdqLUB92APfs6Er1BJv6E)
-    #1:   1gE3qzmCe4cjReAWwJRv6iHHmHDzoejG9Mkp9sGF5qv6SQb (PK: 3E36aezxjRFHz8viGTTpu7us5mPej5d83195GFoHcSnWKCcVpduxKVLuAxxNWN2w9sRsDzdxfVeQpqWkumEJGYUN)
-    #2:   1gK2AvmDBSTYJgqLaJbmY3r1qgC55SyKeQCTjYDPLTxpyRN (PK: 2vCzGFduRi6obJaDitkz1DNqckGerE2oos7ocLRzeaCV28zvvkcKRsofDDWwpML5JaHUjeLKjFGnjmCZnhu2XjGJ)
-    #3:   1fNkZ1oyrV9xGaPizPHMM2hzwdwERyDPQrcLqLz76mqNxC6 (PK: 4856H9Czc65Y7ueCMdhnPtDwUZvH6g5uBEi1TkoN9CqE75ENbSx8jx8ebDgSDFX7A869qNjBe4n9SgZ74NSyr7xx)
+    #0:   addr:      Ae2tdPwUPEZD7r1mGc4BxGj5ikBop9DpdsKDzKpFujdYpd6bZBn9fZYEgsg
+          pk:        ZcrTBz5bwqSA+6pGfg7D55uJfZt++5XiEY7h03ly3++41DDNIerLdILubwKrr1zinBEBJhJORXlla/S4yERogg==
+          pk hash:   f83e9e0270abcc744b26570b069f66db5a83cdebe4bedb7cd435c443
+          HD addr:   DdzFFzCqrhszS1SoxhSTtM8c3qNyvKZvguJ2GNeTjRY5AXyJFia81xS1cERj215orZ9Fd1BzedinMfSXBJerpHxWpu1tzpx53Q2gEJtL
+    #1:   addr:      Ae2tdPwUPEZESKZGFtTEeR761598wbuCEERzqxeEtR69gCEzpTwSiaP7oxj
+          pk:        LxQs4CWIxMp3demqmPBMxrI/v/KpscOVwxiXATy0sByGK3idaFpN72k3U/Nxfhk6HGUFQAfcMwEzy0za95BNJw==
+          pk hash:   df4901e8f6abd96a8bd0579f24036a8b9b24c1df4bed85a1402db09b
+          HD addr:   DdzFFzCqrhtBFQAHQMzQK2vdWLWC55APHkrzQryBgwPN9jNdFTHeSQ4cBVpmQuksLjpeLFCoGwHPxHFvQPNhtXDXFBnAquWumkTdYyDS
+    #2:   addr:      Ae2tdPwUPEZMezLqssf4EMpudh7uNSoLKw6f1VN9F2o8rsAckXvx76PoZdc
+          pk:        mNZwrlO1fVSn2SV0bqfvp5D22gSToWwDxBZLgbFFOp5HdgO/n8iO5JnofvKajPtyujUch7jQZxmMhvBzBMc5zA==
+          pk hash:   c96ac1e118c0d38467e7ff7829e59d051c751c9c371687ed1c3a3cda
+          HD addr:   DdzFFzCqrht1aeEzHjtMBKt1WixjyP5dH1N1rt7H7w5VfmtJqfVKFs1EnZ7Tbjd9n7R2m7aNcQDGDge73BEDCFAhB9CemqwCQRmyNQex
+    #3:   addr:      Ae2tdPwUPEZKUpTf4jDurpvX7fdUrmZvFPM56TAwihnBbAuyvMZ47NeHHdY
+          pk:        ulsqNypOZ39xAbW71PxPsyMbXfEc7RUb+NPHFYA6tdjv0IAAkEN8/yaA9CmdVLFUj1FGZxdpdbTiq6hdeLcJBw==
+          pk hash:   81713ef44a9463104d3c7c48d547c20c869536af3da237d8fc12b5fa
+          HD addr:   DdzFFzCqrht5oYxSwcfYag9fESzGjwC3HGA3ZmdfraXf3STPRBrrek9NUSF68HkbXkApwSTUJamGbLDF6vvaRZigdLFpLuX6BCFzvoEU
 ```
 
 #### Propose update
 
 ```
-propose-update 0 0.1.0 csl-daedalus:1 1 15 2000000 win64 daedalus1.exe none macos daedalus1c.pkg none
+propose-update 0 0.1.0 ~software~csl-daedalus:1 (upd-bin "win64" ./daedalus1.exe) (upd-bin "macos" ./daedalus1c.pkg)
 ```
 
 (`none` states for binary diff package)
@@ -87,8 +99,6 @@ propose-update 0 0.1.0 csl-daedalus:1 1 15 2000000 win64 daedalus1.exe none maco
 Replace `0.1.0` with actual block version from config (i.e. `lastKnownBVMajor.lastKnownBVMinor.lastKnownBVAlt`), if needed.
 
 Replace `csl-daedalus:1` with `applicationName:applicationVersion` as for config.
-
-Replace argument 4, `1` with actual script version.
 
 After launching `propose-update` command you'll see output like this:
 
@@ -139,19 +149,19 @@ Wait for 30-60 seconds.
 
 Execute
 ```
-vote 1 y <upId>
-vote 2 y <upId>
-vote 3 y <upId>
+vote 1 true <upId>
+vote 2 true <upId>
+vote 3 true <upId>
 ```
 
 This will result in output like:
 
 ```
-> vote 1 y b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
+> vote 1 true b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
 Submitted vote
-> vote 2 y b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
+> vote 2 true b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
 Submitted vote
-> vote 3 y b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
+> vote 3 true b66ae7e037ca3503224e8d5b716443b6480df97be114c899f3e7397419e897c1
 Submitted vote
 ```
 

--- a/docs/how-to/test-update-system.md
+++ b/docs/how-to/test-update-system.md
@@ -53,10 +53,10 @@ Then you will appear in `repl` mode and would need to perform few actions:
 #### Import secret keys
 
 ```
-add-key ./nodes2/testnet1.key true
-add-key ./nodes2/testnet2.key true
-add-key ./nodes2/testnet3.key true
-add-key ./nodes2/testnet4.key true
+add-key ./nodes2/testnet1.key primary:true
+add-key ./nodes2/testnet2.key primary:true
+add-key ./nodes2/testnet3.key primary:true
+add-key ./nodes2/testnet4.key primary:true
 ```
 
 Then if you execute
@@ -149,9 +149,9 @@ Wait for 30-60 seconds.
 
 Execute
 ```
-vote 1 true <upId>
-vote 2 true <upId>
-vote 3 true <upId>
+vote 1 agree:true <upId>
+vote 2 agree:true <upId>
+vote 3 agree:true <upId>
 ```
 
 This will result in output like:


### PR DESCRIPTION
`push-update-on-mainnet.md` is updated according to the new auxx interface, as well as the rest of the documentation.

`bvm` argument in `propose-update` command is now optional for convinience.