### PR TITLE
[CSL-2114] Update log configuration files for new log-warper version

### DIFF
--- a/log-config-prod.yaml
+++ b/log-config-prod.yaml
@@ -1,9 +1,8 @@
 rotation:
     logLimit: 5242880 # 5MB
     keepFiles: 20
-severity: Debug
-termSeverity: Debug
-handlers:
-  - file: pub/node.pub    # NB. the / will work on Windows too
-    round: 5              # because we do filepath normalization
-  - file: node
+loggerTree:
+  severity: Debug+
+  files:
+    - pub/node.pub
+    - node

--- a/scripts/log-templates/log-config-greppable.yaml
+++ b/scripts/log-templates/log-config-greppable.yaml
@@ -1,3 +1,3 @@
 # This template is used to grep the output.
 
-termSeverity: Debug
+termSeveritiesOut: All

--- a/scripts/log-templates/log-config-qa.yaml
+++ b/scripts/log-templates/log-config-qa.yaml
@@ -3,9 +3,9 @@
 rotation:
     logLimit: 104857600 # 100MB
     keepFiles: 2
-severity: Debug
-termSeverity: Debug
-handlers:
-  - file: node.pub
-    round: 5
-  - file: node
+loggerTree:
+  severity: Debug+
+  files:
+    - node.pub
+    - node
+

--- a/scripts/log-templates/log-template-demo.yaml
+++ b/scripts/log-templates/log-template-demo.yaml
@@ -3,9 +3,8 @@
 rotation:
     logLimit: 104857600 # 100 MB
     keepFiles: 20
-severity: Debug
-termSeverity: Debug
-handlers:
-  - file: {{file}}.pub
-    round: 5
-  - file: {{file}}
+loggerTree:
+  severity: Debug+
+  files:
+    - {{file}}.pub
+    - {{file}}


### PR DESCRIPTION
Latest log-warper version uses a different structure for its configuration files.

Note: I removed `termSeverity` from all configuration files because the default log-warper behavior writes everything except errors to stdout and errors to stderr. If that needs to be changed, please comment on it, and I'll change that.