### PR TITLE
stack.yaml: Drop directory extra-dep

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -125,7 +125,6 @@ extra-deps:
 - log-warper-1.8.0
 - concurrent-extra-0.7.0.10       # not yet on Stackage
 # - purescript-bridge-0.8.0.1
-- directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8
 - servant-0.12
 - servant-server-0.12
 - servant-client-0.12


### PR DESCRIPTION
The `directory` extra dependency seems to have been added in commit 8d9a444f1a to make it build with GHC 7.4. Since the current stack resolver version is `lts-9.1` which specifies GHC 8.0, this seems completely un-ncessary.

