### PR TITLE
wallet-new: Remove duplicate entry in cabal file

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -190,7 +190,6 @@ test-suite wallet-new-specs
   other-modules:    SwaggerSpec
                     APISpec
                     MarshallingSpec
-                    Spec
 
                     Cardano.Wallet.API.V0.Handlers
                     Cardano.Wallet.API.V1.Handlers


### PR DESCRIPTION
The main file for this build target is called `Spec.hs` so the module `Spec` doesn't need to be listed in `other-modules`.
