### PR TITLE
Use cborg from Hackage

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7883,18 +7883,13 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "cborg" = callPackage
-        ({ mkDerivation, array, base, bytestring, containers, fetchgit
-         , ghc-prim, half, integer-gmp, primitive, stdenv, text
+        ({ mkDerivation, array, base, bytestring, containers, ghc-prim
+         , half, integer-gmp, primitive, stdenv, text
          }:
          mkDerivation {
            pname = "cborg";
-           version = "0.1.1.0";
-           src = fetchgit {
-             url = "https://github.com/well-typed/cborg";
-             sha256 = "06k0sqjfwc75w099vg5yqa5jf5406j9cz2x1dbkp3p887cmik4fv";
-             rev = "c7db82bfd93923f5b08ed51a4cd53e30bd445924";
-           };
-           postUnpack = "sourceRoot+=/cborg; echo source root reset to $sourceRoot";
+           version = "0.2.0.0";
+           sha256 = "808cbd40a3a53e798cc34b38c400154d1209536113f5dc5fd8a17a64e6c77fb7";
            libraryHaskellDepends = [
              array base bytestring containers ghc-prim half integer-gmp
              primitive text

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,13 +35,6 @@ packages:
 - wallet-new # The new (unreleased) version of the wallet
 
 - location:
-    git: https://github.com/well-typed/cborg
-    # Has support for canonical cbor
-    commit: c7db82bfd93923f5b08ed51a4cd53e30bd445924
-  subdirs:
-  - cborg
-  extra-dep: true
-- location:
     git: https://github.com/serokell/time-units.git
     commit: 6c3747c1ac794f952de996dd7ba8a2f6d63bf132
   extra-dep: true
@@ -159,6 +152,7 @@ extra-deps:
 - lens-sop-0.2.0.2
 - json-sop-0.2.0.3
 - servant-generic-0.1.0.1
+- cborg-0.2.0.0
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything


### PR DESCRIPTION
I accidentally noticed that cborg is now available on Hackage, so I guess it's better to use released Hackage version rather than some commit from git.