### PR TITLE
[DEVOPS-565]  appveyor:  disable branch cache updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -132,12 +132,14 @@ test_script:
   - ps: if (-NOT (Test-Path "$($env:WORK_DIR)\$env:STACK_WORK")) { throw "ERROR... Stack cache absent $x" }
 
 after_test:
+ # DEVOPS-565: disable automatic cache updates, as we're running out of memory during this copying
+ #
  # As per https://github.com/input-output-hk/cardano-sl/pull/1773#issue-265730372:
  # > STACK_WORK, as well as CACHED_STACK_WORK are relative directories, since stack doesn't support absolute ones.
- - cd "%WORK_DIR%"
- - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%
- - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
- - xcopy /q /s /e /r /k /i /v /h /y "%WORK_DIR%\daedalus" C:\projects\cardano-sl\daedalus
+ # - cd "%WORK_DIR%"
+ # - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %STACK_ROOT% %CACHED_STACK_ROOT%
+ # - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER IF EXIST %STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %STACK_WORK% %CACHED_STACK_WORK%
+ # - xcopy /q /s /e /r /k /i /v /h /y "%WORK_DIR%\daedalus" C:\projects\cardano-sl\daedalus
 
 artifacts:
   - path: daedalus/


### PR DESCRIPTION
This attempts to work around the out-of-memory on AppVeyor, that happens during the `xcopy` updating the branch cache.