### PR TITLE
[DO NOT MREGE][CSL-1952] Rename 'wallet-new-server' into 'cardano-node'.

### DIFF
--- a/scripts/launch/demo-with-new-wallet-api.sh
+++ b/scripts/launch/demo-with-new-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXE_NAME='cardano-node' WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo-with-new-wallet-api.sh
+++ b/scripts/launch/demo-with-new-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_EXE_NAME='wallet-new-server' WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo-with-wallet-api.sh
+++ b/scripts/launch/demo-with-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXE_NAME='cardano-node-old' WALLET_TEST=1 "$base"/demo.sh $@

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -96,7 +96,7 @@ library
                       ScopedTypeVariables
                       UndecidableInstances
 
-executable wallet-new-server
+executable cardano-node-new
   hs-source-dirs:      server
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -96,7 +96,7 @@ library
                       ScopedTypeVariables
                       UndecidableInstances
 
-executable cardano-node-new
+executable cardano-node
   hs-source-dirs:      server
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -195,7 +195,7 @@ library
   build-tools: cpphs >= 1.19
   ghc-options: -pgmP cpphs -optP --cpp
 
-executable cardano-node
+executable cardano-node-old
   hs-source-dirs:     node
   main-is:            Main.hs
   other-modules:      NodeOptions


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/CSL-1952

As discussed with @adinapoli-iohk - we need to eventually completely replace the calls, renaming the old to simply `cardano-node-old` and the new as `cardano-node` would do the trick and I think we should go for it, but then we *shouldn’t* merge the PR until this one is merged - https://github.com/input-output-hk/cardano-sl/pull/1986 
This is because we want **master** to incorporate the current `wallet-new` whilst it's still not invoked. Then once we port completely the API we merge this PR and on the next merge of `alfredo/wallet-new` into `master` we should be in the position of start using `wallet-new` as if it was “the normal wallet”.
