### PR TITLE
[CSL-2048] Add phantom type to BackupPhrase + fix documentation

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -25,9 +25,6 @@ instance Example Metadata
 instance Example AccountId
 instance Example WalletId
 
--- FIXME: I would like to create `Example (BackupPhrase a)`
--- how to deal with it?
--- Question: http://lpaste.net/360780
 instance Example BackupPhraseNormal
 instance Example BackupPhrasePaperVend
 instance Example AssuranceLevel

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -6,13 +6,16 @@ import           Cardano.Wallet.API.Response
 import           Cardano.Wallet.API.V1.Types
 import qualified Pos.Core.Common as Core
 import qualified Pos.Crypto.Signing as Core
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal, BackupPhrasePaperVend)
 
 import           Test.QuickCheck (Arbitrary (..), Gen, listOf1)
+
 
 class Arbitrary a => Example a where
     example :: Gen a
     example = arbitrary
+
+instance Example Text
 
 instance Example Core.PassPhrase
 instance Example Core.Coin
@@ -21,7 +24,12 @@ instance Example Address
 instance Example Metadata
 instance Example AccountId
 instance Example WalletId
-instance Example BackupPhrase
+
+-- FIXME: I would like to create `Example (BackupPhrase a)`
+-- how to deal with it?
+-- Question: http://lpaste.net/360780
+instance Example BackupPhraseNormal
+instance Example BackupPhrasePaperVend
 instance Example AssuranceLevel
 instance Example SyncProgress
 instance Example BlockchainHeight

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -807,6 +807,19 @@
             }
         },
         "BackupPhrase": {
+            "example": {
+                "bpToList": [
+                    "entry",
+                    "rare",
+                    "idle",
+                    "merit",
+                    "name",
+                    "night",
+                    "transfer",
+                    "screen",
+                    "kitten"
+                ]
+            },
             "required": [
                 "bpToList"
             ],

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -70,7 +70,7 @@ import           Cardano.Wallet.API.Types.UnitOfMeasure (MeasuredIn (..), UnitOf
 import           Cardano.Wallet.Orphans.Aeson ()
 
 -- V0 logic
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal)
 
 
 import           Pos.Aeson.Core ()
@@ -121,7 +121,7 @@ instance ToHttpApiData WalletId where
 
 -- | A type modelling the request for a new 'Wallet'.
 data NewWallet = NewWallet {
-      newwalBackupPhrase     :: !BackupPhrase
+      newwalBackupPhrase     :: !BackupPhraseNormal
     -- ^ The backup phrase to restore the wallet.
     , newwalSpendingPassword :: !(Maybe SpendingPassword)
     -- ^ The spending password to encrypt the private keys.

--- a/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
+++ b/wallet-new/src/Cardano/Wallet/Orphans/Aeson.hs
@@ -31,10 +31,10 @@ mkPassPhrase text =
                      ("Expected spending password to be of either length 0 or "%int%", not "%int)
                      Core.passphraseLength bl
 
-instance ToJSON BackupPhrase where
+instance ToJSON (BackupPhrase a) where
     toJSON (BackupPhrase words) = toJSON words
 
-instance FromJSON BackupPhrase where
+instance FromJSON (BackupPhrase a) where
     parseJSON (Array words) = BackupPhrase . toList <$> traverse parseJSON words
     parseJSON x             = typeMismatch "parseJSON failed for BackupPhrase" x
 

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -15,7 +15,7 @@ import           Test.Hspec.QuickCheck
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal, BackupPhrasePaperVend)
 
 import qualified Pos.Core as Core
 
@@ -24,7 +24,8 @@ spec :: Spec
 spec = describe "Marshalling & Unmarshalling" $ do
     describe "Roundtrips" $ do
         -- Aeson roundrips
-        aesonRoundtripProp @BackupPhrase Proxy
+        aesonRoundtripProp @BackupPhraseNormal Proxy
+        aesonRoundtripProp @BackupPhrasePaperVend Proxy
         aesonRoundtripProp @Account Proxy
         aesonRoundtripProp @AssuranceLevel Proxy
         aesonRoundtripProp @Payment Proxy

--- a/wallet/src/Pos/Util/BackupPhrase.hs
+++ b/wallet/src/Pos/Util/BackupPhrase.hs
@@ -7,7 +7,6 @@ module Pos.Util.BackupPhrase
        , MnemonicType(..)
        , BackupPhrasePaperVend
        , BackupPhraseNormal
-       , backupPhraseWordsNum
        , toSeed
        , keysFromPhrase
        , safeKeysFromPhrase
@@ -47,8 +46,6 @@ instance Typeable a => Bi (BackupPhrase a) where
 instance Arbitrary BackupPhrasePaperVend where
     arbitrary = BackupPhrase <$> vectorOf 9 (elements englishWords)
 
--- FIXME(akegalj): Fix mnemonic generation to be bip39 compatible
-instance Arbitrary BackupPhrasePaperVend where
 instance Arbitrary BackupPhraseNormal where
     arbitrary = BackupPhrase <$> vectorOf 12 (elements englishWords)
 
@@ -63,10 +60,6 @@ englishWords = [ "recycle" , "child" , "universe" , "extend" , "edge" , "tourist
                , "toss" , "atom" , "kitten" , "flush" , "master" , "transfer"
                , "success" , "worry" , "rural" , "silver" , "invest" , "mean "
                ]
-
--- | Number of words in backup phrase
-backupPhraseWordsNum :: Int
-backupPhraseWordsNum = 12
 
 instance Show (BackupPhrase a) where
     show _ = "<backup phrase>"

--- a/wallet/src/Pos/Util/BackupPhrase.hs
+++ b/wallet/src/Pos/Util/BackupPhrase.hs
@@ -51,11 +51,11 @@ arbitraryMnemonic len = do
 
 -- NOTE: it's guaranteed not to fail
 instance Arbitrary BackupPhrasePaperVend where
-    arbitrary = either error identity <$> arbitraryMnemonic 96
+    arbitrary = either error identity <$> arbitraryMnemonic 12
 
 -- NOTE: it's guaranteed not to fail
 instance Arbitrary BackupPhraseNormal where
-    arbitrary = either error identity <$> arbitraryMnemonic 128
+    arbitrary = either error identity <$> arbitraryMnemonic 16
 
 instance Show (BackupPhrase a) where
     show _ = "<backup phrase>"

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -26,9 +26,10 @@ import           Universum
 import           Pos.Client.KeyStorage (AllUserSecrets (..), MonadKeys, MonadKeysRead, addSecretKey,
                                         getSecretKeys, getSecretKeysPlain)
 import           Pos.Core (Address (..), IsBootstrapEraAddr (..), deriveLvl2KeyPair)
-import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..), firstHardened)
+import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..),
+                             firstHardened)
 import           Pos.Util (eitherToThrow)
