### PR TITLE
[CSL-2124] Rebase cardano-sl-exchanges-1.0 to release/1.0.4

### DIFF
--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -12,6 +12,7 @@ module Pos.Wallet.Web.State.Acidic
        , update
 
        , GetProfile (..)
+       , DoesAccountExist (..)
        , GetAccountIds (..)
        , GetAccountMetas (..)
        , GetAccountMeta (..)
@@ -118,6 +119,7 @@ makeAcidic ''WalletStorage
     [
       'WS.testReset
     , 'WS.getProfile
+    , 'WS.doesAccountExist
     , 'WS.getAccountIds
     , 'WS.getAccountMetas
     , 'WS.getAccountMeta

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -16,6 +16,7 @@ module Pos.Wallet.Web.State.State
 
        -- * Getters
        , getProfile
+       , doesAccountExist
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
@@ -128,6 +129,9 @@ updateDisk
     :: (EventState event ~ WalletStorage, UpdateEvent event, WebWalletModeDB ctx m)
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
+
+doesAccountExist :: WebWalletModeDB ctx m => AccountId -> m Bool
+doesAccountExist = queryDisk . A.DoesAccountExist
 
 getAccountIds :: WebWalletModeDB ctx m => m [AccountId]
 getAccountIds = queryDisk A.GetAccountIds

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -19,6 +19,7 @@ module Pos.Wallet.Web.State.Storage
        , flushWalletStorage
        , getProfile
        , setProfile
+       , doesAccountExist
        , getAccountIds
        , getAccountMetas
        , getAccountMeta
@@ -213,6 +214,9 @@ getProfile = view wsProfile
 
 setProfile :: CProfile -> Update ()
 setProfile cProfile = wsProfile .= cProfile
+
+doesAccountExist :: AccountId -> Query Bool
+doesAccountExist accId = view $ wsAccountInfos . at accId . to isJust
 
 getAccountIds :: Query [AccountId]
 getAccountIds = HM.keys <$> view wsAccountInfos

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -5,6 +5,7 @@
 , executable ? "wallet"
 , system ? builtins.currentSystem
 , pkgs ? import localLib.fetchNixPkgs { inherit system config; }
+, exchange ? false
 }:
 
 # TODO: DEVOPS-462: docker to use this script
@@ -36,6 +37,10 @@ let
       valency: 1
       fallbacks: 7
   '';
+  logConfig =
+    if exchange
+    then "log-config-exchanges.yaml"
+    else "log-config-qa.yaml";
 in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   if [[ "$1" == "--delete-state" ]]; then
     echo "Deleting ${stateDir} ... "
@@ -55,7 +60,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
     ${ ifWallet "--tlscert ${src}/scripts/tls-files/server.crt"}   \
     ${ ifWallet "--tlskey ${src}/scripts/tls-files/server.key"}    \
     ${ ifWallet "--tlsca ${src}/scripts/tls-files/ca.crt"}         \
-    --log-config ${src}/scripts/log-templates/log-config-qa.yaml   \
+    --log-config ${src}/scripts/log-templates/${logConfig}         \
     --topology "${topologyFile}"                                   \
     --logs-prefix "${stateDir}/logs"                               \
     --db-path "${stateDir}/db"                                     \

--- a/scripts/log-templates/log-config-exchanges.yaml
+++ b/scripts/log-templates/log-config-exchanges.yaml
@@ -1,0 +1,17 @@
+rotation:
+    logLimit: 104857600 # 100MB
+    keepFiles: 100
+severity: Debug
+node:
+    severity: Debug
+    handlers:
+      - file: node.pub
+        round: 1
+      - file: node
+    comm:
+        severity: Debug
+    dht:
+        severity: Info
+    worker:
+      us:
+        severity: Debug

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -33,19 +33,17 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId, CTx (..)
                                              CTxMeta (..), CWAddressMeta (..),
                                              ScrollLimit, ScrollOffset, Wal, mkCTx)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
+import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending     (PendingTx (..), ptxPoolInfo)
 import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNewTxMetas,
                                              getHistoryCache, getPendingTx, getTxMeta,
                                              getWalletPendingTxs, setWalletTxMeta)
