### PR TITLE
Remove rounding from end users' public logs

### DIFF
--- a/log-config-prod.yaml
+++ b/log-config-prod.yaml
@@ -6,7 +6,7 @@ node:
     severity: Debug
     handlers:
       - file: pub/node.pub    # NB. the / will work on Windows too
-        round: 5              # because we do filepath normalization
+        round: 1              # because we do filepath normalization
       - file: node
     comm:
         severity: Info

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7141,8 +7141,8 @@ self: {
           pname = "utf8-string";
           version = "1.0.1.1";
           sha256 = "fb0b9e3acbe0605bcd1c63e51f290a7bbbe6628dfa3294ff453e4235fbaef140";
-          revision = "2";
-          editedCabalFile = "1b97s9picjl689hcz8scinv7c8k5iaal1livqr0l1l8yc4h0imhr";
+          revision = "3";
+          editedCabalFile = "02vhj5gykkqa2dyn7s6gn8is1b5fdn9xcqqvlls268g7cpv6rk38";
           libraryHaskellDepends = [
             base
             bytestring


### PR DESCRIPTION
This rounding sometimes makes debugging too hard and it's not important
with regards to privacy.
Note that currently used log-warper version doesn't support more granular
timestamps (1 second is maximal precision).