### PR TITLE
[CSL-2087] `newPayment` improvements

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -130,10 +130,10 @@ mkCTx
     -> TxHistoryEntry     -- ^ Tx history entry
     -> CTxMeta            -- ^ Transaction metadata
     -> CPtxCondition      -- ^ State of resubmission
-    -> Set (CId Addr)     -- ^ Addresses of wallet
+    -> (CId Addr -> Bool) -- ^ Whether addresses belongs to the wallet
     -> Either Text CTx
-mkCTx diff THEntry {..} meta pc wAddrsSet = do
-    let isOurTxAddress = flip S.member wAddrsSet . addressToCId . txOutAddress
+mkCTx diff THEntry {..} meta pc addrBelongsToWallet = do
+    let isOurTxAddress = addrBelongsToWallet . addressToCId . txOutAddress
 
         ownInputs = filter isOurTxAddress inputs
         ownOutputs = filter isOurTxAddress outputs

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -16,6 +16,7 @@ module Pos.Wallet.Web.State.Acidic
        , GetAccountIds (..)
        , GetAccountMetas (..)
        , GetAccountMeta (..)
+       , GetAccountAddrMaps (..)
        , GetWalletMetas (..)
        , GetWalletMeta (..)
        , GetWalletMetaIncludeUnready (..)
@@ -125,6 +126,7 @@ makeAcidic ''WalletStorage
     , 'WS.getAccountIds
     , 'WS.getAccountMetas
     , 'WS.getAccountMeta
+    , 'WS.getAccountAddrMaps
     , 'WS.getWalletMetas
     , 'WS.getWalletMeta
     , 'WS.getWalletMetaIncludeUnready

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -5,6 +5,7 @@ module Pos.Wallet.Web.State.State
        , MonadWalletWebDB
        , WalletTip (..)
        , PtxMetaUpdate (..)
+       , AddressInfo (..)
        , getWalletWebState
        , WebWalletModeDB
        , openState
@@ -14,6 +15,7 @@ module Pos.Wallet.Web.State.State
        , NeedSorting (..)
        , AddressLookupMode (..)
        , CustomAddressType (..)
+       , CurrentAndRemoved (..)
 
        -- * Getters
        , getProfile
@@ -21,6 +23,7 @@ module Pos.Wallet.Web.State.State
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
+       , getAccountAddrMaps
        , getAccountWAddresses
        , getWalletMetas
        , getWalletMeta
@@ -114,7 +117,8 @@ import qualified Pos.Wallet.Web.Pending.Functions as F
 import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
-import           Pos.Wallet.Web.State.Storage (AddressLookupMode (..),
+import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMode (..),
+                                               CurrentAndRemoved (..),
                                                CustomAddressType (..), NeedSorting (..),
                                                PtxMetaUpdate (..), WalletBalances,
                                                WalletStorage, WalletTip (..))
@@ -153,6 +157,11 @@ getAccountMetas = queryDisk A.GetAccountMetas
 
 getAccountMeta :: WebWalletModeDB ctx m => AccountId -> m (Maybe CAccountMeta)
 getAccountMeta = queryDisk . A.GetAccountMeta
+
+getAccountAddrMaps
+    :: WebWalletModeDB ctx m
+    => AccountId -> m (CurrentAndRemoved (HashMap (CId Addr) AddressInfo))
+getAccountAddrMaps = queryDisk . A.GetAccountAddrMaps
 
 getWalletAddresses :: WebWalletModeDB ctx m => m [CId Wal]
 getWalletAddresses = queryDisk A.GetWalletAddresses

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -11,6 +11,7 @@ module Pos.Wallet.Web.State.Storage
        , AddressLookupMode (..)
        , NeedSorting (..)
        , CustomAddressType (..)
+       , CurrentAndRemoved (..)
        , WalletBalances
        , WalBalancesAndUtxo
        , WalletTip (..)
@@ -25,6 +26,7 @@ module Pos.Wallet.Web.State.Storage
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
+       , getAccountAddrMaps
        , getWalletMetas
        , getWalletMeta
        , getWalletMetaIncludeUnready