-import           Pos.Wallet.Web.Util        (decodeCTypeOrFail, getAccountAddrsOrThrow,
-                                             getWalletAccountIds, getWalletAddrsSet,
-                                             getWalletAddrs)
-
+import           Pos.Wallet.Web.Util        (getAccountAddrsOrThrow, getWalletAccountIds,
+                                             getWalletAddrs, getWalletAddrsSet)
 
 getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
 getFullWalletHistory cWalId = do
-    addrs <- mapM decodeCTypeOrFail =<< getWalletAddrs Ever cWalId
+    addrs <- getWalletAddrs Ever cWalId >>= convertCIdTOAddrs
 
     unfilteredLocalHistory <- getLocalHistory addrs
 

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -17,8 +17,8 @@ import qualified Data.Map.Strict            as Map
 import qualified Data.Set                   as S
 import           Data.Time.Clock.POSIX      (POSIXTime, getPOSIXTime)
 import           Formatting                 (build, sformat, stext, (%))
-import           Serokell.Util              (listJson)
-import           System.Wlog                (WithLogger, logWarning)
+import           Serokell.Util              (listJson, listJsonIndent)
+import           System.Wlog                (WithLogger, logDebug, logInfo, logWarning)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
@@ -39,11 +39,14 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNe
                                              getHistoryCache, getPendingTx, getTxMeta,
                                              getWalletPendingTxs, setWalletTxMeta)
 import           Pos.Wallet.Web.Util        (getAccountAddrsOrThrow, getWalletAccountIds,
-                                             getWalletAddrs, getWalletAddrsSet)
+                                             getWalletAddrs)
 
 getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
 getFullWalletHistory cWalId = do
-    addrs <- getWalletAddrs Ever cWalId >>= convertCIdTOAddrs
+    logDebug "getFullWalletHistory: start"
+
+    cAddrs <- getWalletAddrs Ever cWalId
+    addrs <- convertCIdTOAddrs cAddrs
 
     unfilteredLocalHistory <- getLocalHistory addrs
 
@@ -55,20 +58,25 @@ getFullWalletHistory cWalId = do
                 cWalId
             pure mempty
 
+    logDebug "getFullWalletHistory: fetched addresses and block/local histories"
     let localHistory = unfilteredLocalHistory `Map.difference` blockHistory
 
-    logTxHistory "Block" blockHistory
     logTxHistory "Mempool" localHistory
 
     fullHistory <- addRecentPtxHistory cWalId $ localHistory `Map.union` blockHistory
-    walAddrs    <- getWalletAddrsSet Ever cWalId
     diff        <- getCurChainDifficulty
+    let !cAddrsSet = S.fromList cAddrs
+    logDebug "getFullWalletHistory: fetched full history"
+
     -- TODO when we introduce some mechanism to react on new tx in mempool,
     -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
     addHistoryTxs cWalId localHistory
-    cHistory <- forM fullHistory (constructCTx cWalId walAddrs diff)
+    logDebug "getFullWalletHistory: invoked addHistoryTxs"
+
+    cHistory <- forM fullHistory (constructCTx cWalId cAddrsSet diff)
+    logDebug "getFullWalletHistory: formed cTxs"
     pure (cHistory, fromIntegral $ Map.size cHistory)
 
 getHistory
@@ -94,7 +102,9 @@ getHistory cWalId accIds mAddrId = do
             | addr `S.member` accAddrs -> filterByAddrs (S.singleton addr)
             | otherwise                -> throw errorBadAddress
 
-    first filterFn <$> getFullWalletHistory cWalId
+    !res <- first filterFn <$> getFullWalletHistory cWalId
+    logDebug "getHistory: filtered transactions"
+    return res
   where
     filterByAddrs :: S.Set (CId Addr)
                   -> Map TxId (CTx, POSIXTime)
@@ -125,7 +135,11 @@ getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit = do
             pure (cWalId', accIds')
         (Nothing, Just accId)   -> pure (aiWId accId, [accId])
     (unsortedThs, n) <- getHistory cWalId accIds mAddrId
-    let sortedTxh = sortByTime (Map.elems unsortedThs)
+
+    let !sortedTxh = forceList $ sortByTime (Map.elems unsortedThs)
+    logDebug "getHistoryLimited: sorted transactions"
+
+    logCTxs "Total last 20" $ take 20 sortedTxh
     pure (applySkipLimit sortedTxh, n)
   where
     sortByTime :: [(CTx, POSIXTime)] -> [CTx]
