### PR TITLE
connect-to-cluster: Fix configuration file path

### DIFF
--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -51,7 +51,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   ${executables.${executable}}                                     \
     ${ ifWallet "--web"}                                           \
     --no-ntp                                                       \
-    --configuration-file ${src}/node/configuration.yaml            \
+    --configuration-file ${src}/lib/configuration.yaml             \
     --configuration-key ${environments.${environment}.confKey}     \
     ${ ifWallet "--tlscert ${src}/scripts/tls-files/server.crt"}   \
     ${ ifWallet "--tlskey ${src}/scripts/tls-files/server.key"}    \


### PR DESCRIPTION
This change fixes the `connect-to-cluster` script generated by this `nix-build` invocation:

```
$ nix-build --attr connect.mainnetWallet -o connect-to-mainnet release.nix
```

The motivation behind this change is to fix this error:

```
parnell ~/Development/oss/cardano-sl ❱❱ /nix/store/ch2006v7g6cb532mr5plci53knrkf77a-wallet-connect-to-mainnet
Keeping state in state-wallet-mainnet
Launching a single node connected to 'mainnet' ...
[*production*:INFO:ThreadId 4] [2017-12-11 06:50:13.01 UTC] [Attention] Software is built with wallet part
[*production*:INFO:ThreadId 4] [2017-12-11 06:50:13.01 UTC] using configurations: ConfigurationOptions {cfoFilePath = "/nix/store/93fwvabqcpl42y0zrvmz4xhz4mmzdai4-cardano-sl/node/configuration.yaml", cfoKey = "mainnet_full", cfoSystemStart = Nothing, cfoSeed = Nothing}
cardano-node: ConfigurationParseFailure "/nix/store/93fwvabqcpl42y0zrvmz4xhz4mmzdai4-cardano-sl/node/configuration.yaml" (InvalidYaml (Just (YamlException "Yaml file not found: /nix/store/93fwvabqcpl42y0zrvmz4xhz4mmzdai4-cardano-sl/node/configuration.yaml")))
```

... which is a result of commit 2448450 moving the `node/configuration.yaml` to `lib/configuration.yaml` and not updating the path referenced in the script template within `scripts/launch/connect-to-cluster/default.nix`.