### PR TITLE
[CSL-1916] Change wallet backend code to use 3 level derivation

### DIFF
--- a/core/Pos/Core/Address.hs
+++ b/core/Pos/Core/Address.hs
@@ -72,7 +72,7 @@ import           Pos.Binary.Class (Bi, biSize)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Binary.Crypto ()
 import           Pos.Core.Coin ()
-import           Pos.Core.Constants (accountGenesisIndex, wAddressGenesisIndex)
+import           Pos.Core.Constants (accountGenesisIndex, chainGenesisIndex, wAddressGenesisIndex)
 import           Pos.Core.Types (AddrAttributes (..), AddrSpendingData (..),
                                  AddrStakeDistribution (..), AddrType (..), Address (..),
                                  Address' (..), AddressHash, Script, StakeholderId)
@@ -386,7 +386,8 @@ deriveFirstHDAddress
     -> EncryptedSecretKey -- ^ key of wallet set
     -> Maybe (Address, EncryptedSecretKey)
 deriveFirstHDAddress ibea passphrase wsKey =
-    deriveLvl2KeyPair ibea (ShouldCheckPassphrase False) passphrase wsKey accountGenesisIndex wAddressGenesisIndex
+    deriveLvl3KeyPair ibea (ShouldCheckPassphrase False) passphrase wsKey
+      accountGenesisIndex chainGenesisIndex wAddressGenesisIndex
 
 ----------------------------------------------------------------------------
 -- Pattern-matching helpers
@@ -444,11 +445,12 @@ maxPubKeyAddressSizeSingleKey = biSize largestPubKeyAddressSingleKey
 -- is serialized using var-length encoding.
 largestHDAddressBoot :: Bi Address' => Address
 largestHDAddressBoot =
-    case deriveLvl2KeyPair
+    case deriveLvl3KeyPair
              (IsBootstrapEraAddr True)
              (ShouldCheckPassphrase False)
              emptyPassphrase
              encSK
+             maxBound
              maxBound
              maxBound of
         Nothing        -> error "largestHDAddressBoot failed"

--- a/core/Pos/Core/Constants.hs
+++ b/core/Pos/Core/Constants.hs
@@ -6,6 +6,7 @@
 module Pos.Core.Constants
        ( sharedSeedLength
        , accountGenesisIndex
+       , chainGenesisIndex
        , wAddressGenesisIndex
        ) where
 
@@ -17,7 +18,11 @@ import           Pos.Crypto.HD (firstHardened)
 accountGenesisIndex :: Word32
 accountGenesisIndex = firstHardened
 
--- | Second index in derivation path for HD account, which is put to genesis
+-- | Second index in derivation path for HD account, which is put to genesis utxo.
+chainGenesisIndex :: Word32
+chainGenesisIndex = firstHardened
+
+-- | Third index in derivation path for HD account, which is put to genesis
 -- utxo
 wAddressGenesisIndex :: Word32
 wAddressGenesisIndex = firstHardened

--- a/crypto/Pos/Crypto/HD.hs
+++ b/crypto/Pos/Crypto/HD.hs
@@ -17,6 +17,8 @@ module Pos.Crypto.HD
 
        , firstHardened
        , firstNonHardened
+       , secondHardened
+       , secondNonHardened
        , isHardened
        ) where
 
@@ -75,6 +77,12 @@ firstHardened = 2 ^ (31 :: Word32)
 
 firstNonHardened :: Word32
 firstNonHardened = 0
+
+secondHardened :: Word32
+secondHardened = firstHardened
+
+secondNonHardened :: Word32
+secondNonHardened = 0
 
 isHardened :: Word32 -> Bool
 isHardened = ( >= firstHardened)

--- a/lib/test/Test/Pos/Core/AddressSpec.hs
+++ b/lib/test/Test/Pos/Core/AddressSpec.hs
@@ -74,7 +74,7 @@ pkAndHdwAreShownDifferently :: Bool -> PublicKey -> Bool
 pkAndHdwAreShownDifferently isBootstrap pk =
     show (makePubKeyAddress (IsBootstrapEraAddr isBootstrap) pk) /=
     (show @_ @Text (makePubKeyHdwAddress (IsBootstrapEraAddr isBootstrap)
-                    (HDAddressPayload "pataq") pk))
+                    (Just $ HDAddressPayload "pataq") pk))
 
 largestAddressProp :: Text -> (SecretKey -> Gen Address) -> Address -> Byte -> Spec
 largestAddressProp addressDescription genAddress largestAddress expectedLargestSize = do

--- a/lib/test/Test/Pos/Core/AddressSpec.hs
+++ b/lib/test/Test/Pos/Core/AddressSpec.hs
@@ -68,7 +68,7 @@ spec = describe "Address" $ do
                 genHDAddrBoot' passphrase esk <$> arbitrary <*> arbitrary
 
         largestAddressProp "HD address with BootstrapEra distribution"
