### PR TITLE
[CSL-2083] High throughput policy for UTXO input selection

### DIFF
--- a/auxx/src/Command/Tx.hs
+++ b/auxx/src/Command/Tx.hs
@@ -146,7 +146,7 @@ sendToAllGenesis sendActions (SendToAllGenesisParams duration conc delay_ sendMo
                 | otherwise = (atomically $ tryReadTQueue txQueue) >>= \case
                       Just (key, txOuts, neighbours) -> do
                           utxo <- getOwnUtxoForPk $ safeToPublic (fakeSigner key)
-                          etx <- createTx utxo (fakeSigner key) txOuts (toPublic key)
+                          etx <- createTx mempty utxo (fakeSigner key) txOuts (toPublic key)
                           case etx of
                               Left err -> do
                                   addTxFailed tpsMVar
@@ -196,6 +196,7 @@ send sendActions idx outputs = do
     etx <- withSafeSigner skey (pure emptyPassphrase) $ \mss -> runExceptT $ do
         ss <- mss `whenNothing` throwError (toException $ AuxxException "Invalid passphrase")
         ExceptT $ try $ submitTx
+            mempty
             (immediateConcurrentConversations sendActions ccPeers)
             ss
             (map TxOutAux outputs)

--- a/node/src/Pos/Client/Txp/Util.hs
+++ b/node/src/Pos/Client/Txp/Util.hs
@@ -35,39 +35,44 @@ module Pos.Client.Txp.Util
 
 import           Universum
 
-import           Control.Lens             (makeLenses, (%=), (.=))
-import           Control.Monad.Except     (ExceptT, MonadError (throwError), runExceptT)
-import           Data.Fixed               (Fixed, HasResolution)
-import           Data.List                (tail)
-import qualified Data.List.NonEmpty       as NE
-import qualified Data.Map                 as M
-import qualified Data.Semigroup           as S
+import           Control.Lens                 (makeLenses, (%=), (.=))
+import           Control.Monad.Except         (ExceptT, MonadError (throwError),
+                                               runExceptT)
+import           Data.Fixed                   (Fixed, HasResolution)
+import           Data.List                    (tail)
+import qualified Data.List.NonEmpty           as NE
+import qualified Data.Map                     as M
+import qualified Data.Semigroup               as S
+import           Data.Set                     (Set)
+import qualified Data.Set                     as S
 import qualified Data.Text.Buildable
-import qualified Data.Vector              as V
-import           Formatting               (bprint, build, sformat, stext, (%))
-import           Serokell.Util            (listJson)
+import qualified Data.Vector                  as V
+import           Formatting                   (bprint, build, sformat, stext, (%))
+import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..))
+import           Serokell.Util                (listJson)
 
