### PR TITLE
[CSL-1966] Decrease testing constants even further

### DIFF
--- a/generator/test/Test/Pos/Block/Logic/VarSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/VarSpec.hs
@@ -54,7 +54,7 @@ spec :: Spec
 -- Unfortunatelly, blocks generation is quite slow nowdays.
 -- See CSL-1382.
 spec = withStaticConfigurations $ withCompileInfo def $
-    describe "Block.Logic.VAR" $ modifyMaxSuccess (min 12) $ do
+    describe "Block.Logic.VAR" $ modifyMaxSuccess (min 4) $ do
         describe "verifyBlocksPrefix" verifyBlocksPrefixSpec
         describe "verifyAndApplyBlocks" verifyAndApplyBlocksSpec
         describe "applyBlocks" applyBlocksSpec

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -192,7 +192,7 @@ test:
         <<: *dev_core_genesis_spec
         protocolConstants:
           <<: *dev_core_genesis_spec_protocolConstants
-          k: 15
+          k: 10
 
 
 ##############################################################################


### PR DESCRIPTION
MacOS CI still fails too often. I am decreasing some values and hope it
will make all or almost all builds pass now.
DEVOPS-562 and CSL-1966 may improve the situation, then we can restore bigger
values.