### PR TITLE
[CSL-2038] More recovery heuristics

### DIFF
--- a/block/src/Pos/Block/Logic/Header.hs
+++ b/block/src/Pos/Block/Logic/Header.hs
@@ -157,8 +157,8 @@ deriving instance Show BlockHeader => Show ClassifyHeadersRes
 --    lca child is returned.
 -- * If chain of headers forks from our main chain too much, CHsUseless
 --    is returned, because paper suggests doing so.
--- * CHsUseless is also returned if we aren't too far behind the current slot
---    (i.e. if 'needRecovery' is false) but the newest header in the list isn't
+-- * CHsUseless is also returned if we aren't too far behind the current slot,
+--    but the newest header in the list isn't
 --    from the current slot. See CSL-177.
 classifyHeaders ::
        forall ctx m.

--- a/block/src/Pos/Block/Worker.hs
+++ b/block/src/Pos/Block/Worker.hs
@@ -254,7 +254,9 @@ recoveryTriggerWorkerImpl SendActions{..} = do
     repeatOnInterval action = void $ do
         delay $ sec 1
         -- REPORT:ERROR 'reportOrLogE' in recovery trigger worker
-        void $ action `catchAny` \e -> reportOrLogE "recoveryTriggerWorker" e
+        void $ action `catchAny` \e -> do 
+            reportOrLogE "recoveryTriggerWorker" e
+            delay $ sec 15
         repeatOnInterval action
 
 ----------------------------------------------------------------------------

--- a/block/src/Pos/Block/Worker.hs
+++ b/block/src/Pos/Block/Worker.hs
@@ -234,7 +234,8 @@ recoveryTriggerWorkerImpl SendActions{..} = do
         -- sometimes ask for tips even if we're in relatively safe
         -- situation.
         (d :: Double) <- liftIO $ randomRIO (0,1)
-        when (not doTrigger && d < 0.005) $ getSyncStatus 5 >>= \case
+        -- 0.003 ~ every 333th time (second) ~ every 5.5 minutes.
+        when (not doTrigger && d < 0.003) $ getSyncStatus 5 >>= \case
             SSKindaSynced -> pass
             SSDoingRecovery -> pass
             _ -> do

--- a/infra/Pos/Recovery/Info.hs
+++ b/infra/Pos/Recovery/Info.hs
@@ -5,6 +5,7 @@ module Pos.Recovery.Info
        ( SyncStatus (..)
        , MonadRecoveryInfo(..)
        , recoveryInProgress
+       , getSyncStatusK
        , recoveryCommGuard
        , needTriggerRecovery
        ) where
@@ -105,8 +106,8 @@ recoveryCommGuard actionName action =
 -- away from the current slot, or current slot isn't known. It also
 -- returns False when we're actually doing recovery. So basically it
 -- returns true if we actually need to ask for tips right now.
-needTriggerRecovery :: (MonadRecoveryInfo m, HasConfiguration) => m Bool
-needTriggerRecovery = getSyncStatusK <&> \case
+needTriggerRecovery :: SyncStatus -> Bool
+needTriggerRecovery = \case
     SSKindaSynced   -> False
     SSDoingRecovery -> False
     SSInFuture{}    -> False

--- a/infra/Pos/Recovery/Info.hs
+++ b/infra/Pos/Recovery/Info.hs
@@ -109,4 +109,5 @@ needTriggerRecovery :: (MonadRecoveryInfo m, HasConfiguration) => m Bool
 needTriggerRecovery = getSyncStatusK <&> \case
     SSKindaSynced   -> False
     SSDoingRecovery -> False
+    SSInFuture{}    -> False
     _               -> True


### PR DESCRIPTION
I've generalized `needRecovery` and related functions. I've also added a probabilistic preventive recovery triggering in case we're stuck >3 slots before current tip, but nobody sends us blocks.