### PR TITLE
[CSL-2087] Don't sort addresses when not necessary

### DIFF
--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -11,6 +11,7 @@ module Pos.Wallet.Web.State.State
        , openMemState
        , closeState
 
+       , NeedSorting (..)
        , AddressLookupMode (..)
        , CustomAddressType (..)
 
@@ -114,9 +115,9 @@ import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemS
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
 import           Pos.Wallet.Web.State.Storage (AddressLookupMode (..),
-                                               CustomAddressType (..), PtxMetaUpdate (..),
-                                               WalletBalances, WalletStorage,
-                                               WalletTip (..))
+                                               CustomAddressType (..), NeedSorting (..),
+                                               PtxMetaUpdate (..), WalletBalances,
+                                               WalletStorage, WalletTip (..))
 
 -- | MonadWalletWebDB stands for monad which is able to get web wallet state
 type MonadWalletWebDB ctx m =
@@ -173,8 +174,8 @@ getWalletSyncTip = queryDisk . A.GetWalletSyncTip
 
 getAccountWAddresses
     :: WebWalletModeDB ctx m
-    => AddressLookupMode -> AccountId -> m (Maybe [CWAddressMeta])
-getAccountWAddresses mode = queryDisk . A.GetAccountWAddresses mode
+    => AddressLookupMode -> NeedSorting -> AccountId -> m (Maybe [CWAddressMeta])
+getAccountWAddresses mode ns ai = queryDisk $ A.GetAccountWAddresses mode ns ai
 
 doesWAddressExist
     :: WebWalletModeDB ctx m

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -30,10 +30,10 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
                                              CWAddressMeta (..), Wal, CAccountMeta,
                                              cwAssurance)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (AddressLookupMode, WebWalletModeDB,
-                                             getAccountIds, getAccountWAddresses,
-                                             getWalletMeta, getAccountMeta)
-
+import           Pos.Wallet.Web.State       (AddressLookupMode, NeedSorting (..),
+                                             WebWalletModeDB, getAccountIds,
+                                             getAccountWAddresses, getWalletMeta,
+                                             getAccountMeta)
 
 getAccountMetaOrThrow :: (WebWalletModeDB ctx m, MonadThrow m) => AccountId -> m CAccountMeta
 getAccountMetaOrThrow accId = getAccountMeta accId >>= maybeThrow noAccount
@@ -46,9 +46,9 @@ getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getAccountIds
 
 getAccountAddrsOrThrow
     :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> AccountId -> m [CWAddressMeta]
-getAccountAddrsOrThrow mode accId =
-    getAccountWAddresses mode accId >>= maybeThrow noWallet
+    => AddressLookupMode -> NeedSorting -> AccountId -> m [CWAddressMeta]
+getAccountAddrsOrThrow mode needSorting accId =
+    getAccountWAddresses mode needSorting accId >>= maybeThrow noWallet
   where
     noWallet =
         RequestError $
@@ -58,7 +58,7 @@ getWalletAddrMetas
     :: (WebWalletModeDB ctx m, MonadThrow m)
     => AddressLookupMode -> CId Wal -> m [CWAddressMeta]
 getWalletAddrMetas lookupMode cWalId =
-    concatMapM (getAccountAddrsOrThrow lookupMode) =<<
+    concatMapM (getAccountAddrsOrThrow lookupMode (NeedSorting False)) =<<
     getWalletAccountIds cWalId
 
 getWalletAddrs

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -33,9 +33,10 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId, CTx (..)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending     (PendingTx (..), ptxPoolInfo, _PtxApplying)
-import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNewTxMetas,
-                                             getHistoryCache, getPendingTx, getTxMeta,
-                                             getWalletPendingTxs, setWalletTxMeta)
+import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), NeedSorting (..),
+                                             addOnlyNewTxMetas, getHistoryCache,
+                                             getPendingTx, getTxMeta, getWalletPendingTxs,
+                                             setWalletTxMeta)
 import           Pos.Wallet.Web.Util        (getAccountAddrsOrThrow, getWalletAccountIds,
                                              getWalletAddrs)
 
@@ -85,7 +86,8 @@ getHistory
     -> m (Map TxId (CTx, POSIXTime), Word)
 getHistory cWalId accIds mAddrId = do
     -- FIXME: searching when only AddrId is provided is not supported yet.
-    accAddrs <- S.fromList . map cwamId <$> concatMapM (getAccountAddrsOrThrow Ever) accIds
+    accAddrs <- S.fromList . map cwamId <$>
+                concatMapM (getAccountAddrsOrThrow Ever (NeedSorting False)) accIds
     allAccIds <- getWalletAccountIds cWalId
 
     let filterFn :: Map TxId (CTx, POSIXTime) -> Map TxId (CTx, POSIXTime)

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -64,7 +64,7 @@ import           Pos.Wallet.Web.State         (AddressLookupMode (Existing),
                                                setAccountMeta, setWalletMeta,
                                                setWalletPassLU, setWalletReady)
 import qualified Pos.Wallet.Web.State         as WS
-import           Pos.Wallet.Web.State.Storage (WalBalancesAndUtxo)
+import           Pos.Wallet.Web.State.Storage (NeedSorting (..), WalBalancesAndUtxo)
 import           Pos.Wallet.Web.Tracking      (CAccModifier (..), CachedCAccModifier,
                                                fixCachedAccModifierFor,
                                                fixingCachedAccModifier, sortedInsertions)
@@ -115,7 +115,7 @@ getAccountMod
     -> AccountId
     -> m CAccount
 getAccountMod balAndUtxo accMod accId = do
-    dbAddrs    <- getAccountAddrsOrThrow Existing accId
+    dbAddrs    <- getAccountAddrsOrThrow Existing (NeedSorting True) accId
     let allAddrIds = gatherAddresses (camAddresses accMod) dbAddrs
     logDebug "getAccountMod: gathering info about addresses.."
     allAddrs <- mapM (getWAddress balAndUtxo accMod) allAddrIds

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -54,7 +54,8 @@ import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxE
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
                                                    convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
-import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing))
+import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing),
+                                                   NeedSorting (..))
 import           Pos.Wallet.Web.State.State       (getPendingTxs)
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
                                                    getAccountAddrsOrThrow,
@@ -101,7 +102,7 @@ data MoneySource
 getMoneySourceAddresses :: MonadWalletWebMode m => MoneySource -> m [CWAddressMeta]
 getMoneySourceAddresses (AddressMoneySource addrId) = return $ one addrId
 getMoneySourceAddresses (AccountMoneySource accId) =
-    getAccountAddrsOrThrow Existing accId
+    getAccountAddrsOrThrow Existing (NeedSorting False) accId
 getMoneySourceAddresses (WalletMoneySource wid) =
     getWalletAccountIds wid >>=
     concatMapM (getMoneySourceAddresses . AccountMoneySource)


### PR DESCRIPTION
Sort addresses only when they are to be displayed to user.

Measures:
Before: 6.97 - 9.42 sec (rarely 12.96)
After: 4.95 - 8.88 sec

(there is a performance regression in `before` result comparing to measures I reported a couple of days ago (on commit X), I don't understand why it so happens, but the same regression happens even if I try to measure right at commit X, so it seems to be caused by my machine)