### PR TITLE
[CSL-2043] Fix block generator in cardano-sl-1.0

### DIFF
--- a/tools/src/block-gen/Main.hs
+++ b/tools/src/block-gen/Main.hs
@@ -3,7 +3,6 @@ module Main where
 import           Universum
 
 import           Control.Monad.Random.Strict (evalRandT)
-import           Data.Default                (def)
 import qualified Data.Map                    as M
 import           Formatting                  (build, sformat, (%))
 import           Mockable                    (runProduction)
@@ -26,44 +25,45 @@ import           Error                       (TBlockGenError (..))
 import           Options                     (BlockGenOptions (..), getBlockGenOptions)
 
 main :: IO ()
-main = flip catch catchEx $ usingLoggerName "block-gen" $ withConfigurations def $ do
+main = flip catch catchEx $ usingLoggerName "block-gen" $ do
     BlockGenOptions{..} <- liftIO getBlockGenOptions
-    seed <- liftIO $ maybe randomIO pure bgoSeed
-    let runMode = bool "PROD" "DEV" isDevelopment
-    putText $ "Generating in " <> runMode <> " mode with seed " <> show seed
+    withConfigurations bgoConfOptions $ do
+      seed <- liftIO $ maybe randomIO pure bgoSeed
+      let runMode = bool "PROD" "DEV" isDevelopment
+      putText $ "Generating in " <> runMode <> " mode with seed " <> show seed
 
-    liftIO $ when bgoAppend $ checkExistence bgoPath
+      liftIO $ when bgoAppend $ checkExistence bgoPath
 
-    allSecrets <- mkAllSecretsSimple <$> case bgoNodes of
-        Left bgoNodesN -> do
-            unless (bgoNodesN > 0) $ throwM NoOneSecrets
-            let secrets = fromMaybe (error "Genesis secret keys are unknown") genesisSecretKeys
-            pure $ take (fromIntegral bgoNodesN) secrets
-        Right bgoSecretFiles -> do
-            when (null bgoSecretFiles) $ throwM NoOneSecrets
-            mapM parseSecret bgoSecretFiles
+      allSecrets <- mkAllSecretsSimple <$> case bgoNodes of
+          Left bgoNodesN -> do
+              unless (bgoNodesN > 0) $ throwM NoOneSecrets
+              let secrets = fromMaybe (error "Genesis secret keys are unknown") genesisSecretKeys
+              pure $ take (fromIntegral bgoNodesN) secrets
+          Right bgoSecretFiles -> do
+              when (null bgoSecretFiles) $ throwM NoOneSecrets
+              mapM parseSecret bgoSecretFiles
 
-    when (M.null $ unGenesisUtxo genesisUtxo) $ throwM EmptyUtxo
+      when (M.null $ unGenesisUtxo genesisUtxo) $ throwM EmptyUtxo
 
-    let bgenParams =
-            BlockGenParams
-                { _bgpSecrets         = allSecrets
-                , _bgpGenStakeholders = gdBootStakeholders genesisData
-                , _bgpBlockCount      = fromIntegral bgoBlockN
-                , _bgpTxGenParams     = bgoTxGenParams
-                , _bgpInplaceDB       = True
-                , _bgpSkipNoKey       = True
-                }
-    liftIO $ bracket (openNodeDBs (not bgoAppend) bgoPath) closeNodeDBs $ \db ->
-        runProduction $
-        initTBlockGenMode db $
-        void $ evalRandT (genBlocks bgenParams) (mkStdGen seed)
-    -- We print it twice because there can be a ton of logs and
-    -- you don't notice the first message.
-    if isDevelopment then
-        putText $ "Generated in DEV mode with seed " <> show seed
-    else
-        putText $ "Generated in PROD mode with seed " <> show seed
+      let bgenParams =
+              BlockGenParams
+                  { _bgpSecrets         = allSecrets
+                  , _bgpGenStakeholders = gdBootStakeholders genesisData
+                  , _bgpBlockCount      = fromIntegral bgoBlockN
+                  , _bgpTxGenParams     = bgoTxGenParams
+                  , _bgpInplaceDB       = True
+                  , _bgpSkipNoKey       = True
+                  }
+      liftIO $ bracket (openNodeDBs (not bgoAppend) bgoPath) closeNodeDBs $ \db ->
+          runProduction $
+          initTBlockGenMode db $
+          void $ evalRandT (genBlocks bgenParams) (mkStdGen seed)
+      -- We print it twice because there can be a ton of logs and
+      -- you don't notice the first message.
+      if isDevelopment then
+          putText $ "Generated in DEV mode with seed " <> show seed
+      else
+          putText $ "Generated in PROD mode with seed " <> show seed
   where
     catchEx :: TBlockGenError -> IO ()
     catchEx e = putText $ sformat ("Error: "%build) e

--- a/tools/src/block-gen/Options.hs
+++ b/tools/src/block-gen/Options.hs
@@ -19,8 +19,10 @@ import           Options.Applicative          (Parser, auto, execParser, footerD
                                                progDesc, strOption, switch, value)
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
+import           Pos.Client.CLI               (configurationOptionsParser)
 import           Pos.Core                     (isDevelopment)
 import           Pos.Generator.Block          (TxGenParams (..))
+import           Pos.Launcher.Configuration   (ConfigurationOptions)
 
 data BlockGenOptions = BlockGenOptions
     { bgoBlockN      :: !Word32
@@ -35,6 +37,7 @@ data BlockGenOptions = BlockGenOptions
     -- ^ Generating seed
     , bgoTxGenParams :: !TxGenParams
     -- ^ Transaction generator parameters
+    , bgoConfOptions :: !ConfigurationOptions
     }
 
 optionsParser :: Parser BlockGenOptions
@@ -73,6 +76,7 @@ optionsParser = do
             metavar "INT" <>
             help "Max number of outputs in tx")
 
+    bgoConfOptions <- configurationOptionsParser
 
     return BlockGenOptions{..}
   where


### PR DESCRIPTION
Yes, blockgen works in master already, but using it in this branch
still does make sense:
1. Switching branches (master/release) is expensive and time consuming.
2. Blockgen interface in cardano-sl-1.0 is somewhat more straight-forward.