@@ -133,6 +147,7 @@ getHistoryLimited mCWalId mAccId mAddrId mSkip mLimit = do
         -- TODO: if we use a (lazy) heap sort here, we can get the
         -- first n values of the m sorted elements in O(m + n log m)
         map fst $ sortWith (Down . snd) thsWTime
+    forceList l = length l `seq` l
     applySkipLimit = take limit . drop skip
     limit = (fromIntegral $ fromMaybe defaultLimit mLimit)
     skip = (fromIntegral $ fromMaybe defaultSkip mSkip)
@@ -201,6 +216,8 @@ addRecentPtxHistory wid currentHistory = do
         .   mapMaybe (ptxPoolInfo . _ptxCond)
         .   fromMaybe []
 
+-- FIXME: use @listChunkedJson k@ with appropriate @k@s, once available,
+-- in these 2 functions
 logTxHistory
     :: (Container t, Element t ~ TxHistoryEntry, WithLogger m, MonadIO m)
     => Text -> t -> m ()
@@ -208,3 +225,11 @@ logTxHistory desc =
     logInfoS .
     sformat (stext%" transactions history: "%listJson) desc .
     map _thTxId . toList
+
+logCTxs
+    :: (Container t, Element t ~ CTx, WithLogger m)
+    => Text -> t -> m ()
+logCTxs desc =
+    logInfo .
+    sformat (stext%" transactions history: "%listJsonIndent 4) desc .
+    map ctId . toList

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -29,6 +29,7 @@ import           Data.List                  (findIndex)
 import qualified Data.Set                   as S
 import           Data.Time.Clock.POSIX      (getPOSIXTime)
 import           Formatting                 (build, sformat, (%))
+import           System.Wlog                (logDebug)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
@@ -99,8 +100,11 @@ getAccount :: MonadWalletWebMode m => CachedCAccModifier -> AccountId -> m CAcco
 getAccount accMod accId = do
     dbAddrs    <- getAccountAddrsOrThrow Existing accId
     let allAddrIds = gatherAddresses (camAddresses accMod) dbAddrs
+    logDebug "getAccountMod: gathering info about addresses.."
     allAddrs <- mapM (getWAddress accMod) allAddrIds
+    logDebug "getAccountMod: info about addresses gathered"
     balance <- sumCCoin (map cadAmount allAddrs)
+    logDebug "getAccountMod: evaluated total balance"
     meta <- getAccountMeta accId >>= maybeThrow noAccount
     pure $ CAccount (encodeCType accId) meta allAddrs balance
   where

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -12,6 +12,7 @@ import           Universum
 
 import           Control.Exception                (throw)
 import           Control.Monad.Except             (runExcept)
+import qualified Data.Map                         as M
 import           Data.Time.Units                  (Second)
 import           Formatting                       (sformat, (%))
 import qualified Formatting                       as F
@@ -171,13 +172,13 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
 
     logDebug "sendMoney: processed addrs"
 
-    let metasAndAdrresses = zip (toList addrMetas) (toList srcAddrs)
+    let metasAndAdrresses = M.fromList $ zip (toList srcAddrs) (toList addrMetas)
     allSecrets <- getSecretKeys
 
     let getSinger addr = runIdentity $ do
           let addrMeta =
                   fromMaybe (error "Corresponding adress meta not found")
-                            (fst <$> find ((== addr) . snd) metasAndAdrresses)
+                            (M.lookup addr metasAndAdrresses)
           case runExcept $ getSKByAddressPure allSecrets (ShouldCheckPassphrase False) passphrase addrMeta of
               Left err -> throw err
               Right sk -> withSafeSignerUnsafe sk (pure passphrase) pure

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -12,8 +12,11 @@ import           Universum
 
 import           Control.Exception                (throw)
 import           Control.Monad.Except             (runExcept)
+import           Data.Time.Units                  (Second)
 import           Formatting                       (sformat, (%))
 import qualified Formatting                       as F
+import           Mockable                         (concurrently, delay)
+import           System.Wlog                      (logDebug)
 
 import           Pos.Aeson.ClientTypes            ()
 import           Pos.Aeson.WalletBackup           ()
@@ -49,7 +52,8 @@ import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
 import qualified Pos.Wallet.Web.Methods.Logic     as L
 import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
                                                    submitAndSaveNewPtx)