-import           Pos.Binary               (biSize)
-import           Pos.Client.Txp.Addresses (MonadAddresses (..))
-import           Pos.Core                 (TxFeePolicy (..), TxSizeLinear (..),
-                                           bvdTxFeePolicy, calculateTxSizeLinear,
-                                           coinToInteger, integerToCoin, isRedeemAddress,
-                                           txSizeLinearMinValue, unsafeAddCoin,
-                                           unsafeSubCoin)
-import           Pos.Core.Configuration   (HasConfiguration)
-import           Pos.Crypto               (RedeemSecretKey, SafeSigner,
-                                           SignTag (SignRedeemTx, SignTx),
-                                           deterministicKeyGen, fakeSigner, hash,
-                                           redeemSign, redeemToPublic, safeSign,
-                                           safeToPublic)
-import           Pos.Data.Attributes      (mkAttributes)
-import           Pos.DB                   (MonadGState, gsAdoptedBVData)
-import           Pos.Script               (Script)
-import           Pos.Script.Examples      (multisigRedeemer, multisigValidator)
-import           Pos.Txp                  (Tx (..), TxAux (..), TxFee (..), TxIn (..),
-                                           TxInWitness (..), TxOut (..), TxOutAux (..),
-                                           TxSigData (..), Utxo)
-import           Pos.Types                (Address, Coin, StakeholderId, mkCoin, sumCoins)
+import           Pos.Binary                   (biSize)
+import           Pos.Client.Txp.Addresses     (MonadAddresses (..))
+import           Pos.Core                     (TxFeePolicy (..), TxSizeLinear (..),
+                                               bvdTxFeePolicy, calculateTxSizeLinear,
+                                               coinToInteger, integerToCoin,
+                                               isRedeemAddress, txSizeLinearMinValue,
+                                               unsafeAddCoin, unsafeSubCoin)
+import           Pos.Core.Configuration       (HasConfiguration)
+import           Pos.Crypto                   (RedeemSecretKey, SafeSigner,
+                                               SignTag (SignRedeemTx, SignTx),
+                                               deterministicKeyGen, fakeSigner, hash,
+                                               redeemSign, redeemToPublic, safeSign,
+                                               safeToPublic)
+import           Pos.Data.Attributes          (mkAttributes)
+import           Pos.DB                       (MonadGState, gsAdoptedBVData)
+import           Pos.Script                   (Script)
+import           Pos.Script.Examples          (multisigRedeemer, multisigValidator)
+import           Pos.Txp                      (Tx (..), TxAux (..), TxFee (..), TxIn (..),
+                                               TxInWitness (..), TxOut (..),
+                                               TxOutAux (..), TxSigData (..), Utxo)
+import           Pos.Types                    (Address, Coin, StakeholderId, mkCoin,
+                                               sumCoins)
 
 type TxInputs = NonEmpty TxIn
 type TxOwnedInputs owner = NonEmpty (owner, TxIn)
@@ -257,16 +262,35 @@ makeLenses ''InputPickerState
 
 type InputPicker = StateT InputPickerState (Either TxError)
 
+reallyPendingTx :: [PendingTx] -> [PendingTx]
+reallyPendingTx = filter isPending
+  where
+    isPending :: PendingTx -> Bool
+    isPending PendingTx{..} = case _ptxCond of
+        PtxInNewestBlocks _ -> False
+        PtxPersisted        -> False
+        _                   -> True
+
+allPendingAddresses :: [PendingTx] -> Set Address
+allPendingAddresses pendingTxs = S.fromList $ concatMap grabTxOutput (reallyPendingTx pendingTxs)
+  where
+    grabTxOutput :: PendingTx -> [Address]
+    grabTxOutput PendingTx{..} =
+        let (TxAux tx _) = _ptxTxAux
+            (UnsafeTx _ outputs _) = tx
+            in map (\(TxOut a _) -> a) (toList outputs)
+
 -- | Given filtered Utxo, desired outputs and fee size,
 -- prepare correct inputs and outputs for transaction
 -- (and tell how much to send to remaining address)
 prepareTxRaw
     :: Monad m
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> TxOutputs
     -> TxFee
     -> TxCreator m TxRaw
-prepareTxRaw utxo outputs (TxFee fee) = do
+prepareTxRaw pendingTx utxo outputs (TxFee fee) = do
     mapM_ (checkIsNotRedeemAddr . txOutAddress . toaOut) outputs
 
     totalMoney <- sumTxOuts outputs
@@ -285,9 +309,12 @@ prepareTxRaw utxo outputs (TxFee fee) = do
             let trOutputs = outputs
             pure TxRaw {..}
   where
+    onlyConfirmedInputs :: S.Set Address -> TxOutAux -> Bool
+    onlyConfirmedInputs addrs (TxOutAux (TxOut addr _)) = not (addr `S.member` addrs)
+
     sumTxOuts = either (throwError . GeneralTxError) pure .
         integerToCoin . sumTxOutCoins
-    allUnspent = M.toList utxo
+    allUnspent = M.toList $ M.filter (onlyConfirmedInputs (allPendingAddresses pendingTx)) utxo
     sortedUnspent =
         sortOn (Down . txOutValue . toaOut . snd) allUnspent
 
