### PR TITLE
[CSL-1947] API v1 endpoint `getAccount`

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -7,13 +7,18 @@ import           Universum
 import qualified Cardano.Wallet.API.V1.Accounts as Accounts
 import           Cardano.Wallet.API.V1.Errors as Errors
 import           Cardano.Wallet.API.V1.Types
+import           Cardano.Wallet.API.V1.Migration
 
 
 import qualified Pos.Core.Coin as Core
+import qualified Pos.Wallet.Web.Methods.Logic as V0
+import qualified Pos.Wallet.Web.Tracking as V0
 import           Servant
 import           Test.QuickCheck (arbitrary, generate, listOf1, resize)
 
-handlers :: WalletId -> Server Accounts.API
+handlers
+    :: (HasCompileInfo, HasConfigurations)
+    => WalletId -> ServerT Accounts.API MonadV1
 handlers walletId =
           deleteAccount walletId
     :<|>  getAccount walletId
@@ -21,27 +26,33 @@ handlers walletId =
     :<|>  newAccount walletId
     :<|>  updateAccount walletId
 
-deleteAccount :: WalletId -> AccountId -> Handler NoContent
-deleteAccount _ _ = return NoContent
+deleteAccount :: WalletId -> AccountId -> MonadV1 NoContent
+deleteAccount _ _ = return NoContent 
 
-getAccount :: WalletId -> AccountId -> Handler Account
-getAccount _ _ = liftIO $ generate arbitrary
+getAccount
+    :: (MonadThrow m, V0.MonadWalletLogicRead ctx m)
+    => WalletId -> AccountId -> m Account
+getAccount _ accId =
+  -- TODO (jk) We have to deal with `WalletId`
+  -- if we know how to migrate `WalletId` from `CAccount`
+    migrate accId >>= V0.fixingCachedAccModifier V0.getAccount >>= migrate
 
+--
 listAccounts :: PaginationParams
-             -> Handler (OneOf [Account] (ExtendedResponse [Account]))
+             -> MonadV1 (OneOf [Account] (ExtendedResponse [Account]))
 listAccounts PaginationParams {..} = do
   example <- liftIO $ generate (resize 3 arbitrary)
   case ppResponseFormat of
-    Extended -> return $ OneOf $ Right $
-      ExtendedResponse {
-        extData = example
-      , extMeta = Metadata {
-          metaTotalPages = 1
-        , metaPage = 1
-        , metaPerPage = 20
-        , metaTotalEntries = 3
-      }
-      }
+    Extended -> return $ OneOf $ Right
+        ExtendedResponse {
+            extData = example
+          , extMeta = Metadata {
+                  metaTotalPages = 1
+                , metaPage = 1
+                , metaPerPage = 20
+                , metaTotalEntries = 3
+              }
+          }
     _ -> return $ OneOf $ Left example
 
 -- | This is an example of how POST requests might look like.
@@ -49,20 +60,20 @@ listAccounts PaginationParams {..} = do
 -- NOTE: This will probably change drastically as soon as we start using our
 -- custom monad as a base of the Handler stack, so the example here is just to
 -- give the idea of how it will look like on Swagger.
-newAccount :: WalletId -> Maybe Text -> AccountUpdate -> Handler Account
-newAccount w@(WalletId wId) _ AccountUpdate{..} = do
-    when (wId /= "testwallet") $ throwError $ Errors.toError Errors.WalletNotFound
+newAccount :: WalletId -> Maybe Text -> AccountUpdate -> MonadV1 Account
+newAccount (WalletId wId) _ AccountUpdate{..} = do
+    when (wId /= "testwallet") $ throwM $ Errors.toError Errors.WalletNotFound
     -- In real code we would generate things like addresses (if needed) or
     -- any other form of Id/data.
     newId <- liftIO $ generate (listOf1 arbitrary)