@@ -218,6 +220,12 @@ customAddressL ChangeAddr = wsChangeAddresses
 -- | Whether need to sort resulting list.
 newtype NeedSorting = NeedSorting Bool
 
+-- | Keeps existing and pseudo-removed entries, e.g. addresses.
+data CurrentAndRemoved a = CurrentAndRemoved
+    { getCurrent :: a
+    , getRemoved :: a
+    }
+
 getProfile :: Query CProfile
 getProfile = view wsProfile
 
@@ -235,6 +243,14 @@ getAccountMetas = map (view aiMeta) . toList <$> view wsAccountInfos
 
 getAccountMeta :: AccountId -> Query (Maybe CAccountMeta)
 getAccountMeta accId = preview (wsAccountInfos . ix accId . aiMeta)
+
+getAccountAddrMaps :: AccountId -> Query (CurrentAndRemoved CAddresses)
+getAccountAddrMaps accId = do
+    getCurrent <- getMap aiAddresses
+    getRemoved <- getMap aiRemovedAddresses
+    return CurrentAndRemoved{..}
+  where
+    getMap aiLens = fmap (fromMaybe mempty) $ preview $ wsAccountInfos . ix accId . aiLens
 
 getWalletMetas :: Query [CWalletMeta]
 getWalletMetas = toList . fmap _wiMeta . HM.filter _wiIsReady <$> view wsWalletInfos
@@ -277,6 +293,7 @@ getAccountWAddresses mode (NeedSorting needSorting) accId =
         pure $
             (map adiCWAddressMeta . sorting . toList)
             <$> cAddresses
+
 
 doesWAddressExist :: AddressLookupMode -> CWAddressMeta -> Query Bool
 doesWAddressExist mode addrMeta@(addrMetaToAccount -> wAddr) =
@@ -564,6 +581,7 @@ deriveSafeCopySimple 0 'base ''CUpdateInfo
 deriveSafeCopySimple 0 'base ''AddressLookupMode
 deriveSafeCopySimple 0 'base ''NeedSorting
 deriveSafeCopySimple 0 'base ''CustomAddressType
+deriveSafeCopySimple 0 'base ''CurrentAndRemoved
 deriveSafeCopySimple 0 'base ''TxAux
 deriveSafeCopySimple 0 'base ''PtxCondition
 deriveSafeCopySimple 0 'base ''PtxSubmitTiming

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -38,7 +38,7 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), NeedSorti
                                              getPendingTx, getTxMeta, getWalletPendingTxs,
                                              setWalletTxMeta)
 import           Pos.Wallet.Web.Util        (getAccountAddrsOrThrow, getWalletAccountIds,
-                                             getWalletAddrs)
+                                             getWalletAddrs, getWalletAddrsDetector)
 
 getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
 getFullWalletHistory cWalId = do
@@ -63,8 +63,8 @@ getFullWalletHistory cWalId = do
     logTxHistory "Mempool" localHistory
 
     fullHistory <- addRecentPtxHistory cWalId $ localHistory `Map.union` blockHistory
+    walAddrsDetector <- getWalletAddrsDetector Ever cWalId
     diff        <- getCurChainDifficulty
-    let !cAddrsSet = S.fromList cAddrs
     logDebug "getFullWalletHistory: fetched full history"
 
     -- TODO when we introduce some mechanism to react on new tx in mempool,
@@ -74,7 +74,7 @@ getFullWalletHistory cWalId = do
     addHistoryTxs cWalId localHistory
     logDebug "getFullWalletHistory: invoked addHistoryTxs"
 
-    cHistory <- forM fullHistory (constructCTx cWalId cAddrsSet diff)
+    cHistory <- forM fullHistory (constructCTx cWalId walAddrsDetector diff)
     logDebug "getFullWalletHistory: formed cTxs"
     pure (cHistory, fromIntegral $ Map.size cHistory)
 
@@ -183,17 +183,17 @@ addHistoryTxs cWalId historyEntries = do
 constructCTx
     :: MonadWalletWebMode m
     => CId Wal
