### PR TITLE
[CSL-1961] Implement `new address` endpoint

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers.hs
@@ -10,6 +10,7 @@ import           Universum
 
 
 import qualified Cardano.Wallet.API.V1 as V1
+import qualified Cardano.Wallet.API.V1.Addresses as Addresses
 import qualified Cardano.Wallet.API.V1.Handlers.Addresses as Addresses
 import qualified Cardano.Wallet.API.V1.Handlers.Info as Info
 import qualified Cardano.Wallet.API.V1.Handlers.Settings as Settings
@@ -31,7 +32,7 @@ handlers :: ( HasConfigurations
             )
             => (forall a. MonadV1 a -> Handler a)
             -> Server V1.API
-handlers naturalTransformation = Addresses.handlers
+handlers naturalTransformation = hoistServer (Proxy @Addresses.API) naturalTransformation Addresses.handlers
                             :<|> hoistServer (Proxy @Wallets.API) naturalTransformation Wallets.handlers
                             :<|> Transactions.handlers
                             :<|> Updates.handlers

--- a/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Handlers/Addresses.hs
@@ -4,18 +4,26 @@ module Cardano.Wallet.API.V1.Handlers.Addresses where
 
 import           Universum
 
+import           Pos.Crypto (emptyPassphrase)
+import qualified Pos.Wallet.Web.Account as V0
+import qualified Pos.Wallet.Web.Methods as V0
+
 import qualified Cardano.Wallet.API.V1.Addresses as Addresses
+import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types
 
 import           Servant
 import           Test.QuickCheck (arbitrary, generate, vectorOf)
 
-handlers :: Server Addresses.API
+handlers
+    :: (MonadThrow m, V0.MonadWalletLogic ctx m)
+    => ServerT Addresses.API m
 handlers =  listAddresses
        :<|> newAddress
 
-listAddresses :: PaginationParams
-              -> Handler (OneOf [Address] (ExtendedResponse [Address]))
+listAddresses
+    :: MonadIO m
+    => PaginationParams -> m (OneOf [Address] (ExtendedResponse [Address]))
 listAddresses PaginationParams {..} = do
     addresses <- liftIO $ generate (vectorOf 2 arbitrary)
     case ppResponseFormat of
@@ -31,5 +39,11 @@ listAddresses PaginationParams {..} = do
               }
         _ -> return $ OneOf $ Left addresses
 
-newAddress :: Address -> Handler Address
-newAddress a = return a
+newAddress
+    :: (MonadThrow m, V0.MonadWalletLogic ctx m)
+    => NewAddress -> m WalletAddress
+newAddress NewAddress {..} = do
+    let password = fromMaybe emptyPassphrase newaddrSpendingPassword
+    accountId <- migrate (newaddrWalletId, newaddrAccountId)
+    V0.newAddress V0.RandomSeed password accountId
+        >>= migrate

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -226,11 +226,15 @@ instance ToDocs Account where
   readOnlyFields   = readOnlyFieldsFromJSON
   descriptionFor _ = "An Account."
 
+instance ToDocs WalletAddress where
+  readOnlyFields   = readOnlyFieldsFromJSON
+  descriptionFor _ = "An Address."
+
 instance ToDocs AccountUpdate where
   descriptionFor _ = updateDescr (Proxy @Account)
 
 instance ToDocs Address where
-  descriptionFor _ = "An Address."
+  descriptionFor _ = "An Address ID."
 
 instance ToDocs WalletId where
   descriptionFor _ = "A Wallet ID."
@@ -240,6 +244,9 @@ instance ToDocs Wallet where
 
 instance ToDocs NewWallet where
   descriptionFor _ = newDescr (Proxy @Wallet)
+
+instance ToDocs NewAddress where
+  descriptionFor _ = newDescr (Proxy @WalletAddress)
 
 instance ToDocs WalletUpdate where
   descriptionFor _ = updateDescr (Proxy @Wallet)
