### PR TITLE
[CSL-2086] Use wallet-db as default db.

### DIFF
--- a/wallet-new/server/Cardano/Wallet/Server/CLI.hs
+++ b/wallet-new/server/Cardano/Wallet/Server/CLI.hs
@@ -161,7 +161,7 @@ dbOptionsParser = WalletDBOptions <$> dbPathParser
     dbPathParser :: Parser FilePath
     dbPathParser = strOption (long  "wallet-db-path" <>
                               help  "Path to the wallet's database." <>
-                              value "wallet-new-db"
+                              value "wallet-db"
                              )
 
     rebuildDbParser :: Parser Bool


### PR DESCRIPTION
This trivial PR allows `wallet-new` to use `wallet-db` as the default DB.