### PR TITLE
[CSL-1939] Check that swagger is spec is valid and up to date

### DIFF
--- a/scripts/ci/check-relevancy-wallet-swagger.sh
+++ b/scripts/ci/check-relevancy-wallet-swagger.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SWAGGER_SPEC_PATH="wallet-new/spec/swagger.json"
+
+stored_spec_hash=($(md5sum $SWAGGER_SPEC_PATH))
+actual_spec_hash=($(stack exec wallet-new-swagger -- --dump | md5sum))
+
+if [[ $stored_spec_hash == $actual_spec_hash ]]; then
+    echo "Swagger doc is up-to-date"
+else
+    echo "Swagger spec $SWAGGER_SPEC_PATH is outdated, current md5 is \
+         \\$stored_spec_hash, actual spec md5 is $actual_spec_hash"
+    exit 1
+fi
+

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -44,6 +44,7 @@ done
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   ./validate-wallet-swagger.sh
+  ./check-relevancy-wallet-swagger.sh
 fi
 
 ./cardano-sl-wallet.root/bin/cardano-wallet-hs2purs

--- a/scripts/ci/travis.sh
+++ b/scripts/ci/travis.sh
@@ -42,6 +42,10 @@ done
   #./update-haddock.sh
 #fi
 
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  ./validate-wallet-swagger.sh
+fi
+
 ./cardano-sl-wallet.root/bin/cardano-wallet-hs2purs
 
 # Generate daedalus-bridge

--- a/scripts/ci/validate-wallet-swagger.sh
+++ b/scripts/ci/validate-wallet-swagger.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+if [[ $TRAVIS_COMMIT == "" ]]; then
+    echo "TRAVIS_COMMIT is unspecified"
+    exit 1
+fi
+
+spec_path="https://raw.githubusercontent.com/input-output-hk/cardano-sl/$TRAVIS_COMMIT/wallet-new/spec/swagger.json"
+validate="curl http://online.swagger.io/validator/debug?url=$spec_path"
+
+echo "Checking swagger spec at $spec_path"
+errors=$(curl $validate 2> /dev/null)
+
+if [[ $errors == '{}' ]]; then
+    echo "Swagger spec is valid"
+else
+    echo "Swagger spec is invalid!: $errors"
+    exit 1
+fi

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -12,6 +12,12 @@ category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
 
+Flag server-only
+  default:     False
+  manual:      True
+
+  description: Build only components required for server
+
 library
   hs-source-dirs:      src
   exposed-modules:     Cardano.Wallet.Orphans
@@ -177,6 +183,77 @@ executable wallet-new-server
                       RecordWildCards
                       ScopedTypeVariables
                       UndecidableInstances
+
+executable wallet-new-swagger
+  hs-source-dirs:      spec
+                       server
+  main-is:             Main.hs
+  other-modules:       SwaggerGenOptions
+                       Cardano.Wallet.API.V1.Swagger
+  build-depends:       base
+                     , aeson
+                     , aeson-pretty
+                     , bytestring
+                     , cardano-sl-wallet-new
+                     , containers
+                     , data-default
+                     , formatting
+                     , insert-ordered-containers
+                     , lens
+                     , optparse-applicative
+                     , neat-interpolation
+                     , servant
+                     , servant-swagger
+                     , string-conv
+                     , swagger2
+                     , text
+                     , QuickCheck
+                     , unordered-containers
+                     , universum
+                     , cardano-sl
+                     , cardano-sl-wallet
+  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts
+                       -Wall
+                       -fno-warn-orphans
+                       -O2
+  default-extensions: TypeOperators
+                      DataKinds
+                      DefaultSignatures
+                      NoImplicitPrelude
+                      MultiParamTypeClasses
+                      OverloadedStrings
+                      ScopedTypeVariables
+                      FlexibleInstances
+                      FlexibleContexts
+                      TypeFamilies
+                      TypeApplications
+                      TypeOperators
+                      TemplateHaskell
+                      RecordWildCards
+                      ScopedTypeVariables
+                      UndecidableInstances
+
+  -- linker speed up for linux
+  if os(linux)
+    ghc-options:       -optl-fuse-ld=gold
+    ld-options:        -fuse-ld=gold
+
+  default-extensions:   FlexibleContexts
+                        FlexibleInstances
+                        NoImplicitPrelude
+                        OverloadedStrings
+                        RecordWildCards
+                        TypeApplications
+                        TypeOperators
+
+  build-tools: cpphs >= 1.19
+  ghc-options: -pgmP cpphs -optP --cpp
+
+  if flag(server-only)
+    buildable: False
+  else
+    buildable: True
 
 test-suite wallet-new-specs
   ghc-options:      -Wall

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -457,3 +457,8 @@ api = toSwagger walletAPI
     , accountExtendedExample = toS $ encodePretty (genExample @(ExtendedResponse [Account]))
     })
   & info.license ?~ ("MIT" & url ?~ URL "http://mit.com")