-import           Pos.Util.BackupPhrase (BackupPhrase, safeKeysFromPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal, safeKeysFromPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
                                              addrMetaToAccount, addressToCId, encToCId)
 import           Pos.Wallet.Web.Error (WalletError (..))
@@ -95,7 +96,7 @@ getSKByAddressPure secrets scp passphrase addrMeta@CWAddressMeta {..} = do
 genSaveRootKey
     :: (AccountMode ctx m, MonadKeys m)
     => PassPhrase
-    -> BackupPhrase
+    -> BackupPhraseNormal
     -> m EncryptedSecretKey
 genSaveRootKey passphrase ph = do
     sk <- either keyFromPhraseFailed (pure . fst) $

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -81,7 +81,7 @@ import           Servant.Multipart (FileData, Mem)
 import           Pos.Client.Txp.Util (InputSelectionPolicy)
 import           Pos.Core (BlockVersion, ChainDifficulty, Coin, ScriptVersion, SoftwareVersion,
                            unsafeGetCoin)
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal, BackupPhrasePaperVend)
 import           Pos.Util.LogSafe (LogSecurityLevel, SecureLog (..), buildUnsecure, secretOnlyF,
                                    secure, secureListF, unsecure)
 import           Pos.Util.Servant (HasTruncateLogPolicy, WithTruncatedLog (..))
@@ -255,7 +255,7 @@ instance Default CAccountMeta where
 -- | Query data for wallet creation
 data CWalletInit = CWalletInit
     { cwInitMeta     :: !CWalletMeta
-    , cwBackupPhrase :: !BackupPhrase
+    , cwBackupPhrase :: !BackupPhraseNormal
     } deriving (Eq, Show, Generic)
 
 instance Buildable CWalletInit where
@@ -282,7 +282,7 @@ instance Buildable (SecureLog CWalletRedeem) where
 data CPaperVendWalletRedeem = CPaperVendWalletRedeem
     { pvWalletId     :: !CAccountId
     , pvSeed         :: !Text -- TODO: newtype!
-    , pvBackupPhrase :: !BackupPhrase
+    , pvBackupPhrase :: !BackupPhrasePaperVend
     } deriving (Show, Generic)
 
 instance Buildable CPaperVendWalletRedeem where

--- a/wallet/src/Pos/Wallet/Web/State/Storage.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Storage.hs
@@ -93,7 +93,6 @@ import           Pos.Core.Txp (TxAux, TxId)
 import           Pos.SafeCopy ()
 import           Pos.Txp (AddrCoinMap, Utxo, UtxoModifier, applyUtxoModToAddrCoinMap,
                           utxoToAddressCoinMap)