@@ -294,6 +301,9 @@ possibleValuesOf (Proxy :: Proxy a) = T.intercalate "," . map show $ ([minBound.
 instance ToSchema Account where
   declareNamedSchema = annotate fromArbitraryJSON
 
+instance ToSchema WalletAddress where
+  declareNamedSchema = annotate fromArbitraryJSON
+
 instance ToSchema AccountUpdate where
   declareNamedSchema = annotate fromArbitraryJSON
 
@@ -310,6 +320,9 @@ instance ToSchema Wallet where
   declareNamedSchema = annotate fromArbitraryJSON
 
 instance ToSchema NewWallet where
+  declareNamedSchema = annotate fromArbitraryJSON
+
+instance ToSchema NewAddress where
   declareNamedSchema = annotate fromArbitraryJSON
 
 instance ToSchema WalletUpdate where

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -8,7 +8,7 @@
             "url": "http://mit.com",
             "name": "MIT"
         },
-        "description": "This is the specification for the Cardano Wallet API, automatically generated\nas a [Swagger](https://swagger.io/) spec from the [Servant](http://haskell-servant.readthedocs.io/en/stable/) API\nof [Cardano](https://github.com/input-output-hk/cardano-sl).\n\n### Request format (all versions)\n\nIssuing requests against this API is conceptually not very different from any other web service out there. The API\nis versioned, meaning is possible to access different versions of the latter by changing the _version number_ in the URL.\n\nFor example, _omitting_ the version number of passing `v0` would call the version 0 of the API. Examples:\n\n```\n/api/version\n/api/v0/version\n```\n\nBoth URL above will return the same result. Compatibility between major versions is not _guaranteed_, i.e. the\nrequest & response formats might differ.\n\n### Response format (V1 onwards)\n\n**All GET requests of the API are paginated by default**. Whilst this can be a source of surprise, is\nthe best way of ensuring the performance of GET requests is not affected by the size of the data storage.\n\nVersion `V1` introduced a different way of requesting information to the API. In particular, GET requests\nwhich returns a _collection_ (i.e. typically a JSON array of resources) lists extra parameters which can be\nused to modify the shape of the response. In particular, those are:\n\n* `page`: (Default value: **1**).\n* `per_page`: (Default value: **10**)\n* `extended`: (Default value: `false`)\n* `Daedalus-Response-Format`: (Default value: `null`)\n\nFor a more accurate description, see the section `Parameters` of each GET request, but as a brief overview\nthe first two control how many results and which results to access in a paginated request. The other two\n(one to be passed as a query parameter, the other as an HTTP Header) controls the response format. By omitting\nboth, the \"naked\" collection will be returned. For example, requesting for a list of _Accounts_ might issue,\nin this case:\n\n``` json\n[\n    {\n        \"amount\": 10574016894293587,\n        \"addresses\": [\n            \"Un4ZpTvXtoKfUHjDCrusx7xrADRVPP11956y3BPMs6Mrgng4qbEQrjPn2dhLTDiqLtptbiGD5ZYc7FPq2iCVTuD9jnWz2KtaSdfWdU1huyKxd795\",\n            \"3qruzscJwnkDgVrhM7QEbBpsLTKgAfGSGoVkvN6frVXPxwsgjbpooVVvYBdmcUaLsLXNVVi1RrkSinxYiFSV1aH8X8FcP8MbzP1QFDKpicCkV78Z61tUKE3bFBASFJXNpmZ8vFkrY36a6WgyQh8VsXpqnvynLDZyFcURF9bhHWqrMBbmxMqWeYX8zcKGCR84BccQr1Bf7vu6xFL7xcdUZHqH55J3a7gGsHRG2XUjEfkF5WyHz6toRpAzzL4rRLL1K2ypckMUrQNeVdMN7ADhfufhqJQsrk\"\n        ],\n        \"name\": \"My account\",\n        \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n        \"id\": \"123456\"\n    },\n    {\n        \"amount\": 18773007703513614,\n        \"addresses\": [\n            \"5oP9ib6ym3XbH2fmvNAm5dUyE7xFqQztrsN41xg7hbXQbmbQnYUgXXt2rFZUgLyYPd\"\n        ],\n        \"name\": \"My account\",\n        \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n        \"id\": \"DEADBeef\"\n    }\n]\n```\n\nIn the second case, instead:\n\n``` json\n{\n    \"data\": [\n        {\n            \"amount\": 23759697234791994,\n            \"addresses\": [\n                \"Un4ZpTvXtoKN7YiPTJZgXcD8uywHboxG9r7ZQqCRnpvnFAq7Gx4gpUd5Wqti65ZXydvyrg8KVe2oWVXi5PiVosGoEWGZLseimCRBEM61DCbL5hqj\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"id\": \"DEADBeef\"\n        },\n        {\n            \"amount\": 39337990575634793,\n            \"addresses\": [\n                \"7J1MaQmKydNVxXeuuEk33yiWbfA9mjA3TSzxsLzVaPq7LzDsx11Wz9qBT738VcPE53sg9sREzDzdRD43AAByWX55rdvigsfAQW1nj7aysmFfmtb\",\n                \"2657WMsDfac6Yj1L8CzH6jr7Xqd82zKm91aYZL61Ft1TV44RtY8YQDgFtJtjoqe5W\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"id\": \"123456\"\n        }\n    ],\n    \"meta\": {\n        \"page\": 1,\n        \"perPage\": 46,\n        \"totalPages\": 1,\n        \"totalEntries\": 2\n    }\n}\n```\n\n### Dealing with errors (V1 onwards)\n\nIn case a request cannot be served by the API, a non-2xx HTTP response will be issue, together with a\n[JSend-compliant](https://labs.omniti.com/labs/jsend) JSON Object describing the error in detail together\nwith a numeric error code which can be used by API consumers to implement proper error handling in their\napplication. For example, here's a typical error which might be issued:\n\n``` json\n{\n    \"diagnostic\": {},\n    \"message\": \"WalletNotFound\"\n}\n```\n"
+        "description": "This is the specification for the Cardano Wallet API, automatically generated\nas a [Swagger](https://swagger.io/) spec from the [Servant](http://haskell-servant.readthedocs.io/en/stable/) API\nof [Cardano](https://github.com/input-output-hk/cardano-sl).\n\n### Request format (all versions)\n\nIssuing requests against this API is conceptually not very different from any other web service out there. The API\nis versioned, meaning is possible to access different versions of the latter by changing the _version number_ in the URL.\n\nFor example, _omitting_ the version number of passing `v0` would call the version 0 of the API. Examples:\n\n```\n/api/version\n/api/v0/version\n```\n\nBoth URL above will return the same result. Compatibility between major versions is not _guaranteed_, i.e. the\nrequest & response formats might differ.\n\n### Response format (V1 onwards)\n\n**All GET requests of the API are paginated by default**. Whilst this can be a source of surprise, is\nthe best way of ensuring the performance of GET requests is not affected by the size of the data storage.\n\nVersion `V1` introduced a different way of requesting information to the API. In particular, GET requests\nwhich returns a _collection_ (i.e. typically a JSON array of resources) lists extra parameters which can be\nused to modify the shape of the response. In particular, those are:\n\n* `page`: (Default value: **1**).\n* `per_page`: (Default value: **10**)\n* `extended`: (Default value: `false`)\n* `Daedalus-Response-Format`: (Default value: `null`)\n\nFor a more accurate description, see the section `Parameters` of each GET request, but as a brief overview\nthe first two control how many results and which results to access in a paginated request. The other two\n(one to be passed as a query parameter, the other as an HTTP Header) controls the response format. By omitting\nboth, the \"naked\" collection will be returned. For example, requesting for a list of _Accounts_ might issue,\nin this case:\n\n``` json\n[\n    {\n        \"amount\": 10574016894293587,\n        \"addresses\": [\n            \"Un4ZpTvXtoKfUHjDCrusx7xrADRVPP11956y3BPMs6Mrgng4qbEQrjPn2dhLTDiqLtptbiGD5ZYc7FPq2iCVTuD9jnWz2KtaSdfWdU1huyKxd795\",\n            \"3qruzscJwnkDgVrhM7QEbBpsLTKgAfGSGoVkvN6frVXPxwsgjbpooVVvYBdmcUaLsLXNVVi1RrkSinxYiFSV1aH8X8FcP8MbzP1QFDKpicCkV78Z61tUKE3bFBASFJXNpmZ8vFkrY36a6WgyQh8VsXpqnvynLDZyFcURF9bhHWqrMBbmxMqWeYX8zcKGCR84BccQr1Bf7vu6xFL7xcdUZHqH55J3a7gGsHRG2XUjEfkF5WyHz6toRpAzzL4rRLL1K2ypckMUrQNeVdMN7ADhfufhqJQsrk\"\n        ],\n        \"name\": \"My account\",\n        \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n        \"id\": 1\n    },\n    {\n        \"amount\": 18773007703513614,\n        \"addresses\": [\n            \"5oP9ib6ym3XbH2fmvNAm5dUyE7xFqQztrsN41xg7hbXQbmbQnYUgXXt2rFZUgLyYPd\"\n        ],\n        \"name\": \"My account\",\n        \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n        \"id\": 2\n    }\n]\n```\n\nIn the second case, instead:\n\n``` json\n{\n    \"data\": [\n        {\n            \"amount\": 23759697234791994,\n            \"addresses\": [\n                \"Un4ZpTvXtoKN7YiPTJZgXcD8uywHboxG9r7ZQqCRnpvnFAq7Gx4gpUd5Wqti65ZXydvyrg8KVe2oWVXi5PiVosGoEWGZLseimCRBEM61DCbL5hqj\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"id\": 2\n        },\n        {\n            \"amount\": 39337990575634793,\n            \"addresses\": [\n                \"7J1MaQmKydNVxXeuuEk33yiWbfA9mjA3TSzxsLzVaPq7LzDsx11Wz9qBT738VcPE53sg9sREzDzdRD43AAByWX55rdvigsfAQW1nj7aysmFfmtb\",\n                \"2657WMsDfac6Yj1L8CzH6jr7Xqd82zKm91aYZL61Ft1TV44RtY8YQDgFtJtjoqe5W\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"id\": 2\n        }\n    ],\n    \"meta\": {\n        \"page\": 1,\n        \"perPage\": 46,\n        \"totalPages\": 1,\n        \"totalEntries\": 2\n    }\n}\n```\n\n### Dealing with errors (V1 onwards)\n\nIn case a request cannot be served by the API, a non-2xx HTTP response will be issue, together with a\n[JSend-compliant](https://labs.omniti.com/labs/jsend) JSON Object describing the error in detail together\nwith a numeric error code which can be used by API consumers to implement proper error handling in their\napplication. For example, here's a typical error which might be issued:\n\n``` json\n{\n    \"diagnostic\": {},\n    \"message\": \"WalletNotFound\"\n}\n```\n"
     },
     "definitions": {
         "CPtxCondition": {
@@ -119,6 +119,31 @@
                 }
             }
         },
