### PR TITLE
[CSL-1890] Add updatePassword endpoint to V1 API

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -62,9 +62,7 @@ updatePassword
     => WalletId -> PasswordUpdate -> m Wallet
 updatePassword wid PasswordUpdate{..} = do
     wid' <- migrate wid
-    _ <- join $ V0.changeWalletPassphrase <$> migrate wid
-                                          <*> pure pwdOld
-                                          <*> pure pwdNew
+    _ <- V0.changeWalletPassphrase wid' pwdOld pwdNew
     V0.getWallet wid' >>= migrate
 
 deleteWallet :: WalletId

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration.hs
@@ -23,6 +23,7 @@ import           Universum
 import           Cardano.Wallet.API.V1.Errors as Errors
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Pos.Core.Types as Core
+import qualified Pos.Util.Servant as V0
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 
 import qualified Control.Monad.Catch as Catch
@@ -89,15 +90,15 @@ instance Migrate V1.AssuranceLevel V0.CWalletAssurance where
 --
 instance Migrate V0.CCoin Core.Coin where
     eitherMigrate =
-        maybe (Left $ Errors.MigrationFailed "error migrating V0.CCoin -> Core.Coin, mkCoin failed.") Right
-        . fmap Core.mkCoin
-        . readMaybe
-        . toString
-        . V0.getCCoin
+        first (const $ Errors.MigrationFailed "error migrating V0.CCoin -> Core.Coin, mkCoin failed.") .
+        V0.decodeCType
 
 --
 instance Migrate (V0.CId V0.Wal) V1.WalletId where
     eitherMigrate (V0.CId (V0.CHash h)) = pure (V1.WalletId h)
+
+instance Migrate V1.WalletId (V0.CId V0.Wal) where
+    eitherMigrate (V1.WalletId h) = pure (V0.CId (V0.CHash h))
 
 -- | Migrates to a V1 `SyncProgress` by computing the percentage as
 -- coded here: https://github.com/input-output-hk/daedalus/blob/master/app/stores/NetworkStatusStore.js#L108

--- a/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
+++ b/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
@@ -49,7 +49,7 @@ instance ToJSON Core.PassPhrase where
 
 instance FromJSON Core.PassPhrase where
     parseJSON Null        = mempty
-    parseJSON x@(String pp) = case mkPassPhrase pp of
-        Left e    -> typeMismatch e x
+    parseJSON (String pp) = case mkPassPhrase pp of
+        Left e    -> fail e
         Right pp' -> pure pp'
     parseJSON x           = typeMismatch "parseJSON failed for PassPhrase" x

--- a/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
+++ b/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
@@ -9,7 +9,7 @@ import           Data.Aeson (FromJSON (..), ToJSON (..))
 import           Data.Aeson.Types (Value (..), typeMismatch)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
-import           Formatting (int, sformat, shown, (%))
+import           Formatting (int, sformat, (%))
 
 import qualified Serokell.Util.Base16 as Base16
 
@@ -41,14 +41,13 @@ instance FromJSON BackupPhrase where
 instance ToJSON CFilePath where
   toJSON (CFilePath c) = toJSON c
 
--- FIXME: This couple of instances is not complementary,
--- can't write roundtrip test for them.
--- It doesn't matter though, because we will hardly need to return password
 instance ToJSON Core.PassPhrase where
-    toJSON = String . sformat shown
+    toJSON passphrase
+        | passphrase == Core.emptyPassphrase = Null
+        | otherwise = String $ Base16.encode (ByteArray.convert passphrase)
 
 instance FromJSON Core.PassPhrase where
-    parseJSON Null        = mempty
+    parseJSON Null        = pure Core.emptyPassphrase
     parseJSON (String pp) = case mkPassPhrase pp of
         Left e    -> fail e
         Right pp' -> pure pp'

--- a/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
+++ b/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
@@ -41,6 +41,9 @@ instance FromJSON BackupPhrase where
 instance ToJSON CFilePath where
   toJSON (CFilePath c) = toJSON c
 
+-- FIXME: This couple of instances is not complementary,
+-- can't write roundtrip test for them.
+-- It doesn't matter though, because we will hardly need to return password
 instance ToJSON Core.PassPhrase where
     toJSON = String . sformat shown
 

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -27,6 +27,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @PaymentDistribution Proxy
         aesonRoundtripProp @NewWallet Proxy
         aesonRoundtripProp @Core.Coin Proxy