-    -> Set (CId Addr)
+    -> (CId Addr -> Bool)
     -> ChainDifficulty
     -> TxHistoryEntry
     -> m (CTx, POSIXTime)
-constructCTx cWalId walAddrsSet diff wtx@THEntry{..} = do
+constructCTx cWalId addrBelongsToWallet diff wtx@THEntry{..} = do
     let cId = encodeCType _thTxId
     meta <- maybe (CTxMeta <$> liftIO getPOSIXTime) -- It's impossible case but just in case
             pure =<< getTxMeta cWalId cId
     ptxCond <- encodeCType . fmap _ptxCond <$> getPendingTx cWalId _thTxId
     either (throwM . InternalError) (pure . (, ctmDate meta)) $
-        mkCTx diff wtx meta ptxCond walAddrsSet
+        mkCTx diff wtx meta ptxCond addrBelongsToWallet
 
 getCurChainDifficulty :: MonadWalletWebMode m => m ChainDifficulty
 getCurChainDifficulty = maybe localChainDifficulty pure =<< networkChainDifficulty

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -41,10 +41,9 @@ import           Pos.Util                         (eitherToThrow, maybeThrow)
 import           Pos.Wallet.KeyStorage            (getSecretKeys)
 import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAddressPure,
                                                    getSKById)
-import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CAddress (..),
-                                                   CCoin, CId, CTx (..),
-                                                   CWAddressMeta (..), Wal,
-                                                   addrMetaToAccount, mkCCoin)
+import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CCoin, CId,
+                                                   CTx (..), CWAddressMeta (..), Wal,
+                                                   addrMetaToAccount, cadId, mkCCoin)
 import           Pos.Wallet.Web.Error             (WalletError (..))
 import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
                                                    getCurChainDifficulty)
@@ -59,7 +58,8 @@ import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Exis
 import           Pos.Wallet.Web.State.State       (getPendingTxs)
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
                                                    getAccountAddrsOrThrow,
-                                                   getWalletAccountIds, getWalletAddrsSet)
+                                                   getWalletAccountIds,
+                                                   getWalletAddrsDetector)
 
 newPayment
     :: MonadWalletWebMode m
@@ -210,8 +210,8 @@ sendMoney SendActions{..} passphrase moneySource dstDistr = do
         return th
 
     addHistoryTx srcWallet th
-    srcWalletAddrs <- getWalletAddrsSet Ever srcWallet
     diff <- getCurChainDifficulty
+    srcWalletAddrsDetector <- getWalletAddrsDetector Ever srcWallet
 
     logDebug "sendMoney: constructing response"
-    fst <$> constructCTx srcWallet srcWalletAddrs diff th
+    fst <$> constructCTx srcWallet srcWalletAddrsDetector diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -36,7 +36,8 @@ import           Pos.Wallet.Web.Methods.Txp     (rewrapTxError, submitAndSaveNew
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending         (mkPendingTx)
 import           Pos.Wallet.Web.State           (AddressLookupMode (Ever))
-import           Pos.Wallet.Web.Util            (decodeCTypeOrFail, getWalletAddrsSet)
+import           Pos.Wallet.Web.Util            (decodeCTypeOrFail,
+                                                 getWalletAddrsDetector)
 
 
 redeemAda
@@ -109,6 +110,6 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     -- add redemption transaction to the history of new wallet
     let cWalId = aiWId accId
     addHistoryTx cWalId th
-    cWalAddrs <- getWalletAddrsSet Ever cWalId
+    cWalAddrsDetector <- getWalletAddrsDetector Ever cWalId
     diff <- getCurChainDifficulty
-    fst <$> constructCTx cWalId cWalAddrs diff th
+    fst <$> constructCTx cWalId cWalAddrsDetector diff th


### PR DESCRIPTION
Avoid conversion `HashMap (CId Addr) a` to `Set (CId Addr)` when viable.

Measures:
Before: 6.97 - 9.42 sec (rarely 12.96)
After: 5.93 - 9.48 sec

(there is a performance regression in before result comparing to measures I reported a couple of days ago (on commit X), I don't understand why it so happens, but the same regression happens even if I try to measure right at commit X, so it seems to be caused by my machine)