### PR TITLE
[CSL-1968] Implement GET /api/v1/user-profile

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -33,6 +33,7 @@ library
                        Cardano.Wallet.API.V1.Wallets
                        Cardano.Wallet.API.V1.Errors
                        Cardano.Wallet.API.V1.Updates
+                       Cardano.Wallet.API.V1.Users
                        Cardano.Wallet.API.V1.Migration
                        Cardano.Wallet.API.V0
                        Cardano.Wallet.API.V0.Types
@@ -109,6 +110,7 @@ executable wallet-new-server
                        Cardano.Wallet.API.V1.Handlers.Info
                        Cardano.Wallet.API.V1.Handlers.Wallets
                        Cardano.Wallet.API.V1.Handlers.Updates
+                       Cardano.Wallet.API.V1.Handlers.Users
                        Cardano.Wallet.API.V1.Swagger
                        Cardano.Wallet.Server
                        Cardano.Wallet.Server.CLI
@@ -197,6 +199,7 @@ test-suite wallet-new-specs
                     Cardano.Wallet.API.V1.Handlers.Info
                     Cardano.Wallet.API.V1.Handlers.Wallets
                     Cardano.Wallet.API.V1.Handlers.Updates
+                    Cardano.Wallet.API.V1.Handlers.Users
                     Cardano.Wallet.API.V1.Swagger
   build-depends:    base
                   , QuickCheck

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers.hs
@@ -15,9 +15,11 @@ import qualified Cardano.Wallet.API.V1.Handlers.Info as Info
 import qualified Cardano.Wallet.API.V1.Handlers.Settings as Settings
 import qualified Cardano.Wallet.API.V1.Handlers.Transactions as Transactions
 import qualified Cardano.Wallet.API.V1.Handlers.Updates as Updates
+import qualified Cardano.Wallet.API.V1.Handlers.Users as Users
 import qualified Cardano.Wallet.API.V1.Handlers.Wallets as Wallets
 import qualified Cardano.Wallet.API.V1.Info as Info
 import qualified Cardano.Wallet.API.V1.Settings as Settings
+import qualified Cardano.Wallet.API.V1.Users as Users
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
 
 import           Cardano.Wallet.API.V1.Migration
@@ -37,3 +39,4 @@ handlers naturalTransformation = Addresses.handlers
                             :<|> Updates.handlers
                             :<|> hoistServer (Proxy @Settings.API) naturalTransformation Settings.handlers
                             :<|> hoistServer (Proxy @Info.API) naturalTransformation Info.handlers
+                            :<|> hoistServer (Proxy @Users.API) naturalTransformation Users.handlers

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Users.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Users.hs
@@ -1,0 +1,27 @@
+module Cardano.Wallet.API.V1.Handlers.Users where
+
+import           Universum
+
+import qualified Pos.Wallet.Web.Methods.Misc as V0
+
+import           Cardano.Wallet.API.V1.Migration
+import           Cardano.Wallet.API.V1.Types as V1
+import qualified Cardano.Wallet.API.V1.Users as Users
+
+import           Pos.Wallet.Web.State (MonadWalletDBRead)
+import           Servant
+
+-- | All the @Servant@ handlers for users-specific operations.
+handlers :: ( HasConfigurations
+            , HasCompileInfo
+            )
+         => ServerT Users.API MonadV1
+handlers =  getUserProfile
+       :<|> updateUserProfile
+
+getUserProfile :: (MonadThrow m, MonadWalletDBRead ctx m) => m V1.UserProfile
+getUserProfile = V0.getUserProfile >>= migrate
+
+-- TODO(adinapoli) Will be done as part of https://iohk.myjetbrains.com/youtrack/issue/CSL-1969
+updateUserProfile :: V1.UserProfile -> MonadV1 V1.UserProfile
+updateUserProfile x = return x

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -286,6 +286,9 @@ instance ToDocs TransactionGroupingPolicy where
                   <> "determine how a `Transaction` is assembled. "
                   <> "Possible values: [" <> possibleValuesOf @TransactionGroupingPolicy Proxy <> "]."
 
+instance ToDocs UserProfile where
+  descriptionFor _ = "User settings relative to this wallet, for example the language locale."
+
 possibleValuesOf :: (Show a, Enum a, Bounded a) => Proxy a -> T.Text
 possibleValuesOf (Proxy :: Proxy a) = T.intercalate "," . map show $ ([minBound..maxBound] :: [a])
 
@@ -334,6 +337,9 @@ instance ToSchema NodeSettings where
   declareNamedSchema = annotate fromArbitraryJSON
 
 instance ToSchema NodeInfo where
+  declareNamedSchema = annotate fromArbitraryJSON
+
+instance ToSchema UserProfile where
   declareNamedSchema = annotate fromArbitraryJSON
 
 instance ToDocs a => ToDocs (ExtendedResponse a) where

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -794,6 +794,21 @@
                 }
             }
         },