-import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode)
+import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
+                                                   convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
 import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing))
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
@@ -65,13 +69,16 @@ newPayment
     -> Coin
     -> InputSelectionPolicy
     -> m CTx
-newPayment sa passphrase srcAccount dstAccount coin policy = do
+newPayment sa passphrase srcAccount dstAccount coin policy =
+    notFasterThan (1 :: Second) $  -- in order not to overflow relay
     sendMoney
         sa
         passphrase
         (AccountMoneySource srcAccount)
         (one (dstAccount, coin))
         policy
+  where
+    notFasterThan time action = fst <$> concurrently action (delay time)
 
 getTxFee
      :: MonadWalletWebMode m
@@ -153,11 +160,17 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     checkPassMatches passphrase rootSk `whenNothing`
         throwM (RequestError "Passphrase doesn't match")
 
+    logDebug "sendMoney: start retrieving addrs"
+
     addrMetas' <- getMoneySourceAddresses moneySource
     addrMetas <- nonEmpty addrMetas' `whenNothing`
         throwM (RequestError "Given money source has no addresses!")
+    logDebug "sendMoney: retrieved addrs"
 
-    srcAddrs <- forM addrMetas $ decodeCTypeOrFail . cwamId
+    srcAddrs <- convertCIdTOAddrs $ map cwamId addrMetas
+
+    logDebug "sendMoney: processed addrs"
+
     let metasAndAdrresses = zip (toList addrMetas) (toList srcAddrs)
     allSecrets <- getSecretKeys
 
@@ -173,8 +186,10 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     outputs <- coinDistrToOutputs dstDistr
     (th, dstAddrs) <-
         rewrapTxError "Cannot send transaction" $ do
+            logDebug "sendMoney: we're to prepareMTx"
             (txAux, inpTxOuts') <-
                 prepareMTx getSinger policy srcAddrs outputs (relatedAccount, passphrase)
+            logDebug "sendMoney: performed prepareMTx"
 
             ts <- Just <$> getCurrentTimestamp
             let tx = taTx txAux
@@ -185,6 +200,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
                 th = THEntry txHash tx Nothing inpTxOuts dstAddrs ts
             ptx <- mkPendingTx srcWallet txHash txAux th
 
+            logDebug "sendMoney: performed mkPendingTx"
             (th, dstAddrs) <$ submitAndSaveNewPtx enqueueMsg ptx
 
     logInfoS $

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -7,79 +7,89 @@ module Pos.Wallet.Web.Mode
        , WalletWebModeContextTag
        , WalletWebModeContext(..)
        , MonadWalletWebMode
+       , convertCIdTOAddrs
+       , convertCIdTOAddr
+       , AddrCIdHashes(AddrCIdHashes)
        ) where
 
 import           Universum
 
-import           Control.Lens                   (makeLensesWith)
-import qualified Control.Monad.Reader           as Mtl
-import           Ether.Internal                 (HasLens (..))
-import           Mockable                       (Production)
-import           System.Wlog                    (HasLoggerName (..))
+import           Control.Lens                     (makeLensesWith)
+import qualified Control.Monad.Reader             as Mtl
+import qualified Data.Foldable                    as Foldable
+import qualified Data.Map                         as M
+import           Ether.Internal                   (HasLens (..))
+import           Mockable                         (Production)
+import           System.Wlog                      (HasLoggerName (..))
 
