### PR TITLE
[CSL-2087] Don't do extra work for change address creation

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -141,8 +141,8 @@ instance
   where
     type AddrData Pos.Wallet.Web.Mode.WalletWebMode = (AccountId, PassPhrase)
     getNewAddress (accId, passphrase) = do
-        clientAddress <- L.newAddress RandomSeed passphrase accId
-        decodeCTypeOrFail (cadId clientAddress)
+        cAddrMeta <- L.newAddress_ RandomSeed passphrase accId
+        decodeCTypeOrFail (cwamId cAddrMeta)
 
 sendMoney
     :: MonadWalletWebMode m


### PR DESCRIPTION
Do now gather info about addresses in `newAddress` when not necessary.

Measures:
Before: 6.97 - 9.42 sec (rarely 12.96)
After: 6.10 - 8.8 sec

(there is a performance regression in before result comparing to measures I reported a couple of days ago (on commit X), I don't understand why it so happens, but the same regression happens even if I try to measure right at commit X, so it seems to be caused by my machine)