### PR TITLE
[CSL-1931] Use forward links in getHeadersRange

### DIFF
--- a/explorer/src/Pos/Explorer/Socket/Methods.hs
+++ b/explorer/src/Pos/Explorer/Socket/Methods.hs
@@ -32,6 +32,7 @@ module Pos.Explorer.Socket.Methods
 import           Control.Lens                   (at, ix, lens, non, (.=), _Just)
 import           Control.Monad.State            (MonadState)
 import           Data.Aeson                     (ToJSON)
+import qualified Data.List.NonEmpty             as NE
 import qualified Data.Set                       as S
 import           Formatting                     (sformat, shown, stext, (%))
 import           Network.EngineIO               (SocketId)
@@ -68,6 +69,7 @@ import           Pos.Explorer.Web.ClientTypes   (CAddress, CTxBrief, CTxEntry (.
 import           Pos.Explorer.Web.Error         (ExplorerError (..))
 import           Pos.Explorer.Web.Server        (ExplorerMode, getBlocksLastPage,
                                                  topsortTxsOrFail)
+
 
 -- * Event names
 
@@ -297,10 +299,11 @@ notifyTxsSubscribers cTxEntries =
 getBlundsFromTo
     :: forall ctx m . ExplorerMode ctx m
     => HeaderHash -> HeaderHash -> m (Maybe [Blund SscGodTossing])
-getBlundsFromTo recentBlock oldBlock = do
-    mheaders <- DB.getHeadersFromToIncl @SscGodTossing oldBlock recentBlock
-    forM (getOldestFirst <$> mheaders) $ \(_ :| headers) ->
-        fmap catMaybes $ forM headers (DB.blkGetBlund @SscGodTossing)
+getBlundsFromTo recentBlock oldBlock =
+    DB.getHeadersRange @SscGodTossing Nothing oldBlock recentBlock >>= \case
+        Left _ -> pure Nothing
+        Right (getOldestFirst -> headers) ->
+            Just . catMaybes <$> forM (NE.tail headers) (DB.blkGetBlund @SscGodTossing)
 
 addrsTouchedByTx
     :: (MonadDBRead m, WithLogger m)

--- a/node/src/Pos/Block/Network/Listeners.hs
+++ b/node/src/Pos/Block/Network/Listeners.hs
@@ -67,7 +67,7 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
             mgb nodeId
         -- We fail if we're requested to give more than
         -- recoveryHeadersMessage headers at once.
-        getHeadersRange @ssc (Just $ recoveryHeadersMessage - 1) mgbFrom mgbTo >>= \case
+        getHeadersRange @ssc (Just $ recoveryHeadersMessage) mgbFrom mgbTo >>= \case
             Right hashes -> do
                 logDebug $ sformat
                     ("handleGetBlocks: started sending "%int%

--- a/node/src/Pos/Client/Txp/History.hs
+++ b/node/src/Pos/Client/Txp/History.hs
@@ -38,7 +38,7 @@ import           Control.Monad.Trans          (MonadTrans)
 import           Control.Monad.Trans.Control  (MonadBaseControl)
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Data.Coerce                  (coerce)
-import qualified Data.Map.Strict              as M (lookup, insert, fromList)
+import qualified Data.Map.Strict              as M (fromList, insert, lookup)
 import qualified Data.Text.Buildable
 import qualified Ether
 import           Formatting                   (bprint, build, (%))
@@ -48,14 +48,13 @@ import           System.Wlog                  (WithLogger)
 
 import           Pos.Block.Core               (Block, MainBlock, mainBlockSlot,
                                                mainBlockTxPayload)
-import           Pos.Block.Types              (Blund)
 import           Pos.Context                  (genesisBlock0)
 import           Pos.Core                     (Address, ChainDifficulty, HasConfiguration,
                                                HeaderHash, Timestamp (..), difficultyL,
                                                headerHash)
 import           Pos.Crypto                   (WithHash (..), withHash)
 import           Pos.DB                       (MonadDBRead, MonadGState, MonadRealDB)
-import           Pos.DB.Block                 (MonadBlockDB)
+import           Pos.DB.Block                 (MonadBlockDB, blkGetBlock)
 import qualified Pos.GState                   as GS
 import           Pos.Reporting                (MonadReporting)
 import           Pos.Slotting                 (MonadSlots, getSlotStartPure,
@@ -257,14 +256,11 @@ getBlockHistoryDefault addrs = do
     sd          <- GS.getSlottingData
     systemStart <- getSystemStartM
 
-    let fromBlund :: Blund ssc -> GenesisHistoryFetcher m (Block ssc)
-        fromBlund = pure . fst
-
-        getBlockTimestamp :: MainBlock ssc -> Maybe Timestamp
+    let getBlockTimestamp :: MainBlock ssc -> Maybe Timestamp
         getBlockTimestamp blk = getSlotStartPure systemStart (blk ^. mainBlockSlot) sd
 
         blockFetcher :: HeaderHash -> GenesisHistoryFetcher m (Map TxId TxHistoryEntry)
-        blockFetcher start = GS.foldlUpWhileM fromBlund start (const $ const True)
+        blockFetcher start = GS.foldlUpWhileM (lift . blkGetBlock) start (const $ const True)
             (deriveAddrHistoryBlk addrs getBlockTimestamp) mempty
 
     runGenesisToil . evalToilTEmpty $ blockFetcher bot

--- a/node/src/Pos/GState/BlockExtra.hs
+++ b/node/src/Pos/GState/BlockExtra.hs
@@ -11,6 +11,7 @@ module Pos.GState.BlockExtra
        , getFirstGenesisBlockHash
        , BlockExtraOp (..)
        , foldlUpWhileM
+       , loadHashesUpWhile
        , loadHeadersUpWhile
        , loadBlocksUpWhile
        , initGStateBlockExtra
@@ -26,14 +27,13 @@ import           Serokell.Util.Text   (listJson)
 import           Pos.Binary.Class     (serialize')
 import           Pos.Block.Core       (Block, BlockHeader, blockHeader)
 import           Pos.Block.Slog.Types (LastBlkSlots, noLastBlkSlots)
-import           Pos.Block.Types      (Blund)
 import           Pos.Core             (FlatSlotId, HasConfiguration, HasHeaderHash,
-                                       HeaderHash, headerHash, slotIdF, unflattenSlotId,
-                                       genesisHash)
+                                       HeaderHash, genesisHash, headerHash, slotIdF,
+                                       unflattenSlotId)
 import           Pos.Crypto           (shortHashF)
 import           Pos.DB               (DBError (..), MonadDB, MonadDBRead,
                                        RocksBatchOp (..), dbSerializeValue)
-import           Pos.DB.Block         (MonadBlockDB, blkGetBlund)
+import           Pos.DB.Block         (MonadBlockDB, blkGetBlock)
 import           Pos.DB.GState.Common (gsGetBi, gsPutBi)
 import           Pos.Util.Chrono      (OldestFirst (..))
 import           Pos.Util.Util        (maybeThrow)
@@ -113,45 +113,52 @@ instance HasConfiguration => RocksBatchOp BlockExtraOp where
 ----------------------------------------------------------------------------
 
 foldlUpWhileM
-    :: forall a b ssc m r .
-    ( MonadBlockDB ssc m
+    :: forall a b m r .
+    ( MonadDBRead m
     , HasHeaderHash a
     )
-    => (Blund ssc -> m b)
-    -> a
-    -> ((Blund ssc, b) -> Int -> Bool)
-    -> (r -> b -> m r)
-    -> r
+    => (HeaderHash -> m (Maybe b)) -- ^ For each header we get b(lund)
+    -> a                           -- ^ We start iterating from it
+    -> (b -> Int -> Bool)          -- ^ Condition on b and depth
+    -> (r -> b -> m r)             -- ^ Conversion function
+    -> r                           -- ^ Starting value
     -> m r
-foldlUpWhileM morphM start condition accM init =
+foldlUpWhileM getData start condition accM init =
     loadUpWhileDo (headerHash start) 0 init
   where
     loadUpWhileDo :: HeaderHash -> Int -> r -> m r
-    loadUpWhileDo curH height !res = blkGetBlund curH >>= \case
+    loadUpWhileDo curH height !res = getData curH >>= \case
         Nothing -> pure res
-        Just x -> do
-            curB <- morphM x
+        Just someData -> do
             mbNextLink <- resolveForwardLink curH
-            if | not (condition (x, curB) height) -> pure res
+            if | not (condition someData height) -> pure res
                | Just nextLink <- mbNextLink -> do
-                     newRes <- accM res curB
+                     newRes <- accM res someData
                      loadUpWhileDo nextLink (succ height) newRes
-               | otherwise -> accM res curB
+               | otherwise -> accM res someData
 
--- Loads something from old to new.
+-- Loads something from old to new. foldlUpWhileM for (OldestFirst []).
 loadUpWhile
-    :: forall a b ssc m . (MonadBlockDB ssc m, HasHeaderHash a)
-    => (Blund ssc -> b)
+    :: forall a b m . (MonadDBRead m, HasHeaderHash a)
+    => (HeaderHash -> m (Maybe b))
     -> a
     -> (b -> Int -> Bool)
     -> m (OldestFirst [] b)
 loadUpWhile morph start condition = OldestFirst . reverse <$>
     foldlUpWhileM
-        (pure . morph)
+        morph
         start
-        (\b h -> condition (snd b) h)
+        condition
         (\l e -> pure (e : l))
         []
+
+-- | Return hashes loaded up. Basically a forward links traversal.
+loadHashesUpWhile
+    :: forall m a. (HasHeaderHash a, MonadDBRead m)
+    => a
+    -> (HeaderHash -> Int -> Bool)
+    -> m (OldestFirst [] HeaderHash)
+loadHashesUpWhile = loadUpWhile (pure . Just)
 
 -- | Returns headers loaded up.
 loadHeadersUpWhile
@@ -159,8 +166,7 @@ loadHeadersUpWhile
     => a
     -> (BlockHeader ssc -> Int -> Bool)
     -> m (OldestFirst [] (BlockHeader ssc))
-loadHeadersUpWhile start condition =
-    loadUpWhile (view blockHeader . fst) start condition
+loadHeadersUpWhile = loadUpWhile $ fmap (fmap $ view blockHeader) . blkGetBlock
 
 -- | Returns blocks loaded up.
 loadBlocksUpWhile
@@ -168,7 +174,7 @@ loadBlocksUpWhile
     => a
     -> (Block ssc -> Int -> Bool)
     -> m (OldestFirst [] (Block ssc))
-loadBlocksUpWhile start condition = loadUpWhile fst start condition
+loadBlocksUpWhile = loadUpWhile $ blkGetBlock
 
 ----------------------------------------------------------------------------
 -- Initialization


### PR DESCRIPTION
This should speed up `MsgBlock` listener on the server side.

I've also fixed a recovery worker that wasn't triggered when we were not in recovery, though too late (it was a bug, apparently).