### PR TITLE
[CSL-1927] Update V1 new revision

### DIFF
--- a/wallet-new/docs/updates.md
+++ b/wallet-new/docs/updates.md
@@ -236,12 +236,14 @@ data WalletSoftwareUpdate = WalletSoftwareUpdate
     , wsuNegativeStake   :: !CCoin
     , wsuSeverity        :: !UpdateSeverity
     -- ^ The severity of the update (i.e. optional or mandatory).
-    , wsuUpdateState     :: !UpdateState
+    , wsuState     :: !UpdateState
     -- ^ The state of this update from users point of view.
-    , wsuSha256Checksum  :: !Sha256Checksum
-    -- ^ The checksum expected for this installer. It will probably
-    -- need to be passed as part of the `UpdateProposal` (maybe in an attribute?),
-    -- or we could reuse the hash which is part of the name, if possible.
+    , wsuDownloadProgress  :: !Word8
+    -- ^ A progress in percentage (from 0 to 100).
+    -- N.B. In the real implementation this can be refined to a better type.
+    , wsuId  :: !Hash
+    -- ^ The update id, which is also the checksum expected for this installer,
+    -- and correspond to the @Blake2b256@ hash of the installer.
     } deriving (Eq, Show, Generic, Typeable)
 ```
 
@@ -252,37 +254,40 @@ data UpdateSeverity = Mandatory
                     | Optional
 ```
 
-For hard forks updates (or security-critical issues) we might want to set the severity
-to `Mandatory`, for soft forks and other non-critical updates we can label an update as `Optional`.
+For security-critical issues we might want to set the severity
+to `Mandatory`, for other non-critical updates we can label an update as `Optional`, which is
+the default anyway.
 
 -   `Optional` updates can be rejected by the user, as well as applied to will at a later stage;
 -   `Mandatory` updates will need to be applied immediately and won't allow the user to proceed
     in using Daedalus.
 
-On the other hand, `wsuUpdateState` records the users' decision towards the update:
+On the other hand, `wsuState` records the users' decision towards the update:
 
 ```haskell
 data UpdateState = Applied
                  -- ^ The update has been fully applied.
-                 | Downloaded !Sha256Checksum !FilePath
+                 | Downloading
+                 -- ^ The update is downloading.
+                 | Downloaded !Hash !FilePath
                  -- ^ The update has been downloaded but not applied yet. A Checksum
                  -- can be stored to verify the integrity of the download.
                  | Skipped
                  -- ^ The update has been skipped by the user.
-                 | Proposed
-                 -- ^ The update has been just proposed and is waiting for users' feedback.
+                 | Available
+                 -- ^ The update is available to the user.
 ```
 
 Note how we could add an intermediate `Downloading` state, but this would complicate state-handling
 in case a user hard-quits Daedalus whilst the upgrade is being downloaded. In this case, we would
-need to catch the exception and update the state back to `Proposed`, but that case be more error
-prone than not updating the state in the first place. Having the state back to `Proposed` is
+need to catch the exception and update the state back to `Available`, but that case be more error
+prone than not updating the state in the first place. Having the state back to `Available` is
 important so that the wallet is left in a clean state and upon re-launched Daedalus the update can
 be downloaded again with no harm being done.
 
 ## Determining the severity<a id="sec-5-2" name="sec-5-2"></a>
 
