### PR TITLE
[CSL-2087] Primary endpoints speedup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ before_test:
 - IF EXIST %CACHED_STACK_ROOT% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_ROOT% %STACK_ROOT%
 - IF EXIST %CACHED_STACK_WORK% xcopy /q /s /e /r /k /i /v /h /y %CACHED_STACK_WORK% %STACK_WORK%
 # Install OpenSSL 1.0.2 (see https://github.com/appveyor/ci/issues/1665)
-- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2L.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
+- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2n.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
 - ps: cmd /c start /wait "$($env:USERPROFILE)\Win64OpenSSL.exe" /silent /verysilent /sp- /suppressmsgboxes /DIR=C:\OpenSSL-Win64-v102
 - ps: Install-Product node 6
 # Install stack

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -12,6 +12,7 @@ module Pos.Wallet.Web.State.Acidic
        , update
 
        , GetProfile (..)
+       , DoesAccountExist (..)
        , GetAccountIds (..)
        , GetAccountMetas (..)
        , GetAccountMeta (..)
@@ -117,6 +118,7 @@ makeAcidic ''WalletStorage
     [
       'WS.testReset
     , 'WS.getProfile
+    , 'WS.doesAccountExist
     , 'WS.getAccountIds
     , 'WS.getAccountMetas
     , 'WS.getAccountMeta

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -16,6 +16,7 @@ module Pos.Wallet.Web.State.State
 
        -- * Getters
        , getProfile
+       , doesAccountExist
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
@@ -127,6 +128,9 @@ updateDisk
     :: (EventState event ~ WalletStorage, UpdateEvent event, WebWalletModeDB ctx m)
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
+
+doesAccountExist :: WebWalletModeDB ctx m => AccountId -> m Bool
+doesAccountExist = queryDisk . A.DoesAccountExist
 
 getAccountIds :: WebWalletModeDB ctx m => m [AccountId]
 getAccountIds = queryDisk A.GetAccountIds

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -20,6 +20,7 @@ module Pos.Wallet.Web.State.Storage
        , flushWalletStorage
        , getProfile
        , setProfile
+       , doesAccountExist
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
@@ -214,6 +215,9 @@ getProfile = view wsProfile
 
 setProfile :: CProfile -> Update ()
 setProfile cProfile = wsProfile .= cProfile
+
+doesAccountExist :: AccountId -> Query Bool
+doesAccountExist accId = view $ wsAccountInfos . at accId . to isJust
 
 getAccountIds :: Query [AccountId]
 getAccountIds = HM.keys <$> view wsAccountInfos

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2839,8 +2839,8 @@ self: {
           pname = "distributive";
           version = "0.5.3";
           sha256 = "0y566r97sfyvhsmd4yxiz4ns2mqgwf5bdbp56wgxl6wlkidq0wwi";
-          revision = "1";
-          editedCabalFile = "0hsq03i0qa0jvw7kaaqic40zvfkzhkd25dgvbdg6hjzylf1k1gax";
+          revision = "2";
+          editedCabalFile = "02j27xvlj0jw3b2jpfg6wbysj0blllin792wj6qnrgnrvd4haj7v";
           setupHaskellDepends = [
             base
             Cabal
@@ -5691,8 +5691,8 @@ self: {
           pname = "semigroupoids";
           version = "5.2.1";
           sha256 = "006jys6kvckkmbnhf4jc51sh64hamkz464mr8ciiakybrfvixr3r";
-          revision = "2";
-          editedCabalFile = "049j2jl6f5mxqnavi1aadx37j4bk5xksvkxsl43hp4rg7n53p11z";
+          revision = "3";
+          editedCabalFile = "0wzcnpz8pyjk823vqnq5s8krsb8i6cw573hcschpd9x5ynq4li70";
           setupHaskellDepends = [
             base
             Cabal

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -22,7 +22,7 @@ import           System.Wlog                (WithLogger, logInfo, logWarning)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
-import           Pos.Client.Txp.History     (txHistoryListToMap, TxHistoryEntry (..))
+import           Pos.Client.Txp.History     (TxHistoryEntry (..), txHistoryListToMap)
 import           Pos.Core                   (ChainDifficulty, timestampToPosix)
 import           Pos.Txp.Core.Types         (TxId)
 import           Pos.Util.Servant           (encodeCType)
@@ -31,19 +31,17 @@ import           Pos.Wallet.WalletMode      (getLocalHistory, localChainDifficul
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId, CTx (..), CTxId,
                                              CTxMeta (..), CWAddressMeta (..), Wal, mkCTx)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
+import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending     (PendingTx (..), ptxPoolInfo)
 import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNewTxMetas,
                                              getHistoryCache, getPendingTx, getTxMeta,
                                              getWalletPendingTxs, setWalletTxMeta)
-import           Pos.Wallet.Web.Util        (decodeCTypeOrFail, getAccountAddrsOrThrow,
-                                             getWalletAccountIds, getWalletAddrsSet,
-                                             getWalletAddrs)
-
+import           Pos.Wallet.Web.Util        (getAccountAddrsOrThrow, getWalletAccountIds,
+                                             getWalletAddrs, getWalletAddrsSet)
 
 getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
 getFullWalletHistory cWalId = do
-    addrs <- mapM decodeCTypeOrFail =<< getWalletAddrs Ever cWalId
+    addrs <- getWalletAddrs Ever cWalId >>= convertCIdTOAddrs
 
     unfilteredLocalHistory <- getLocalHistory addrs
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -49,7 +49,7 @@ import           Pos.Wallet.Web.ClientTypes   (AccountId (..), CAccount (..),
                                                CWallet (..), CWalletMeta (..), Wal,
                                                addrMetaToAccount, encToCId, mkCCoin)
 import           Pos.Wallet.Web.Error         (WalletError (..))
-import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
+import           Pos.Wallet.Web.Mode          (MonadWalletWebMode, convertCIdTOAddr)
 import           Pos.Wallet.Web.State         (AddressLookupMode (Existing),
                                                CustomAddressType (ChangeAddr, UsedAddr),
                                                addWAddress, createAccount, createWallet,
@@ -86,7 +86,8 @@ getWAddressBalanceWithMod
     -> CWAddressMeta
     -> m Coin
 getWAddressBalanceWithMod balancesAndUtxo accMod addr =
-    getBalanceWithMod balancesAndUtxo accMod <$> decodeCTypeOrFail (cwamId addr)
+    getBalanceWithMod balancesAndUtxo accMod
+        <$> convertCIdTOAddr (cwamId addr)
 
 -- BE CAREFUL: this function works for O(number of used and change addresses)
 getWAddress

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -192,11 +192,15 @@ newAddress addGenSeed passphrase accId = do
     balAndUtxo <- WS.getWalletBalancesAndUtxo
     fixCachedAccModifierFor accId $ \accMod -> do
         -- check whether account exists
-        _ <- getAccountMod balAndUtxo accMod accId
+        parentExists <- WS.doesAccountExist accId
+        unless parentExists $ throwM noAccount
 
         cAccAddr <- genUniqueAddress addGenSeed passphrase accId
         addWAddress cAccAddr
         getWAddress balAndUtxo accMod cAccAddr
+  where
+    noAccount =
+        RequestError $ sformat ("No account with id "%build%" found") accId
 
 newAccountIncludeUnready
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -25,7 +25,8 @@ module Pos.Wallet.Web.Methods.Logic
 import           Universum
 
 import qualified Data.HashMap.Strict          as HM
-import           Data.List                    (findIndex, notElem)
+import           Data.List                    (findIndex)
+import qualified Data.Set                     as S
 import           Data.Time.Clock.POSIX        (getPOSIXTime)
 import           Formatting                   (build, sformat, (%))
 
@@ -125,9 +126,9 @@ getAccountMod balAndUtxo accMod accId = do
         RequestError $ sformat ("No account with id "%build%" found") accId
     gatherAddresses addrModifier dbAddrs = do
         let memAddrs = sortedInsertions addrModifier
+            dbAddrsSet = S.fromList dbAddrs
             relatedMemAddrs = filter ((== accId) . addrMetaToAccount) memAddrs
-            -- @|relatedMemAddrs|@ is O(1) while @dbAddrs@ is large
-            unknownMemAddrs = filter (`notElem` dbAddrs) relatedMemAddrs
+            unknownMemAddrs = filter (`S.notMember` dbAddrsSet) relatedMemAddrs
         dbAddrs <> unknownMemAddrs
 
 getAccount :: MonadWalletWebMode m => AccountId -> m CAccount

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -12,8 +12,10 @@ import           Universum
 
 import           Control.Exception                (throw)
 import           Control.Monad.Except             (runExcept)
+import           Data.Time.Units                  (Second)
 import           Formatting                       (sformat, (%))
 import qualified Formatting                       as F
+import           Mockable                         (concurrently, delay)
 import           System.Wlog                      (logDebug, logInfo)
 
 import           Pos.Aeson.ClientTypes            ()
@@ -65,11 +67,14 @@ newPayment
     -> Coin
     -> m CTx
 newPayment sa passphrase srcAccount dstAccount coin =
+    notFasterThan (1 :: Second) $  -- in order not to overflow relay
     sendMoney
         sa
         passphrase
         (AccountMoneySource srcAccount)
         (one (dstAccount, coin))
+  where
+    notFasterThan time action = fst <$> concurrently action (delay time)
 
 getTxFee
      :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -48,7 +48,8 @@ import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
 import qualified Pos.Wallet.Web.Methods.Logic     as L
 import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
                                                    submitAndSaveNewPtx)
-import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
+import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
+                                                   convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
 import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing))
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
@@ -155,7 +156,8 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         throwM (RequestError "Given money source has no addresses!")
     logDebug "sendMoney: retrieved addrs"
 
-    srcAddrs <- forM addrMetas $ decodeCTypeOrFail . cwamId
+    srcAddrs <- convertCIdTOAddrs $ map cwamId addrMetas
+
     logDebug "sendMoney: processed addrs"
 
     let metasAndAdrresses = zip (toList addrMetas) (toList srcAddrs)

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -31,7 +31,8 @@ import           Pos.Launcher.Runner            (runRealBasedMode)
 import           Pos.Util.TimeWarp              (NetworkAddress)
 import           Pos.Wallet.SscType             (WalletSscType)
 import           Pos.Wallet.Web.Methods         (addInitialRichAccount)
-import           Pos.Wallet.Web.Mode            (WalletWebMode, WalletWebModeContext (..),
+import           Pos.Wallet.Web.Mode            (AddrCIdHashes (..), WalletWebMode,
+                                                 WalletWebModeContext (..),
                                                  WalletWebModeContextTag)
 import           Pos.Wallet.Web.Server.Launcher (walletApplication, walletServeImpl,
                                                  walletServer)
@@ -47,10 +48,13 @@ runWRealMode
     -> NodeResources WalletSscType WalletWebMode
     -> (ActionSpec WalletWebMode a, OutSpecs)
     -> Production a
-runWRealMode db conn =
+runWRealMode db conn res acts = do
+    ref <- newIORef mempty
     runRealBasedMode
-        (Mtl.withReaderT (WalletWebModeContext db conn))
-        (Mtl.withReaderT (\(WalletWebModeContext _ _ rmc) -> rmc))
+        (Mtl.withReaderT (WalletWebModeContext db conn $ AddrCIdHashes ref))
+        (Mtl.withReaderT (\(WalletWebModeContext _ _ _ rmc) -> rmc))
+        res
+        acts
 
 walletServeWebFull
     :: HasConfigurations


### PR DESCRIPTION
Improves performance of `newPayment`, `getWallets` and `getTxHistory`  endpoints.
Detected problems:
1. `newPayment` need to create change address in the process, and `newAddress` endpoint did some extra work, which now removed.
2. Addresses are kept in database as `CId Addr` strings, and mentioned endpoints require to deserialize them all. As simple solution we keep cache with `Map (CId Addr) Address`. Proper database migration will be performed as part of moving to wallet-new.

Now we get following times in local demo when creating 60k addresses artificially:
* `newPayment` - ~1 second
* `getTxHistory` - < 1 second
* `getWallets` - 1-2 seconds

Tested with:
* Basic testing (create transactions, see at tx history and wallets info)
* Daedalus acceptance tests