+        aesonRoundtripProp @PassPhrase Proxy
         aesonRoundtripProp @TransactionGroupingPolicy Proxy
         aesonRoundtripProp @TransactionType Proxy
         aesonRoundtripProp @TransactionDirection Proxy
@@ -53,7 +54,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
 
 aesonRoundtrip :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a) => proxy a -> Property
 aesonRoundtrip (_ :: proxy a) = forAll arbitrary $ \(s :: a) -> do
-    decode (encode (toJSON s)) === Just s
+    eitherDecode (encode (toJSON s)) === Right s
 
 aesonRoundtripProp
     :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a, Typeable a)

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -6,6 +6,7 @@ import           Cardano.Wallet.API.V1.Errors (WalletError)
 import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.Orphans ()
 import           Data.Aeson
+import           Data.Typeable (typeRep)
 import           Pos.Util.BackupPhrase (BackupPhrase)
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
@@ -17,24 +18,31 @@ import qualified Pos.Core.Types as Core
 -- | Tests whether or not some instances (JSON, Bi, etc) roundtrips.
 spec :: Spec
 spec = describe "Marshalling & Unmarshalling" $ do
-    prop "Aeson BackupPhrase roundtrips" (aesonRoundtrip @BackupPhrase Proxy)
-    prop "Aeson AssuranceLevel roundtrips" (aesonRoundtrip @AssuranceLevel Proxy)
-    prop "Aeson Payment roundtrips" (aesonRoundtrip @Payment Proxy)
-    prop "Aeson PaymentDistribution roundtrips" (aesonRoundtrip @PaymentDistribution Proxy)
-    prop "Aeson NewWallet roundtrips" (aesonRoundtrip @NewWallet Proxy)
-    prop "Aeson Coin roundtrips" (aesonRoundtrip @Core.Coin Proxy)
-    prop "Aeson TransactionGroupingPolicy roundtrips" (aesonRoundtrip @TransactionGroupingPolicy Proxy)
-    prop "Aeson TransactionType roundtrips" (aesonRoundtrip @TransactionType Proxy)
-    prop "Aeson TransactionDirection roundtrips" (aesonRoundtrip @TransactionDirection Proxy)
-    prop "Aeson Transaction roundtrips" (aesonRoundtrip @Transaction Proxy)
-    prop "Aeson WalletError roundtrips" (aesonRoundtrip @WalletError Proxy)
-    prop "Aeson SlotDuration roundtrips" (aesonRoundtrip @SlotDuration Proxy)
-    prop "Aeson LocalTimeDifference roundtrips" (aesonRoundtrip @LocalTimeDifference Proxy)
-    prop "Aeson BlockchainHeight roundtrips" (aesonRoundtrip @BlockchainHeight Proxy)
-    prop "Aeson SyncProgress roundtrips" (aesonRoundtrip @SyncProgress Proxy)
-    prop "Aeson NodeInfo roundtrips" (aesonRoundtrip @NodeInfo Proxy)
-    prop "Aeson NodeSettings roundtrips" (aesonRoundtrip @NodeSettings Proxy)
+  aesonRoundtripProp @BackupPhrase Proxy
+  aesonRoundtripProp @AssuranceLevel Proxy
+  aesonRoundtripProp @Payment Proxy
+  aesonRoundtripProp @PaymentDistribution Proxy
+  aesonRoundtripProp @NewWallet Proxy
+  aesonRoundtripProp @Core.Coin Proxy
+  aesonRoundtripProp @TransactionGroupingPolicy Proxy
+  aesonRoundtripProp @TransactionType Proxy
+  aesonRoundtripProp @TransactionDirection Proxy
+  aesonRoundtripProp @Transaction Proxy
+  aesonRoundtripProp @WalletError Proxy
+  aesonRoundtripProp @SlotDuration Proxy
+  aesonRoundtripProp @LocalTimeDifference Proxy
+  aesonRoundtripProp @BlockchainHeight Proxy
+  aesonRoundtripProp @SyncProgress Proxy
+  aesonRoundtripProp @NodeInfo Proxy
+  aesonRoundtripProp @NodeSettings Proxy
+
 
 aesonRoundtrip :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a) => proxy a -> Property
 aesonRoundtrip (_ :: proxy a) = forAll arbitrary $ \(s :: a) -> do
     decode (encode (toJSON s)) === Just s
