### PR TITLE
[CSL-2007] Revise tx resubmitter logic

### DIFF
--- a/node/src/Pos/Wallet/Web/Pending/Updates.hs
+++ b/node/src/Pos/Wallet/Web/Pending/Updates.hs
@@ -41,15 +41,15 @@ ptxMarkAcknowledgedPure = execState $ do
     wasAcked <- ptxPeerAck <<.= True
     unless wasAcked $ ptxSubmitTiming . pstNextDelay %= (* 8)
 
--- | If given transaction is in 'PtxWontApply' condition, sets its condition to 'PtxApplying'.
--- This allows "stuck" transactions to be resubmitted again.
--- | Has no effect for transactions in other conditions.
+-- | If given transaction is in 'PtxWontApply' condition, sets its condition
+-- to 'PtxApplying'. This allows "stuck" transactions to be resubmitted
+-- again.
+--
+-- Has no effect for transactions in other conditions.
 resetFailedPtx :: HasConfiguration => SlotId -> PendingTx -> PendingTx
 resetFailedPtx curSlot ptx@PendingTx{..}
     | PtxWontApply _ poolInfo <- _ptxCond =
-        PendingTx
-        { _ptxCond = PtxApplying poolInfo
-        , _ptxSubmitTiming = mkPtxSubmitTiming curSlot
-        , ..
-        }
+          ptx { _ptxCond = PtxApplying poolInfo
+              , _ptxSubmitTiming = mkPtxSubmitTiming curSlot
+              }
     | otherwise = ptx

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -69,6 +69,7 @@ module Pos.Wallet.Web.State.Acidic
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
+       , ResetFailedPtxs (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
@@ -174,6 +175,7 @@ makeAcidic ''WalletStorage
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
+    , 'WS.resetFailedPtxs
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -76,6 +76,7 @@ module Pos.Wallet.Web.State.State
        , casPtxCondition
        , ptxUpdateMeta
        , addOnlyNewPendingTx
+       , resetFailedPtxs
        , getWalletStorage
        , flushWalletStorage
        ) where
@@ -90,7 +91,7 @@ import           Universum
 import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Txp                      (TxId, Utxo, UtxoModifier)
-import           Pos.Types                    (HeaderHash)
+import           Pos.Types                    (HeaderHash, SlotId)
 import           Pos.Util.Servant             (encodeCType)
 import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
                                                CProfile, CTxId, CTxMeta, CUpdateInfo,
@@ -325,6 +326,9 @@ ptxUpdateMeta = updateDisk ... A.PtxUpdateMeta
 
 addOnlyNewPendingTx :: WebWalletModeDB ctx m => PendingTx -> m ()
 addOnlyNewPendingTx = updateDisk ... A.AddOnlyNewPendingTx
+
+resetFailedPtxs :: WebWalletModeDB ctx m => SlotId -> m ()
+resetFailedPtxs = updateDisk ... A.ResetFailedPtxs
 
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -76,6 +76,7 @@ module Pos.Wallet.Web.State.Storage
        , casPtxCondition
        , ptxUpdateMeta
        , addOnlyNewPendingTx
+       , resetFailedPtxs
        ) where
 
 import           Universum
@@ -110,7 +111,7 @@ import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition,
                                                  ptxSubmitTiming)
 import           Pos.Wallet.Web.Pending.Updates (incPtxSubmitTimingPure,
                                                  mkPtxSubmitTiming,
-                                                 ptxMarkAcknowledgedPure)
+                                                 ptxMarkAcknowledgedPure, resetFailedPtx)
 
 type AddressSortingKey = Int
 
@@ -489,6 +490,11 @@ addOnlyNewPendingTx :: PendingTx -> Update ()
 addOnlyNewPendingTx ptx =
     wsWalletInfos . ix (_ptxWallet ptx) .
     wsPendingTxs . at (_ptxTxId ptx) %= (<|> Just ptx)