-For the proposed schema to succeed, we would need a function like the following:
+For the proposed schema to succeed, we would need (eventually) a function like the following:
 
 ```haskell
 updateSeverity :: UpdateProposal -> UpdateSeverity
@@ -300,47 +305,46 @@ user stories for the update system.
 
 -   (1) As a Daedalus user, I want the wallet to prompt me if there is a new update available.
 
-At startup Daedalus would make a call to `GET /api/v1/update` to fetch the last available update. If
-no update is available (for example if this is the first time we are configuring this Daedalus instance),
-404 will be returned.
+At startup Daedalus would make a call to `GET /api/v1/updates` to fetch the updates known to this
+node, which are no more than two (the current one and the next available). If no update is
+available (for example if this is the first time we are configuring this Daedalus instance),
+an empty JSON array will be returned.
 
-In case of a 404 answer or a `WalletSoftwareUpdate` which has the `wsuUpdateState` field set to
+In case of an empty answer or a `WalletSoftwareUpdate` which has the `wsuState` field set to
 `Applied`, Daedalus would consider itself updated. In case the fetched `WalletSoftwareUpdate`
 had `Mandatory` severity (but is not yet applied), Daedalus would freeze the UI and prevent the
 user from doing anything but update. At this stage, closing Daedalus won't have any effect,
 as upon the next startup the RESTful call would be performed again.
 
 **N.B** A very fair point could be made that we are giving clients too many responsibility and we are offloading
-too much logic to them. If that's the case, we can easily create a new endpoint such as `GET /api/v1/update/severity`
+too much logic to them. If that's the case, we can easily create a new endpoint such as `GET /api/v1/updates/severity`
 which would reply with a JSON `{ "updateSeverity": "mandatory" }` in case an update is available, is not fully
 applied and is marked as `Mandatory` (names and payloads might vary to make them more fitting).
 
 -   (1.1) As a Daedalus user, I want to be able to download an update.
 
-After having grabbed a `WalletSoftwareUpdate` via a successful `GET /api/v1/update` Daedalus is now in the position to
+After having grabbed a `WalletSoftwareUpdate` via a successful `GET /api/v1/updates` Daedalus is now in the position to
 react to user's input. In this story, the user would choose to continue with the update process. To do so, the update
-would need to be downloaded. More specifically, the user would call `POST /api/v1/update/download` which
-would begin the download process. No state change would be necessary in the backend yet. Story `1.2.` assumes
-that this endpoint has been called and it details its behaviour.
+would need to be downloaded. More specifically, the user would call `POST /api/v1/updates/{updateId}` passing the state
+he want the update to transition to, in this case `Downloading`, which would begin the download process.
 
 -   (1.2) As a Daedalus user, I want to be able to see the download progress for an update.
 
-To accomplish this, one possible idea would be to use [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding)
-to send Daedalus information about the progress of the update. For this to work, we would need to store
-the total size of the binary we need to download somewhere, so that Daedalus could compute a progress
-percentage by doing simple math. (**Note**: it has to be investigated how much painful it is on the Servant side).
+To accomplish this, the user would call `GET /api/v1/updates/{updateId}` periodically and grab the value of
+`wsuDownloadProgress`. For this to work, we would need to store the total size of the binary we need to download somewhere,
+as well of how much we download up until now, in order to compute a progress percentage by doing simple math.
 
 Once the process is complete, the backend would update the `UpdateState` of a `WalletSoftwareUpdate`
 to remember the fact this update was already downloaded, also recording the `FilePath` where this binary lives and
-the `Sha256Checksum` to be used later on in case an update is downloaded but not applied. This will allow the update
+the `Hash` to be used later on in case an update is downloaded but not applied. This will allow the update
 process to skip a new download, whilst ensuring integrity of the data.
 
 -   (2) As a Daedalus user, I want to be able to dismiss an update, unless this is a critical one;
 
 In this scenario, Daedalus would prompt the user that a new update is available (and is non critical) but
 the user would dismiss the update, for example closing a modal in Daedalus. As a consequence, Daedalus
-would call `PUT /api/v1/update/skip` to skip the update. The backend would register this information by
-updating the `UpdateState` to `Skipped`. This endpoint is idempotent, and can be called more than once.
+would call `POST /api/v1/updates/{updateId}` to skip the update by passing `{"state": "skipped"}` in
+the JSON body. The backend would register this information by updating the `UpdateState` to `Skipped`.
 
 -   (2.1) As a Daedalus user, I want to be sure that once an update is dismissed, it won't be silently applied
     next time I restart the program;
@@ -351,17 +355,16 @@ moved from the download directory into the folder the Cardano Launcher monitors 
 -   (3) As a Daedalus user, I want to be able to check for new updates by clicking a button in Daedalus.
 
 Under this scenario, the user must be able to fetch updates which have been dismissed (or downloaded) but not
-applied yet. This is now easy to accomplish as querying `GET /api/v1/update` would return either an applied update,
-(in which case "No Updates Available" should be shown), a 404 (which entails the former) or an update which
-has been downloaded already, or skipped. Either way, the user will be in the position to move
-forward in the update process.
+applied yet. This is easy to accomplish by querying `GET /api/v1/updates` and filtering by `state`. For example
+`GET /api/v1/updates?state=skipped` would returned all the skipped updates.
 
 -   (4) As a Daedalus user, I want to be able to install an update immediately.
 
 Once an update has been downloaded, users can choose whether or not install it. In case Daedalus is abruptly closed (but
 the download completed) it will always be possible to recover the installation as per User Story 3.
-Applying an upgrade entails calling `POST /api/v1/update` which conceptually "creates an update" and performs
-a side effect (thus the use of post and the lack of extra names/resources in the URL).
+Applying an upgrade entails calling `POST /api/v1/updates/{updatesId}` with `{"state": "applied"}` as JSON
+body, which conceptually "creates an update" and performs a side effect (thus the use of post and the
+lack of extra names/resources in the URL).
 
 The wallet backend would react to this request by simply moving the downloaded binary into the directory where
 the Cardano Launcher expects it, and finally updating the state of the `WalletSoftwareUpdate` to be marked as
@@ -373,6 +376,26 @@ can resume via User Story 3.
 
 This trivially follows from (4), with the difference that after downloading & moving the binary, we won't
 restart Daedalus.
+
+-   (5) As a Daedalus user, I want to be able to issue an update proposal.
+
+To do so, we would call `POST /api/v1/update-proposals`, passing a `UpdateProposal` as input in the JSON
+body. We have chosen to split update proposals from the `updates` API, because conceptually they represents
+two different resources. One is an already confirmed update proposal (`WalletSoftwareUpdate`) which can be
+installed safely, whereas the latter is something which needs to undergo a democratic voting process.
+After a successful request, the system returns a `ProposedUpdate`, which is a type which bundles an `UpId`
+and an `UpdateProposal` together.
+
+-   (6) As a Daedalus user, I want to be able to vote an update proposal.
+
+In order to vote for an update proposal, users have two choices:
+
+- If they just proposed a new update, they can grab its `UpId` and use it to vote;
+- Users can vote an arbitrary non-expired `UpdateProposal` in the voting center. In this case Daedalus
+  would ask for the full list of `UpdateProposal`(s) by querying `GET /api/v1/update-proposals`.
+
+Either way, the users are expected to pass as input the *stake key*, because the stake they have delegated
+must be taken into account for voting.
 
 ## Installers retention<a id="sec-5-4" name="sec-5-4"></a>
 
@@ -464,7 +487,7 @@ The way updates will transition from the *next* to the *current* can be the foll
 - When a new update arrives, store it as the _next_ update. If there is already an
   update designed as next, replace it.
 
-- When `GET /api/v1/update` is called:
+- When `GET /api/v1/updates` is called:
    - If the _current_ update is `Nothing` (no update was ever seen by this node), and a _next_ update
      is available, the replace _current_ with _next_.
 
@@ -473,7 +496,7 @@ The way updates will transition from the *next* to the *current* can be the foll
      cause state inconsistencies by the virtue of the fact the input
      `WalletSoftwareUpdate` won't match anymore.
 
-   - If the _current_ update is in the `Proposed` state, and a _next_ update is available,
+   - If the _current_ update is in the `Available` state, and a _next_ update is available,
      then replace _current_ with _next_. *In-transit* `POST/PUT` http-requests won't
      cause state inconsistencies by the virtue of the fact the input
      `WalletSoftwareUpdate` won't match anymore.
@@ -482,7 +505,7 @@ The way updates will transition from the *next* to the *current* can be the foll
      chances are we want to return the current (downloaded but not applied update) update so
      that Daedalus can warn the user it has a downloaded (but not applied) update.
 
-- When `POST /api/v1/update` is called:
+- When `POST /api/v1/updates` is called:
     - If the input `WalletSoftwareUpdate` doesn't match the _current_ update, ignore the request
       and return a [422](https://httpstatuses.com/422) error code together with a proper
       domain-specific error.
@@ -497,179 +520,316 @@ The way updates will transition from the *next* to the *current* can be the foll
 A mockup for the new update API might look like this (some HTTP errors and uninteresting
 types omitted for brevity):
 
-    swagger: '2.0'
-    info:
-      version: 1.0.2
-      title: V0 Update API
-      description: This is a subset of the API for Cardano SL wallet.
-    host: 'localhost:8090'
-    # Note how we still keep the singular name for the resource, as
-    # described here: http://www.restapitutorial.com/media/RESTful_Best_Practices-v1_1.pdf
-    # in the section "Pluralization (singleton resources)".
-    paths:
-      /api/v1/update:
-        get:
-          description: >
-            Returns the latest available update.
-            It's Daedalus' responsibility to check whether the returned update is
-            mandatory (at startup) and stop the user by using the Wallet. Note: this
-            might not be enough in case of clients different from Daedalus, as this is
-            an invariant which is not imposed anywhere if not on paper.
-          produces:
-            - application/json;charset=utf-8
-          responses:
-            '200':
-              schema:
-                $ref: '#/definitions/WalletSoftwareUpdate'
-              description: 'The latest available update, which can be available, downloaded, skipped or applied already.'
-            '404':
-              description: 'There are no updates available (this node never saw one)'
-        post:
-          description: >
-            Applies this update. It takes as input in the body
-            a JSON representing the `WalletSoftwareUpdate` to perform.
-            In case the update has been already performed, the request
-            is simply ignored.
-          parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/WalletSoftwareUpdate'
-          consumes:
-            - application/json;charset=utf-8
-          produces:
-            - application/json;charset=utf-8
-          responses:
-            '204':
-              description: 'The update has been applied.'
-            '422':
-              description: 'Invalid update provided.'
-      /api/v1/update/download:
-        post:
-          description: >
-           Download the requested update. If the input `WalletSoftwareUpdate`
-           is not the current update anymore, an error is returned.
-           Streams the progress as a chunked HTTP response.
-          parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/WalletSoftwareUpdate'
-          consumes:
-            - application/json;charset=utf-8
-          produces:
-            - application/octet-stream
-          responses:
-            '204':
-              description: 'The download has started.'
-            '422':
-              description: 'Invalid update provided.'
-      /api/v1/update/skip:
-        put:
-          description: >
-            Skip the update. If the input `WalletSoftwareUpdate`
-            is not the current update anymore, the request is simply
-            ignored.
-          produces:
-            - application/json;charset=utf-8
-          responses:
-            '204':
-              description: 'The update has been skipped.'
-    definitions:
-      CCoin:
-        required:
-          - getCCoin
-        properties:
-          getCCoin:
-            type: string
-        type: object
-      WalletSoftwareUpdate:
-        required:
-          - wsuSoftwareVersion
-          - wsuBlockVesion
-          - wsuScriptVersion
-          - wsuImplicit
-          - wsuVotesFor
-          - wsuVotesAgainst
-          - wsuPositiveStake
-          - wsuNegativeStake
-          - wsuSeverity
-          - wsuUpdateState
-          - wsuSha256Checksum
-        properties:
-          wsuSoftwareVersion:
-            $ref: '#/definitions/SoftwareVersion'
-          wsuBlockVesion:
-            $ref: '#/definitions/BlockVersion'
-          wsuScriptVersion:
-            maximum: 65535
-            minimum: 0
-            type: integer
-          wsuImplicit:
-            type: boolean
-          wsuVotesFor:
-            maximum: 9223372036854776000
-            minimum: -9223372036854776000
-            type: integer
-          wsuVotesAgainst:
-            maximum: 9223372036854776000
-            minimum: -9223372036854776000
-            type: integer
-          wsuPositiveStake:
-            $ref: '#/definitions/CCoin'
-          wsuNegativeStake:
-            $ref: '#/definitions/CCoin'
-          wsuSeverity:
-            $ref: '#/definitions/UpdateSeverity'
-          wsuUpdateState:
-            $ref: '#/definitions/UpdateState'
-          wsuSha256Checksum:
-            description: "A checksum for data integrity."
-            type: string
-        type: object
-      SoftwareVersion:
-        required:
-          - svAppName
-          - svNumber
-        properties:
-          svAppName:
-            $ref: '#/definitions/ApplicationName'
-          svNumber:
-            maximum: 4294967295
-            minimum: 0
-            type: integer
-        type: object
-      ApplicationName:
-        required:
-          - getApplicationName
-        properties:
-          getApplicationName:
-            type: string
-        type: object
-      BlockVersion:
-        required:
-          - bvMajor
-          - bvMinor
-          - bvAlt
-        properties:
-          bvMajor:
-            maximum: 65535
-            minimum: 0
-            type: integer
-          bvMinor:
-            maximum: 65535
-            minimum: 0
-            type: integer
-          bvAlt:
-            maximum: 255
-            minimum: 0
-            type: integer
-        type: object
-      UpdateSeverity:
+swagger: '2.0'
+info:
+  version: 1.0.2
+  title: V1 Update API
+  description: This is a subset of the API for Cardano SL wallet.
+host: 'localhost:8090'
+paths:
+  /api/v1/updates:
+    get:
+      summary: "Get all the confirmed updates the system knows about."
+      description: >
+        Returns the **confirmed** updates known to this wallet, **ordered by age**.
+        It's user's responsibility to check whether the next suitable update is
+        mandatory (at startup) and stop the user by using the Wallet. Note: this
+        might not be enough in case of clients different from Daedalus, as this is
+        an invariant which is not imposed anywhere if not on paper.
+        For more information about the various `UpdateProposal` states, check
+        [this link](https://github.com/input-output-hk/cardano-sl/blob/master/docs/block-processing/us.md).
+      produces:
+        - application/json;charset=utf-8
+      parameters:
+        - name: state
+          in: query
+          type: string
+          required: false
+          enum: [applied, downloaded, available,skipped]
+          description: "Filter by update state."
+      responses:
+        '200':
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/WalletSoftwareUpdate'
+          description: 'The updates, which can be available, downloaded, skipped or applied already.'
+  /api/v1/updates/{updateId}:
+    get:
+      summary: "Get a specific update given its Id."
+      description: >
+        Get the information about a specific update.
+      parameters:
+        - name: updateId
+          required: true
+          in: path
+          type: string
+          description: "The update ID."
+      produces:
+        - application/json;charset=utf-8
+      responses:
+        '200':
+          description: "The requested update."
+          schema:
+            $ref: '#/definitions/WalletSoftwareUpdate'
+    post:
+      summary: "Apply, download or skip an update, given its Id."
+      description: >
+        Modify the status of an update, which allows the user to either
+        skip, apply or download it. It's a post as downloading or applying an
+        update are not idempotent.
+      produces:
+        - application/json;charset=utf-8
+      parameters:
+        - required: true
+          name: updateId
+          in: path
+          description: "The update identifier (a Blake2b-256 hash)."
+          type: string
+        - required: true
+          name: body
+          in: body
+          description: "The update status-change."
+          schema:
+            $ref: '#/definitions/UpdateStateChange'
+      responses:
+        '204':
+          description: 'The update state has been changed.'
+        '403':
+          description: 'Invalid state transition attempted.'
+  /api/v1/updates-proposals:
+    get:
+      summary: "Get all the available update proposals."
+      description: >
+        Get all the available update proposals this node knows about.
+      responses:
+        '200':
+          description: 'The list of update proposals'
+          schema:
+            $ref: '#/definitions/ProposedUpdate'
+    post:
+      summary: "Propose a new update."
+      description: >
+        Proposes an update.
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateProposal'
+      consumes:
+        - application/json;charset=utf-8
+      produces:
+        - application/json;charset=utf-8
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProposedUpdate'
+        '400':
+            description: 'Not enough stake'
+  /api/v1/updates-proposals/{proposalId}/votes:
+    post:
+      summary: "Vote on an update."
+      description: >
+        Vote with stake on the update proposal. Voting must
+        abide to the [votes verification rules](https://github.com/input-output-hk/cardano-sl/blob/master/docs/block-processing/us.md#votes-verification)
+        and issuing the same vote twice, or changing the vote more than one
+        time is not allowed.
+      parameters:
+        - in: path
+          name: proposalId
+          type: string
+          required: true
+          description: Proposal ID to vote on
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateProposalVote'
+      consumes:
+        - application/json;charset=utf-8
+      responses:
+        '200':
+          description: 'Returns the proposal the user voted on.'
+          schema:
+            $ref: '#/definitions/ProposedUpdate'
+        '403':
+          description: 'Invalid stake key.'
+        '404':
+          description: 'Voted proposal is not active anymore.'
+        '400':
+          description: 'Not enough stake to vote on this proposal.'
+definitions:
+  Installer:
+    description: "A Daedalus installer."
+    type: object
+    properties:
+      platform:
         type: string
-        enum: [mandatory, optional]
-      UpdateState:
-      # Just a stub for now.
-        type: object
+        example: "linux"
+      url:
+        type: string
+        example: "https://s3.iohk.io/installers/daedalus.zip"
+      checksum:
+        description: "A Blake2b-256 hash."
+        example: "A8ADD4BDDDFD93E4877D2746E62817B116364A1FA7BC148D95090BC7333B3673"
+        type: string
+  ProtocolUpgrade:
+    type: object
+    properties:
+      maxHeaderSize:
+        type: integer
+        maximum: 65535
+        minimum: 0
+  Installers:
+    type: array
+    items:
+      $ref: '#/definitions/Installer'
+  UpdateProposal:
+    type: object
+    description:
+      An update proposal.
+    properties:
+      blockVersion:
+         $ref: '#/definitions/BlockVersion'
+      protocolUpgrade:
+         $ref: '#/definitions/ProtocolUpgrade'
+      installers:
+         $ref: '#/definitions/Installers'
+      softwareVersion:
+         $ref: '#/definitions/SoftwareVersion'
+    required:
+       - blockVersion
+       - protocolUpgrade
+       - installers
+       - softwareVersion
+  ProposedUpdate:
+    type: object
+    description: >
+      Bundles an `UpdateId` and an `UpdateProposal`, as well as the
+      original stakeholder which issued the update.
+    properties:
+      proposalId:
+          type: string
+          description: "The hash of the UpdateProposal (Blake2b_256)."
+          example: "EFC9C8BABCFA93E49F1D2946E628173C7"
+      issuerId:
+          $ref: '#/definitions/StakeholderId'
+      updateProposal:
+        $ref: '#/definitions/UpdateProposal'
+    required:
+      - proposalId
+  UpdateProposalVote:
+    type: object
+    properties:
+      vote:
+        $ref: '#/definitions/Vote'
+    required:
+      - vote
+  WalletSoftwareUpdate:
+    required:
+      - softwareVersion
+      - blockVesion
+      - scriptVersion
+      - implicit
+      - votesFor
+      - votesAgainst
+      - positiveStake
+      - negativeStake
+      - severity
+      - state
+      - downloadProgress
+      - id
+    properties:
+      softwareVersion:
+        $ref: '#/definitions/SoftwareVersion'
+      blockVesion:
+        $ref: '#/definitions/BlockVersion'
+      scriptVersion:
+        maximum: 65535
+        minimum: 0
+        type: integer
+      implicit:
+        type: boolean
+      votesFor:
+        maximum: 9223372036854776000
+        minimum: -9223372036854776000
+        type: integer
+      votesAgainst:
+        maximum: 9223372036854776000
+        minimum: -9223372036854776000
+        type: integer
+      positiveStake:
+        type: integer
+      negativeStake:
+        type: integer
+      severity:
+        $ref: '#/definitions/UpdateSeverity'
+      state:
+        $ref: '#/definitions/UpdateState'
+      downloadProgress:
+        minimum: 0
+        maximum: 100
+        type: integer
+      id:
+        description: >
+          A update identifier, which also correspond to the
+          checksum for data integrity (it technically correspond to the
+          hash of the installer).
+        type: string
+        example: "A8ADD4BDDDFD93E4877D2746E62817B116364A1FA7BC148D95090BC7333B3673"
+    type: object
+  SoftwareVersion:
+    required:
+      - applicationName
+      - version
+    properties:
+      applicationName:
+        type: string
+        example: "cardano-sl"
+      version:
+        maximum: 4294967295
+        minimum: 0
+        type: integer
+    type: object
+  BlockVersion:
+    required:
+      - major
+      - minor
+      - alt
+    properties:
+      major:
+        maximum: 65535
+        minimum: 0
+        type: integer
+      minor:
+        maximum: 65535
+        minimum: 0
+        type: integer
+      alt:
+        maximum: 255
+        minimum: 0
+        type: integer
+    type: object
+  UpdateSeverity:
+    type: string
+    enum: [mandatory, optional]
+  UpdateState:
+    type: string
+    enum: [applied, downloaded, available, skipped]
+  Vote:
+    type: string
+    enum: [approve, reject]
+    description: "User's will towards an update proposal."
+  UpdateStateChange:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/UpdateState'
+  StakeholderId:
+    type: string
+    example: "A8ADD4BDDDFD93E4877D2746E62817B116"
+    description: >
+      The Stakeholder Id, modeled as a Blake-224 hash of
+      its public key.


### PR DESCRIPTION
@georgeee , @domenkozar , here is the proposed new revision for the update API for V1, which includes the new endpoints to propose & vote for an update. You might notice the API is quite different from the one Domen originally proposed and that I proposed as part of [this PR](https://github.com/input-output-hk/cardano-sl/pull/1884). This is because I have had time to think about @georgeee 's review and I am now much more happy of how the API looks & feels as it's way more RESTful in my opinion, and all the custom ad-hoc actions (except for one, hehe) are gone.

[Play with the rendered API here!](https://editor.swagger.io/?url=https://gist.githubusercontent.com/adinapoli-iohk/b8d54d04101e60e83166cb32dfa9d8ff/raw/2e8193777aea781d01c0aa5ac96f50d9ef79d640/updates_v1_rev1.yaml#)

Here is a glimpse of the endpoints:

![screen shot 2017-11-30 at 17 06 15](https://user-images.githubusercontent.com/29383371/33440639-cbd49e70-d5f0-11e7-9925-706ec4726525.png)


You will see how I have conceptually separated the concept of a `WalletSoftwareUpdate` (which technically represents a confirmed `UpdateProposal`) from the concept of the `UpdateProposal` itself which is something that everybody (but for now just devops) can propose.

The vote endpoint now takes the `stakeKey` into account, as @georgeee requested.

Apart from that, I feel we are close to the final revision. I have a question for you: am I right that the schema Domen is proposing (with the addition of those `installers` etc) would need to be reflected in the code by modifying the current [UpdateProposal](https://github.com/input-output-hk/cardano-sl/blob/8507d03ba928e07daea57f9a52f6dc03a9d65779/core/Pos/Core/Update.hs#L176) datatype?

Let me know!