@@ -326,71 +353,77 @@ mkOutputsWithRem addrData TxRaw {..}
 
 prepareInpsOuts
     :: TxCreateMode m
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> TxOutputs
     -> AddrData m
     -> TxCreator m (TxOwnedInputs TxOut, TxOutputs)
-prepareInpsOuts utxo outputs addrData = do
-    txRaw@TxRaw {..} <- prepareTxWithFee utxo outputs
+prepareInpsOuts pendingTxs utxo outputs addrData = do
+    txRaw@TxRaw {..} <- prepareTxWithFee pendingTxs utxo outputs
     outputsWithRem <- mkOutputsWithRem addrData txRaw
     pure (trInputs, outputsWithRem)
 
 createGenericTx
     :: TxCreateMode m
-    => (TxOwnedInputs TxOut -> TxOutputs -> TxAux)
+    => [PendingTx]
+    -> (TxOwnedInputs TxOut -> TxOutputs -> TxAux)
     -> Utxo
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createGenericTx creator utxo outputs addrData = runTxCreator $ do
-    (inps, outs) <- prepareInpsOuts utxo outputs addrData
+createGenericTx pendingTxs creator utxo outputs addrData = runTxCreator $ do
+    (inps, outs) <- prepareInpsOuts pendingTxs utxo outputs addrData
     pure (creator inps outs, map fst inps)
 
 createGenericTxSingle
     :: TxCreateMode m
-    => (TxInputs -> TxOutputs -> TxAux)
+    => [PendingTx]
+    -> (TxInputs -> TxOutputs -> TxAux)
     -> Utxo
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createGenericTxSingle creator = createGenericTx (creator . map snd)
+createGenericTxSingle pendingTxs creator = createGenericTx pendingTxs (creator . map snd)
 
 -- | Make a multi-transaction using given secret key and info for outputs.
 -- Currently used for HD wallets only, thus `HDAddressPayload` is required
 createMTx
     :: TxCreateMode m
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> (Address -> SafeSigner)
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMTx utxo hdwSigners outputs addrData =
-    createGenericTx (makeMPubKeyTxAddrs hdwSigners)
+createMTx pendingTxs utxo hdwSigners outputs addrData =
+    createGenericTx pendingTxs (makeMPubKeyTxAddrs hdwSigners)
     utxo outputs addrData
 
 -- | Make a multi-transaction using given secret key and info for
 -- outputs.
 createTx
     :: TxCreateMode m
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> SafeSigner
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createTx utxo ss outputs addrData =
-    createGenericTxSingle (makePubKeyTx ss)
+createTx pendingTxs utxo ss outputs addrData =
+    createGenericTxSingle pendingTxs (makePubKeyTx ss)
     utxo outputs addrData
 
 -- | Make a transaction, using M-of-N script as a source
 createMOfNTx
     :: TxCreateMode m
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> [(StakeholderId, Maybe SafeSigner)]
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMOfNTx utxo keys outputs addrData =
-    createGenericTxSingle (makeMOfNTx validator sks)
+createMOfNTx pendingTxs utxo keys outputs addrData =
+    createGenericTxSingle pendingTxs (makeMOfNTx validator sks)
     utxo outputs addrData
   where
     ids = map fst keys
@@ -406,7 +439,7 @@ createRedemptionTx
     -> TxOutputs
     -> m (Either TxError TxAux)
 createRedemptionTx utxo rsk outputs = runTxCreator $ do
-    TxRaw {..} <- prepareTxRaw utxo outputs (TxFee $ mkCoin 0)
+    TxRaw {..} <- prepareTxRaw mempty utxo outputs (TxFee $ mkCoin 0)
     let bareInputs = snd <$> trInputs
     pure $ makeRedemptionTx rsk bareInputs trOutputs
 