-    return $ Account {
-             accId = fromString newId
-           , accAmount = Core.mkCoin 0
-           , accAddresses = mempty
-           , accName = uaccName
-          --  , accWalletId = w
-          -- TODO (jk) ^ Uncomment it if we know how to migrate `WalletId` from `CAccount`
-           }
+    return Account
+        { accId = fromString newId
+        , accAmount = Core.mkCoin 0
+        , accAddresses = mempty
+        , accName = uaccName
+        --  , accWalletId = w
+        -- TODO (jk) ^ Uncomment it if we know how to migrate `WalletId` from `CAccount`
+        }
 
-updateAccount :: WalletId -> AccountId -> AccountUpdate -> Handler Account
+updateAccount :: WalletId -> AccountId -> AccountUpdate -> MonadV1 Account
 updateAccount w _ u = newAccount w Nothing u

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Accounts.hs
@@ -60,7 +60,8 @@ newAccount w@(WalletId wId) _ AccountUpdate{..} = do
            , accAmount = Core.mkCoin 0
            , accAddresses = mempty
            , accName = uaccName
-           , accWalletId = w
+          --  , accWalletId = w
+          -- TODO (jk) ^ Uncomment it if we know how to migrate `WalletId` from `CAccount`
            }
 
 updateAccount :: WalletId -> AccountId -> AccountUpdate -> Handler Account

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Wallets.hs
@@ -5,6 +5,7 @@ import           Universum
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 import qualified Pos.Wallet.Web.Methods.Restore as V0
 
+import qualified Cardano.Wallet.API.V1.Handlers.Accounts as Accounts
 import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
@@ -20,12 +21,12 @@ handlers :: ( HasConfigurations
          => ServerT Wallets.API MonadV1
 handlers =   newWallet
         :<|> listWallets
-        :<|> (\walletId -> do
+        :<|> (\walletId ->
                      updatePassword walletId
                 :<|> deleteWallet walletId
                 :<|> getWallet walletId
                 :<|> updateWallet walletId
-                -- :<|> Accounts.handlers walletId
+                :<|> Accounts.handlers walletId
              )
 
 -- | Creates a new @wallet@ given a 'NewWallet' payload.

--- a/wallet-new/src/Cardano/Wallet/API/V1/Accounts.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Accounts.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module Cardano.Wallet.API.V1.Accounts where
 
 import           Universum

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -314,7 +314,8 @@ data Account = Account
   , accAmount    :: !Core.Coin
   , accName      :: !Text
   -- ^ The Account name.
-  , accWalletId  :: WalletId
+  -- , accWalletId  :: WalletId
+  -- TODO (jk) ^ Uncomment it if we know how to migrate `WalletId` from `CAccount`
   -- ^ The 'WalletId' this 'Account' belongs to.
   } deriving (Show, Eq, Generic)
 
@@ -325,7 +326,8 @@ instance Arbitrary Account where
                                    <*> listOf1 arbitrary
                                    <*> arbitrary
                                    <*> pure "My account"
-                                   <*> arbitrary
+                                  --  <*> arbitrary
+                                  -- TODO (jk) ^ Uncomment it if we know how to migrate `WalletId` from `CAccount`
 
 data AccountUpdate = AccountUpdate {
     uaccName      :: !Text

--- a/wallet-new/src/Cardano/Wallet/API/V1/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Wallets.hs
@@ -1,7 +1,9 @@
 module Cardano.Wallet.API.V1.Wallets where
 
+import           Cardano.Wallet.API.Types
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Types
+import qualified Cardano.Wallet.API.V1.Accounts as Accounts
 
 import           Servant
 
@@ -24,5 +26,5 @@ type API =
                         :> ReqBody '[JSON] (Update Wallet)
                         :> Put '[JSON] Wallet
                    -- Nest the Accounts API
-                   -- :<|> Tags '["Accounts"] :> Accounts.API
+                   :<|> Tags '["Accounts"] :> Accounts.API
                    )


### PR DESCRIPTION
_Task_ https://iohk.myjetbrains.com/youtrack/issue/CSL-1949

_Note:_ Field `accWalletId :: WalletId` of `V1.Account` has a been deactivated temporally in this PR. As mentioned in https://input-output-rnd.slack.com/archives/C819S481Y/p1511970392000449 we have to discuss how to get a `WalletId` while migrating `V0.CAccount` to  `V1.Account`. 