### PR TITLE
[CSL-1869] Improve block(header) server performance

### DIFF
--- a/auxx/src/Plugin.hs
+++ b/auxx/src/Plugin.hs
@@ -140,4 +140,5 @@ addLogging SendActions{..} = SendActions{
                      Nothing  -> sformat ("Auxx received end of input")
                      Just rcv -> sformat ("Auxx received " % stext) (formatMessage rcv)
                  return mRcv
+      , sendRaw = sendRaw
       }

--- a/node/cardano-sl.cabal
+++ b/node/cardano-sl.cabal
@@ -342,6 +342,7 @@ library
                       , cardano-sl-ssc
                       , cardano-sl-txp
                       , cardano-sl-update
+                      , cborg
                       , cereal
                       , conduit >= 1.2.8
                       , containers

--- a/node/src/Pos/Binary/Communication.hs
+++ b/node/src/Pos/Binary/Communication.hs
@@ -2,9 +2,13 @@
 
 -- | Communication-related serialization -- messages mostly.
 
-module Pos.Binary.Communication () where
+module Pos.Binary.Communication
+    ( msgBlockPrefix
+    ) where
 
 import           Universum
+import qualified Data.ByteString                  as BS
+import qualified Codec.CBOR.Write                 as CBOR (toStrictByteString)
 
 import           Pos.Binary.Block                 ()
 import           Pos.Binary.Class                 (Bi (..), Cons (..), Field (..),
@@ -62,6 +66,12 @@ instance (HasConfiguration, SscHelpersClass ssc) => Bi (MsgBlock ssc) where
             0 -> MsgBlock <$> decode
             1 -> MsgNoBlock <$> decode
             t -> fail $ "MsgBlock wrong tag: " <> show t
+
+-- | Get an encoded MsgBlock from an encoded block.
+msgBlockPrefix :: BS.ByteString
+msgBlockPrefix = CBOR.toStrictByteString prefix
+  where
+    prefix = encodeListLen 2 <> encode (0 :: Word8)
 
 -- deriveSimpleBi is not happy with constructors without arguments
 -- "fake" deriving as per `MempoolMsg`.

--- a/node/src/Pos/Block/Network/Listeners.hs
+++ b/node/src/Pos/Block/Network/Listeners.hs
@@ -1,16 +1,21 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Server which deals with blocks processing.
 
 module Pos.Block.Network.Listeners
        ( blockListeners
        ) where
 
+import qualified Data.ByteString.Lazy            as BL (fromChunks)
 import           Formatting                      (build, int, sformat, (%))
 import qualified Network.Broadcast.OutboundQueue as OQ
+import           Node.Conversation               (sendRaw)
 import           Serokell.Util.Text              (listJson)
 import           System.Wlog                     (logDebug, logWarning)
 import           Universum
 
-import           Pos.Binary.Communication        ()
+-- Also brings in Bi instances.
+import           Pos.Binary.Communication        (msgBlockPrefix)
 import           Pos.Block.Logic                 (getHeadersFromToIncl)
 import           Pos.Block.Network.Announce      (handleHeadersCommunication)
 import           Pos.Block.Network.Logic         (handleUnsolicitedHeaders)
@@ -29,12 +34,13 @@ import           Pos.Util.Chrono                 (NewestFirst (..))
 import           Pos.WorkMode.Class              (WorkMode)
 
 blockListeners
-    :: (SscWorkersClass ssc, WorkMode ssc ctx m)
+    :: forall pack ssc ctx m .
+       (SscWorkersClass ssc, WorkMode ssc ctx m)
     => OQ.OutboundQ pack NodeId Bucket
     -> MkListeners m
 blockListeners oq = constantListeners $ map ($ oq)
     [ handleGetHeaders
-    , handleGetBlocks
+    , handleGetBlocks (Proxy @ssc)
     , handleBlockHeaders
     ]
 
@@ -55,11 +61,15 @@ handleGetHeaders oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
     handleHeadersCommunication conv --(convToSProxy conv)
 
 handleGetBlocks
-    :: forall pack ssc ctx m.
-       (WorkMode ssc ctx m)
-    => OQ.OutboundQ pack NodeId Bucket
+    :: forall pack ssc ctx m .
+       ( WorkMode ssc ctx m
+       )
+    => Proxy ssc
+    -> OQ.OutboundQ pack NodeId Bucket
     -> (ListenerSpec m, OutSpecs)
-handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
+handleGetBlocks (Proxy :: Proxy ssc) oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
+    -- Must tell GHC what the 'ssc' type is for the conversation.
+    let _ = conv :: ConversationActions (MsgBlock ssc) MsgGetBlocks m
     mbMsg <- recvLimited conv
     whenJust mbMsg $ \mgb@MsgGetBlocks{..} -> do
         logDebug $ sformat ("handleGetBlocks: got request "%build%" from "%build)
@@ -72,12 +82,20 @@ handleGetBlocks oq = listenerConv oq $ \__ourVerInfo nodeId conv -> do
                      " blocks to "%build%" one-by-one: "%listJson)
                     (length hashes) nodeId hashes
                 for_ hashes $ \hHash ->