-import           Pos.Util.BackupPhrase (BackupPhrase)
 import qualified Pos.Util.Modifier as MM
 import           Pos.Wallet.Web.ClientTypes (AccountId, Addr, CAccountMeta, CCoin, CHash, CId,
                                              CProfile, CTxId, CTxMeta, CUpdateInfo,
@@ -624,7 +623,6 @@ deriveSafeCopySimple 0 'base ''CHash
 deriveSafeCopySimple 0 'base ''CId
 deriveSafeCopySimple 0 'base ''Wal
 deriveSafeCopySimple 0 'base ''Addr
-deriveSafeCopySimple 0 'base ''BackupPhrase
 deriveSafeCopySimple 0 'base ''AccountId
 deriveSafeCopySimple 0 'base ''CWAddressMeta
 deriveSafeCopySimple 0 'base ''CWalletAssurance
@@ -646,6 +644,7 @@ deriveSafeCopySimple 0 'base ''AddressInfo
 deriveSafeCopySimple 0 'base ''AccountInfo
 deriveSafeCopySimple 0 'base ''WalletTip
 deriveSafeCopySimple 0 'base ''WalletInfo
+
 
 -- Legacy versions, for migrations
 

--- a/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
@@ -92,9 +92,6 @@ instance ToSchema      CT.ClientInfo
 genExample :: (ToJSON a, Arbitrary a) => a
 genExample = (unGen (resize 3 arbitrary)) (mkQCGen 42) 42
 
--- FIXME: hm, I would like to create `ToSchema (BackupPhrase a)`
--- how to deal with it?
--- Question: http://lpaste.net/360780
 instance ToSchema BackupPhraseNormal where
     declareNamedSchema proxy =
         genericDeclareNamedSchema defaultSchemaOptions proxy

--- a/wallet/test/Test/Pos/Types/Identity/BinarySpec.hs
+++ b/wallet/test/Test/Pos/Types/Identity/BinarySpec.hs
@@ -16,8 +16,5 @@ spec :: Spec
 spec = withDefInfraConfiguration $ withDefConfiguration $ describe "Types" $ do
     describe "Bi instances" $ do
         describe "Util" $ do
-            -- FIXME: I would like to create `binaryTest @(BackupPhrase a)`
-            -- how to deal with it?
-            -- Question: http://lpaste.net/360780
             binaryTest @BackupPhrasePaperVend
             binaryTest @BackupPhraseNormal

--- a/wallet/test/Test/Pos/Types/Identity/BinarySpec.hs
+++ b/wallet/test/Test/Pos/Types/Identity/BinarySpec.hs
@@ -7,7 +7,7 @@ module Test.Pos.Types.Identity.BinarySpec
 import           Test.Hspec (Spec, describe)
 import           Universum
 
-import           Pos.Util.BackupPhrase (BackupPhrase)
+import           Pos.Util.BackupPhrase (BackupPhraseNormal, BackupPhrasePaperVend)
 
 import           Test.Pos.Helpers (binaryTest)
 import           Test.Pos.Util (withDefConfiguration, withDefInfraConfiguration)
@@ -16,4 +16,8 @@ spec :: Spec
 spec = withDefInfraConfiguration $ withDefConfiguration $ describe "Types" $ do
     describe "Bi instances" $ do
         describe "Util" $ do
-            binaryTest @BackupPhrase
+            -- FIXME: I would like to create `binaryTest @(BackupPhrase a)`
+            -- how to deal with it?
+            -- Question: http://lpaste.net/360780
+            binaryTest @BackupPhrasePaperVend
+            binaryTest @BackupPhraseNormal


### PR DESCRIPTION
This issue extends straightens `BackupPhrase` with a phantom type. We are using backup phrase for:
 * paper vend - 9 words
 * wallet backup - 12 words
 * paper wallets - 16 words ?
 * maybe more usecases in future

We are adding phantom type to differentiate between those.

Pros:
 * cleaner type signatures
      - it is clear now both in types and documentation that wallet creation requires 12 words but paper vend requires 9 words
 *  swagger documentation is able to generate right instance of 9 words vs 12 words based on this phantom type
 * smaller space for errors in future to mix those up

Cons:
 * extra language extensions (although not dangerous) in single module where `BackupPhrase` is defined
 * some boilerplate with extra class instances
     - confusion http://lpaste.net/360780

Accidentally, this PR also removes potentially wired/dangerous `SafeCopy` instance of `BackupPhrase` - we should never be able to save `BackupPhrase` on disk!

## TODO
 * [ ] ~fix boilerplate http://lpaste.net/360780~
        - tried with GADTs, failed - giving up
 * [x] fix `Arbitrary (BackupPhrase a)` to be bip39 compatible