### PR TITLE
 [DEVOPS-522] Docs: don't mention stack setup when using Nix

### DIFF
--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -89,10 +89,6 @@ Enter `nix-shell`:
 
     $ nix-shell
 
-And if it is the first project in Haskell on this machine, run `stack setup`:
-
-    [nix-shell:~/cardano-sl]$ stack setup --nix
-
 After that, in order to build Cardano SL with wallet capabilities, run the following script:
 
     [nix-shell:~/cardano-sl]$ ./scripts/build/cardano-sl.sh


### PR DESCRIPTION
@nh2 found that running `stack setup` breaks Nix, since it mixes glibc with system one.

```
[pid 24854] execve("/home/syd/.stack/programs/x86_64-linux-nix/ghc-8.0.2/bin/ghc", ["/home/syd/.stack/programs/x86_64"..., "--make", "-fbuilding-cabal-package", "-O", "-static", "-dynamic-too", "-dynosuf", "dyn_o", "-dynhisuf", "dyn_hi", "-outputdir", ".stack-work/dist/x86_64-linux-ni"..., "-odir", ".stack-work/dist/x86_64-linux-ni"..., "-hidir", ".stack-work/dist/x86_64-linux-ni"..., ...], [/* 71 vars */] <unfinished ...>
...
[pid 24854] open("/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC) = 3
```