-            genHDAddrBoot largestHDAddressBoot 76
+            genHDAddrBoot largestHDAddressBoot 81
 
 pkAndHdwAreShownDifferently :: Bool -> PublicKey -> Bool
 pkAndHdwAreShownDifferently isBootstrap pk =

--- a/wallet/src/Pos/Wallet/Aeson/Storage.hs
+++ b/wallet/src/Pos/Wallet/Aeson/Storage.hs
@@ -43,8 +43,12 @@ instance ToJSON CTxId => ToJSONKey CTxId where
 
 accountIdFromText :: Text -> Either Text AccountId
 accountIdFromText t = case T.splitOn "@" t of
-    [walId, idx] -> AccountId (CId $ CHash walId) <$> readEither idx
-    _            -> fail $ toString $ "Invalid AccountId " <> t
+    [walId, accIdx, chainIdx] ->
+        AccountId (CId $ CHash walId)
+          <$> readEither accIdx
+          <*> readEither chainIdx
+    _                         ->
+        fail $ toString $ "Invalid AccountId " <> t
 
 instance FromJSON AccountId => FromJSONKey AccountId where
     fromJSONKey = FromJSONKeyTextParser (eitherToFail . accountIdFromText)

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -142,8 +142,9 @@ mkCTx diff THEntry {..} meta pc wAddrsSet = do
 
 addrMetaToAccount :: CWAddressMeta -> AccountId
 addrMetaToAccount CWAddressMeta{..} = AccountId
-    { aiWId  = cwamWId
-    , aiIndex = cwamAccountIndex
+    { aiWId        = cwamWId
+    , aiIndex      = cwamAccountIndex
+    , aiChainIndex = cwamChainIndex
     }
 
 -- | Return counts of negative and positive votes

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -58,10 +58,12 @@ type instance OriginType CAccountId = AccountId
 instance FromCType CAccountId where
     decodeCType (CAccountId url) =
         case splitOn "@" url of
-            [part1, part2] -> do
+            [part1, part2, part3] -> do
                 aiWId  <- encodeCType <$> decodeTextAddress part1
-                aiIndex <- maybe (Left "Invalid wallet index") Right $
+                aiIndex <- maybe (Left "Invalid wallet account index") Right $
                             readMaybe $ toString part2
+                aiChainIndex <- maybe (Left "Invalid wallet chain index") Right $
+                                  readMaybe $ toString part3
                 return AccountId{..}
             _ -> Left "Expected 2 parts separated by '@'"
 

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -163,16 +163,18 @@ type PassPhraseLU = POSIXTime
 
 data AccountId = AccountId
     { -- | Address of wallet this account belongs to
-      aiWId   :: CId Wal
-    , -- | Derivation index of this account key
-      aiIndex :: Word32
+      aiWId        :: CId Wal
+    , -- | First derivation index of this account key
+      aiIndex      :: Word32
+    , -- | Second derivation index of this account key
+      aiChainIndex :: Word32
     } deriving (Eq, Ord, Show, Generic, Typeable)
 
 instance Hashable AccountId
 
 instance Buildable AccountId where
     build AccountId{..} =
-        bprint (build%"@"%build) aiWId aiIndex
+        bprint (build%"@"%build%"@"%build) aiWId aiIndex aiChainIndex
 
 instance Buildable (SecureLog AccountId) where
     build _ = "<account id>"
@@ -189,6 +191,8 @@ data CWAddressMeta = CWAddressMeta
     , -- | First index in derivation path of this account key
       cwamAccountIndex :: Word32
     , -- | Second index in derivation path of this account key
+      cwamChainIndex   :: Word32
+    , -- | Third index in derivation path of this account key
       cwamAddressIndex :: Word32
     , -- | Actual address
       cwamId           :: CId Addr
@@ -196,8 +200,8 @@ data CWAddressMeta = CWAddressMeta
 
 instance Buildable CWAddressMeta where
     build CWAddressMeta{..} =
-        bprint (build%"@"%build%"@"%build%" ("%build%")")
-        cwamWId cwamAccountIndex cwamAddressIndex cwamId
+        bprint (build%"@"%build%"@"%build%"@"%build%" ("%build%")")
+        cwamWId cwamAccountIndex cwamChainIndex cwamAddressIndex cwamId
 
 instance Hashable CWAddressMeta
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -47,7 +47,7 @@ import qualified Pos.Util.Modifier as MM
 import           Pos.Util.Servant (encodeCType)
 import           Pos.Wallet.Aeson ()
 import           Pos.Wallet.WalletMode (MonadBalances (..), WalletMempoolExt)
-import           Pos.Wallet.Web.Account (AddrGenSeed, genUniqueAccountId, genUniqueAddress,
+import           Pos.Wallet.Web.Account (AddressGenerationMode, genUniqueAccountId, genUniqueAddress,
                                          getSKById)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccount (..), CAccountInit (..),
                                              CAccountMeta (..), CAddress (..), CCoin, CId,
@@ -181,35 +181,35 @@ getWallets = getWalletAddresses >>= mapM getWallet
 
 newAddress
     :: MonadWalletLogic ctx m
-    => AddrGenSeed
+    => AddressGenerationMode
     -> PassPhrase
     -> AccountId
     -> m CAddress
-newAddress addGenSeed passphrase accId =
+newAddress addGenMode passphrase accId =
     fixCachedAccModifierFor accId $ \accMod -> do
         -- check whether account exists
         _ <- getAccount accMod accId
 
-        cAccAddr <- genUniqueAddress addGenSeed passphrase accId
+        cAccAddr <- genUniqueAddress addGenMode passphrase accId
         addWAddress cAccAddr
         getWAddress accMod cAccAddr
 
 newAccountIncludeUnready
     :: MonadWalletLogic ctx m
-    => Bool -> AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
-newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} =
+    => Bool -> AddressGenerationMode -> PassPhrase -> CAccountInit -> m CAccount
+newAccountIncludeUnready includeUnready addGenMode passphrase CAccountInit {..} =
     fixCachedAccModifierFor caInitWId $ \accMod -> do
         -- check wallet exists
         _ <- getWalletIncludeUnready includeUnready caInitWId
 
-        cAddr <- genUniqueAccountId addGenSeed caInitWId
+        cAddr <- genUniqueAccountId addGenMode caInitWId
         createAccount cAddr caInitMeta
-        () <$ newAddress addGenSeed passphrase cAddr
+        () <$ newAddress addGenMode passphrase cAddr
         getAccount accMod cAddr
 
 newAccount
     :: MonadWalletLogic ctx m
-    => AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
+    => AddressGenerationMode -> PassPhrase -> CAccountInit -> m CAccount
 newAccount = newAccountIncludeUnready False
 
 createWalletSafe

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -19,7 +19,7 @@ import           Pos.Crypto (PassPhrase, aesDecrypt, deriveAesKeyBS, hash,
                              redeemDeterministicKeyGen)
 import           Pos.Util (maybeThrow)
 import           Pos.Util.BackupPhrase (toSeed)
-import           Pos.Wallet.Web.Account (GenSeed (..))
+import           Pos.Wallet.Web.Account (GenerationMode (..))
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountId (..), CAddress (..),
                                              CPaperVendWalletRedeem (..), CTx (..),
                                              CWalletRedeem (..))