+
+aesonRoundtripProp
+    :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a, Typeable a)
+    => proxy a -> Spec
+aesonRoundtripProp proxy =
+    prop ("Aeson " <> show (typeRep proxy) <> " roundtrips") (aesonRoundtrip proxy)

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -7,34 +7,48 @@ import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.Orphans ()
 import           Data.Aeson
 import           Data.Typeable (typeRep)
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Crypto (PassPhrase, emptyPassphrase)
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
+
+import           Pos.Util.BackupPhrase (BackupPhrase)
 
 import qualified Pos.Core.Types as Core
 
 -- | Tests whether or not some instances (JSON, Bi, etc) roundtrips.
 spec :: Spec
 spec = describe "Marshalling & Unmarshalling" $ do
-  aesonRoundtripProp @BackupPhrase Proxy
-  aesonRoundtripProp @AssuranceLevel Proxy
-  aesonRoundtripProp @Payment Proxy
-  aesonRoundtripProp @PaymentDistribution Proxy
-  aesonRoundtripProp @NewWallet Proxy
-  aesonRoundtripProp @Core.Coin Proxy
-  aesonRoundtripProp @TransactionGroupingPolicy Proxy
-  aesonRoundtripProp @TransactionType Proxy
-  aesonRoundtripProp @TransactionDirection Proxy
-  aesonRoundtripProp @Transaction Proxy
-  aesonRoundtripProp @WalletError Proxy
-  aesonRoundtripProp @SlotDuration Proxy
-  aesonRoundtripProp @LocalTimeDifference Proxy
-  aesonRoundtripProp @BlockchainHeight Proxy
-  aesonRoundtripProp @SyncProgress Proxy
-  aesonRoundtripProp @NodeInfo Proxy
-  aesonRoundtripProp @NodeSettings Proxy
+    describe "Roundtrips" $ do
+        aesonRoundtripProp @BackupPhrase Proxy
+        aesonRoundtripProp @AssuranceLevel Proxy
+        aesonRoundtripProp @Payment Proxy
+        aesonRoundtripProp @PaymentDistribution Proxy
+        aesonRoundtripProp @NewWallet Proxy
+        aesonRoundtripProp @Core.Coin Proxy
+        aesonRoundtripProp @TransactionGroupingPolicy Proxy
+        aesonRoundtripProp @TransactionType Proxy
+        aesonRoundtripProp @TransactionDirection Proxy
+        aesonRoundtripProp @Transaction Proxy
+        aesonRoundtripProp @WalletError Proxy
+        aesonRoundtripProp @SlotDuration Proxy
+        aesonRoundtripProp @LocalTimeDifference Proxy
+        aesonRoundtripProp @BlockchainHeight Proxy
+        aesonRoundtripProp @SyncProgress Proxy
+        aesonRoundtripProp @NodeInfo Proxy
+        aesonRoundtripProp @NodeSettings Proxy
+
+    describe "Invariants" $ do
+        describe "password" $ do
+            it "empty string decodes to empty password" $
+                jsonString "" `decodesTo` (== emptyPassphrase)
+            it "base-16 string of length 32 decodes to nonempty password" $
+                jsonString (fromString $ replicate 64 'a')
+                    `decodesTo` (/= emptyPassphrase)
+            it "invalid length password decoding fails" $
+                -- currently passphrase should be either empty or of length 32
+                decodingFails @PassPhrase "aabbcc" Proxy
 
 
 aesonRoundtrip :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a) => proxy a -> Property
@@ -46,3 +60,13 @@ aesonRoundtripProp
     => proxy a -> Spec
 aesonRoundtripProp proxy =
     prop ("Aeson " <> show (typeRep proxy) <> " roundtrips") (aesonRoundtrip proxy)
+
+decodesTo :: (FromJSON a, Show a) => LByteString -> (a -> Bool) -> Expectation
+decodesTo s p = either expectationFailure (`shouldSatisfy` p) $ eitherDecode s
+
+decodingFails :: (FromJSON a, Show a) => LByteString -> proxy a -> Expectation
+decodingFails s (_ :: proxy a) = eitherDecode @a s `shouldSatisfy` isLeft
+
+-- | Take a string value, and make a JSON-string from it.
+jsonString :: LByteString -> LByteString
+jsonString bs = "\"" <> bs <> "\""


### PR DESCRIPTION
This adds implementation of `V1.updatePassword` endpoint via corresponding endpoint in `V0`.
Also some tests on password.