+
+resetFailedPtxs :: SlotId -> Update ()
+resetFailedPtxs curSlot =
+    wsWalletInfos . traversed .
+    wsPendingTxs . traversed %= resetFailedPtx curSlot
 
 
 getWalletStorage :: Query WalletStorage

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3851,8 +3851,8 @@ self: {
       hscolour = callPackage ({ base, containers, mkDerivation, stdenv }:
       mkDerivation {
           pname = "hscolour";
-          version = "1.24.2";
-          sha256 = "55fb86bafdcad9613c25910b1cbca4b071c1ddc6365538c3b3d4e350cb30cf22";
+          version = "1.24.4";
+          sha256 = "243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d";
           isLibrary = true;
           isExecutable = true;
           enableSeparateDataOutput = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3851,8 +3851,8 @@ self: {
       hscolour = callPackage ({ base, containers, mkDerivation, stdenv }:
       mkDerivation {
           pname = "hscolour";
-          version = "1.24.4";
-          sha256 = "243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d";
+          version = "1.24.2";
+          sha256 = "55fb86bafdcad9613c25910b1cbca4b071c1ddc6365538c3b3d4e350cb30cf22";
           isLibrary = true;
           isExecutable = true;
           enableSeparateDataOutput = true;

--- a/stack2nix-src.json
+++ b/stack2nix-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/stack2nix.git",
-  "rev": "173b7ecae6e38f2",
-  "sha256": "01b8kc205m6p2q3l4an0gx9062w9szjkk139m3qnra7g4bh5551g",
+  "rev": "3a95621ea44548b25e75c6169dd5071531a3a5f3",
+  "sha256": "13cp43424hj4sami4h547qi67p5d3dl8kcjj9qi1jy1p0r8nasik",
   "fetchSubmodules": true
 }

--- a/stack2nix-src.json
+++ b/stack2nix-src.json
@@ -1,6 +1,0 @@
-{
-  "url": "https://github.com/input-output-hk/stack2nix.git",
-  "rev": "3a95621ea44548b25e75c6169dd5071531a3a5f3",
-  "sha256": "13cp43424hj4sami4h547qi67p5d3dl8kcjj9qi1jy1p0r8nasik",
-  "fetchSubmodules": true
-}

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -41,6 +41,7 @@ module Pos.Wallet.Web.Api
 
        , NewPayment
        , TxFee
+       , ResetFailedPtxs
        , UpdateTx
        , GetHistory
 
@@ -67,35 +68,36 @@ module Pos.Wallet.Web.Api
        ) where
 
 
-import           Control.Lens               (from)
-import           Control.Monad.Catch        (try)
-import           Data.Reflection            (Reifies (..))
-import           Servant.API                ((:<|>), (:>), Capture, Delete, Get, JSON,
-                                             Post, Put, QueryParam, ReflectMethod (..),
-                                             ReqBody, Verb)
-import           Servant.Server             (HasServer (..))
-import           Servant.Swagger.UI         (SwaggerSchemaUI)
-import           Servant.API.ContentTypes   (OctetStream)
+import           Control.Lens                (from)
+import           Control.Monad.Catch         (try)
+import           Data.Reflection             (Reifies (..))
+import           Servant.API                 ((:<|>), (:>), Capture, Delete, Get, JSON,
+                                              Post, Put, QueryParam, ReflectMethod (..),
+                                              ReqBody, Verb)
+import           Servant.API.ContentTypes    (OctetStream)
+import           Servant.Server              (HasServer (..))
+import           Servant.Swagger.UI          (SwaggerSchemaUI)
 import           Universum
 
-import           Pos.Client.Txp.Util        (InputSelectionPolicy)
-import           Pos.Types                  (Coin, SoftwareVersion)
-import           Pos.Util.Servant           (ApiLoggingConfig, CCapture, CQueryParam,
-                                             CReqBody, DCQueryParam, DReqBody,
-                                             HasLoggingServer (..), LoggingApi,
-                                             ModifiesApiRes (..), ReportDecodeError (..),
-                                             VerbMod, WithTruncatedLog (..),
-                                             applyLoggingToHandler, inRouteServer,
-                                             serverHandlerL')
-import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit,
-                                             CAccountMeta, CAddress, CCoin, CFilePath, ClientInfo,
-                                             CId, CInitialized, CPaperVendWalletRedeem,
-                                             CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
-                                             CUpdateInfo, CWallet, CWalletInit,
-                                             CWalletMeta, CWalletRedeem, ScrollLimit,
-                                             ScrollOffset, SyncProgress, Wal)
-import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
-                                             catchEndpointErrors)
+import           Pos.Client.Txp.Util         (InputSelectionPolicy)
+import           Pos.Types                   (Coin, SoftwareVersion)
+import           Pos.Util.Servant            (ApiLoggingConfig, CCapture, CQueryParam,
+                                              CReqBody, DCQueryParam, DReqBody,
+                                              HasLoggingServer (..), LoggingApi,
+                                              ModifiesApiRes (..), ReportDecodeError (..),
+                                              VerbMod, WithTruncatedLog (..),
+                                              applyLoggingToHandler, inRouteServer,
+                                              serverHandlerL')
+import           Pos.Wallet.Web.ClientTypes  (Addr, CAccount, CAccountId, CAccountInit,
+                                              CAccountMeta, CAddress, CCoin, CFilePath,
+                                              CId, CInitialized, CPaperVendWalletRedeem,
+                                              CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
+                                              CUpdateInfo, CWallet, CWalletInit,
+                                              CWalletMeta, CWalletRedeem, ClientInfo,
+                                              ScrollLimit, ScrollOffset, SyncProgress,
+                                              Wal)
+import           Pos.Wallet.Web.Error        (WalletError (DecodeError),
+                                              catchEndpointErrors)
 import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot)
 
 -- | Common prefix for all endpoints.
@@ -290,6 +292,12 @@ type TxFee =
     :> DReqBody '[JSON] (Maybe InputSelectionPolicy)
     :> WRes Post CCoin
 
+type ResetFailedPtxs =
+       "txs"
+    :> "resubmission"
+    :> "reset"
+    :> WRes Get ()
+
 type UpdateTx =
        "txs"
     :> "payments"
@@ -468,6 +476,8 @@ type WalletApi = ApiPrefix :> (
      NewPayment
     :<|>
      TxFee
+    :<|>
+     ResetFailedPtxs
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Pending/Util.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Util.hs
@@ -78,3 +78,4 @@ isReclaimableFailure = \case
 
 usingPtxCoords :: (CId Wal -> TxId -> a) -> PendingTx -> a
 usingPtxCoords f PendingTx{..} = f _ptxWallet _ptxTxId
+

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -100,11 +100,12 @@ resubmitPtxsDuringSlot sendActions ptxs = do
 processPtxsToResubmit
     :: MonadPendings m
     => SendActions m -> SlotId -> [PendingTx] -> m ()
-processPtxsToResubmit sendActions curSlot ptxs = do
+processPtxsToResubmit sendActions _curSlot ptxs = do
     ptxsPerSlotLimit <- evalPtxsPerSlotLimit
     let toResubmit =
-            take ptxsPerSlotLimit $
-            filter ((curSlot >=) . view ptxNextSubmitSlot) $
+            take (min 1 ptxsPerSlotLimit) $  -- for now the limit will be 1,
+                                             -- though properly “min 1”
+                                             -- shouldn't be needed
             filter (has _PtxApplying . _ptxCond) $
             ptxs
     unless (null toResubmit) $
@@ -137,7 +138,6 @@ processPtxsOnSlot
 processPtxsOnSlot sendActions curSlot = do
     ptxs <- getPendingTxs
     let sortedPtxs =
-            sortWith _ptxCreationSlot $
             flip fromMaybe =<< topsortTxs wHash $
             ptxs
 

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -72,6 +72,8 @@ servantHandlers sendActions =
     :<|>
      M.getTxFee
     :<|>
+     M.resetAllFailedPtxs
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -143,6 +143,12 @@ instance HasCustomSwagger UpdateTx where
     swaggerModifier = modifyDescription
         "Update payment transaction."
 
+instance HasCustomSwagger ResetFailedPtxs where
+    swaggerModifier = modifyDescription
+        "For all transactions in CPtxWontApply condition, \
+        \reset them to CPtxApplying condition so that they will \
+        \be passed to resubmition"
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."


### PR DESCRIPTION
Now we
1. Choose and resubmit only one transaction per slot
2. Allow to reset status of all failed transactions so that they will be processed by resubmitter again