### PR TITLE
[CSL-1925] Define new solution to address generation

### DIFF
--- a/docs/CSL-1925.md
+++ b/docs/CSL-1925.md
@@ -4,24 +4,28 @@
 An address in Cardano is always derived from a root key using BIP32 style derivation
 except it uses a different elliptic curve than Bitcoin (Ed25519). 
 
-The problem initially raised concerns exchanges which have only one account per root
-key and thus 2^31 possible addresses. In this scenario according to the birthday
-paradox there is a non negligible chance of a collision occuring.
+The problem initially raised concerns exchanges which typically use one, single,
+giant wallet per crypto currency and all users share the same space for addresses.
+
+In the HD wallet case this translates to one account per wallet and thus the total
+space for user addresses becomes 2^31. In this scenario according to the birthday
+problem there is a non negligible chance of a collision occuring after a sufficient
+amount of addresses have been generated.
 
 The first child (or branch) of the root key is derived according to the _account index_
-which by default is 2^31 or in binary `10000000000000000000000000000000` where the
-first bit represents the hardened state. As a BIP32 path this can be represented as 
-`m/aH`. The second child is derived according to an _address index_.
+which by default lies within the range (2^31 (`10000000...`) -> 2^30) where the first 
+bit represents the hardened state. As a BIP32 path this can be represented as `m/a'`. 
 
-Both the account and address indices fall within the range 2^31 in terms of how many
-addresses can be derived.
+The second child is derived according to an _address index_ which follows the same 
+rules as the account index for derivation.
 
-In the current scheme the address size is 76 bytes, where each index takes up 5 bytes.
+In the current scheme the serialised form of an address has a size of 76 bytes, where 
+each index takes up 5 bytes (4 bytes for Word32 and 1 byte CBOR overhead).
 
 # Generation Strategies
 
 There are currently two ways of generating a unique address, as depicted by the following