@@ -84,7 +84,7 @@ redeemAdaInternal passphrase cAccId seedBs = do
     _ <- fixingCachedAccModifier L.getAccount accId
 
     dstAddr <- decodeCTypeOrFail . cadId =<<
-               L.newAddress RandomSeed passphrase accId
+               L.newAddress RandomMode passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
                 prepareRedemptionTx redeemSK dstAddr

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -88,7 +88,7 @@ import           Pos.Wallet.Redirect (MonadBlockchainInfo (..), MonadUpdates (..
                                       networkChainDifficultyWebWallet, txpNormalizeWebWallet,
                                       txpProcessTxWebWallet, waitForUpdateWebWallet)
 import           Pos.Wallet.WalletMode (WalletMempoolExt)
-import           Pos.Wallet.Web.Account (AccountMode, GenSeed (RandomSeed))
+import           Pos.Wallet.Web.Account (AccountMode, GenerationMode (RandomMode))
 import           Pos.Wallet.Web.ClientTypes (AccountId, cadId)
 import           Pos.Wallet.Web.Methods (MonadWalletLogic, newAddress)
 import           Pos.Wallet.Web.Sockets.Connection (MonadWalletWebSockets)
@@ -328,7 +328,7 @@ getNewAddressWebWallet
     :: MonadWalletLogic ctx m
     => (AccountId, PassPhrase) -> m Address
 getNewAddressWebWallet (accId, passphrase) = do
-    clientAddress <- newAddress RandomSeed passphrase accId
+    clientAddress <- newAddress RandomMode passphrase accId
     decodeCTypeOrFail (cadId clientAddress)
 
 instance (HasConfigurations, HasCompileInfo)

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -17,7 +17,7 @@ import           Servant.Swagger.UI (swaggerSchemaUIServer)
 
 import           Pos.Update.Configuration (curSoftwareVersion)
 import           Pos.Wallet.WalletMode (blockchainSlotDuration)
-import           Pos.Wallet.Web.Account (GenSeed (RandomSeed))
+import           Pos.Wallet.Web.Account (GenerationMode (RandomMode))
 import           Pos.Wallet.Web.Api (WalletApi, WalletSwaggerApi, walletApi)
 import qualified Pos.Wallet.Web.Methods as M
 import           Pos.Wallet.Web.Mode (MonadFullWalletWebMode)
@@ -55,12 +55,12 @@ servantHandlers =
     :<|>
      M.updateAccount
     :<|>
-     M.newAccount RandomSeed
+     M.newAccount RandomMode
     :<|>
      M.deleteAccount
     :<|>
 
-     M.newAddress RandomSeed
+     M.newAddress RandomMode
     :<|>
 
      M.isValidAddress

--- a/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
@@ -92,5 +92,5 @@ decryptAddress :: WalletDecrCredentials -> Address -> Maybe CWAddressMeta
 decryptAddress (hdPass, wCId) addr = do
     hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
     derPath <- unpackHDAddressAttr hdPass hdPayload
-    guard $ length derPath == 2
-    pure $ CWAddressMeta wCId (derPath !! 0) (derPath !! 1) (encodeCType addr)
+    guard $ length derPath == 3
+    pure $ CWAddressMeta wCId (derPath !! 0) (derPath !! 1) (derPath !! 2) (encodeCType addr)

--- a/wallet/test/Test/Pos/Wallet/Web/Util.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Util.hs
@@ -12,7 +12,7 @@ module Test.Pos.Wallet.Web.Util
        , importSingleWallet
        , mostlyEmptyPassphrases
        , deriveRandomAddress
-       , genWalletLvl2KeyPair
+       , genWalletLvl3KeyPair
        , genWalletAddress
        , genWalletUtxo
        , expectedAddrBalance
@@ -36,7 +36,7 @@ import           Pos.Client.Txp.Balances (getBalance)
 import           Pos.Context (LastKnownHeaderTag, ProgressHeaderTag)
 import           Pos.Core (Address, BlockCount, Coin, HasConfiguration, genesisSecretsPoor,
                            headerHashG)
-import           Pos.Core.Address (IsBootstrapEraAddr (..), deriveLvl2KeyPair)
+import           Pos.Core.Address (IsBootstrapEraAddr (..), deriveLvl3KeyPair)
 import           Pos.Core.Block (blockHeader)
 import           Pos.Core.Txp (TxIn, TxOut (..), TxOutAux (..))
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..),
@@ -135,7 +135,7 @@ mostlyEmptyPassphrases =
 
 -- | Take passphrases of our wallets
 -- and return some address from one of our wallets and id of this wallet.
--- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl2KeyPair@
+-- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl3KeyPair@
 deriveRandomAddress :: [PassPhrase] -> WalletProperty (CId Addr, CId Wal)
 deriveRandomAddress passphrases = do
     skeys <- lift getSecretKeysPlain
@@ -156,30 +156,31 @@ deriveRandomAddress passphrases = do
 -- | Take root secret key of wallet and a passphrase
 -- and generate arbitrary wallet address with corresponding lvl 2
 -- secret key
--- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl2KeyPair@
-genWalletLvl2KeyPair
+-- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl3KeyPair@
+genWalletLvl3KeyPair
     :: EncryptedSecretKey
     -> PassPhrase
     -> Gen (Maybe (Address, EncryptedSecretKey))
-genWalletLvl2KeyPair sk psw = do
+genWalletLvl3KeyPair sk psw = do
     accountIdx <- getDerivingIndex <$> arbitrary
+    chainIdx <- getDerivingIndex <$> arbitrary
     addressIdx <- getDerivingIndex <$> arbitrary
-    pure $ deriveLvl2KeyPair
+    pure $ deriveLvl3KeyPair
         (IsBootstrapEraAddr True)
         (ShouldCheckPassphrase False)
-        psw sk accountIdx addressIdx
+        psw sk accountIdx chainIdx addressIdx
 
 -- | Take root secret key of wallet and a passphrase
 -- and generate arbitrary wallet address
--- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl2KeyPair@
+-- BE CAREFUL: this functions might take long time b/c it uses @deriveLvl3KeyPair@
 genWalletAddress
     :: EncryptedSecretKey
     -> PassPhrase
     -> Gen (Maybe Address)
-genWalletAddress sk psw = fst <<$>> genWalletLvl2KeyPair sk psw
+genWalletAddress sk psw = fst <<$>> genWalletLvl3KeyPair sk psw
 
 -- | Generate utxo which contains only addresses from given wallet
--- BE CAREFUL: @deriveLvl2KeyPair@ is called `size` times here -
+-- BE CAREFUL: @deriveLvl3KeyPair@ is called `size` times here -
 -- generating large utxos will take a long time
 genWalletUtxo
     :: EncryptedSecretKey


### PR DESCRIPTION
Summary:
* chainGenesisIndex added to constants for firstHDAddress.
* max address size upped from 76 to 81 to account for the new derivation path.
* minor re-factorings / chainIndex added where code failed.