### PR TITLE
docs: run `stack setup` to install `ghc` first.

### DIFF
--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -89,6 +89,10 @@ Enter `nix-shell`:
 
     $ nix-shell
 
+If this is the first time you are initializing the nix-shell, install `ghc` first by running:
+
+    [nix-shell:~/cardano-sl]$ stack setup
+
 After that, in order to build Cardano SL with wallet capabilities, run the following script:
 
     [nix-shell:~/cardano-sl]$ ./scripts/build/cardano-sl.sh


### PR DESCRIPTION
Else you will run into the following error:

> No compiler found, expected minor version match with ghc-8.0.2 (x86_64) (based on resolver setting in /home/user/.opt/cardano-sl/stack.yaml).
>
> To install the correct GHC into /home/user/.stack/programs/x86_64-linux-nix/, try running "stack setup" or use the "--install-ghc" flag. To use your system GHC installation, run "stack config set system-ghc --global true", or use the "--system-ghc" flag.