+
+-- | We store actual swagger spec at this location
+-- (counting from the root of the project).
+specFile :: FilePath
+specFile = "wallet-new/spec/swagger.json"

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -117,7 +117,7 @@ startEdgeNode WalletStartupOptions{..} = do
 -- better-looking YAMLs.
 generateSwaggerDocumentation :: IO ()
 generateSwaggerDocumentation = do
-    BL8.writeFile "wallet-new/spec/swagger.json" (encodePretty Swagger.api)
+    BL8.writeFile Swagger.specFile (encodePretty Swagger.api)
     putText "Swagger API written on disk."
 
 -- | The main entrypoint for the Wallet.

--- a/wallet-new/spec/Main.hs
+++ b/wallet-new/spec/Main.hs
@@ -1,0 +1,41 @@
+-- | Swagger spec generation.
+
+module Main
+    ( main
+    ) where
+
+import           Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString.Lazy.Char8 as BSL8
+import           Data.Version (showVersion)
+import           Options.Applicative (execParser, footer, fullDesc, header, help, helper,
+                                      infoOption, long, progDesc)
+import qualified Options.Applicative as Opt
+import           Universum
+
+import qualified Paths_cardano_sl as CSL
+
+import qualified Cardano.Wallet.API.V1.Swagger as Swagger
+
+import           SwaggerGenOptions (SwaggerGenOptions (..), swaggerGenOptionsParser)
+
+
+getSwaggerGenOptions :: IO SwaggerGenOptions
+getSwaggerGenOptions = execParser programInfo
+  where
+    programInfo = Opt.info (helper <*> versionOption <*> swaggerGenOptionsParser) $
+        fullDesc <> progDesc "Generate Swagger specification for Wallet web API."
+                 <> header   "Cardano SL Wallet web API docs generator."
+                 <> footer   ""
+
+    versionOption = infoOption
+        ("cardano-swagger-" <> showVersion CSL.version)
+        (long "version" <> help "Show version.")
+
+main :: IO ()
+main = do
+    SwaggerGenOptions{..} <- getSwaggerGenOptions
+    let spec = encodePretty Swagger.api
+    if sgoDumpToConsole
+        then BSL8.putStr spec
+        else do BSL8.writeFile sgoFile spec
+                putText $ "Done. See " <> toText sgoFile <> "."

--- a/wallet-new/spec/SwaggerGenOptions.hs
+++ b/wallet-new/spec/SwaggerGenOptions.hs
@@ -1,0 +1,35 @@
+-- | Command line options of swagger generator.
+
+module SwaggerGenOptions
+    ( SwaggerGenOptions (..)
+    , swaggerGenOptionsParser
+    ) where
+
+import qualified Options.Applicative as Opt
+import           Universum
+
+import qualified Cardano.Wallet.API.V1.Swagger as Swagger
+
+data SwaggerGenOptions = SwaggerGenOptions
+    { sgoFile          :: FilePath
+    , sgoDumpToConsole :: Bool
+    }
+
+swaggerGenOptionsParser :: Opt.Parser SwaggerGenOptions
+swaggerGenOptionsParser =
+    SwaggerGenOptions
+        <$> sgoFileParser
+        <*> sgoDumpToConsoleParser
+  where
+    sgoFileParser = Opt.strOption $
+        Opt.long "output" <>
+        Opt.short 'o' <>
+        Opt.metavar "FILEPATH" <>
+        Opt.help "Path to file where write swagger spec to" <>
+        Opt.value Swagger.specFile
+
+    sgoDumpToConsoleParser = Opt.switch $
+        Opt.long "dump" <>
+        Opt.help "Prints doc to console instead of writing to file"
+
+


### PR DESCRIPTION
Make CI check `wallet-new/spec/swagger.json`.
* It will ensure that swagger is valid via `http://online.swagger.io/validator` online API.
(If you disagree with using online API, please let's discuss this point over further, actually I feel a bit unstable about using such things)
* Also it will regenerate its own copy of doc, and compare that `wallet-new/spec/swagger.json` matches to it.

To accomplish this task, executable to generate swagger doc was added.
To avoid need in building tons of executables (okay, currently only extra one, but still), option to build with `--flag cardano-sl-wallet-new:exclude-aux` was added