### PR TITLE
Fixes for demo.sh

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -92,8 +92,8 @@ function gen_kademlia_topology {
   fi
 
   echo "Cleaning up topology/kademlia files"
-  rm -v $out_dir/topology*.yaml
-  rm -v $out_dir/kademlia*.yaml
+  rm -fv $out_dir/topology*.yaml
+  rm -fv $out_dir/kademlia*.yaml
 
   echo "Generating new topology/kademlia files"
   for i in $(seq 0 $total_nodes); do

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -50,9 +50,13 @@ config_dir=$2
 
 if [[ $config_dir == "" ]]; then
   config_dir="./run"
+  if [[ ! -d $config_dir ]]; then
+    mkdir $config_dir
+  fi
   echo $(pwd)
   gen_kademlia_topology $n
 fi
+
 
 # Stats are not mandatory either
 stats=$4


### PR DESCRIPTION
* use `rm -rf` in case when the `$out_dir` does not exists (fresh run)
* create `./run` directory if it does not exists