@@ -428,21 +461,23 @@ withLinearFeePolicy action = view tcdFeePolicy >>= \case
 -- | Prepare transaction considering fees
 prepareTxWithFee
     :: (HasConfiguration, Monad m)
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> TxOutputs
     -> TxCreator m TxRaw
-prepareTxWithFee utxo outputs = withLinearFeePolicy $ \linearPolicy ->
-    stabilizeTxFee linearPolicy utxo outputs
+prepareTxWithFee pendingTxs utxo outputs = withLinearFeePolicy $ \linearPolicy ->
+    stabilizeTxFee pendingTxs linearPolicy utxo outputs
 
 -- | Compute, how much fees we should pay to send money to given
 -- outputs
 computeTxFee
     :: (HasConfiguration, Monad m)
-    => Utxo
+    => [PendingTx]
+    -> Utxo
     -> TxOutputs
     -> TxCreator m TxFee
-computeTxFee utxo outputs = do
-    TxRaw {..} <- prepareTxWithFee utxo outputs
+computeTxFee pendingTxs utxo outputs = do
+    TxRaw {..} <- prepareTxWithFee pendingTxs utxo outputs
     let outAmount = sumTxOutCoins trOutputs
         inAmount = sumCoins $ map (txOutValue . fst) trInputs
         remaining = coinToInteger trRemainingMoney
@@ -494,11 +529,12 @@ computeTxFee utxo outputs = do
 -- To possibly find better solutions we iterate for several times more.
 stabilizeTxFee
     :: forall m. (HasConfiguration, Monad m)
-    => TxSizeLinear
+    => [PendingTx]
+    -> TxSizeLinear
     -> Utxo
     -> TxOutputs
     -> TxCreator m TxRaw
-stabilizeTxFee linearPolicy utxo outputs = do
+stabilizeTxFee pendingTxs linearPolicy utxo outputs = do
     minFee <- fixedToFee (txSizeLinearMinValue linearPolicy)
     mtx <- stabilizeTxFeeDo (False, firstStageAttempts) minFee
     case mtx of
@@ -513,7 +549,7 @@ stabilizeTxFee linearPolicy utxo outputs = do
                      -> TxCreator m $ Maybe (S.ArgMin TxFee TxRaw)
     stabilizeTxFeeDo (_, 0) _ = pure Nothing
     stabilizeTxFeeDo (isSecondStage, attempt) expectedFee = do
-        txRaw <- prepareTxRaw utxo outputs expectedFee
+        txRaw <- prepareTxRaw pendingTxs utxo outputs expectedFee
         txMinFee <- txToLinearFee linearPolicy $
                     createFakeTxFromRawTx txRaw
 

--- a/node/src/Pos/Communication/Tx.hs
+++ b/node/src/Pos/Communication/Tx.hs
@@ -11,32 +11,33 @@ module Pos.Communication.Tx
        , sendTxOuts
        ) where
 
-import           Formatting                 (build, sformat, (%))
-import           Mockable                   (MonadMockable)
-import           System.Wlog                (logInfo)
+import           Formatting                   (build, sformat, (%))
+import           Mockable                     (MonadMockable)
+import           System.Wlog                  (logInfo)
 import           Universum
 