-ADT.
+ADT, which is based on the source code at [wallet/src/Pos/Wallet/Web/Account.hs](https://github.com/input-output-hk/cardano-sl/blob/d7e01933912cdd127b6ffac6bd01e0fb3f15a4f5/wallet/src/Pos/Wallet/Web/Account.hs#L109).
 
 ```haskell
 data GenerationMode 
@@ -33,18 +37,17 @@ data GenerationMode
 
 The difference between `RandomMode` and `DeterministicMode` is that in `DeterministicMode` the
 application / dependent code or user must supply the seed used to generate the index instead 
-of it being generated randomly. `DeterministicMode` is there in order to be able to recover 
-the address at a later date.
+of it being generated randomly. `DeterministicMode` is used during the wallet backup and 
+recovery process in order to recover the generated indices. 
 
 The wallet uses a function called `genUniqueAddress` to generate addresses which in turn
-uses the function shown below named `generateUnique`. In RandomMode this function tries 
+uses the function shown below named `generateUnique`. In `RandomMode` this function tries 
 to ensure that the index used is unique according to an arbitrary predicate `isDuplicate`. 
 For addresses this predicate is called `doesWAddressExist` which checks storage for a 
 pre-existing address.
 
-In terms of BIP32 paths this extra index forms the `bH` in the derivation path `m/aH/bH` 
-where `bH` is the random index and H is there to denote that the function also runs 
-`isHardened` on the random index.
+In terms of BIP32 paths this extra index forms the `b'` in the derivation path `m/a'/b'` 
+where `b'` is the hardened random address index.
 
 ## Random Address Generation
 

--- a/docs/CSL-1925.md
+++ b/docs/CSL-1925.md
@@ -14,8 +14,7 @@ first bit represents the hardened state. As a BIP32 path this can be represented
 `m/aH`. The second child is derived according to an _address index_.
 
 Both the account and address indices fall within the range 2^31 in terms of how many
-addresses can be derived however only the last is generated at random, where the first
-bit is reserved for encoding whether the index is hardened or not.
+addresses can be derived.
 
 In the current scheme the address size is 76 bytes, where each index takes up 5 bytes.
 
@@ -88,12 +87,13 @@ The `genUniqueAddress` function attempts to prevent collisions by checking a loc
 cache for the same address and retrying in case of failure. The function relies on 
 local storage instead of natural cryptographic constraints.
 
-This is a problem because it assumes that every existing address is stored within the local
-Cardano cache which may not be the case. 
-
 Should the address being generated not be within storage or should storage fail, there is 
 then a non-negligible chance of collision which can occur and go unnoticed by dependent
 applications.
+
+Lastly `genUniqueAddress` is broken in the above implementation due to isHardened being 
+used inapropriately and being able to simplify the implementation via randomRIO. This will be 
+fixed as a matter of priority as a short term solution to the problem.
 
 # Non-Random Generation
 
@@ -233,6 +233,7 @@ It would be possible to have 4 levels of extra indices in order to guarantee tha
 ### Pros
 * No more collisions.
 * No more need for storage / book keeping in order to guarantee uniqueness in address generation.
+
 ### Cons
 * Major breaking changes.
 * Address size grows to 91 bytes.

--- a/docs/CSL-1925.md
+++ b/docs/CSL-1925.md
@@ -1,0 +1,255 @@
+
+# Problem Definition
+
+An address in Cardano is always derived from a root key using BIP32 style derivation
+except it uses a different elliptic curve than Bitcoin (Ed25519). 
+
+The problem initially raised concerns exchanges which have only one account per root
+key and thus 2^31 possible addresses. In this scenario according to the birthday
+paradox there is a non negligible chance of a collision occuring.
+
+The first child (or branch) of the root key is derived according to the _account index_
+which by default is 2^31 or in binary `10000000000000000000000000000000` where the
+first bit represents the hardened state. As a BIP32 path this can be represented as 
+`m/aH`. The second child is derived according to an _address index_.
+
+Both the account and address indices fall within the range 2^31 in terms of how many
+addresses can be derived however only the last is generated at random, where the first
+bit is reserved for encoding whether the index is hardened or not.
+
+In the current scheme the address size is 76 bytes, where each index takes up 5 bytes.
+
+# Generation Strategies
+
+There are currently two ways of generating a unique address, as depicted by the following
+ADT.
+
+```haskell
+data GenerationMode 
+  = RandomMode
+  -- ^ Generates an address where the second index is random and hardened.
+  | DeterministicMode Word32 
+  -- ^ Generates an address where the second index is parameterised.
+```
+
+The difference between `RandomMode` and `DeterministicMode` is that in `DeterministicMode` the
+application / dependent code or user must supply the seed used to generate the index instead 
+of it being generated randomly. `DeterministicMode` is there in order to be able to recover 
+the address at a later date.
+
+The wallet uses a function called `genUniqueAddress` to generate addresses which in turn
+uses the function shown below named `generateUnique`. In RandomMode this function tries 
+to ensure that the index used is unique according to an arbitrary predicate `isDuplicate`. 
+For addresses this predicate is called `doesWAddressExist` which checks storage for a 
+pre-existing address.
+
+In terms of BIP32 paths this extra index forms the `bH` in the derivation path `m/aH/bH` 
+where `bH` is the random index and H is there to denote that the function also runs 
+`isHardened` on the random index.
+
+## Random Address Generation
+
+Currently the random address generation / deterministic generation is coded as follows.
+
+```haskell
+generateUnique
+    :: (MonadIO m, MonadThrow m)
+    => Text
+    -> GenerationMode             -- ^ The type of address generation to use.
+    -> (Word32 -> m b)
+    -> (b -> m Bool)              -- ^ Whether this account is a duplicate of existing.
+    -> m b
+generateUnique desc RandomMode generator isDuplicate = loop (100 :: Int)
+  where
+    loop 0 = throwM . RequestError $
+             sformat (build%": generation of unique item seems too difficult, \
+                      \you are approaching the limit") desc
+    loop i = do
+        rand <- liftIO randomIO
+        value <- generator rand
+        bad <- orM
+            [ isDuplicate value
+            , pure $ isHardened rand      -- using hardened keys only for now
+            ]
+        if bad then
+            loop (i - 1)
+        else
+            return value
+generateUnique desc (DeterministicMode s1) generator notFit = do
+    value <- generator (fromIntegral s1)
+    whenM (notFit value) $
+        throwM . InternalError $
+        sformat (build%": this index is already taken")
+        desc
+    return value
+```
+
+The `genUniqueAddress` function attempts to prevent collisions by checking a local acid-state
+cache for the same address and retrying in case of failure. The function relies on 
+local storage instead of natural cryptographic constraints.
+
+This is a problem because it assumes that every existing address is stored within the local
+Cardano cache which may not be the case. 
+
+Should the address being generated not be within storage or should storage fail, there is 
+then a non-negligible chance of collision which can occur and go unnoticed by dependent
+applications.
+
+# Non-Random Generation
+
+There is less chance of a collision in random generation when generating two
+distinct accounts on the same root key since the index is picked randomly. 
+In practice however this only matters when storage is not available and 
+if no storage is available then the random generation is prone to collisions
+and cannot be recovered and thus is strictly worse than sequential indices.
+
+In the sequential case one can enumerate all the possible indices and then
+fail when the maximum bound is reached, ensuring that no collision can occur.
+Similarly in the case where storage fails once can simply iterate from 
+firstHardened to find the user addresses.
+
+Both depend on a notion of pre-existing indices however in the sequential
+case there is only the reliance on one index which is the latest index. e.g: 
+A wallet with an account index of 10 would mean that from 0 to 10 there are 
+11 accounts in this wallet. In the random case one would have to store every
+seed which is much less convenient.
+
+The following algorithm solves the unique account problem sequentially.
+
+```haskell
+nextAccountId
+    :: AccountMode ctx m
+    => CId Wal                   -- FIXME Confusing name
+    -> m (Either Text AccountId)
+nextAccountId walletId = do
+  walletMetaMay <- getWalletMetaIncludeUnready True walletId
+  case walletMetaMay of
+      Just walletMeta -> do
+          updateWalletMeta walletMeta (cwAccountIndex walletMeta + 1)
+      Nothing -> do
+          return $ Left "No wallet was found"
+  where
+    updateWalletMeta walletMeta nextAccountIndex
+        | nextAccountIndex > maxBound = do
+            return $ Left "Account index max bound exceeded"
+        | otherwise = do
+            let nextWalletMeta = walletMeta { cwAccountIndex = nextAccountIndex }
+            setWalletMeta walletId nextWalletMeta
+            return $ Right AccountId
+                { aiWId   = walletId
+                , aiIndex = cwAccountIndex walletMeta
+                }
+```
+
+Similar to this the following algorithm solves the unique address problem deterministically 
+without reliance on randomness but instead relying on storage as above. Both of these
+functions have been added to this pull request for demonstration purposes.
+
+```haskell
+nextAddress
+    :: AccountMode ctx m
+    => AccountId
+    -> PassPhrase
+    -> m (Either Text CWAddressMeta)
+nextAddress accountId passphrase = do
+    accountMetaMay <- getAccountMeta accountId
+    case accountMetaMay of
+        Just accountMeta -> do
+            updateAccountMeta accountMeta (caAddressIndex accountMeta + 1)
+        Nothing -> do
+            return $ Left "No account was found"
+  where
+    updateAccountMeta accountMeta nextAddressIndex
+        | nextAddressIndex > maxBound = do
+            return $ Left "Address index max bound exceeded"
+        | otherwise = do
+            let nextAccountMeta = accountMeta { caAddressIndex = nextAddressIndex }
+            setAccountMeta accountId nextAccountMeta
+            addressMeta <- deriveAddress passphrase accountId (caAddressIndex accountMeta)
+            return $ Right addressMeta
+```
+
+In the sequential case one does not actually need to store the paths within Cardano storage
+since there is only dependence on the root key and exchanges can have the freedom to define
+whichever HD paths they desire. 
+
+# Level 3 Derivation Path
+
+Adding an extra path as per BIP32 (m/aH/bH/cH) where bH will be known as the chain index
+has the effect of decreasing the probability of a collision under random generation and
+adds a chain index which significantly adds to the amount of addresses which can be 
+contained within the HD wallet derivations.
+
+In the sequential case this is a trivial addition although there is still the need to
+update the format and test for backwards compatibility.
+
+It also makes it substantially harder to bruteforce the key providing someone finds the 
+root key though this would still not be considered secure (2^62 attempts) under standard
+cryptographic assumptions. Similarly a collision space of 2^62 is still not desireable
+if assuming the same account index.
+
+Adding an extra path increases the max size of addresses from 76 bytes to 81 bytes under 
+the current binary packing scheme.
+
+# Solution 1 - Level 3 Extension
+
+The initial proposed solution was to extend the addresses to be level-3 addresses and thus
+random generation would be less prone to collisions.
+
+### Pros
+* Less chance of a collision occuring under random generation.
+* Larger address space per account.
+* Harder to bruteforce from the root key.
+
+### Cons
+* Requires major breaking changes and backwards compatibility testing.
+* Is still prone to collisions.
+* Book keeping of user address indices is the burden of Cardano.
+* Address size grows to 81 bytes.
+
+# Solution 2 - Sequential Indices
+
+Another solution would be to replace the random generation code with sequential indices.
+Given the current `genUniqueAddress` implementation this is similar to current except
+with the added benefit of exchanges being able to keep track of linear indices for user
+addresses.
+
+### Pros
+* Minor incompatibilities.
+* No more collisions.
+* Interface for exchanges is more convenient / predictable.
+* Book keeping of user address indices can be decentralised.
+* Forces random wallets to obtain entropy (and collision resistance) from the root key.
+
+### Cons
+* More prone to collisions if storage fails than current solution.
+
+# Solution 3 - Deeper Level Extension
+
+UUIDs require 122-bits in order to store enough data such that collisions are negligible.
+It would be possible to have 4 levels of extra indices in order to guarantee that collisions
+(`m/aH/bH/cH/dH/eH`) never happen when generating the HD addresses randomly.
+
+### Pros
+* No more collisions.
+* No more need for storage / book keeping in order to guarantee uniqueness in address generation.
+### Cons
+* Major breaking changes.
+* Address size grows to 91 bytes.
+
+# Proposed Solution
+
+The proposed solution which has been implemented (mostly) as part of this pull request is the
+following:
+1. Removal of random generation of HD addresses altogether since they introduce the possibility
+of collisions.
+2. Addition of nextAccountId / nextAddress for obtaining unique accounts / addresses using
+sequential enumeration.
+3. If a new _random_ address must be generated then re-generate the root key and re-derive 
+according to the first hardened index.
+
+In the long term it may make sense to update the wallets to be level-3 for the convenience
+of having a larger address space and being closer to BIP32. I do not think this is critical
+and it is a major task to ensure backwards compatibility.
+
+The pros and cons are the same as 'sequential indices'.

--- a/docs/CSL-1925.md
+++ b/docs/CSL-1925.md
@@ -13,7 +13,7 @@ problem there is a non negligible chance of a collision occuring after a suffici
 amount of addresses have been generated.
 
 The first child (or branch) of the root key is derived according to the _account index_
-which by default lies within the range (2^31 (`10000000...`) -> 2^30) where the first 
+which by default lies within the range 2^31 (`10000000...`) to 2^31 + 2^30 where the first 
 bit represents the hardened state. As a BIP32 path this can be represented as `m/a'`. 
 
 The second child is derived according to an _address index_ which follows the same 
@@ -178,7 +178,7 @@ whichever HD paths they desire.
 
 # Level 3 Derivation Path
 
-Adding an extra path as per BIP32 (m/aH/bH/cH) where bH will be known as the chain index
+Adding an extra path as per BIP32 (`m/a'/b'/c'`) where `b'` will be known as the chain index
 has the effect of decreasing the probability of a collision under random generation and
 adds a chain index which significantly adds to the amount of addresses which can be 
 contained within the HD wallet derivations.
@@ -231,7 +231,7 @@ addresses.
 
 UUIDs require 122-bits in order to store enough data such that collisions are negligible.
 It would be possible to have 4 levels of extra indices in order to guarantee that collisions
-(`m/aH/bH/cH/dH/eH`) never happen when generating the HD addresses randomly.
+(`m/a'/b'/c'/d'/e'`) never happen when generating the HD addresses randomly.
 
 ### Pros
 * No more collisions.

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -10,6 +10,7 @@ import           Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
 
 import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogic)