-import           Pos.Block.Core                 (Block, BlockHeader)
-import           Pos.Block.Slog                 (HasSlogContext (..), HasSlogGState (..))
-import           Pos.Block.Types                (Undo)
-import           Pos.Configuration              (HasNodeConfiguration)
-import           Pos.Context                    (HasNodeContext (..))
-import           Pos.Core                       (HasConfiguration, HasPrimaryKey (..),
-                                                 IsHeader)
-import           Pos.DB                         (MonadGState (..))
-import           Pos.DB.Block                   (dbGetBlockDefault, dbGetBlockSscDefault,
-                                                 dbGetHeaderDefault,
-                                                 dbGetHeaderSscDefault, dbGetUndoDefault,
-                                                 dbGetUndoSscDefault, dbPutBlundDefault)
-import           Pos.DB.Class                   (MonadBlockDBGeneric (..),
-                                                 MonadBlockDBGenericWrite (..),
-                                                 MonadDB (..), MonadDBRead (..))
-import           Pos.DB.DB                      (gsAdoptedBVDataDefault)
-import           Pos.DB.Rocks                   (dbDeleteDefault, dbGetDefault,
-                                                 dbIterSourceDefault, dbPutDefault,
-                                                 dbWriteBatchDefault)
+import           Pos.Block.Core                   (Block, BlockHeader)
+import           Pos.Block.Slog                   (HasSlogContext (..),
+                                                   HasSlogGState (..))
+import           Pos.Block.Types                  (Undo)
+import           Pos.Configuration                (HasNodeConfiguration)
+import           Pos.Context                      (HasNodeContext (..))
+import           Pos.Core                         (Address, HasConfiguration,
+                                                   HasPrimaryKey (..), IsHeader)
+import           Pos.DB                           (MonadGState (..))
+import           Pos.DB.Block                     (dbGetBlockDefault,
+                                                   dbGetBlockSscDefault,
+                                                   dbGetHeaderDefault,
+                                                   dbGetHeaderSscDefault,
+                                                   dbGetUndoDefault, dbGetUndoSscDefault,
+                                                   dbPutBlundDefault)
+import           Pos.DB.Class                     (MonadBlockDBGeneric (..),
+                                                   MonadBlockDBGenericWrite (..),
+                                                   MonadDB (..), MonadDBRead (..))
+import           Pos.DB.DB                        (gsAdoptedBVDataDefault)
+import           Pos.DB.Rocks                     (dbDeleteDefault, dbGetDefault,
+                                                   dbIterSourceDefault, dbPutDefault,
+                                                   dbWriteBatchDefault)
 