+        "NewAddress": {
+            "example": {
+                "accountId": 2,
+                "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg",
+                "spendingPassword": "<passphrase>"
+            },
+            "required": [
+                "accountId",
+                "walletId",
+                "spendingPassword"
+            ],
+            "type": "object",
+            "description": "A type represending an request for creating a(n) WalletAddress.",
+            "properties": {
+                "accountId": {
+                    "type": "number"
+                },
+                "walletId": {
+                    "type": "string"
+                },
+                "spendingPassword": {
+                    "type": "string"
+                }
+            }
+        },
         "CTxMeta": {
             "required": [
                 "ctmDate"
@@ -138,7 +163,7 @@
         },
         "Payment": {
             "example": {
-                "sourceAccount": "[",
+                "sourceAccount": 1,
                 "groupingPolicy": "OptimiseForSecurity",
                 "destinations": [
                     {
@@ -166,7 +191,7 @@
             "description": "A transfer of `Coin`(s) from one source to one or more destinations.",
             "properties": {
                 "sourceAccount": {
-                    "type": "string"
+                    "type": "number"
                 },
                 "groupingPolicy": {
                     "type": "string"
@@ -207,7 +232,7 @@
                 },
                 "softwareInfo": {
                     "version": 0,
-                    "applicationName": "RB6n"
+                    "applicationName": "1"
                 }
             },
             "required": [
@@ -442,11 +467,6 @@
                 }
             }
         },
-        "Address": {
-            "example": "NBimUZYpm3Fghc938FCyLqookUReTpSMSePrnXaHce6cVsLXWKnmwATymbSRg6mc6v9",
-            "type": "string",
-            "description": "An Address."
-        },
         "CWalletInit": {
             "required": [
                 "cwInitMeta",
@@ -488,6 +508,36 @@
                 "OptimizeForSecurity",
                 "OptimizeForSize"
             ]
+        },
+        "WalletAddress": {
+            "example": {
+                "used": false,
+                "changeAddress": true,
+                "balance": 11091176260625603,
+                "id": "2reD6PLk2vQ44znyXUjiNZ6GBu4U4ibssQMv1f1B4sMhZecZ5yE2ZPtSZmFBqdA7QA88h337S9s4t6qBNeTYRsGsKPTP8xdxkFpXsJs4J9qPRX3zi1rCrvsuF2sF6s9TSKokGvigySsm73jRuusBaCyvYY4tiGdoY5X9XRihqR56PpgA2Ty5XCrb3gVhZyfxiJtn5ZpS1baxQMGrcJ8dFn76Ko8HXqo9C62EqdCiWcFEmkUPq15Kj5oUS9eZryU5izRCjp9EWmubNp3YgEgRJjFx6wr8aZxxFyphaUYueuRGzcjGDv8vaATXfTmLVtWrusjwc45QscHvPv6yk1"
+            },
+            "required": [
+                "used",
+                "changeAddress",
+                "balance",
+                "id"
+            ],
+            "type": "object",
+            "description": "An Address.",
+            "properties": {
+                "used": {
+                    "type": "boolean"
+                },
+                "changeAddress": {
+                    "type": "boolean"
+                },
+                "balance": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
         },
         "CWalletMeta": {
             "required": [
@@ -3475,7 +3525,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/Address"
+                            "$ref": "#/definitions/WalletAddress"
                         },
                         "description": ""
                     }
@@ -3487,7 +3537,7 @@
                     {
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/Address"
+                            "$ref": "#/definitions/NewAddress"
                         },
                         "in": "body",
                         "name": "body"

--- a/wallet-new/src/Cardano/Wallet/API/V1/Addresses.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Addresses.hs
@@ -10,6 +10,6 @@ import           Cardano.Wallet.API.V1.Types
 type API = "addresses" :> WalletRequestParams
                        :> Summary "Returns all the addresses."
                        :> Get '[JSON] (OneOf [Address] (ExtendedResponse [Address]))
-      :<|> "addresses" :> ReqBody '[JSON] Address
+      :<|> "addresses" :> ReqBody '[JSON] NewAddress
                        :> Summary "Creates a new Address."
-                       :> Post '[JSON] Address
+                       :> Post '[JSON] WalletAddress

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -22,6 +22,7 @@ spec = describe "Marshalling & Unmarshalling" $ do
     prop "Aeson Payment roundtrips" (aesonRoundtrip @Payment Proxy)
     prop "Aeson PaymentDistribution roundtrips" (aesonRoundtrip @PaymentDistribution Proxy)
     prop "Aeson NewWallet roundtrips" (aesonRoundtrip @NewWallet Proxy)
+    prop "Aeson NewAddress roundtrips" (aesonRoundtrip @NewAddress Proxy)
     prop "Aeson Coin roundtrips" (aesonRoundtrip @Core.Coin Proxy)
     prop "Aeson TransactionGroupingPolicy roundtrips" (aesonRoundtrip @TransactionGroupingPolicy Proxy)
     prop "Aeson TransactionType roundtrips" (aesonRoundtrip @TransactionType Proxy)


### PR DESCRIPTION
In the process I dared to change API of this endpoint, please point out whether it's correct or I went too far with changes :slightly_smiling_face: 
In particular, I made endpoint accepting `AccountId` and returning summary about newly created address, as old API did.

Also, marshaling test is failing for `NewAddress` due to incorrect JSON instances for `PassPhrase`, fix is in #1957 