+import           Pos.Crypto (firstHardened)
 import           Servant
 import           Test.QuickCheck (arbitrary, generate, resize)
 
@@ -37,6 +38,7 @@ newWallet NewWallet{..} = do
   initMeta <- V0.CWalletMeta <$> pure newwalName
                              <*> migrate newwalAssuranceLevel
                              <*> pure 0
+                             <*> pure firstHardened
   let walletInit = V0.CWalletInit initMeta newwalBackupPhrase
   V0.newWallet spendingPassword walletInit >>= migrate
 

--- a/wallet/src/Pos/Wallet/Aeson/WalletBackup.hs
+++ b/wallet/src/Pos/Wallet/Aeson/WalletBackup.hs
@@ -57,6 +57,7 @@ instance FromJSON V.Version where
 instance FromJSON AccountMetaBackup where
     parseJSON = withObject "AccountMetaBackup" $ \o -> do
         caName <- o .: "name"
+        caAddressIndex <- o .: "address_index"
         return $ AccountMetaBackup $ CAccountMeta {..}
 
 instance FromJSON WalletMetaBackup where
@@ -64,6 +65,7 @@ instance FromJSON WalletMetaBackup where
         cwName <- o .: "name"
         cwAssurance <- strToAssurance =<< o .: "assurance"
         cwUnit <- strToUnit =<< o .: "unit"
