### PR TITLE
cardano-sl: Fix broken cardano-bench-criterion target

### DIFF
--- a/lib/bench/Bench/Pos/Criterion/FollowTheSatoshiBench.hs
+++ b/lib/bench/Bench/Pos/Criterion/FollowTheSatoshiBench.hs
@@ -1,17 +1,17 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Bench.Pos.Criterion.FollowTheSatoshiBench
     ( runBenchmark
     ) where
 
 import           Criterion.Main (Benchmark, bench, defaultConfig, defaultMainWith, env, whnf)
 import           Criterion.Types (Config (..))
-import           Data.Map (fromList)
 import           Formatting (int, sformat, (%))
 import           Test.QuickCheck (Arbitrary (..), Gen, generate, infiniteListOf)
 import           Universum
 
 import           Pos.Core (HasConfiguration)
+import           Pos.Core.Common (Coin, StakeholderId)
 import           Pos.Lrc (followTheSatoshi)
-import           Pos.Txp (Utxo)
 import           Pos.Util (arbitraryUnsafe)
 
 import           Bench.Configuration (giveCoreConf)
@@ -20,8 +20,8 @@ type UtxoSize = Int
 
 -- [CSL-192]: make a trick and use special unsafe arbitrary instances
 -- for generation of such things
-arbitraryUtxoOfSize :: UtxoSize -> Gen Utxo
-arbitraryUtxoOfSize n = fromList . take n <$> infiniteListOf arbitraryUnsafe
+arbitraryUtxoOfSize :: UtxoSize -> Gen [(StakeholderId, Coin)]
+arbitraryUtxoOfSize n = take n <$> infiniteListOf arbitraryUnsafe
 
 ftsBench :: HasConfiguration => UtxoSize -> Benchmark
 ftsBench n = env genArgs $ bench msg . whnf (uncurry followTheSatoshi)

--- a/lib/bench/Local/Criterion.hs
+++ b/lib/bench/Local/Criterion.hs
@@ -6,11 +6,11 @@ import           Universum
 
 import           System.IO (hSetEncoding, stdout, utf8)
 
--- import qualified Bench.Pos.Criterion.FollowTheSatoshiBench as FTS
+import qualified Bench.Pos.Criterion.FollowTheSatoshiBench as FTS
 import qualified Bench.Pos.Criterion.TxSigningBench as TS
 
 main :: IO ()
 main = do
     hSetEncoding stdout utf8
-    -- FTS.runBenchmark
+    FTS.runBenchmark
     TS.runBenchmark

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -157,7 +157,7 @@ library
                       , cardano-sl-db
                       , cardano-sl-delegation
                       , cardano-sl-infra
-                      , cardano-sl-lrc     
+                      , cardano-sl-lrc
                       , cardano-sl-networking
                       , cardano-sl-ssc
                       , cardano-sl-txp
@@ -421,12 +421,15 @@ benchmark cardano-bench-criterion
                      , aeson
                      , base
                      , cardano-sl
+                     , cardano-sl-block
                      , cardano-sl-core
                      , cardano-sl-crypto
                      , cardano-sl-txp
                      , cardano-sl-ssc
                      , cardano-sl-util
+                     , containers
                      , criterion
+                     , formatting
                      , universum >= 0.1.11
                      , vector
   default-language:    Haskell2010


### PR DESCRIPTION
This benchmark target wouldn't compile due to changes elsewhere in
the tree.