-import           Pos.Client.Txp.Balances        (MonadBalances (..), getBalanceDefault,
-                                                 getOwnUtxosDefault)
-import           Pos.Client.Txp.History         (MonadTxHistory (..),
-                                                 getBlockHistoryDefault,
-                                                 getLocalHistoryDefault, saveTxDefault)
-import           Pos.Infra.Configuration        (HasInfraConfiguration)
-import           Pos.KnownPeers                 (MonadFormatPeers (..),
-                                                 MonadKnownPeers (..))
-import           Pos.Reporting                  (HasReportingContext (..))
-import           Pos.Network.Types              (HasNodeType (..))
-import           Pos.Shutdown                   (HasShutdownContext (..))
-import           Pos.Slotting.Class             (MonadSlots (..))
-import           Pos.Slotting.Impl.Sum          (currentTimeSlottingSum,
-                                                 getCurrentSlotBlockingSum,
-                                                 getCurrentSlotInaccurateSum,
-                                                 getCurrentSlotSum)
-import           Pos.Slotting.MemState          (HasSlottingVar (..), MonadSlotsData)
-import           Pos.Ssc.Class.Types            (HasSscContext (..), SscBlock)
+import           Pos.Client.Txp.Balances          (MonadBalances (..), getBalanceDefault,
+                                                   getOwnUtxosDefault)
+import           Pos.Client.Txp.History           (MonadTxHistory (..),
+                                                   getBlockHistoryDefault,
+                                                   getLocalHistoryDefault, saveTxDefault)
+import           Pos.Infra.Configuration          (HasInfraConfiguration)
+import           Pos.KnownPeers                   (MonadFormatPeers (..),
+                                                   MonadKnownPeers (..))
+import           Pos.Network.Types                (HasNodeType (..))
+import           Pos.Reporting                    (HasReportingContext (..))
+import           Pos.Shutdown                     (HasShutdownContext (..))
+import           Pos.Slotting.Class               (MonadSlots (..))
+import           Pos.Slotting.Impl.Sum            (currentTimeSlottingSum,
+                                                   getCurrentSlotBlockingSum,
+                                                   getCurrentSlotInaccurateSum,
+                                                   getCurrentSlotSum)
+import           Pos.Slotting.MemState            (HasSlottingVar (..), MonadSlotsData)
+import           Pos.Ssc.Class.Types              (HasSscContext (..), SscBlock)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Util                       (Some (..))
-import           Pos.Util.JsonLog               (HasJsonLogConfig (..), jsonLogDefault)
-import           Pos.Util.LoggerName            (HasLoggerName' (..),
-                                                 getLoggerNameDefault,
-                                                 modifyLoggerNameDefault)
-import qualified Pos.Util.OutboundQueue         as OQ.Reader
-import           Pos.Util.TimeWarp              (CanJsonLog (..))
-import           Pos.Util.UserSecret            (HasUserSecret (..))
-import           Pos.Util.Util                  (postfixLFields)
-import           Pos.Update.Configuration       (HasUpdateConfiguration)
-import           Pos.Wallet.Redirect            (MonadBlockchainInfo (..),
-                                                 MonadUpdates (..),
-                                                 applyLastUpdateWebWallet,
-                                                 blockchainSlotDurationWebWallet,
-                                                 connectedPeersWebWallet,
-                                                 localChainDifficultyWebWallet,
-                                                 networkChainDifficultyWebWallet,
-                                                 waitForUpdateWebWallet)
-import           Pos.Wallet.SscType             (WalletSscType)
-import           Pos.Wallet.Web.Sockets.ConnSet (ConnectionsVar)
-import           Pos.Wallet.Web.State.State     (WalletState)
-import           Pos.Wallet.Web.Tracking        (MonadBListener (..), onApplyTracking,
-                                                 onRollbackTracking)
-import           Pos.WorkMode                   (RealModeContext (..))
+import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util                         (Some (..))
+import           Pos.Util.JsonLog                 (HasJsonLogConfig (..), jsonLogDefault)
+import           Pos.Util.LoggerName              (HasLoggerName' (..),
+                                                   getLoggerNameDefault,
+                                                   modifyLoggerNameDefault)
+import qualified Pos.Util.OutboundQueue           as OQ.Reader
+import           Pos.Util.TimeWarp                (CanJsonLog (..))
+import           Pos.Util.UserSecret              (HasUserSecret (..))
+import           Pos.Util.Util                    (postfixLFields)
+import           Pos.Wallet.Redirect              (MonadBlockchainInfo (..),
+                                                   MonadUpdates (..),
+                                                   applyLastUpdateWebWallet,
+                                                   blockchainSlotDurationWebWallet,
+                                                   connectedPeersWebWallet,
+                                                   localChainDifficultyWebWallet,
+                                                   networkChainDifficultyWebWallet,
+                                                   waitForUpdateWebWallet)
+import           Pos.Wallet.SscType               (WalletSscType)
+import           Pos.Wallet.Web.ClientTypes       (Addr, CHash, CId (..), cIdToAddress)
+import           Pos.Wallet.Web.Error             (WalletError (..))
+import           Pos.Wallet.Web.Sockets.ConnSet   (ConnectionsVar)
+import           Pos.Wallet.Web.State.State       (WalletState)
+import           Pos.Wallet.Web.Tracking          (MonadBListener (..), onApplyTracking,
+                                                   onRollbackTracking)
+import           Pos.WorkMode                     (RealModeContext (..))
 
 
 
@@ -87,10 +97,45 @@ import           Pos.WorkMode                   (RealModeContext (..))
 data WalletWebModeContext = WalletWebModeContext
     { wwmcWalletState     :: !WalletState
     , wwmcConnectionsVar  :: !ConnectionsVar
+    , wwmcHashes          :: !AddrCIdHashes
     , wwmcRealModeContext :: !(RealModeContext WalletSscType)
     }
 
+newtype AddrCIdHashes = AddrCIdHashes { unAddrCIdHashes :: (IORef (Map CHash Address)) }
+
 makeLensesWith postfixLFields ''WalletWebModeContext
