### PR TITLE
[CSL-2127] Make getHistoryCache return empty history instead of Nothing

### DIFF
--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -181,7 +181,7 @@ getUpdates = queryDisk A.GetUpdates
 getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
 getNextUpdate = queryDisk A.GetNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe (Map TxId TxHistoryEntry))
+getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Map TxId TxHistoryEntry)
 getHistoryCache = queryDisk . A.GetHistoryCache
 
 getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -300,8 +300,8 @@ getUpdates = view wsReadyUpdates
 getNextUpdate :: Query (Maybe CUpdateInfo)
 getNextUpdate = preview (wsReadyUpdates . _head)
 
-getHistoryCache :: CId Wal -> Query (Maybe (Map TxId TxHistoryEntry))
-getHistoryCache cWalId = view $ wsHistoryCache . at cWalId
+getHistoryCache :: CId Wal -> Query (Map TxId TxHistoryEntry)
+getHistoryCache cWalId = view $ wsHistoryCache . at cWalId . non' _Empty
 
 getCustomAddresses :: CustomAddressType -> Query [CId Addr]
 getCustomAddresses t = HM.keys <$> view (customAddressL t)

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -16,9 +16,9 @@ import           Control.Exception          (throw)
 import qualified Data.Map.Strict            as Map
 import qualified Data.Set                   as S
 import           Data.Time.Clock.POSIX      (POSIXTime, getPOSIXTime)
-import           Formatting                 (build, sformat, stext, (%))
+import           Formatting                 (sformat, stext, (%))
 import           Serokell.Util              (listJson)
-import           System.Wlog                (WithLogger, logWarning)
+import           System.Wlog                (WithLogger)
 
 import           Pos.Aeson.ClientTypes      ()
 import           Pos.Aeson.WalletBackup     ()
@@ -39,8 +39,8 @@ import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), addOnlyNe
                                              getHistoryCache, getPendingTx, getTxMeta,
                                              getWalletPendingTxs, setWalletTxMeta)
 import           Pos.Wallet.Web.Util        (decodeCTypeOrFail, getAccountAddrsOrThrow,
-                                             getWalletAccountIds, getWalletAddrsSet,
-                                             getWalletAddrs)
+                                             getWalletAccountIds, getWalletAddrs,
+                                             getWalletAddrsSet)
 
 
 getFullWalletHistory :: MonadWalletWebMode m => CId Wal -> m (Map TxId (CTx, POSIXTime), Word)
@@ -49,13 +49,7 @@ getFullWalletHistory cWalId = do
 
     unfilteredLocalHistory <- getLocalHistory addrs
 
-    blockHistory <- getHistoryCache cWalId >>= \case
-        Just hist -> pure hist
-        Nothing -> do
-            logWarning $
-                sformat ("getFullWalletHistory: history cache is empty for wallet #"%build)
-                cWalId
-            pure mempty
+    blockHistory <- getHistoryCache cWalId
 
     let localHistory = unfilteredLocalHistory `Map.difference` blockHistory
 


### PR DESCRIPTION
This has already been done before (see https://github.com/input-output-hk/cardano-sl/blob/9e38d21cbeef62c7bb64169bba84c22ee7d5d687/node/src/Pos/Wallet/Web/State/Storage.hs#L450 for evidence), but was lost during rebase.

It results in unpleasant false warning appearing in logs.