+        cwAccountIndex <- o .: "account_index"
         return $ WalletMetaBackup $ CWalletMeta {..}
 
 instance FromJSON IndexedAccountMeta where

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -78,6 +78,7 @@ import           Servant.Multipart (FileData, Mem)
 
 import           Pos.Core.Types (BlockVersion, ChainDifficulty, Coin, ScriptVersion,
                                  SoftwareVersion, unsafeGetCoin)
+import           Pos.Crypto.HD (firstHardened)
 import           Pos.Util.BackupPhrase (BackupPhrase)
 import           Pos.Util.LogSafe (SecureLog (..), buildUnsecure)
 import           Pos.Util.Servant (HasTruncateLogPolicy, WithTruncatedLog (..))
@@ -212,9 +213,12 @@ instance Buildable CWalletAssurance where
 
 -- | Meta data of 'CWallet'
 data CWalletMeta = CWalletMeta
-    { cwName      :: !Text
-    , cwAssurance :: !CWalletAssurance
-    , cwUnit      :: !Int -- ^ https://issues.serokell.io/issue/CSM-163#comment=96-2480
+    { cwName         :: !Text
+    , cwAssurance    :: !CWalletAssurance
+    -- | FIXME Cannot access this comment https://issues.serokell.io/issue/CSM-163#comment=96-2480
+    , cwUnit         :: !Int
+    -- | The last account derivation index (firstHardened + N accounts)
+    , cwAccountIndex :: !Word32
     } deriving (Show, Eq, Generic)
 
 instance Buildable CWalletMeta where
@@ -226,11 +230,13 @@ instance Buildable (SecureLog CWalletMeta) where
     build = buildUnsecure
 
 instance Default CWalletMeta where
-    def = CWalletMeta "Personal Wallet Set" CWANormal 0
+    def = CWalletMeta "Personal Wallet Set" CWANormal 0 firstHardened
 
 -- Includes data which are not provided by Cardano
 data CAccountMeta = CAccountMeta
-    { caName      :: !Text
+    { caName         :: !Text
+    -- | The last address derivation index (firstHardened + N addresses)
+    , caAddressIndex :: !Word32
     } deriving (Eq, Show, Generic)
 
 instance Buildable CAccountMeta where
@@ -241,7 +247,7 @@ instance Buildable (SecureLog CAccountMeta) where
     build (SecureLog CAccountMeta{..}) = "<meta>"
 
 instance Default CAccountMeta where
-    def = CAccountMeta "Personal Wallet"
+    def = CAccountMeta "Personal Wallet" firstHardened
 
 ----------------------------------------------------------------------------
 -- Wallet structure - requests

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -19,7 +19,6 @@ import           Pos.Crypto (PassPhrase, aesDecrypt, deriveAesKeyBS, hash,
                              redeemDeterministicKeyGen)
 import           Pos.Util (maybeThrow)
 import           Pos.Util.BackupPhrase (toSeed)
-import           Pos.Wallet.Web.Account (GenSeed (..))
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountId (..), CAddress (..),
                                              CPaperVendWalletRedeem (..), CTx (..),
                                              CWalletRedeem (..))
@@ -84,7 +83,7 @@ redeemAdaInternal passphrase cAccId seedBs = do
     _ <- fixingCachedAccModifier L.getAccount accId
 
     dstAddr <- decodeCTypeOrFail . cadId =<<
-               L.newAddress RandomSeed passphrase accId
+               L.newAddress passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
                 prepareRedemptionTx redeemSK dstAddr

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -88,7 +88,7 @@ import           Pos.Wallet.Redirect (MonadBlockchainInfo (..), MonadUpdates (..
                                       networkChainDifficultyWebWallet, txpNormalizeWebWallet,
                                       txpProcessTxWebWallet, waitForUpdateWebWallet)
 import           Pos.Wallet.WalletMode (WalletMempoolExt)
-import           Pos.Wallet.Web.Account (AccountMode, GenSeed (RandomSeed))
+import           Pos.Wallet.Web.Account (AccountMode)
 import           Pos.Wallet.Web.ClientTypes (AccountId, cadId)
 import           Pos.Wallet.Web.Methods (MonadWalletLogic, newAddress)
 import           Pos.Wallet.Web.Sockets.Connection (MonadWalletWebSockets)
@@ -328,7 +328,7 @@ getNewAddressWebWallet
     :: MonadWalletLogic ctx m
     => (AccountId, PassPhrase) -> m Address
 getNewAddressWebWallet (accId, passphrase) = do
-    clientAddress <- newAddress RandomSeed passphrase accId
+    clientAddress <- newAddress passphrase accId
     decodeCTypeOrFail (cadId clientAddress)
 
 instance (HasConfigurations, HasCompileInfo)

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -17,7 +17,6 @@ import           Servant.Swagger.UI (swaggerSchemaUIServer)
 
 import           Pos.Update.Configuration (curSoftwareVersion)
 import           Pos.Wallet.WalletMode (blockchainSlotDuration)
-import           Pos.Wallet.Web.Account (GenSeed (RandomSeed))
 import           Pos.Wallet.Web.Api (WalletApi, WalletSwaggerApi, walletApi)
 import qualified Pos.Wallet.Web.Methods as M
 import           Pos.Wallet.Web.Mode (MonadFullWalletWebMode)
@@ -55,12 +54,12 @@ servantHandlers =
     :<|>
      M.updateAccount
     :<|>
-     M.newAccount RandomSeed
+     M.newAccount
     :<|>
      M.deleteAccount
     :<|>
 
-     M.newAddress RandomSeed
+     M.newAddress
     :<|>
 
      M.isValidAddress


### PR DESCRIPTION
Summary:
* As requested by @georgeee there is an improved proposal at docs/CSL-1925.md.
* Includes an implementation which passes the current tests using sequential indices.
* These modifications are intended as an example of what would happen if random is taken out of the equation altogether and the amount of work this introduces. The temporary solution is still intended to be CSL-1955.
 
(Rendered [here](https://github.com/et4te/cardano-sl/blob/6c0ef26722e549d9b48da0e2bf4f28d89219ee63/docs/CSL-1925.md) )