+
+instance HasLens AddrCIdHashes WalletWebModeContext AddrCIdHashes where
+    lensOf = wwmcHashes_L
+
+convertCIdTOAddr :: (MonadWalletWebMode m) => CId Addr -> m Address
+convertCIdTOAddr i@(CId id) = do
+    hmRef <- unAddrCIdHashes <$> view (lensOf @AddrCIdHashes)
+    maddr <- atomicModifyIORef' hmRef $ \hm ->
+      case id `M.lookup` hm of
+       Just addr -> (hm, Right addr)
+       _         -> case cIdToAddress i of
+                    -- decoding can fail, but we don't cache failures
+                      Right addr -> (M.insert id addr hm, Right addr)
+                      Left  err  -> (hm,                  Left err)
+    either (throwM . DecodeError) pure maddr
+
+convertCIdTOAddrs :: (MonadWalletWebMode m, Traversable t) => t (CId Addr) -> m (t Address)
+convertCIdTOAddrs cids = do
+    hmRef <- unAddrCIdHashes <$> view (lensOf @AddrCIdHashes)
+    maddrs <- atomicModifyIORef' hmRef $ \hm ->
+      let lookups = map (\cid@(CId h) -> (h, M.lookup h hm, cIdToAddress cid)) cids
+          hm'     = Foldable.foldl' accum hm lookups
+
+          accum m (cid, Nothing, Right addr) = M.insert cid addr m
+          accum m _                          = m
+
+          result (_, Just addr, _)   = Right addr
+          result (_, Nothing, maddr) = maddr
+
+       in (hm', map result lookups)
+
+    mapM (either (throwM . DecodeError) pure) maddrs
 
 instance HasSscContext WalletSscType WalletWebModeContext where
     sscContext = wwmcRealModeContext_L . sscContext

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -15,7 +15,7 @@ import           Universum
 
 import           Control.Monad.Catch          (Handler (..), catches)
 import           Formatting                   (build, sformat, shown, stext, (%))
-import           System.Wlog                  (WithLogger, logInfo)
+import           System.Wlog                  (WithLogger, logDebug, logInfo)
 
 import           Pos.Client.Txp.History       (saveTx)
 import           Pos.Communication            (EnqueueMsg, submitTxRaw)
@@ -111,6 +111,7 @@ submitAndSavePtx
     => PtxSubmissionHandlers m -> EnqueueMsg m -> PendingTx -> m ()
 submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
     ack <- submitTxRaw enqueue _ptxTxAux
+    reportSubmitted ack
     saveTx (_ptxTxId, _ptxTxAux) `catches` handlers ack
     addOnlyNewPendingTx ptx
     when ack $ ptxUpdateMeta _ptxWallet _ptxTxId PtxMarkAcknowledged
@@ -138,3 +139,8 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
         logInfoS $
         sformat ("Transaction #"%build%" application failed ("%shown%" - "
                 %stext%")"%stext) _ptxTxId e desc outcome
+    reportSubmitted ack =
+        logDebug $
+        sformat ("submitAndSavePtx: transaction submitted with confirmation?: "
+                %build) ack
+

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -31,7 +31,8 @@ import           Pos.Launcher.Runner            (runRealBasedMode)
 import           Pos.Util.TimeWarp              (NetworkAddress)
 import           Pos.Wallet.SscType             (WalletSscType)
 import           Pos.Wallet.Web.Methods         (addInitialRichAccount)
-import           Pos.Wallet.Web.Mode            (WalletWebMode, WalletWebModeContext (..),
+import           Pos.Wallet.Web.Mode            (AddrCIdHashes (..), WalletWebMode,
+                                                 WalletWebModeContext (..),
                                                  WalletWebModeContextTag)
 import           Pos.Wallet.Web.Server.Launcher (walletApplication, walletServeImpl,
                                                  walletServer)
@@ -47,10 +48,13 @@ runWRealMode
     -> NodeResources WalletSscType WalletWebMode
     -> (ActionSpec WalletWebMode a, OutSpecs)
     -> Production a
-runWRealMode db conn =
+runWRealMode db conn res acts = do
+    ref <- newIORef mempty
     runRealBasedMode
-        (Mtl.withReaderT (WalletWebModeContext db conn))
-        (Mtl.withReaderT (\(WalletWebModeContext _ _ rmc) -> rmc))
+        (Mtl.withReaderT (WalletWebModeContext db conn $ AddrCIdHashes ref))
+        (Mtl.withReaderT (\(WalletWebModeContext _ _ _ rmc) -> rmc))
+        res
+        acts
 
 walletServeWebFull
     :: HasConfigurations


### PR DESCRIPTION
Got everything needed from `cardano-sl-exchanges-1.0` up to `efabf6c414c176bd9deb6bf6f055a291190d73f8` (special policy for transaction inputs picking)
In short:
* `Do single DB and mempool read when computing wallet balance` is skipped, we're going to have it done in another way
* Main wallet endpoints speed up and logging
* Make special log-config for exchages
* Commit with high throughput policy for UTXO inputs selection is skipped, see #2160 for it

_Still need to test that `scripts/launch/connect-to-cluster/default.nix` works_
  
  
  