-                    DB.blkGetBlock @ssc hHash >>= \case
+                    DB.blkGetBlockBytes hHash >>= \case
                         Nothing -> do
                             send conv (MsgNoBlock $
                                        "Couldn't retrieve block with hash " <> pretty hHash)
                             failMalformed
-                        Just b -> send conv (MsgBlock b)
+                        -- Warning: unsafe magic stopgap measure.
+                        -- We don't want to deserialize the block, because that
+                        -- is prohibitively expensive. Instead, we read the
+                        -- bytes from the database and assume they are
+                        -- well-formed, and then throw on the MsgBlock
+                        -- encoding prefix so that clients can still decode it.
+                        Just bytes ->
+                            let prefix = msgBlockPrefix
+                            in  sendRaw conv (BL.fromChunks [prefix, bytes])
                 logDebug "handleGetBlocks: blocks sending done"
             _ -> logWarning $ "getBlocksByHeaders@retrieveHeaders returned Nothing"
   where

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1151,6 +1151,7 @@ self: {
             cardano-sl-ssc
             cardano-sl-txp
             cardano-sl-update
+            cborg
             cereal
             conduit
             containers
@@ -4984,8 +4985,8 @@ self: {
           version = "0.2.0.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "0lyh7ydvlcjrdy9ffdp4dqymwgx7zwhqp61hx3ibq93k4j1s0m2j";
-            rev = "77a5db07bac949cf4ff1797eec44a036513be719";
+            sha256 = "0dwxcg3x62mghaz3zm77lnqdi8c63ny9sxrq4p0kwf51zyr6ip4d";
+            rev = "b199cfd9c7a1cf9bb12bc307e717d08df8b77cd1";
           };
           isLibrary = true;
           isExecutable = true;

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: d6205adccf90af07f60808b507354138a5914a42
+    commit: b199cfd9c7a1cf9bb12bc307e717d08df8b77cd1
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,7 +48,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/time-warp-nt.git
-    commit: 77a5db07bac949cf4ff1797eec44a036513be719
+    commit: d6205adccf90af07f60808b507354138a5914a42
   extra-dep: true
 # These two are needed for time-warp-nt
 - location:


### PR DESCRIPTION
Block deserialization is skipped when sending.
Loading headers performance improved (slightly).

It's a real pain, but I've managed to verify the improvements locally.
Block generator in cardano-sl-1.0 generated a chain of poor quality!
I couldn't figure out how to get the system start time right so that
the test nodes wouldn't immediately jump into recovery mode.

Anyway, since the test node was always in recovery mode, I
noticed that the recovery mode block headers server also suffers
from the block deserialization inefficiency: it will load headers
"up" using `GS.loadHeadersUpWhile`, which in fact loads more than
just the header, it deserializes the block with undo. We can fix that
later, as our relays are probably not going to be in recovery mode (I
hope not!) so it won't affect us. 