+        "UserProfile": {
+            "example": {
+                "locale": "ko-KR"
+            },
+            "required": [
+                "locale"
+            ],
+            "type": "object",
+            "description": "User settings relative to this wallet, for example the language locale.",
+            "properties": {
+                "locale": {
+                    "type": "string"
+                }
+            }
+        },
         "Version": {
             "required": [
                 "versionBranch",
@@ -1525,6 +1540,60 @@
                 ],
                 "tags": [
                     "V0"
+                ]
+            }
+        },
+        "/api/v1/user-profile": {
+            "get": {
+                "summary": "Returns the user profile for this wallet.",
+                "responses": {
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/UserProfile"
+                        },
+                        "description": ""
+                    }
+                },
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "tags": [
+                    "User Profile",
+                    "V1"
+                ]
+            },
+            "put": {
+                "summary": "Update user-related information.",
+                "consumes": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid `body`"
+                    },
+                    "200": {
+                        "schema": {
+                            "$ref": "#/definitions/UserProfile"
+                        },
+                        "description": ""
+                    }
+                },
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "parameters": [
+                    {
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UserProfile"
+                        },
+                        "in": "body",
+                        "name": "body"
+                    }
+                ],
+                "tags": [
+                    "User Profile",
+                    "V1"
                 ]
             }
         },

--- a/wallet-new/src/Cardano/Wallet/API/V1.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1.hs
@@ -9,6 +9,7 @@ import qualified Cardano.Wallet.API.V1.Info as Info
 import qualified Cardano.Wallet.API.V1.Settings as Settings
 import qualified Cardano.Wallet.API.V1.Transactions as Transactions
 import qualified Cardano.Wallet.API.V1.Updates as Updates
+import qualified Cardano.Wallet.API.V1.Users as Users
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
 
 type API =  Tags '["Addresses"]    :> Addresses.API
@@ -17,3 +18,4 @@ type API =  Tags '["Addresses"]    :> Addresses.API
        :<|> Tags '["Updates"]      :> Updates.API
        :<|> Tags '["Settings"]     :> Settings.API
        :<|> Tags '["Info"]         :> Info.API
+       :<|> Tags '["User Profile"] :> Users.API

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration.hs
@@ -108,3 +108,9 @@ instance Migrate V0.SyncProgress V1.SyncProgress where
                 Just nd | _spLocalCD >= nd -> 100
                 Just nd -> round @Double $ (fromIntegral _spLocalCD / fromIntegral nd) * 100.0
         in pure $ V1.mkSyncProgress (fromIntegral percentage)
+
+--
+instance Migrate V0.CProfile V1.UserProfile where
+    eitherMigrate V0.CProfile{..} =
+        let locale = if cpLocale == mempty then "en-US" else cpLocale
+        in pure $ V1.UserProfile (V1.I18n locale)

--- a/wallet-new/src/Cardano/Wallet/API/V1/Users.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Users.hs
@@ -1,0 +1,12 @@
+module Cardano.Wallet.API.V1.Users where
+
+import           Cardano.Wallet.API.V1.Types
+
+import           Servant
+
+type API =
+         "user-profile" :> Summary "Returns the user profile for this wallet."
+                        :> Get '[JSON] UserProfile
+    :<|> "user-profile" :> Summary "Update user-related information."
+                        :> ReqBody '[JSON] (Update UserProfile)
+                        :> Put '[JSON] UserProfile

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -34,6 +34,8 @@ spec = describe "Marshalling & Unmarshalling" $ do
     prop "Aeson SyncProgress roundtrips" (aesonRoundtrip @SyncProgress Proxy)
     prop "Aeson NodeInfo roundtrips" (aesonRoundtrip @NodeInfo Proxy)
     prop "Aeson NodeSettings roundtrips" (aesonRoundtrip @NodeSettings Proxy)
+    prop "Aeson I18nLocale roundtrips" (aesonRoundtrip @I18nLocale Proxy)
+    prop "Aeson UserProfile roundtrips" (aesonRoundtrip @UserProfile Proxy)
 
 aesonRoundtrip :: (Arbitrary a, ToJSON a, FromJSON a, Eq a, Show a) => proxy a -> Property
 aesonRoundtrip (_ :: proxy a) = forAll arbitrary $ \(s :: a) -> do


### PR DESCRIPTION
This PR implements what was called `/api/v1/profile` in the old API.

@DominikGuzei you will see I have made a precise choice: the default in case no locale is set is `en-US`, as taken from:

https://github.com/input-output-hk/daedalus/blob/master/translations/translation-runner.js#L7

I hope that's correct! This is how it looks like in Swagger:

![screen shot 2017-11-28 at 17 43 46](https://user-images.githubusercontent.com/29383371/33332275-2852381c-d464-11e7-9f48-2543e658c750.png)