-import           Pos.Binary                 ()
-import           Pos.Client.Txp.Addresses   (MonadAddresses (..))
-import           Pos.Client.Txp.Balances    (MonadBalances (..), getOwnUtxo,
-                                             getOwnUtxoForPk)
-import           Pos.Client.Txp.History     (MonadTxHistory (..))
-import           Pos.Client.Txp.Util        (TxCreateMode, TxError (..), createMTx,
-                                             createRedemptionTx, createTx)
-import           Pos.Communication.Methods  (sendTx)
-import           Pos.Communication.Protocol (EnqueueMsg, OutSpecs)
-import           Pos.Communication.Specs    (createOutSpecs)
-import           Pos.Communication.Types    (InvOrDataTK)
-import           Pos.Core                   (Address, Coin, makeRedeemAddress, mkCoin,
-                                             unsafeAddCoin)
-import           Pos.Crypto                 (RedeemSecretKey, SafeSigner, hash,
-                                             redeemToPublic, safeToPublic)
-import           Pos.DB.Class               (MonadGState)
-import           Pos.Txp.Core               (TxAux (..), TxId, TxOut (..), TxOutAux (..),
-                                             txaF)
-import           Pos.Txp.Network.Types      (TxMsgContents (..))
-import           Pos.Util.Util              (eitherToThrow)
-import           Pos.WorkMode.Class         (MinWorkMode)
+import           Pos.Binary                   ()
+import           Pos.Client.Txp.Addresses     (MonadAddresses (..))
+import           Pos.Client.Txp.Balances      (MonadBalances (..), getOwnUtxo,
+                                               getOwnUtxoForPk)
+import           Pos.Client.Txp.History       (MonadTxHistory (..))
+import           Pos.Client.Txp.Util          (TxCreateMode, TxError (..), createMTx,
+                                               createRedemptionTx, createTx)
+import           Pos.Communication.Methods    (sendTx)
+import           Pos.Communication.Protocol   (EnqueueMsg, OutSpecs)
+import           Pos.Communication.Specs      (createOutSpecs)
+import           Pos.Communication.Types      (InvOrDataTK)
+import           Pos.Core                     (Address, Coin, makeRedeemAddress, mkCoin,
+                                               unsafeAddCoin)
+import           Pos.Crypto                   (RedeemSecretKey, SafeSigner, hash,
+                                               redeemToPublic, safeToPublic)
+import           Pos.DB.Class                 (MonadGState)
+import           Pos.Txp.Core                 (TxAux (..), TxId, TxOut (..),
+                                               TxOutAux (..), txaF)
+import           Pos.Txp.Network.Types        (TxMsgContents (..))
+import           Pos.Util.Util                (eitherToThrow)
+import           Pos.Wallet.Web.Pending.Types (PendingTx)
+import           Pos.WorkMode.Class           (MinWorkMode)
 
 type TxMode ssc m
     = ( MinWorkMode m
@@ -60,27 +61,29 @@ submitAndSave enqueue txAux@TxAux {..} = do
 -- | Construct Tx using multiple secret keys and given list of desired outputs.
 prepareMTx
     :: TxMode ssc m
-    => (Address -> SafeSigner)
+    => [PendingTx]
+    -> (Address -> SafeSigner)
     -> NonEmpty Address
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-prepareMTx hdwSigners addrs outputs addrData = do
+prepareMTx pendingTxs hdwSigners addrs outputs addrData = do
     utxo <- getOwnUtxos (toList addrs)
-    eitherToThrow =<< createMTx utxo hdwSigners outputs addrData
+    eitherToThrow =<< createMTx pendingTxs utxo hdwSigners outputs addrData
 
 -- | Construct Tx using secret key and given list of desired outputs
 submitTx
     :: TxMode ssc m
-    => EnqueueMsg m
+    => [PendingTx]
+    -> EnqueueMsg m
     -> SafeSigner
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-submitTx enqueue ss outputs addrData = do
+submitTx pendingTxs enqueue ss outputs addrData = do
     let ourPk = safeToPublic ss
     utxo <- getOwnUtxoForPk ourPk
-    txWSpendings <- eitherToThrow =<< createTx utxo ss outputs addrData
+    txWSpendings <- eitherToThrow =<< createTx pendingTxs utxo ss outputs addrData
     txWSpendings <$ submitAndSave enqueue (fst txWSpendings)
 
 -- | Construct redemption Tx using redemption secret key and a output address

--- a/node/src/Pos/Generator/Block/Payload.hs
+++ b/node/src/Pos/Generator/Block/Payload.hs
@@ -216,7 +216,7 @@ genTxPayload = do
             makeTestTx = makeMPubKeyTxAddrs getSigner
 
         eTx <- lift . lift $
-            createGenericTx makeTestTx ownUtxo txOutAuxs changeAddrData
+            createGenericTx mempty makeTestTx ownUtxo txOutAuxs changeAddrData
         (txAux, _) <- either (throwM . BGFailedToCreate . pretty) pure eTx
 
         let tx = taTx txAux

--- a/node/test/Test/Pos/Client/Txp/UtilSpec.hs
+++ b/node/test/Test/Pos/Client/Txp/UtilSpec.hs
@@ -95,7 +95,7 @@ getSignerFromList (HM.fromList . map swap . toList -> hm) =
 
 createMTxWorksWhenWeAreRichSpec :: HasTxpConfigurations => TxpTestProperty ()
 createMTxWorksWhenWeAreRichSpec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left err -> stopProperty $ sformat ("Failed to create tx: "%build) err
         Right tx -> ensureTxMakesSense tx cmpUtxo cmpOutputs
@@ -104,7 +104,7 @@ createMTxWorksWhenWeAreRichSpec = do
 
 stabilizationDoesNotFailSpec :: HasTxpConfigurations => TxpTestProperty ()
 stabilizationDoesNotFailSpec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left err@FailedToStabilize -> stopProperty $ pretty err
         Left _                     -> return ()
@@ -114,7 +114,7 @@ stabilizationDoesNotFailSpec = do
 
 feeIsNonzeroSpec :: HasTxpConfigurations => TxpTestProperty ()
 feeIsNonzeroSpec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left (NotEnoughMoney _) -> return ()
         Left err -> stopProperty $ pretty err
@@ -126,7 +126,7 @@ feeIsNonzeroSpec = do
 
 manyUtxoTo1Spec :: HasTxpConfigurations => TxpTestProperty ()
 manyUtxoTo1Spec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left err -> stopProperty $ pretty err
         Right tx -> ensureTxMakesSense tx cmpUtxo cmpOutputs
@@ -135,7 +135,7 @@ manyUtxoTo1Spec = do
 
 manyAddressesTo1Spec :: HasTxpConfigurations => TxpTestProperty ()
 manyAddressesTo1Spec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left err -> stopProperty $ pretty err
         Right tx -> ensureTxMakesSense tx cmpUtxo cmpOutputs
@@ -144,7 +144,7 @@ manyAddressesTo1Spec = do
 
 manyAddressesToManySpec :: HasTxpConfigurations => TxpTestProperty ()
 manyAddressesToManySpec = do
-    txOrError <- createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+    txOrError <- createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     case txOrError of
         Left err -> stopProperty $ pretty err
         Right tx -> ensureTxMakesSense tx cmpUtxo cmpOutputs
@@ -169,7 +169,7 @@ redemptionSpec = do
 
 txWithRedeemOutputFailsSpec :: HasTxpConfigurations => TxpTestProperty ()
 txWithRedeemOutputFailsSpec = do
-    txOrError <- createMTx utxo (getSignerFromList signers) outputs addrData
+    txOrError <- createMTx mempty utxo (getSignerFromList signers) outputs addrData
     case txOrError of
         Left (OutputIsRedeem _) -> return ()
         Left err -> stopProperty $ pretty err
@@ -227,7 +227,7 @@ feeForManyAddressesSpec manyAddrs =
         Right _  -> return ()
   where
     createTxWithParams CreateMTxParams {..} =
-        createMTx cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
+        createMTx mempty cmpUtxo (getSignerFromList cmpSigners) cmpOutputs cmpAddrData
     -- considering two corner cases of utxo outputs distribution
     mkParams
         | manyAddrs = makeManyAddressesTo1Params


### PR DESCRIPTION
This PR delivers what can be called a "high throughput" policy for UTXO input selection by passing a list of `PendingTx` to the functions which picks the UXTO inputs, in a way that only confirmed addresses (i.e addresses associated to an already-confirmed transaction) will be picked, if available.