### PR TITLE
[CSL-2129] Add blockchain dumping and loading the dump

### DIFF
--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -20,7 +20,7 @@ library
                        Command.BlockGen
                        Command.Proc
                        Command.Rollback
-                       Command.Dump
+                       Command.DumpBlockchain
                        Command.Tx
                        Command.TyProjection
                        Command.Update

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -59,6 +59,7 @@ library
                      , cardano-sl-txp
                      , cardano-sl-update
                      , cardano-sl-util
+                     , conduit-combinators
                      , constraints
                      , containers
                      , data-default
@@ -71,7 +72,6 @@ library
                      , lens
                      , loc
                      , log-warper
-                     , lzma
                      , megaparsec
                      , mmorph
                      , mtl
@@ -135,13 +135,14 @@ executable cardano-auxx
                      , cardano-sl-networking
                      , cardano-sl-txp
                      , cardano-sl-util
+                     , conduit-combinators
                      , constraints
+                     , formatting
                      , log-warper
-                     , temporary
                      , network-transport-tcp
                      , safe-exceptions
+                     , temporary
                      , universum
-                     , formatting
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts
                        -Wall
@@ -199,6 +200,7 @@ test-suite cardano-auxx-test
                      , cardano-sl-auxx
                      , cardano-sl-core
                      , cardano-sl-crypto
+                     , conduit-combinators
                      , hspec
                      , universum >= 0.1.11
 

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -71,6 +71,7 @@ library
                      , lens
                      , loc
                      , log-warper
+                     , lzma
                      , megaparsec
                      , mmorph
                      , mtl

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -66,6 +66,7 @@ library
                      , directory
                      , ether
                      , filepath
+                     , fmt
                      , formatting
                      , generic-arbitrary
                      , haskeline
@@ -75,12 +76,14 @@ library
                      , megaparsec
                      , mmorph
                      , mtl
+                     , natural-sort
                      , neat-interpolation
                      , optparse-applicative
                      , parser-combinators
                      , quickcheck-instances
                      , random
                      , reflection
+                     , resourcet
                      , safe-exceptions
                      , scientific
                      , serokell-util >= 0.1.3.4
@@ -140,6 +143,7 @@ executable cardano-auxx
                      , formatting
                      , log-warper
                      , network-transport-tcp
+                     , resourcet
                      , safe-exceptions
                      , temporary
                      , universum

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -20,6 +20,7 @@ library
                        Command.BlockGen
                        Command.Proc
                        Command.Rollback
+                       Command.Dump
                        Command.Tx
                        Command.TyProjection
                        Command.Update
@@ -61,7 +62,9 @@ library
                      , constraints
                      , containers
                      , data-default
+                     , directory
                      , ether
+                     , filepath
                      , formatting
                      , generic-arbitrary
                      , haskeline

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -92,6 +92,7 @@ library
                      , transformers
                      , universum >= 0.1.11
                      , unordered-containers
+                     , vector
 
   default-language:    Haskell2010
   ghc-options:        -Wall

--- a/auxx/src/Command/Dump.hs
+++ b/auxx/src/Command/Dump.hs
@@ -13,20 +13,75 @@ import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
 import           System.Wlog (logInfo, logWarning)
 
-import           Pos.Binary (serialize)
-import           Pos.Block.Types (Blund)
-import           Pos.Core (BlockHeader, EpochIndex (..), HeaderHash, blockHeaderHash, difficultyL,
-                           epochIndexL, genesisHash, getBlockHeader, prevBlockL)
-import           Pos.Crypto (shortHashF)
-import           Pos.DB.Block (getBlund)
+import           Pos.Binary (Bi (..), encodeListLen, enforceSize, serialize)
+import           Pos.Core (Block, BlockHeader, EpochIndex (..), HeaderHash, blockHeaderHash,
+                           difficultyL, epochIndexL, genesisHash, getBlockHeader, prevBlockL)
+import qualified Pos.Core as C
+import           Pos.Core.Block (GenericBlock (..), GenericBlockHeader (..))
+import           Pos.Crypto (HasCryptoConfiguration, getProtocolMagic, protocolMagic, shortHashF)
+import           Pos.DB.Block (getBlock)
 import qualified Pos.DB.BlockIndex as DB
 import           Pos.DB.Class (MonadDBRead)
 import           Pos.DB.Error (DBError (..))
 import           Pos.StateLock (Priority (..), withStateLock)
 import           Pos.Util.Chrono (NewestFirst (..))
-import           Pos.Util.Util (maybeThrow)
+import           Pos.Util.Util (eitherToFail, maybeThrow)
 
 import           Mode (MonadAuxxMode)
+
+newtype GenericBlockNoProof b = GenericBlockNoProof (GenericBlock b)
+
+type BlockNoProof = Either GenesisBlockNoProof MainBlockNoProof
+type GenesisBlockNoProof = GenericBlockNoProof C.GenesisBlockchain
+type MainBlockNoProof = GenericBlockNoProof C.MainBlockchain
+
+instance ( Typeable b
+         , Bi (C.BHeaderHash b)
+         , Bi (C.ConsensusData b)
+         , Bi (C.ExtraHeaderData b)
+         , Bi (C.Body b)
+         , Bi (C.ExtraBodyData b)
+         , C.BlockchainHelpers b
+         , HasCryptoConfiguration
+         ) =>
+         Bi (GenericBlockNoProof b) where
+    encode (GenericBlockNoProof gb) =
+        encodeListLen 3
+        <> encodeHeader (_gbHeader gb)
+        <> encode (_gbBody gb)
+        <> encode (_gbExtra gb)
+      where
+        encodeHeader bh =
+            encodeListLen 4
+            <> encode (getProtocolMagic protocolMagic)
+            <> encode (_gbhPrevBlock bh)
+            <> encode (_gbhConsensus bh)
+            <> encode (_gbhExtra bh)
+
+    decode = do
+        enforceSize "GenericBlock" 3
+        (prevBlock, consensus, headerExtra) <- decodeHeader'
+        body  <- decode
+        extra <- decode
+        let bodyProof = C.mkBodyProof body
+        header <- eitherToFail $
+            C.recreateGenericHeader prevBlock bodyProof consensus headerExtra
+        block <- eitherToFail $ C.recreateGenericBlock header body extra
+        pure $ GenericBlockNoProof block
+      where
+        decodeHeader' = do
+            enforceSize "GenericBlockHeader b" 4
+            blockMagic <- decode
+            when (blockMagic /= getProtocolMagic protocolMagic) $
+                fail $ "GenericBlockHeader failed with wrong magic: " <> show blockMagic
+            prevBlock <- decode
+            consensus <- decode
+            extra     <- decode
+            pure $ (prevBlock, consensus, extra)
+
+stripProof :: Block -> BlockNoProof
+stripProof (Left gb)  = Left $ GenericBlockNoProof gb
+stripProof (Right mb) = Right $ GenericBlockNoProof mb
 
 -- | Dump whole blockchain in CBOR format to the specified folder.
 -- Each epoch will be at <outFolder>/epoch<epochIndex>.cbor.
@@ -48,18 +103,18 @@ dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
     loadEpoch
         :: MonadAuxxMode m
         => HeaderHash
-        -> m (Maybe HeaderHash, NewestFirst [] Blund)
+        -> m (Maybe HeaderHash, NewestFirst [] Block)
     loadEpoch start = do
         -- returns Maybe (tip of previous epoch)
-        (maybePrev, blundsMaybeEmpty) <- doIt [] start
-        pure (maybePrev, NewestFirst blundsMaybeEmpty)
+        (maybePrev, blocksMaybeEmpty) <- doIt [] start
+        pure (maybePrev, NewestFirst blocksMaybeEmpty)
       where
-        doIt :: MonadAuxxMode m => [Blund] -> HeaderHash -> m (Maybe HeaderHash, [Blund])
+        doIt :: MonadAuxxMode m => [Block] -> HeaderHash -> m (Maybe HeaderHash, [Block])
         doIt !acc h = do
-            d <- getBlundThrow h
+            d <- getBlockThrow h
             let newAcc = d : acc
                 prev = d ^. prevBlockL
-            case d ^. _1 of
+            case d of
                 Left _ -> pure
                     ( if prev == genesisHash then Nothing else Just prev
                     , reverse newAcc)
@@ -73,23 +128,23 @@ dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
     doDump start = do
         let epochIndex = start ^. epochIndexL
         logInfo $ sformat ("Processing "%build) epochIndex
-        (maybePrev, blundsMaybeEmpty) <- loadEpoch $ blockHeaderHash start
-        case _Wrapped nonEmpty blundsMaybeEmpty of
+        (maybePrev, blocksMaybeEmpty) <- loadEpoch $ blockHeaderHash start
+        case _Wrapped nonEmpty blocksMaybeEmpty of
             Nothing -> pass
-            Just (blunds :: NewestFirst NonEmpty Blund) -> do
-                let sblunds = serialize (0 :: Word8, blunds)
-                    outPath = getOutPath epochIndex
-                liftIO $ BSL.writeFile outPath $ compress sblunds
+            Just (blocks :: NewestFirst NonEmpty Block) -> do
+                let stripped   = map stripProof blocks
+                    serialized = serialize (0 :: Word8, stripped)
+                    outPath    = getOutPath epochIndex
+                liftIO $ BSL.writeFile outPath $ compress serialized
                 whenJust maybePrev $ \prev -> do
                     maybeHeader <- DB.getHeader prev
                     case maybeHeader of
                         Just header -> doDump header
                         Nothing     ->
                             let anchorHash =
-                                    blunds &
+                                    blocks &
                                     getNewestFirst &
                                     last &
-                                    fst &
                                     getBlockHeader &
                                     blockHeaderHash in
                             logWarning $ sformat ("DB contains block "%build%
@@ -101,10 +156,10 @@ dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
                 sformat ("epoch"%build%".cbor.lzma") (getEpochIndex epochIndex)
         in outFolder </> outFile
 
-    getBlundThrow
+    getBlockThrow
         :: MonadDBRead m
-        => HeaderHash -> m Blund
-    getBlundThrow hash =
-        maybeThrow (DBMalformed $ sformat errFmt hash) =<< getBlund hash
+        => HeaderHash -> m Block
+    getBlockThrow hash =
+        maybeThrow (DBMalformed $ sformat errFmt hash) =<< getBlock hash
       where
-        errFmt = "getBlundThrow: no blund with HeaderHash: "%shortHashF
+        errFmt = "getBlockThrow: no block with HeaderHash: "%shortHashF

--- a/auxx/src/Command/Dump.hs
+++ b/auxx/src/Command/Dump.hs
@@ -8,6 +8,7 @@ import           Codec.Compression.Lzma (compress)
 import           Control.Lens (_Wrapped)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.List.NonEmpty (last)
+import qualified Data.Vector as V
 import           Formatting (build, sformat, (%))
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
@@ -133,7 +134,7 @@ dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
             Nothing -> pass
             Just (blocks :: NewestFirst NonEmpty Block) -> do
                 let stripped   = map stripProof blocks
-                    serialized = serialize (0 :: Word8, stripped)
+                    serialized = serialize (0 :: Word8, V.fromList $ toList stripped)
                     outPath    = getOutPath epochIndex
                 liftIO $ BSL.writeFile outPath $ compress serialized
                 whenJust maybePrev $ \prev -> do

--- a/auxx/src/Command/Dump.hs
+++ b/auxx/src/Command/Dump.hs
@@ -1,0 +1,93 @@
+module Command.Dump
+    ( dump
+    ) where
+
+import           Universum
+
+import           Control.Lens (_Wrapped)
+import qualified Data.ByteString as BS
+import           Formatting (build, sformat, string, (%))
+import           System.Directory (createDirectoryIfMissing)
+import           System.FilePath (pathSeparator)
+import           System.Wlog (logInfo)
+
+import           Pos.Binary (serialize')
+import           Pos.Block.Types (Blund)
+import           Pos.Core (BlockHeader, HeaderHash, blockHeaderHash, difficultyL, epochIndexL,
+                           genesisHash, getEpochIndex, prevBlockL)
+import           Pos.Crypto (shortHashF)
+import           Pos.DB.Block (getBlund)
+import qualified Pos.DB.BlockIndex as DB
+import           Pos.DB.Class (MonadDBRead)
+import           Pos.DB.Error (DBError (..))
+import           Pos.StateLock (Priority (..), withStateLock)
+import           Pos.Util.Chrono (NewestFirst (..))
+import           Pos.Util.Util (maybeThrow)
+
+import           Mode (MonadAuxxMode)
+
+-- | Dump whole blockchain in CBOR format to the specified folder.
+-- Each epoch will be at <outFolder>/epoch<epochIndex>.cbor.
+dump
+    :: (MonadAuxxMode m, MonadIO m)
+    => FilePath
+    -> m ()
+dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
+    printTipDifficulty
+    liftIO $ createDirectoryIfMissing True outFolder
+    tipHeader <- DB.getTipHeader
+    doDump tipHeader
+  where
+    printTipDifficulty :: MonadAuxxMode m => m ()
+    printTipDifficulty = do
+        tipDifficulty <- view difficultyL <$> DB.getTipHeader
+        logInfo $ sformat ("Our tip's difficulty is "%build) tipDifficulty
+
+    loadEpoch
+        :: MonadAuxxMode m
+        => HeaderHash
+        -> m (Maybe HeaderHash, NewestFirst [] Blund)
+    loadEpoch start = do
+        -- returns Maybe (tip of previous epoch)
+        (maybePrev, blundsMaybeEmpty) <- doIt [] start
+        pure (maybePrev, NewestFirst blundsMaybeEmpty)
+      where
+        doIt :: MonadAuxxMode m => [Blund] -> HeaderHash -> m (Maybe HeaderHash, [Blund])
+        doIt !acc h
+            | h == genesisHash = pure (Nothing, reverse acc)
+            | otherwise = do
+                d <- getBlundThrow h
+                let prev = d ^. prevBlockL
+                    newAcc = d : acc
+                case d ^. _1 of
+                    Left _  -> pure (Just prev, reverse newAcc)
+                    Right _ -> doIt newAcc prev
+
+    doDump
+        :: (MonadAuxxMode m, MonadIO m)
+        => BlockHeader
+        -> m ()
+    doDump start = do
+        let epochIndex = start ^. epochIndexL
+        logInfo $ sformat ("Processing "%build) epochIndex
+        (maybePrev, blundsMaybeEmpty) <- loadEpoch $ blockHeaderHash start
+        case _Wrapped nonEmpty blundsMaybeEmpty of
+            Nothing -> pass
+            Just blunds -> do
+                let sblunds = serialize' (0 :: Word8, blunds)
+                    path = sformat (string%string%"epoch"%build%".cbor")
+                            outFolder [pathSeparator] (getEpochIndex epochIndex)
+                liftIO $ BS.writeFile (toString path) sblunds
+                whenJust maybePrev $ \prev -> do
+                    maybeHeader <- DB.getHeader prev
+                    case maybeHeader of
+                        Just header -> doDump header
+                        Nothing     -> error "DB contains block but not its parent"
+
+    getBlundThrow
+        :: MonadDBRead m
+        => HeaderHash -> m Blund
+    getBlundThrow hash =
+        maybeThrow (DBMalformed $ sformat errFmt hash) =<< getBlund hash
+      where
+        errFmt = "getBlundThrow: no blund with HeaderHash: "%shortHashF

--- a/auxx/src/Command/Dump.hs
+++ b/auxx/src/Command/Dump.hs
@@ -98,7 +98,7 @@ dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
     getOutPath :: EpochIndex -> FilePath
     getOutPath epochIndex =
         let outFile = toString $
-                sformat ("epoch"%build%".cbor") (getEpochIndex epochIndex)
+                sformat ("epoch"%build%".cbor.lzma") (getEpochIndex epochIndex)
         in outFolder </> outFile
 
     getBlundThrow

--- a/auxx/src/Command/DumpBlockchain.hs
+++ b/auxx/src/Command/DumpBlockchain.hs
@@ -1,5 +1,5 @@
-module Command.Dump
-    ( dump
+module Command.DumpBlockchain
+    ( dumpBlockchain
     ) where
 
 import           Universum
@@ -86,11 +86,11 @@ stripProof (Right mb) = Right $ GenericBlockNoProof mb
 
 -- | Dump whole blockchain in CBOR format to the specified folder.
 -- Each epoch will be at <outFolder>/epoch<epochIndex>.cbor.
-dump
+dumpBlockchain
     :: (MonadAuxxMode m, MonadIO m)
     => FilePath
     -> m ()
-dump outFolder = withStateLock HighPriority "auxx" $ \_ -> do
+dumpBlockchain outFolder = withStateLock HighPriority "auxx" $ \_ -> do
     printTipDifficulty
     liftIO $ createDirectoryIfMissing True outFolder
     tipHeader <- DB.getTipHeader

--- a/auxx/src/Command/DumpBlockchain.hs
+++ b/auxx/src/Command/DumpBlockchain.hs
@@ -4,85 +4,27 @@ module Command.DumpBlockchain
 
 import           Universum
 
-import           Codec.Compression.Lzma (compress)
+import           Conduit (runConduit, runResourceT, sinkFile, yieldMany, (.|))
 import           Control.Lens (_Wrapped)
-import qualified Data.ByteString.Lazy as BSL
 import           Data.List.NonEmpty (last)
-import qualified Data.Vector as V
 import           Formatting (build, sformat, (%))
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
 import           System.Wlog (logInfo, logWarning)
 
-import           Pos.Binary (Bi (..), encodeListLen, enforceSize, serialize)
+import           Pos.Block.Dump (encodeBlockDump)
 import           Pos.Core (Block, BlockHeader, EpochIndex (..), HeaderHash, blockHeaderHash,
                            difficultyL, epochIndexL, genesisHash, getBlockHeader, prevBlockL)
-import qualified Pos.Core as C
-import           Pos.Core.Block (GenericBlock (..), GenericBlockHeader (..))
-import           Pos.Crypto (HasCryptoConfiguration, getProtocolMagic, protocolMagic, shortHashF)
+import           Pos.Crypto (shortHashF)
 import           Pos.DB.Block (getBlock)
 import qualified Pos.DB.BlockIndex as DB
 import           Pos.DB.Class (MonadDBRead)
 import           Pos.DB.Error (DBError (..))
 import           Pos.StateLock (Priority (..), withStateLock)
-import           Pos.Util.Chrono (NewestFirst (..))
-import           Pos.Util.Util (eitherToFail, maybeThrow)
+import           Pos.Util.Chrono (NewestFirst (..), toOldestFirst)
+import           Pos.Util.Util (maybeThrow)
 
 import           Mode (MonadAuxxMode)
-
-newtype GenericBlockNoProof b = GenericBlockNoProof (GenericBlock b)
-
-type BlockNoProof = Either GenesisBlockNoProof MainBlockNoProof
-type GenesisBlockNoProof = GenericBlockNoProof C.GenesisBlockchain
-type MainBlockNoProof = GenericBlockNoProof C.MainBlockchain
-
-instance ( Typeable b
-         , Bi (C.BHeaderHash b)
-         , Bi (C.ConsensusData b)
-         , Bi (C.ExtraHeaderData b)
-         , Bi (C.Body b)
-         , Bi (C.ExtraBodyData b)
-         , C.BlockchainHelpers b
-         , HasCryptoConfiguration
-         ) =>
-         Bi (GenericBlockNoProof b) where
-    encode (GenericBlockNoProof gb) =
-        encodeListLen 3
-        <> encodeHeader (_gbHeader gb)
-        <> encode (_gbBody gb)
-        <> encode (_gbExtra gb)
-      where
-        encodeHeader bh =
-            encodeListLen 4
-            <> encode (getProtocolMagic protocolMagic)
-            <> encode (_gbhPrevBlock bh)
-            <> encode (_gbhConsensus bh)
-            <> encode (_gbhExtra bh)
-
-    decode = do
-        enforceSize "GenericBlock" 3
-        (prevBlock, consensus, headerExtra) <- decodeHeader'
-        body  <- decode
-        extra <- decode
-        let bodyProof = C.mkBodyProof body
-        header <- eitherToFail $
-            C.recreateGenericHeader prevBlock bodyProof consensus headerExtra
-        block <- eitherToFail $ C.recreateGenericBlock header body extra
-        pure $ GenericBlockNoProof block
-      where
-        decodeHeader' = do
-            enforceSize "GenericBlockHeader b" 4
-            blockMagic <- decode
-            when (blockMagic /= getProtocolMagic protocolMagic) $
-                fail $ "GenericBlockHeader failed with wrong magic: " <> show blockMagic
-            prevBlock <- decode
-            consensus <- decode
-            extra     <- decode
-            pure $ (prevBlock, consensus, extra)
-
-stripProof :: Block -> BlockNoProof
-stripProof (Left gb)  = Left $ GenericBlockNoProof gb
-stripProof (Right mb) = Right $ GenericBlockNoProof mb
 
 -- | Dump whole blockchain in CBOR format to the specified folder.
 -- Each epoch will be at <outFolder>/epoch<epochIndex>.cbor.
@@ -130,13 +72,15 @@ dumpBlockchain outFolder = withStateLock HighPriority "auxx" $ \_ -> do
         let epochIndex = start ^. epochIndexL
         logInfo $ sformat ("Processing "%build) epochIndex
         (maybePrev, blocksMaybeEmpty) <- loadEpoch $ blockHeaderHash start
+        -- TODO: use forward links instead so that we'd be able to stream
+        -- the blocks into the compression conduit
         case _Wrapped nonEmpty blocksMaybeEmpty of
             Nothing -> pass
             Just (blocks :: NewestFirst NonEmpty Block) -> do
-                let stripped   = map stripProof blocks
-                    serialized = serialize (0 :: Word8, V.fromList $ toList stripped)
-                    outPath    = getOutPath epochIndex
-                liftIO $ BSL.writeFile outPath $ compress serialized
+                runResourceT $ runConduit $
+                    yieldMany (toList (toOldestFirst blocks)) .|
+                    encodeBlockDump .|
+                    sinkFile (getOutPath epochIndex)
                 whenJust maybePrev $ \prev -> do
                     maybeHeader <- DB.getHeader prev
                     case maybeHeader of

--- a/auxx/src/Command/DumpBlockchain.hs
+++ b/auxx/src/Command/DumpBlockchain.hs
@@ -16,7 +16,7 @@ import           System.Directory (createDirectoryIfMissing, doesDirectoryExist,
 import           System.FilePath ((</>))
 import           System.Wlog (logInfo, logWarning)
 
-import           Pos.Block.Dump (decodeBlockDump, encodeBlockDump)
+import           Pos.Block.Dump (decodeBlockDumpC, encodeBlockDumpC)
 import           Pos.Block.Logic.VAR (verifyAndApplyBlocksC)
 import           Pos.Core (Block, BlockHeader, EpochIndex (..), HeaderHash, difficultyL,
                            epochIndexL, genesisHash, getBlockHeader, headerHash, prevBlockL)
@@ -88,7 +88,7 @@ dumpBlockchain outFolder = withStateLock HighPriority "auxx" $ \_ -> do
             Just (blocks :: NewestFirst NonEmpty Block) -> do
                 runConduitRes $
                     C.yieldMany (toList (toOldestFirst blocks)) .|
-                    encodeBlockDump .|
+                    encodeBlockDumpC .|
                     C.sinkFile (getOutPath epochIndex)
                 whenJust maybePrev $ \prev -> do
                     maybeHeader <- DB.getHeader prev
@@ -149,7 +149,7 @@ applyEpoch path = do
              "difficulty is "+|difficulty|+"")
     result <- runConduitRes $
            C.sourceFile path
-        .| decodeBlockDump                            -- get a stream of blocks
+        .| decodeBlockDumpC                            -- get a stream of blocks
         .| (C.dropWhileC ((/= tip) . view prevBlockL) -- skip blocks until tip
         >> verifyAndApplyBlocksC True)                -- apply blocks w/ rollback
     whenLeft result throwM

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -34,6 +34,7 @@ import           Pos.Util.UserSecret (WalletUserSecret (..), readUserSecret, usK
 import           Pos.Util.Util (eitherToFail)
 
 import           Command.BlockGen (generateBlocks)
+import qualified Command.Dump as Dump
 import           Command.Help (mkHelpMessage)
 import qualified Command.Rollback as Rollback
 import qualified Command.Tx as Tx
@@ -48,9 +49,10 @@ import qualified Command.Update as Update
 import           Lang.Argument (getArg, getArgMany, getArgOpt, getArgSome, typeDirectedKwAnn)
 import           Lang.Command (CommandProc (..), UnavailableCommand (..))
 import           Lang.Name (Name)
-import           Lang.Value (AddKeyParams (..), AddrDistrPart (..), GenBlocksParams (..),
-                             ProposeUpdateParams (..), ProposeUpdateSystem (..),
-                             RollbackParams (..), SendMode (..), Value (..))
+import           Lang.Value (AddKeyParams (..), AddrDistrPart (..), DumpParams (..),
+                             GenBlocksParams (..), ProposeUpdateParams (..),
+                             ProposeUpdateSystem (..), RollbackParams (..), SendMode (..),
+                             Value (..))
 import           Mode (CmdCtx (..), MonadAuxxMode, deriveHDAddressAuxx, getCmdCtx,
                        makePubKeyAddressAuxx)
 import           Repl (PrintAction)
@@ -463,6 +465,20 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
         pure RollbackParams{..}
     , cpExec = \RollbackParams{..} -> do
         Rollback.rollbackAndDump rpNum rpDumpPath
+        return ValueUnit
+    , cpHelp = ""
+    },
+
+    let name = "dump" in
+    needsAuxxMode name >>= \Dict ->
+    return CommandProc
+    { cpName = name
+    , cpArgumentPrepare = identity
+    , cpArgumentConsumer = do
+        dumpOutFolder <- getArg tyFilePath "dump-folder"
+        pure DumpParams{..}
+    , cpExec = \DumpParams{..} -> do
+        Dump.dump dumpOutFolder
         return ValueUnit
     , cpHelp = ""
     },

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -34,7 +34,7 @@ import           Pos.Util.UserSecret (WalletUserSecret (..), readUserSecret, usK
 import           Pos.Util.Util (eitherToFail)
 
 import           Command.BlockGen (generateBlocks)
-import qualified Command.Dump as Dump
+import qualified Command.DumpBlockchain as DumpBlockchain
 import           Command.Help (mkHelpMessage)
 import qualified Command.Rollback as Rollback
 import qualified Command.Tx as Tx
@@ -49,7 +49,7 @@ import qualified Command.Update as Update
 import           Lang.Argument (getArg, getArgMany, getArgOpt, getArgSome, typeDirectedKwAnn)
 import           Lang.Command (CommandProc (..), UnavailableCommand (..))
 import           Lang.Name (Name)
-import           Lang.Value (AddKeyParams (..), AddrDistrPart (..), DumpParams (..),
+import           Lang.Value (AddKeyParams (..), AddrDistrPart (..), DumpBlockchainParams (..),
                              GenBlocksParams (..), ProposeUpdateParams (..),
                              ProposeUpdateSystem (..), RollbackParams (..), SendMode (..),
                              Value (..))
@@ -469,16 +469,16 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
     , cpHelp = ""
     },
 
-    let name = "dump" in
+    let name = "dump-blockchain" in
     needsAuxxMode name >>= \Dict ->
     return CommandProc
     { cpName = name
     , cpArgumentPrepare = identity
     , cpArgumentConsumer = do
         dumpOutFolder <- getArg tyFilePath "dump-folder"
-        pure DumpParams{..}
-    , cpExec = \DumpParams{..} -> do
-        Dump.dump dumpOutFolder
+        pure DumpBlockchainParams{..}
+    , cpExec = \DumpBlockchainParams{..} -> do
+        DumpBlockchain.dumpBlockchain dumpOutFolder
         return ValueUnit
     , cpHelp = ""
     },

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -282,11 +282,13 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
     return CommandProc
     { cpName = name
     , cpArgumentPrepare = identity
-    , cpArgumentConsumer = getArg tyFilePath "file/directory"
+    , cpArgumentConsumer = getArg tyFilePath "path"
     , cpExec = \path -> do
         DumpBlockchain.applyBlockchainDump path
         return ValueUnit
-    , cpHelp = ""
+    , cpHelp = "take a single .cbor.lzma file containing a blockchain dump \
+               \(or a folder with such files), and apply all blocks from \
+               \those files as if they were received from the network"
     },
 
     return CommandProc
@@ -492,7 +494,9 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
     , cpExec = \DumpBlockchainParams{..} -> do
         DumpBlockchain.dumpBlockchain dumpOutFolder
         return ValueUnit
-    , cpHelp = ""
+    , cpHelp = "dump all available blocks as a number of .cbor.lzma files, \
+               \each corresponding to a single epoch (the last epoch might \
+               \be truncated"
     },
 
     let name = "listaddr" in

--- a/auxx/src/Command/Rollback.hs
+++ b/auxx/src/Command/Rollback.hs
@@ -25,16 +25,13 @@ import           Pos.Ssc.Configuration (HasSscConfiguration)
 import           Pos.StateLock (Priority (..), withStateLock)
 import           Pos.Txp (flattenTxPayload)
 import           Pos.Util.Chrono (NewestFirst, _NewestFirst)
-import           Pos.Util.CompileInfo (HasCompileInfo)
 
 import           Mode (MonadAuxxMode)
 
 -- | Rollback given number of blocks from the DB and dump transactions
 -- from it to the given file.
 rollbackAndDump
-    :: ( MonadAuxxMode m
-       , HasCompileInfo
-       )
+    :: MonadAuxxMode m
     => Word
     -> FilePath
     -> m ()

--- a/auxx/src/Lang/Value.hs
+++ b/auxx/src/Lang/Value.hs
@@ -27,7 +27,7 @@ module Lang.Value
        , AddrDistrPart(..)
        , ProposeUpdateParams(..)
        , RollbackParams(..)
-       , DumpParams(..)
+       , DumpBlockchainParams(..)
        , ProposeUpdateSystem(..)
        , GenBlocksParams(..)
        , AddKeyParams (..)
@@ -73,7 +73,7 @@ data RollbackParams = RollbackParams
     , rpDumpPath :: !FilePath
     } deriving (Show)
 
-data DumpParams = DumpParams
+data DumpBlockchainParams = DumpBlockchainParams
     { dumpOutFolder :: !FilePath
     } deriving (Show)
 

--- a/auxx/src/Lang/Value.hs
+++ b/auxx/src/Lang/Value.hs
@@ -27,6 +27,7 @@ module Lang.Value
        , AddrDistrPart(..)
        , ProposeUpdateParams(..)
        , RollbackParams(..)
+       , DumpParams(..)
        , ProposeUpdateSystem(..)
        , GenBlocksParams(..)
        , AddKeyParams (..)
@@ -70,6 +71,10 @@ data ProposeUpdateParams = ProposeUpdateParams
 data RollbackParams = RollbackParams
     { rpNum      :: !Word
     , rpDumpPath :: !FilePath
+    } deriving (Show)
+
+data DumpParams = DumpParams
+    { dumpOutFolder :: !FilePath
     } deriving (Show)
 
 data ProposeUpdateSystem = ProposeUpdateSystem

--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -25,6 +25,7 @@ import           Universum
 import           Control.Lens (lens, makeLensesWith)
 import           Control.Monad.Morph (hoist)
 import           Control.Monad.Reader (withReaderT)
+import           Control.Monad.Trans.Resource (ResourceT)
 import           Data.Default (def)
 import           Mockable (Production)
 import           System.Wlog (HasLoggerName (..))
@@ -245,6 +246,17 @@ instance (HasConfigurations) =>
          MonadTxpLocal (BlockGenMode EmptyMempoolExt AuxxMode) where
     txpNormalize = withCompileInfo def $ txNormalize
     txpProcessTx = withCompileInfo def $ txProcessTransactionNoLock
+
+-- ResourceT instances
+
+instance HasAdoptedBlockVersionData AuxxMode =>
+         HasAdoptedBlockVersionData (ResourceT AuxxMode) where
+    adoptedBVData = lift adoptedBVData
+
+instance MonadTxpLocal AuxxMode =>
+         MonadTxpLocal (ResourceT AuxxMode) where
+    txpNormalize = lift txpNormalize
+    txpProcessTx = lift . txpProcessTx
 
 -- | In order to create an 'Address' from a 'PublicKey' we need to
 -- choose suitable stake distribution. We want to pick it based on

--- a/binary/Pos/Binary/Conduit.hs
+++ b/binary/Pos/Binary/Conduit.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Conduit utilities.
+module Pos.Binary.Conduit
+       ( awaitBi
+       , awaitCbor
+       ) where
+
+import           Universum
+
+import qualified Codec.CBOR.Decoding as Cbor hiding (DecodeAction (..))
+import qualified Codec.CBOR.Read as Cbor
+import           Conduit (Consumer)
+import qualified Conduit as C
+import           Control.Monad.Morph (hoist)
+import           Control.Monad.ST (RealWorld, ST)
+import           Data.NonNull (toNullable)
+
+import           Pos.Binary.Class (Bi)
+import qualified Pos.Binary.Class as Bi
+
+-- | Decode one 'Bi'-serialized value from the input.
+--
+-- Returns a 'Nothing' if there's no input left.
+awaitBi
+    :: (MonadIO m, Bi a)
+    => Consumer ByteString m (Maybe (Either Cbor.DeserialiseFailure a))
+awaitBi = awaitCbor Bi.decode
+
+-- | Like 'awaitBi', but allows supplying a custom decoder.
+--
+-- TODO: it should be possible to avoid 'MonadIO' here, but I don't know
+-- how. (On the other hand, see <https://redd.it/1vcvxe> – maybe it's
+-- impossible after all.)
+awaitCbor
+    :: MonadIO m
+    => Cbor.Decoder RealWorld a
+    -> Consumer ByteString m (Maybe (Either Cbor.DeserialiseFailure a))
+awaitCbor decoder = hoist stToIO $ do
+    mbChunk <- awaitNonNull
+    case mbChunk of
+        Nothing    -> pure Nothing
+        Just chunk -> do
+            C.leftover chunk
+            initResult <- lift (Cbor.deserialiseIncremental decoder)
+            Just <$> go False initResult
+  where
+    go :: Bool                    -- ^ End of input reached?
+       -> Bi.IDecode RealWorld a  -- ^ Result of decoding so far
+       -> Consumer ByteString (ST RealWorld) (Either Cbor.DeserialiseFailure a)
+    go eof = \case
+        Cbor.Fail rest _ failure -> do
+            C.leftover rest
+            pure (Left failure)
+        Cbor.Partial f | not eof -> do
+            mbChunk <- awaitNonNull
+            go (isNothing mbChunk) =<< lift (f mbChunk)
+        Cbor.Partial _ ->    -- impossible, I think
+            let err = "CBOR decoder returned 'Partial' after end of input"
+            in  pure (Left (Cbor.DeserialiseFailure (-1) err))
+        Cbor.Done rest _ x -> do
+            C.leftover rest
+            pure (Right x)
+
+    -- Like C.awaitNonNull but without the NonNull wrapper nonsense
+    awaitNonNull = fmap toNullable <$> C.awaitNonNull

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -15,6 +15,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:
                        Pos.Binary.Class
+                       Pos.Binary.Conduit
 
   other-modules:
                        Pos.Binary.Class.Core
@@ -28,11 +29,14 @@ library
                      , binary
                      , bytestring
                      , cborg
+                     , conduit-combinators
                      , containers
                      , digest
                      , formatting
                      , hashable
                      , lens
+                     , mmorph
+                     , mono-traversable
                      , mtl
                      , parsec
                      , process

--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -19,6 +19,7 @@ library
                         Pos.Block.BHelpers
                         Pos.Block.BListener
                         Pos.Block.Configuration
+                        Pos.Block.Dump
                         Pos.Block.Error
                         Pos.Block.Logic
                         Pos.Block.Network
@@ -88,7 +89,9 @@ library
                       , cardano-sl-txp
                       , cardano-sl-update
                       , cardano-sl-util
+                      , cborg
                       , conduit
+                      , conduit-combinators >= 1.1.2
                       , containers
                       , cryptonite
                       , data-default
@@ -101,6 +104,8 @@ library
                       , generic-arbitrary
                       , lens
                       , log-warper
+                      , lzma-conduit
+                      , mmorph
                       , mtl
                       , random
                       , reflection

--- a/block/src/Pos/Block/Dump.hs
+++ b/block/src/Pos/Block/Dump.hs
@@ -1,0 +1,250 @@
+{-# LANGUAGE RankNTypes #-}
+
+{- | Block dumps (used for snapshots).
+
+A block dump looks like this:
+
+@
+[block version, [block1, block2, ...]]
+@
+
+In CBOR terms, this is translated into this sequence of tokens:
+
+@
+listlen=2, block version, list_indef_len, [block1] [block2] ...
+@
+
+When we encode blocks, we strip proofs from them. When we decode blocks, we
+reconstruct those proofs.
+
+-}
+
+module Pos.Block.Dump
+       (
+       -- * Encoding
+         encodeBlockDump
+
+       -- * Decoding
+       , decodeBlockDump
+       , BlockDumpDecodeError (..)
+
+       -- * Internals
+       -- ** Encoding
+       , encodeDumpHeader
+       , encodeBlockStream
+       -- ** Decoding
+       , decodeDumpHeader
+       , decodeBlockStream
+       -- ** Stripped blocks
+       , GenericBlockNoProof (..)
+       , BlockNoProof
+       , GenesisBlockNoProof
+       , MainBlockNoProof
+       , stripProof
+       , addProof
+       ) where
+
+import           Universum
+
+import qualified Codec.CBOR.Decoding as Cbor hiding (DecodeAction (..))
+import qualified Codec.CBOR.Encoding as Cbor
+import qualified Codec.CBOR.Read as Cbor
+import qualified Codec.CBOR.Write as Cbor
+import           Conduit (Conduit, Consumer, Producer, yield, (.|))
+import qualified Conduit
+import qualified Data.Conduit.Lzma as Lzma
+import qualified Data.Text.Buildable
+import           Formatting (bprint, int, stext, (%))
+import           Serokell.Util (listJson)
+
+import           Pos.Binary.Class (Bi (..), serialize')
+import qualified Pos.Binary.Class as Bi
+import qualified Pos.Binary.Conduit as Bi
+import           Pos.Core (Block, GenericBlock (..), GenericBlockHeader (..))
+import qualified Pos.Core as C
+import           Pos.Crypto (HasCryptoConfiguration)
+import           Pos.Util.Util (eitherToFail)
+
+----------------------------------------------------------------------------
+-- Encoding
+----------------------------------------------------------------------------
+
+-- | Encode a block dump. The blocks should be coming oldest-first.
+encodeBlockDump
+    :: (Bi BlockNoProof, Conduit.MonadResource m)
+    => Conduit Block m ByteString
+encodeBlockDump = (encodeDumpHeader >> encodeBlockStream)
+               .| Lzma.compress Nothing
+
+encodeDumpHeader :: Monad m => Producer m ByteString
+encodeDumpHeader = yield $ Cbor.toStrictByteString $
+    Cbor.encodeListLen 2 <>                     -- tuple with 2 elements
+    Cbor.encodeWord16 0 <>                      -- 1st element: version
+    Cbor.encodeListLenIndef                     -- 2nd element: list
+
+encodeBlockStream
+    :: (Bi BlockNoProof, Monad m)
+    => Conduit Block m ByteString
+encodeBlockStream = Conduit.mapC (serialize' . stripProof)
+
+----------------------------------------------------------------------------
+-- Decoding
+----------------------------------------------------------------------------
+
+-- | All errors that can happen when decoding a block dump.
+data BlockDumpDecodeError
+
+    -- | Couldn't decode a block
+    = BlockDecodeError
+        { bddeBlockIndex :: !Int            -- ^ at which block we failed
+        , bddeByteOffset :: !Int64          -- ^ offset inside the block
+        , bddeMessage    :: !Text }
+
+    -- | The dump (header) has wrong structure
+    | DumpFormatError
+        { bddeByteOffset :: !Int64
+        , bddeMessage    :: !Text }
+
+    -- | The dump is for “bad” block version which we don't support
+    | UnsupportedBlockVersion
+        { bddeFoundVersion    :: !Word16
+        , bddeExpectedVersion :: !(Set Word16) }
+
+    -- | The dump is completely empty
+    | EmptyInput
+
+    deriving (Show, Eq)
+
+instance Exception BlockDumpDecodeError
+
+instance Buildable BlockDumpDecodeError where
+    build (BlockDecodeError index offset reason) =
+        bprint ("Failed to decode block with index "%int%": "%
+                "at offset "%int%": "%stext) index offset reason
+    build (DumpFormatError offset reason) =
+        bprint ("Block dump has wrong format: "%
+                "at offset "%int%": "%stext) offset reason
+    build (UnsupportedBlockVersion got expected) =
+        bprint ("Expected one of block versions "%listJson%", got "%int)
+               expected got
+    build EmptyInput =
+        bprint "Block dump is completely empty (no bytes)"
+
+-- | A conduit that decodes blocks from a CBOR-encoded LZMA-compressed list.
+--
+-- /Throws:/ 'BlockDumpDecodeError'
+decodeBlockDump
+    :: (Bi BlockNoProof, Conduit.MonadResource m, MonadThrow m)
+    => Conduit ByteString m Block
+decodeBlockDump =
+    Lzma.decompress memlimit .| do
+        ver <- decodeDumpHeader
+        when (ver /= 0) $ throwM (UnsupportedBlockVersion ver (one 0))
+        decodeBlockStream
+  where
+    memlimit = Just (200*1024*1024)  -- 200 MB
+
+-- | Deserialize the header of a dump and return data decoded from the
+-- header (i.e. block version).
+decodeDumpHeader
+    :: (MonadThrow m, MonadIO m)
+    => Consumer ByteString m Word16
+decodeDumpHeader =
+    Bi.awaitCbor decoder >>= \case
+        Nothing ->
+            throwM EmptyInput
+        Just (Left (Cbor.DeserialiseFailure off err)) ->
+            throwM (DumpFormatError off (toText err))
+        Just (Right x) ->
+            pure x
+  where
+    -- A decoder for everything preceding the block stream
+    decoder = do
+        Cbor.decodeListLenCanonicalOf 2        -- tuple with two elements
+        ver <- Cbor.decodeWord16Canonical      -- 1st element: version
+        Cbor.decodeListLenIndef                -- 2nd element: list
+        pure ver
+
+-- | Decode a stream of blocks.
+decodeBlockStream
+    :: forall m. (Bi BlockNoProof, MonadIO m, MonadThrow m)
+    => Conduit ByteString m Block
+decodeBlockStream = go 0
+  where
+    go :: Bi BlockNoProof => Int -> Conduit ByteString m Block
+    go i = Bi.awaitBi >>= \case
+        Nothing ->
+            pure ()
+        Just (Left (Cbor.DeserialiseFailure off err)) ->
+            throwM (BlockDecodeError i off (toText err))
+        Just (Right block) -> do
+            yield (addProof block)
+            go (i + 1)
+
+----------------------------------------------------------------------------
+-- Stripped blocks
+----------------------------------------------------------------------------
+
+-- | To make snapshots more compact, we strip proofs from blocks. This is a
+-- helper newtype for that.
+newtype GenericBlockNoProof b = GenericBlockNoProof (GenericBlock b)
+
+type GenesisBlockNoProof = GenericBlockNoProof C.GenesisBlockchain
+type MainBlockNoProof    = GenericBlockNoProof C.MainBlockchain
+
+type BlockNoProof = Either GenesisBlockNoProof MainBlockNoProof
+
+stripProof :: Block -> BlockNoProof
+stripProof (Left gb)  = Left  $ GenericBlockNoProof gb
+stripProof (Right mb) = Right $ GenericBlockNoProof mb
+
+addProof :: BlockNoProof -> Block
+addProof (Left  (GenericBlockNoProof gb)) = Left gb
+addProof (Right (GenericBlockNoProof mb)) = Right mb
+
+-- | Encode the block without including any proofs. When decoding, recreate
+-- the proofs.
+instance ( Typeable b
+         , Bi (C.BHeaderHash b)
+         , Bi (C.ConsensusData b)
+         , Bi (C.ExtraHeaderData b)
+         , Bi (C.Body b)
+         , Bi (C.ExtraBodyData b)
+         , C.BlockchainHelpers b
+         , HasCryptoConfiguration
+         , C.HasProtocolConstants
+         ) =>
+         Bi (GenericBlockNoProof b) where
+    encode (GenericBlockNoProof gb) =
+        Bi.encodeListLen 3
+        <> encodeHeader (_gbHeader gb)
+        <> encode (_gbBody gb)
+        <> encode (_gbExtra gb)
+      where
+        encodeHeader bh =
+            Bi.encodeListLen 4
+            <> encode C.protocolMagic
+            <> encode (_gbhPrevBlock bh)
+            <> encode (_gbhConsensus bh)
+            <> encode (_gbhExtra bh)
+
+    decode = do
+        Bi.enforceSize "GenericBlock" 3
+        (prevBlock, consensus, headerExtra) <- decodeHeader
+        body  <- decode
+        extra <- decode
+        let bodyProof = C.mkBodyProof body
+        header <- eitherToFail $
+            C.recreateGenericHeader prevBlock bodyProof consensus headerExtra
+        block <- eitherToFail $ C.recreateGenericBlock header body extra
+        pure $ GenericBlockNoProof block
+      where
+        decodeHeader = do
+            Bi.enforceSize "GenericBlockHeader b" 4
+            blockMagic <- decode
+            when (blockMagic /= C.protocolMagic) $
+                fail $ "GenericBlockHeader failed with wrong magic: " <> show blockMagic
+            prevBlock <- decode
+            consensus <- decode
+            extra     <- decode
+            pure (prevBlock, consensus, extra)

--- a/block/src/Pos/GState/SanityCheck.hs
+++ b/block/src/Pos/GState/SanityCheck.hs
@@ -7,7 +7,7 @@ module Pos.GState.SanityCheck
 import           Universum
 
 import           Control.Monad.Catch (MonadMask)
-import           System.Wlog (WithLogger)
+import           System.Wlog (WithLogger, logDebug)
 
 import           Pos.DB.Class (MonadDBRead)
 import           Pos.DB.GState.Stakes (getRealTotalStake)
@@ -21,7 +21,9 @@ sanityCheckDB ::
        , MonadReader ctx m
        )
     => m ()
-sanityCheckDB = inAssertMode sanityCheckGStateDB
+sanityCheckDB = inAssertMode $ do
+    sanityCheckGStateDB
+    logDebug "Finished sanity check"
 
 -- | Check that GState DB is consistent.
 sanityCheckGStateDB ::

--- a/core/Pos/Binary/Core/Blockchain.hs
+++ b/core/Pos/Binary/Core/Blockchain.hs
@@ -9,7 +9,7 @@ import           Universum
 import           Pos.Binary.Class (Bi (..), encodeListLen, enforceSize)
 import           Pos.Binary.Core.Common ()
 import qualified Pos.Core.Block.Blockchain as T
-import           Pos.Crypto.Configuration (HasCryptoConfiguration, getProtocolMagic, protocolMagic)
+import           Pos.Crypto.Configuration (HasCryptoConfiguration, protocolMagic)
 import           Pos.Util.Util (eitherToFail)
 
 instance ( Typeable b
@@ -22,7 +22,7 @@ instance ( Typeable b
          ) =>
          Bi (T.GenericBlockHeader b) where
     encode bh =  encodeListLen 5
-              <> encode (getProtocolMagic protocolMagic)
+              <> encode protocolMagic
               <> encode (T._gbhPrevBlock bh)
               <> encode (T._gbhBodyProof bh)
               <> encode (T._gbhConsensus bh)
@@ -30,7 +30,7 @@ instance ( Typeable b
     decode = do
         enforceSize "GenericBlockHeader b" 5
         blockMagic <- decode
-        when (blockMagic /= getProtocolMagic protocolMagic) $
+        when (blockMagic /= protocolMagic) $
             fail $ "GenericBlockHeader failed with wrong magic: " <> show blockMagic
         prevBlock <- decode
         bodyProof <- decode

--- a/crypto/Pos/Binary/Crypto.hs
+++ b/crypto/Pos/Binary/Crypto.hs
@@ -20,6 +20,7 @@ import           Formatting (int, sformat, (%))
 import           Pos.Binary.Class (AsBinary (..), Bi (..), Cons (..), Field (..), decodeBinary,
                                    deriveSimpleBi, encodeBinary, encodeListLen, enforceSize)
 import           Pos.Crypto.AsBinary (decShareBytes, encShareBytes, secretBytes, vssPublicKeyBytes)
+import           Pos.Crypto.Configuration (ProtocolMagic (..))
 import           Pos.Crypto.Hashing (AbstractHash (..), HashAlgorithm, WithHash (..), withHash)
 import           Pos.Crypto.HD (HDAddressPayload (..))
 import           Pos.Crypto.Scrypt (EncryptedPass (..))
@@ -239,3 +240,11 @@ instance Bi EdStandard.Signature where
 deriving instance Bi RedeemPublicKey
 deriving instance Bi RedeemSecretKey
 deriving instance Typeable a => Bi (RedeemSignature a)
+
+----------------------------------------------------------------------------
+-- Configuration
+----------------------------------------------------------------------------
+
+instance Bi ProtocolMagic where
+    encode (ProtocolMagic magic) = encode magic
+    decode = ProtocolMagic <$> decode

--- a/crypto/Pos/Crypto/Signing/Redeem.hs
+++ b/crypto/Pos/Crypto/Signing/Redeem.hs
@@ -15,6 +15,7 @@ import           Data.Coerce (coerce)
 import qualified Crypto.Sign.Ed25519 as Ed25519
 import           Pos.Binary.Class (Bi, Raw)
 import qualified Pos.Binary.Class as Bi
+import           Pos.Binary.Crypto ()
 import           Pos.Crypto.Configuration (HasCryptoConfiguration, ProtocolMagic)
 import           Pos.Crypto.Signing.Tag (SignTag, signTag)
 import           Pos.Crypto.Signing.Types.Redeem
@@ -46,7 +47,7 @@ redeemDeterministicKeyGen seed =
 
 -- | Encode something with 'Binary' and sign it.
 redeemSign ::
-       (HasCryptoConfiguration, Bi a, Bi ProtocolMagic)
+       (HasCryptoConfiguration, Bi a)
     => SignTag
     -> RedeemSecretKey
     -> a
@@ -54,8 +55,8 @@ redeemSign ::
 redeemSign tag k = coerce . redeemSignRaw (Just tag) k . Bi.serialize'
 
 -- | Alias for constructor.
-redeemSignRaw ::
-       (HasCryptoConfiguration, Bi ProtocolMagic)
+redeemSignRaw
+    :: HasCryptoConfiguration
     => Maybe SignTag
     -> RedeemSecretKey
     -> ByteString
@@ -68,7 +69,7 @@ redeemSignRaw mbTag (RedeemSecretKey k) x =
 -- CHECK: @redeemCheckSig
 -- | Verify a signature.
 redeemCheckSig
-    :: (HasCryptoConfiguration, Bi a, Bi ProtocolMagic)
+    :: (HasCryptoConfiguration, Bi a)
     => SignTag -> RedeemPublicKey -> a -> RedeemSignature a -> Bool
 redeemCheckSig tag k x s =
     redeemVerifyRaw (Just tag) k (Bi.serialize' x) (coerce s)
@@ -76,7 +77,7 @@ redeemCheckSig tag k x s =
 -- CHECK: @redeemVerifyRaw
 -- | Verify raw 'ByteString'.
 redeemVerifyRaw ::
-       (HasCryptoConfiguration, Bi ProtocolMagic)
+       HasCryptoConfiguration
     => Maybe SignTag
     -> RedeemPublicKey
     -> ByteString

--- a/crypto/Pos/Crypto/Signing/Redeem.hs
+++ b/crypto/Pos/Crypto/Signing/Redeem.hs
@@ -15,7 +15,7 @@ import           Data.Coerce (coerce)
 import qualified Crypto.Sign.Ed25519 as Ed25519
 import           Pos.Binary.Class (Bi, Raw)
 import qualified Pos.Binary.Class as Bi
-import           Pos.Crypto.Configuration (HasCryptoConfiguration)
+import           Pos.Crypto.Configuration (HasCryptoConfiguration, ProtocolMagic)
 import           Pos.Crypto.Signing.Tag (SignTag, signTag)
 import           Pos.Crypto.Signing.Types.Redeem
 
@@ -46,7 +46,7 @@ redeemDeterministicKeyGen seed =
 
 -- | Encode something with 'Binary' and sign it.
 redeemSign ::
-       (HasCryptoConfiguration, Bi a)
+       (HasCryptoConfiguration, Bi a, Bi ProtocolMagic)
     => SignTag
     -> RedeemSecretKey
     -> a
@@ -55,7 +55,7 @@ redeemSign tag k = coerce . redeemSignRaw (Just tag) k . Bi.serialize'
 
 -- | Alias for constructor.
 redeemSignRaw ::
-       HasCryptoConfiguration
+       (HasCryptoConfiguration, Bi ProtocolMagic)
     => Maybe SignTag
     -> RedeemSecretKey
     -> ByteString
@@ -68,7 +68,7 @@ redeemSignRaw mbTag (RedeemSecretKey k) x =
 -- CHECK: @redeemCheckSig
 -- | Verify a signature.
 redeemCheckSig
-    :: (HasCryptoConfiguration, Bi a)
+    :: (HasCryptoConfiguration, Bi a, Bi ProtocolMagic)
     => SignTag -> RedeemPublicKey -> a -> RedeemSignature a -> Bool
 redeemCheckSig tag k x s =
     redeemVerifyRaw (Just tag) k (Bi.serialize' x) (coerce s)
@@ -76,7 +76,7 @@ redeemCheckSig tag k x s =
 -- CHECK: @redeemVerifyRaw
 -- | Verify raw 'ByteString'.
 redeemVerifyRaw ::
-       HasCryptoConfiguration
+       (HasCryptoConfiguration, Bi ProtocolMagic)
     => Maybe SignTag
     -> RedeemPublicKey
     -> ByteString

--- a/crypto/Pos/Crypto/Signing/Tag.hs
+++ b/crypto/Pos/Crypto/Signing/Tag.hs
@@ -5,14 +5,16 @@ module Pos.Crypto.Signing.Tag
 
 import           Universum
 
-import qualified Pos.Binary.Class as Bi
+import           Pos.Binary.Class (Bi, serialize')
 import           Pos.Crypto.Configuration (HasCryptoConfiguration, ProtocolMagic (..),
                                            protocolMagic)
 import           Pos.Crypto.Signing.Types.Tag
 
 -- | Get magic bytes corresponding to a 'SignTag'. Guaranteed to be different
 -- (and begin with a different byte) for different tags.
-signTag :: HasCryptoConfiguration => SignTag -> ByteString
+signTag
+    :: (Bi ProtocolMagic, HasCryptoConfiguration)
+    => SignTag -> ByteString
 signTag = \case
     SignForTestingOnly -> "\x00"
     SignTx             -> "\x01" <> network
@@ -26,4 +28,4 @@ signTag = \case
     SignMainBlockHeavy -> "\x09" <> network
     SignProxySK        -> "\x0a" <> network
   where
-    network = Bi.serialize' (getProtocolMagic protocolMagic)
+    network = serialize' protocolMagic

--- a/crypto/Pos/Crypto/Signing/Tag.hs
+++ b/crypto/Pos/Crypto/Signing/Tag.hs
@@ -6,6 +6,7 @@ module Pos.Crypto.Signing.Tag
 import           Universum
 
 import           Pos.Binary.Class (Bi, serialize')
+import           Pos.Binary.Crypto ()
 import           Pos.Crypto.Configuration (HasCryptoConfiguration, ProtocolMagic (..),
                                            protocolMagic)
 import           Pos.Crypto.Signing.Types.Tag
@@ -13,7 +14,7 @@ import           Pos.Crypto.Signing.Types.Tag
 -- | Get magic bytes corresponding to a 'SignTag'. Guaranteed to be different
 -- (and begin with a different byte) for different tags.
 signTag
-    :: (Bi ProtocolMagic, HasCryptoConfiguration)
+    :: HasCryptoConfiguration
     => SignTag -> ByteString
 signTag = \case
     SignForTestingOnly -> "\x00"

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -280,6 +280,7 @@ test-suite cardano-test
                        -- Pos.Block testing
                        Test.Pos.Block.Identity.BinarySpec
                        Test.Pos.Block.Identity.SafeCopySpec
+                       Test.Pos.Block.DumpSpec
 
                        -- Core
                        Test.Pos.Core.AddressSpec

--- a/lib/src/Pos/Client/CLI/NodeOptions.hs
+++ b/lib/src/Pos/Client/CLI/NodeOptions.hs
@@ -28,7 +28,6 @@ import           Pos.Client.CLI.Options (CommonArgs (..), commonArgsParser, opti
 import           Pos.HealthCheck.Route53 (route53HealthCheckOption)
 import           Pos.Network.CLI (NetworkConfigOpts, networkConfigOption)
 import           Pos.Statistics (EkgParams, StatsdParams, ekgParamsOption, statsdParamsOption)
-import           Pos.Util (textOption)
 import           Pos.Util.CompileInfo (CompileTimeInfo (..), HasCompileInfo, compileInfo)
 import           Pos.Util.TimeWarp (NetworkAddress)
 
@@ -104,7 +103,7 @@ commonNodeArgsParser = do
         long "dump-genesis-data-to" <>
         help "Dump genesis data in canonical JSON format to this file."
 
-    cnaBlockStorageMirror <- optional $ textOption $
+    cnaBlockStorageMirror <- optional $ strOption $
         long "block-storage-mirror" <>
         help "URL for a mirror that stores epochs in *.cbor.lzma format."
 

--- a/lib/src/Pos/Client/CLI/NodeOptions.hs
+++ b/lib/src/Pos/Client/CLI/NodeOptions.hs
@@ -28,6 +28,7 @@ import           Pos.Client.CLI.Options (CommonArgs (..), commonArgsParser, opti
 import           Pos.HealthCheck.Route53 (route53HealthCheckOption)
 import           Pos.Network.CLI (NetworkConfigOpts, networkConfigOption)
 import           Pos.Statistics (EkgParams, StatsdParams, ekgParamsOption, statsdParamsOption)
+import           Pos.Util (textOption)
 import           Pos.Util.CompileInfo (CompileTimeInfo (..), HasCompileInfo, compileInfo)
 import           Pos.Util.TimeWarp (NetworkAddress)
 
@@ -49,6 +50,7 @@ data CommonNodeArgs = CommonNodeArgs
     , ekgParams              :: !(Maybe EkgParams)
     , statsdParams           :: !(Maybe StatsdParams)
     , cnaDumpGenesisDataPath :: !(Maybe FilePath)
+    , cnaBlockStorageMirror  :: !(Maybe Text)
     } deriving Show
 
 commonNodeArgsParser :: Parser CommonNodeArgs
@@ -101,6 +103,10 @@ commonNodeArgsParser = do
     cnaDumpGenesisDataPath <- optional $ strOption $
         long "dump-genesis-data-to" <>
         help "Dump genesis data in canonical JSON format to this file."
+
+    cnaBlockStorageMirror <- optional $ textOption $
+        long "block-storage-mirror" <>
+        help "URL for a mirror that stores epochs in *.cbor.lzma format."
 
     pure CommonNodeArgs{..}
 

--- a/lib/src/Pos/Client/CLI/Options.hs
+++ b/lib/src/Pos/Client/CLI/Options.hs
@@ -67,11 +67,11 @@ configurationOptionsParser = do
         Opt.help    "Path to a yaml configuration file" <>
         Opt.value   (cfoFilePath def)
     keyParser :: Opt.Parser Text
-    keyParser = fmap toText $ Opt.strOption $
+    keyParser = Opt.strOption $
         Opt.long    "configuration-key" <>
         Opt.metavar "TEXT" <>
         Opt.help    "Key within the configuration file to use" <>
-        Opt.value   (toString (cfoKey def))
+        Opt.value   (cfoKey def)
     systemStartParser :: Opt.Parser (Maybe Timestamp)
     systemStartParser = Opt.option (Just . Timestamp . sec <$> Opt.auto) $
         Opt.long    "system-start" <>
@@ -125,7 +125,6 @@ portOption portNum =
 reportServersOption :: Opt.Parser [Text]
 reportServersOption =
     many $
-    toText <$>
     Opt.strOption
         (templateParser
              "report-server"
@@ -135,7 +134,6 @@ reportServersOption =
 updateServersOption :: Opt.Parser [Text]
 updateServersOption =
     many $
-    toText <$>
     Opt.strOption
         (templateParser "update-server" "URI" "Server to download updates from.")
 

--- a/lib/src/Pos/Client/CLI/Params.hs
+++ b/lib/src/Pos/Client/CLI/Params.hs
@@ -94,5 +94,6 @@ getNodeParams defaultLoggerName cArgs@CommonNodeArgs{..} NodeArgs{..} = do
         , npEnableMetrics = enableMetrics
         , npEkgParams = ekgParams
         , npStatsdParams = statsdParams
+        , npBlockStorageMirror = cnaBlockStorageMirror
         , ..
         }

--- a/lib/src/Pos/Communication/Limits.hs
+++ b/lib/src/Pos/Communication/Limits.hs
@@ -29,9 +29,9 @@ import           Pos.Block.Network (MsgBlock (..), MsgGetBlocks (..), MsgGetHead
 import           Pos.Communication.Types.Protocol (MsgSubscribe (..))
 import           Pos.Communication.Types.Relay (DataMsg (..))
 import           Pos.Configuration (HasNodeConfiguration)
-import           Pos.Core (EpochIndex, VssCertificate, BlockVersionData (..),
-                           coinPortionToDouble)
-import           Pos.Core.Block (MainBlock, GenesisBlock, Block, MainBlockHeader, GenesisBlockHeader, BlockHeader)
+import           Pos.Core (BlockVersionData (..), EpochIndex, VssCertificate, coinPortionToDouble)
+import           Pos.Core.Block (Block, BlockHeader, GenesisBlock, GenesisBlockHeader, MainBlock,
+                                 MainBlockHeader)
 import           Pos.Core.Configuration (HasConfiguration, blkSecurityParam)
 import           Pos.Core.Ssc (Commitment (..), InnerSharesMap, Opening (..), SignedCommitment)
 import           Pos.Core.Txp (TxAux)

--- a/lib/src/Pos/Diffusion/Full.hs
+++ b/lib/src/Pos/Diffusion/Full.hs
@@ -73,7 +73,7 @@ import           Pos.Util.OutboundQueue (EnqueuedConversation (..))
 
 -- Orphan instance to get the adopted block version data through reflection.
 --
--- TODO: I rather dislike this instance phgvbpqsahgpsviqhaep
+-- TODO: I rather dislike this instance
 -- — @neongreen
 instance (Given (m BlockVersionData)) => HasAdoptedBlockVersionData m where
   adoptedBVData = given

--- a/lib/src/Pos/Diffusion/Full.hs
+++ b/lib/src/Pos/Diffusion/Full.hs
@@ -72,6 +72,9 @@ import           Pos.Util.OutboundQueue (EnqueuedConversation (..))
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 -- Orphan instance to get the adopted block version data through reflection.
+--
+-- TODO: I rather dislike this instance phgvbpqsahgpsviqhaep
+-- — @neongreen
 instance (Given (m BlockVersionData)) => HasAdoptedBlockVersionData m where
   adoptedBVData = given
 

--- a/lib/src/Pos/Launcher/Param.hs
+++ b/lib/src/Pos/Launcher/Param.hs
@@ -49,21 +49,22 @@ data BaseParams = BaseParams
 -- | This data type contains all data necessary to launch node and
 -- known in advance (from CLI, configs, etc.)
 data NodeParams = NodeParams
-    { npDbPathM        :: !(Maybe FilePath)     -- ^ Path to node's database
-    , npRebuildDb      :: !Bool                 -- ^ @True@ if data-base should be rebuilt
-    , npSecretKey      :: !SecretKey            -- ^ Primary secret key of node
-    , npUserSecret     :: !UserSecret           -- ^ All node secret keys
-    , npBaseParams     :: !BaseParams           -- ^ See 'BaseParams'
-    , npJLFile         :: !(Maybe FilePath)     -- TODO COMMENT
-    , npReportServers  :: ![Text]               -- ^ List of report server URLs
-    , npUpdateParams   :: !UpdateParams         -- ^ Params for update system
-    , npUseNTP         :: !Bool                 -- ^ Whether to use synchronisation with NTP servers.
-    , npRoute53Params  :: !(Maybe NetworkAddress) -- ^ Where to listen for the Route53 DNS health-check.
-    , npEnableMetrics  :: !Bool                 -- ^ Gather runtime statistics.
-    , npEkgParams      :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
-    , npStatsdParams   :: !(Maybe StatsdParams) -- ^ statsd statistics backend.
-    , npNetworkConfig  :: !(NetworkConfig KademliaParams)
-    , npBehaviorConfig :: !BehaviorConfig       -- ^ Behavior (e.g. SSC settings)
+    { npDbPathM            :: !(Maybe FilePath)     -- ^ Path to node's database
+    , npRebuildDb          :: !Bool                 -- ^ @True@ if data-base should be rebuilt
+    , npSecretKey          :: !SecretKey            -- ^ Primary secret key of node
+    , npUserSecret         :: !UserSecret           -- ^ All node secret keys
+    , npBaseParams         :: !BaseParams           -- ^ See 'BaseParams'
+    , npJLFile             :: !(Maybe FilePath)     -- TODO COMMENT
+    , npReportServers      :: ![Text]               -- ^ List of report server URLs
+    , npUpdateParams       :: !UpdateParams         -- ^ Params for update system
+    , npUseNTP             :: !Bool                 -- ^ Whether to use synchronisation with NTP servers.
+    , npRoute53Params      :: !(Maybe NetworkAddress) -- ^ Where to listen for the Route53 DNS health-check.
+    , npEnableMetrics      :: !Bool                 -- ^ Gather runtime statistics.
+    , npEkgParams          :: !(Maybe EkgParams)    -- ^ EKG statistics monitoring.
+    , npStatsdParams       :: !(Maybe StatsdParams) -- ^ statsd statistics backend.
+    , npNetworkConfig      :: !(NetworkConfig KademliaParams)
+    , npBehaviorConfig     :: !BehaviorConfig       -- ^ Behavior (e.g. SSC settings)
+    , npBlockStorageMirror :: !(Maybe Text)         -- ^ URL for a mirror that stores epochs in *.cbor.lzma format.
     } -- deriving (Show)
 
 makeLensesWith postfixLFields ''NodeParams

--- a/lib/test/Test/Pos/Block/DumpSpec.hs
+++ b/lib/test/Test/Pos/Block/DumpSpec.hs
@@ -1,0 +1,51 @@
+-- | This module tests blockchain dumps.
+
+module Test.Pos.Block.DumpSpec
+       ( spec
+       ) where
+
+import           Universum
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import           Test.Hspec (Spec, describe)
+import           Test.Hspec.QuickCheck (prop)
+import           Test.QuickCheck ((===))
+import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Monadic as QC
+
+import           Pos.Arbitrary.Block ()
+import           Pos.Block.Dump (decodeBlockDump', encodeBlockDump')
+import qualified Pos.Communication ()
+import qualified Pos.Core.Block as BT
+import           Pos.Core.Configuration (HasConfiguration)
+import           Pos.Util.Chrono (OldestFirst (..))
+
+import           Test.Pos.Util (withDefConfiguration)
+
+spec :: Spec
+spec = withDefConfiguration $ describe "Blockchain dump" $ do
+    prop "decode . encode === identity" $
+        QC.forAll (QC.choose (0, 30))    $ \blockCount ->
+        QC.forAll (QC.vector blockCount) $ \blocks ->
+        QC.forAll (QC.choose (1, 10000)) $ \chunkSize ->
+            decodeEncodeIdentity blocks chunkSize
+    -- TODO: write tests for failures
+
+decodeEncodeIdentity
+    :: HasConfiguration
+    => [BT.Block]            -- ^ Blocks to be encoded
+    -> Int                   -- ^ Chunk size
+    -> QC.Property
+decodeEncodeIdentity blocks chunkSize = QC.monadicIO $ do
+    enc <- QC.run $ encodeBlockDump' $ OldestFirst blocks
+    dec <- QC.run $ decodeBlockDump' $
+        BSL.fromChunks $ chunkBS chunkSize $ BSL.toStrict enc
+    pure (OldestFirst blocks === dec)
+
+----------------------------------------------------------------------------
+-- Utilities
+----------------------------------------------------------------------------
+
+chunkBS :: Int -> ByteString -> [ByteString]
+chunkBS n = takeWhile (not . null) . map (BS.take n) . iterate (BS.drop n)

--- a/lib/test/Test/Pos/Block/DumpSpec.hs
+++ b/lib/test/Test/Pos/Block/DumpSpec.hs
@@ -15,7 +15,7 @@ import qualified Test.QuickCheck as QC
 import qualified Test.QuickCheck.Monadic as QC
 
 import           Pos.Arbitrary.Block ()
-import           Pos.Block.Dump (decodeBlockDump', encodeBlockDump')
+import           Pos.Block.Dump (decodeBlockDump, encodeBlockDump)
 import qualified Pos.Communication ()
 import qualified Pos.Core.Block as BT
 import           Pos.Core.Configuration (HasConfiguration)
@@ -38,8 +38,8 @@ decodeEncodeIdentity
     -> Int                   -- ^ Chunk size
     -> QC.Property
 decodeEncodeIdentity blocks chunkSize = QC.monadicIO $ do
-    enc <- QC.run $ encodeBlockDump' $ OldestFirst blocks
-    dec <- QC.run $ decodeBlockDump' $
+    enc <- QC.run $ encodeBlockDump $ OldestFirst blocks
+    dec <- QC.run $ decodeBlockDump $
         BSL.fromChunks $ chunkBS chunkSize $ BSL.toStrict enc
     pure (OldestFirst blocks === dec)
 

--- a/networking/src/Mockable/Instances.hs
+++ b/networking/src/Mockable/Instances.hs
@@ -11,6 +11,7 @@ module Mockable.Instances
 
 import           Control.Lens (view)
 import           Control.Monad.Trans.Reader (ReaderT (..))
+import           Control.Monad.Trans.Resource.Internal (ResourceT (..))
 import           Serokell.Util.Lens (WrappedM (..), _UnwrappedM)
 import           System.Wlog (LoggerName, LoggerNameBox)
 
@@ -37,6 +38,9 @@ instance ( Mockable d m
          ) => Mockable d (LoggerNameBox m) where
     liftMockable = liftMockableWrappedM
 
+instance (Mockable d m, MFunctor' d (ResourceT m) m) => Mockable d (ResourceT m) where
+    liftMockable dmt = ResourceT $ \r -> liftMockable $ hoist' (flip unResourceT r) dmt
+
 type instance ThreadId (LoggerNameBox m) = ThreadId m
 type instance Promise (LoggerNameBox m) = Promise m
 type instance SharedAtomicT (LoggerNameBox m) = SharedAtomicT m
@@ -54,3 +58,12 @@ type instance ChannelT (ReaderT r m) = ChannelT m
 type instance Gauge (ReaderT r m) = Gauge m
 type instance Counter (ReaderT r m) = Counter m
 type instance Distribution (ReaderT r m) = Distribution m
+
+type instance ThreadId (ResourceT m) = ThreadId m
+type instance Promise (ResourceT m) = Promise m
+type instance SharedAtomicT (ResourceT m) = SharedAtomicT m
+type instance SharedExclusiveT (ResourceT m) = SharedExclusiveT m
+type instance ChannelT (ResourceT m) = ChannelT m
+type instance Gauge (ResourceT m) = Gauge m
+type instance Counter (ResourceT m) = Counter m
+type instance Distribution (ResourceT m) = Distribution m

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -388,8 +388,8 @@ self: {
           pname = "active";
           version = "0.2.0.13";
           sha256 = "5d9a141d58bcefbf699ed233a22309ded671c25ed64bcee11a663d00731280fb";
-          revision = "2";
-          editedCabalFile = "1ml42hbvfhqzpdi1y5q6dqp4wq6zqb30f15r34n9ip9iv44qjwwf";
+          revision = "3";
+          editedCabalFile = "0jm8kkqa5k9nppis3jdx11nmds6w0x62rmnv5bn5q3b75llhnlc1";
           libraryHaskellDepends = [
             base
             lens
@@ -5059,6 +5059,8 @@ self: {
           pname = "json-sop";
           version = "0.2.0.3";
           sha256 = "3065f11df636f9b72d988247bcc1273de9155255d8b31ed9105929e2ab67c22b";
+          revision = "1";
+          editedCabalFile = "1bvmfl6fqdr8fklv8zai5jgzlnv1jf9xy8i656lfz1ys95q9yr48";
           libraryHaskellDepends = [
             aeson
             base

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -388,8 +388,8 @@ self: {
           pname = "active";
           version = "0.2.0.13";
           sha256 = "5d9a141d58bcefbf699ed233a22309ded671c25ed64bcee11a663d00731280fb";
-          revision = "2";
-          editedCabalFile = "1ml42hbvfhqzpdi1y5q6dqp4wq6zqb30f15r34n9ip9iv44qjwwf";
+          revision = "3";
+          editedCabalFile = "0jm8kkqa5k9nppis3jdx11nmds6w0x62rmnv5bn5q3b75llhnlc1";
           libraryHaskellDepends = [
             base
             lens
@@ -4472,8 +4472,8 @@ self: {
       happy = callPackage ({ Cabal, array, base, containers, directory, filepath, mkDerivation, mtl, stdenv }:
       mkDerivation {
           pname = "happy";
-          version = "1.19.8";
-          sha256 = "4df739965d559e48a9b0044fa6140241c07e8f3c794c6c0a6323024fd7f0d3a0";
+          version = "1.19.9";
+          sha256 = "3e81a3e813acca3aae52721c412cde18b7b7c71ecbacfaeaa5c2f4b35abf1d8d";
           isLibrary = false;
           isExecutable = true;
           setupHaskellDepends = [
@@ -4941,8 +4941,8 @@ self: {
           pname = "insert-ordered-containers";
           version = "0.2.1.0";
           sha256 = "d71d126bf455898492e1d2ba18b2ad04453f8b0e4daff3926a67f0560a712298";
-          revision = "3";
-          editedCabalFile = "0ik4n32rvamxvlp80ixjrbhskivynli7b89s4hk6401bcy3ykp3g";
+          revision = "4";
+          editedCabalFile = "0ls5rm5hg2lqp2m6bfssa30y72x8xyyl7izvwr3w804dpa9fvwrm";
           libraryHaskellDepends = [
             aeson
             base
@@ -4958,7 +4958,7 @@ self: {
           doHaddock = false;
           doCheck = false;
           homepage = "https://github.com/phadej/insert-ordered-containers#readme";
-          description = "Associative containers retating insertion order for traversals";
+          description = "Associative containers retaining insertion order for traversals";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       integer-gmp = callPackage ({ ghc-prim, mkDerivation, stdenv }:
@@ -5059,6 +5059,8 @@ self: {
           pname = "json-sop";
           version = "0.2.0.3";
           sha256 = "3065f11df636f9b72d988247bcc1273de9155255d8b31ed9105929e2ab67c22b";
+          revision = "1";
+          editedCabalFile = "1bvmfl6fqdr8fklv8zai5jgzlnv1jf9xy8i656lfz1ys95q9yr48";
           libraryHaskellDepends = [
             aeson
             base
@@ -5996,6 +5998,8 @@ self: {
           pname = "parsec";
           version = "3.1.11";
           sha256 = "6f87251cb1d11505e621274dec15972de924a9074f07f7430a18892064c2676e";
+          revision = "1";
+          editedCabalFile = "0prqjj2gxlwh2qhpcck5k6cgk4har9xqxc67yzjqd44mr2xgl7ir";
           libraryHaskellDepends = [
             base
             bytestring

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1325,7 +1325,7 @@ self: {
           description = "Cardano SL main implementation";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-auxx = callPackage ({ Earley, MonadRandom, QuickCheck, ansi-wl-pprint, async, base, bytestring, canonical-json, cardano-sl, cardano-sl-block, cardano-sl-client, cardano-sl-core, cardano-sl-crypto, cardano-sl-db, cardano-sl-generator, cardano-sl-infra, cardano-sl-networking, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cardano-sl-util, constraints, containers, cpphs, data-default, ether, formatting, generic-arbitrary, haskeline, hspec, lens, loc, log-warper, megaparsec, mkDerivation, mmorph, mtl, neat-interpolation, network-transport-tcp, optparse-applicative, parser-combinators, quickcheck-instances, random, reflection, safe-exceptions, scientific, serokell-util, split, stdenv, stm, temporary, text, text-format, time-units, transformers, universum, unix, unordered-containers }:
+      cardano-sl-auxx = callPackage ({ Earley, MonadRandom, QuickCheck, ansi-wl-pprint, async, base, bytestring, canonical-json, cardano-sl, cardano-sl-block, cardano-sl-client, cardano-sl-core, cardano-sl-crypto, cardano-sl-db, cardano-sl-generator, cardano-sl-infra, cardano-sl-networking, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cardano-sl-util, conduit-combinators, constraints, containers, cpphs, data-default, directory, ether, filepath, fmt, formatting, generic-arbitrary, haskeline, hspec, lens, loc, log-warper, megaparsec, mkDerivation, mmorph, mtl, natural-sort, neat-interpolation, network-transport-tcp, optparse-applicative, parser-combinators, quickcheck-instances, random, reflection, resourcet, safe-exceptions, scientific, serokell-util, split, stdenv, stm, temporary, text, text-format, time-units, transformers, universum, unix, unordered-containers, vector }:
       mkDerivation {
           pname = "cardano-sl-auxx";
           version = "1.0.3";
@@ -1351,11 +1351,15 @@ self: {
             cardano-sl-txp
             cardano-sl-update
             cardano-sl-util
+            conduit-combinators
             constraints
             containers
             data-default
+            directory
             Earley
             ether
+            filepath
+            fmt
             formatting
             generic-arbitrary
             haskeline
@@ -1366,6 +1370,7 @@ self: {
             mmorph
             MonadRandom
             mtl
+            natural-sort
             neat-interpolation
             optparse-applicative
             parser-combinators
@@ -1373,6 +1378,7 @@ self: {
             quickcheck-instances
             random
             reflection
+            resourcet
             safe-exceptions
             scientific
             serokell-util
@@ -1385,6 +1391,7 @@ self: {
             universum
             unix
             unordered-containers
+            vector
           ];
           libraryToolDepends = [ cpphs ];
           executableHaskellDepends = [
@@ -1394,10 +1401,12 @@ self: {
             cardano-sl-networking
             cardano-sl-txp
             cardano-sl-util
+            conduit-combinators
             constraints
             formatting
             log-warper
             network-transport-tcp
+            resourcet
             safe-exceptions
             temporary
             universum
@@ -1409,6 +1418,7 @@ self: {
           testHaskellDepends = [
             cardano-sl-core
             cardano-sl-crypto
+            conduit-combinators
             hspec
             QuickCheck
             universum
@@ -1419,7 +1429,7 @@ self: {
           description = "Cardano SL - Auxx";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-binary = callPackage ({ QuickCheck, autoexporter, base, binary, bytestring, cborg, containers, cpphs, digest, formatting, hashable, lens, mkDerivation, mtl, parsec, process, quickcheck-instances, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
+      cardano-sl-binary = callPackage ({ QuickCheck, autoexporter, base, binary, bytestring, cborg, conduit-combinators, containers, cpphs, digest, formatting, hashable, lens, mkDerivation, mmorph, mono-traversable, mtl, parsec, process, quickcheck-instances, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, th-lift-instances, th-utilities, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "cardano-sl-binary";
           version = "1.0.3";
@@ -1430,11 +1440,14 @@ self: {
             binary
             bytestring
             cborg
+            conduit-combinators
             containers
             digest
             formatting
             hashable
             lens
+            mmorph
+            mono-traversable
             mtl
             parsec
             process
@@ -1463,7 +1476,7 @@ self: {
           description = "Cardano SL - binary serialization";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-block = callPackage ({ QuickCheck, aeson, base, bytestring, cardano-sl-binary, cardano-sl-core, cardano-sl-crypto, cardano-sl-db, cardano-sl-delegation, cardano-sl-infra, cardano-sl-lrc, cardano-sl-networking, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cardano-sl-util, conduit, containers, cpphs, cryptonite, data-default, directory, ekg-core, ether, exceptions, filepath, formatting, generic-arbitrary, lens, log-warper, mkDerivation, mtl, random, reflection, rocksdb-haskell, safe-exceptions, serokell-util, stdenv, stm, text, text-format, time-units, transformers, universum, unordered-containers }:
+      cardano-sl-block = callPackage ({ QuickCheck, aeson, base, bytestring, cardano-sl-binary, cardano-sl-core, cardano-sl-crypto, cardano-sl-db, cardano-sl-delegation, cardano-sl-infra, cardano-sl-lrc, cardano-sl-networking, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cardano-sl-util, cborg, conduit, conduit-combinators, containers, cpphs, cryptonite, data-default, directory, ekg-core, ether, exceptions, filepath, formatting, generic-arbitrary, lens, log-warper, lzma-conduit, mkDerivation, mmorph, mtl, random, reflection, rocksdb-haskell, safe-exceptions, serokell-util, stdenv, stm, text, text-format, time-units, transformers, universum, unordered-containers }:
       mkDerivation {
           pname = "cardano-sl-block";
           version = "1.0.3";
@@ -1484,7 +1497,9 @@ self: {
             cardano-sl-txp
             cardano-sl-update
             cardano-sl-util
+            cborg
             conduit
+            conduit-combinators
             containers
             cryptonite
             data-default
@@ -1497,6 +1512,8 @@ self: {
             generic-arbitrary
             lens
             log-warper
+            lzma-conduit
+            mmorph
             mtl
             QuickCheck
             random
@@ -2416,7 +2433,7 @@ self: {
           description = "Cardano SL - update";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-util = callPackage ({ QuickCheck, aeson, autoexporter, base, bytestring, cardano-sl-networking, concurrent-extra, containers, cpphs, cryptonite, data-default, deepseq, directory, ether, exceptions, filepath, formatting, hashable, lens, log-warper, lrucache, mkDerivation, mmorph, mtl, parsec, process, quickcheck-instances, random, reflection, resourcet, safe-exceptions, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
+      cardano-sl-util = callPackage ({ QuickCheck, aeson, autoexporter, base, bytestring, cardano-sl-networking, concurrent-extra, conduit-combinators, containers, cpphs, cryptonite, data-default, deepseq, directory, ether, exceptions, filepath, formatting, hashable, lens, log-warper, lrucache, mkDerivation, mmorph, mtl, parsec, primitive, process, quickcheck-instances, random, reflection, resourcet, safe-exceptions, semigroups, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "cardano-sl-util";
           version = "1.0.3";
@@ -2428,6 +2445,7 @@ self: {
             bytestring
             cardano-sl-networking
             concurrent-extra
+            conduit-combinators
             containers
             cryptonite
             data-default
@@ -2444,6 +2462,7 @@ self: {
             mmorph
             mtl
             parsec
+            primitive
             process
             QuickCheck
             quickcheck-instances
@@ -2755,6 +2774,8 @@ self: {
           pname = "case-insensitive";
           version = "1.2.0.10";
           sha256 = "66321c40fffb35f3a3188ba508753b74aada53fb51c822a9752614b03765306c";
+          revision = "1";
+          editedCabalFile = "153x2i7gw7lyhydlf0924vfxmkk53r65c40104bbha2bhp1vj7fi";
           libraryHaskellDepends = [
             base
             bytestring
@@ -2829,6 +2850,26 @@ self: {
           description = "Serialize instances for Data.Vector types.";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      chunked-data = callPackage ({ base, bytestring, containers, mkDerivation, semigroups, stdenv, text, transformers, vector }:
+      mkDerivation {
+          pname = "chunked-data";
+          version = "0.3.0";
+          sha256 = "e1be9da64c3682fd907aa9f1a118e8bfba7964d509fddf54bd245b199dc15f2f";
+          libraryHaskellDepends = [
+            base
+            bytestring
+            containers
+            semigroups
+            text
+            transformers
+            vector
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/snoyberg/mono-traversable";
+          description = "Typeclasses for dealing with various chunked data representations";
+          license = stdenv.lib.licenses.mit;
+        }) {};
       clock = callPackage ({ base, mkDerivation, stdenv }:
       mkDerivation {
           pname = "clock";
@@ -2890,8 +2931,8 @@ self: {
           pname = "comonad";
           version = "5.0.2";
           sha256 = "1bb0fe396ecd16008411862ee453e8bd7c3e0f3a7299537dd59466604a54b784";
-          revision = "1";
-          editedCabalFile = "1lnsnx8p3wlfhd1xfc68za3b00vq77z2m6b0vqiw2laqmpj9akcw";
+          revision = "2";
+          editedCabalFile = "1ngks9bym68rw0xdq43n14nay4kxdxv2n7alwfd9wcpismfz009g";
           setupHaskellDepends = [
             base
             Cabal
@@ -2950,6 +2991,39 @@ self: {
           doCheck = false;
           homepage = "http://github.com/snoyberg/conduit";
           description = "Streaming data processing library";
+          license = stdenv.lib.licenses.mit;
+        }) {};
+      conduit-combinators = callPackage ({ base, base16-bytestring, base64-bytestring, bytestring, chunked-data, conduit, conduit-extra, filepath, mkDerivation, monad-control, mono-traversable, mwc-random, primitive, resourcet, stdenv, text, transformers, transformers-base, unix, unix-compat, vector, void }:
+      mkDerivation {
+          pname = "conduit-combinators";
+          version = "1.1.2";
+          sha256 = "840baed33ca32b5197817d6db1e70c4fb53eba01f86bd11c3b358cd8e08d6138";
+          libraryHaskellDepends = [
+            base
+            base16-bytestring
+            base64-bytestring
+            bytestring
+            chunked-data
+            conduit
+            conduit-extra
+            filepath
+            monad-control
+            mono-traversable
+            mwc-random
+            primitive
+            resourcet
+            text
+            transformers
+            transformers-base
+            unix
+            unix-compat
+            vector
+            void
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/snoyberg/mono-traversable#readme";
+          description = "Commonly used conduit functions, for both chunked and unchunked data";
           license = stdenv.lib.licenses.mit;
         }) {};
       conduit-extra = callPackage ({ async, attoparsec, base, blaze-builder, bytestring, conduit, directory, exceptions, filepath, mkDerivation, monad-control, network, primitive, process, resourcet, stdenv, stm, streaming-commons, text, transformers, transformers-base }:
@@ -3446,10 +3520,8 @@ self: {
       diagrams-svg = callPackage ({ JuicyPixels, base, base64-bytestring, bytestring, colour, containers, diagrams-core, diagrams-lib, filepath, hashable, lens, mkDerivation, monoid-extras, mtl, optparse-applicative, semigroups, split, stdenv, svg-builder, text }:
       mkDerivation {
           pname = "diagrams-svg";
-          version = "1.4.1";
-          sha256 = "ce691378025835c7e794898a5f03299341f5f1e35a20de4afd12b1f9b0667f87";
-          revision = "1";
-          editedCabalFile = "12cp0898pplap5skhq43xsxh0m2ilv5lz9zw2fhkkjmnr4pbl2dx";
+          version = "1.4.1.1";
+          sha256 = "c80668c6ac1bf62b108016d36bfe3e603897ca8e331522b0e80b77152915daaa";
           libraryHaskellDepends = [
             base
             base64-bytestring
@@ -3512,8 +3584,8 @@ self: {
           pname = "distributive";
           version = "0.5.3";
           sha256 = "9173805b9c941bda1f37e5aeb68ae30f57a12df9b17bd2aa86db3b7d5236a678";
-          revision = "2";
-          editedCabalFile = "02j27xvlj0jw3b2jpfg6wbysj0blllin792wj6qnrgnrvd4haj7v";
+          revision = "3";
+          editedCabalFile = "17qqdl8p04vy314jp045100989lh84cbhqv6ghizm87xpk7ck4j3";
           setupHaskellDepends = [
             base
             Cabal
@@ -3916,8 +3988,8 @@ self: {
           pname = "exceptions";
           version = "0.8.3";
           sha256 = "4d6ad97e8e3d5dc6ce9ae68a469dc2fd3f66e9d312bc6faa7ab162eddcef87be";
-          revision = "2";
-          editedCabalFile = "1vl59j0l7m53hkzlcfmdbqbab8dk4lp9gzwryn7nsr6ylg94wayw";
+          revision = "4";
+          editedCabalFile = "18iip6wffnrp1jgnf09gxg4v17ymjank50kjshxvcy9s9l9g13ln";
           libraryHaskellDepends = [
             base
             mtl
@@ -4583,6 +4655,8 @@ self: {
           pname = "hspec-core";
           version = "2.4.4";
           sha256 = "601d321cdf7f2685880ee80c31154763884cb90dc512906005c4a485e8c8bfdf";
+          revision = "1";
+          editedCabalFile = "0m4bmclgs7as957wdnq1y4zh49hrwpslgz5m9430myl4dc14r81l";
           libraryHaskellDepends = [
             ansi-terminal
             array
@@ -4652,6 +4726,8 @@ self: {
           pname = "http-api-data";
           version = "0.3.7.1";
           sha256 = "8c633e95113c8ab655f4ba67e51e41a2c9035f0122ea68bfbb876b37277075fd";
+          revision = "1";
+          editedCabalFile = "0g57k71bssf81yba6xf9fcxlys8m5ax5kvrs4gvckahf5ihdxds6";
           setupHaskellDepends = [
             base
             Cabal
@@ -4865,8 +4941,8 @@ self: {
           pname = "insert-ordered-containers";
           version = "0.2.1.0";
           sha256 = "d71d126bf455898492e1d2ba18b2ad04453f8b0e4daff3926a67f0560a712298";
-          revision = "3";
-          editedCabalFile = "0ik4n32rvamxvlp80ixjrbhskivynli7b89s4hk6401bcy3ykp3g";
+          revision = "4";
+          editedCabalFile = "0ls5rm5hg2lqp2m6bfssa30y72x8xyyl7izvwr3w804dpa9fvwrm";
           libraryHaskellDepends = [
             aeson
             base
@@ -4882,7 +4958,7 @@ self: {
           doHaddock = false;
           doCheck = false;
           homepage = "https://github.com/phadej/insert-ordered-containers#readme";
-          description = "Associative containers retating insertion order for traversals";
+          description = "Associative containers retaining insertion order for traversals";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       integer-gmp = callPackage ({ ghc-prim, mkDerivation, stdenv }:
@@ -4905,6 +4981,8 @@ self: {
           pname = "integer-logarithms";
           version = "1.0.2";
           sha256 = "31069ccbff489baf6c4a93cb7475640aabea9366eb0b583236f10714a682b570";
+          revision = "1";
+          editedCabalFile = "0sccd0d6qrcm3a7nni5lqv40g5m5knf965z4skkgbyyhb3z6qsq8";
           libraryHaskellDepends = [
             array
             base
@@ -5163,6 +5241,8 @@ self: {
           pname = "lifted-base";
           version = "0.2.3.11";
           sha256 = "8ec47a9fce7cf5913766a5c53e1b2cf254be733fa9d62e6e2f3f24e538005aab";
+          revision = "1";
+          editedCabalFile = "0vrik0j1xv2yp759ffa7jb7q838z4wglnbgsrja97mx0dwsbavnx";
           libraryHaskellDepends = [
             base
             monad-control
@@ -5622,13 +5702,30 @@ self: {
           description = "Fast, high quality pseudo random number generation";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      natural-sort = callPackage ({ base, bytestring, mkDerivation, parsec, stdenv, text }:
+      mkDerivation {
+          pname = "natural-sort";
+          version = "0.1.2";
+          sha256 = "7b72b734680827ab07df38a004d4f523540055389d62fcd587edd2fcf19a6b50";
+          libraryHaskellDepends = [
+            base
+            bytestring
+            parsec
+            text
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://john-millikin.com/software/natural-sort/";
+          description = "User-friendly text collation";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
       natural-transformation = callPackage ({ base, mkDerivation, stdenv }:
       mkDerivation {
           pname = "natural-transformation";
           version = "0.4";
           sha256 = "aac28e2c1147ed77c1ec0f0eb607a577fa26d0fd67474293ba860ec124efc8af";
-          revision = "2";
-          editedCabalFile = "1j90pd1zznr18966axskad5w0kx4dvqg62r65rmw1ihqwxm1ndix";
+          revision = "3";
+          editedCabalFile = "0z6vmdgz9r2fbgzh2xvrw6cy5h7m1jv911jah615s6xgr52smhrf";
           libraryHaskellDepends = [
             base
           ];
@@ -5845,8 +5942,8 @@ self: {
       optparse-applicative = callPackage ({ ansi-wl-pprint, base, mkDerivation, process, stdenv, transformers, transformers-compat }:
       mkDerivation {
           pname = "optparse-applicative";
-          version = "0.13.2.0";
-          sha256 = "5c83cfce7e53f4d3b1f5d53f082e7e61959bf14e6be704c698c3ab7f1b956ca2";
+          version = "0.14.0.0";
+          sha256 = "b55b32fdd5d101b2d6edb2746a66648fc2cd1b850d7adea185f201ac71b83c1a";
           libraryHaskellDepends = [
             ansi-wl-pprint
             base
@@ -7375,8 +7472,8 @@ self: {
           pname = "tagged";
           version = "0.8.5";
           sha256 = "e47c51c955ed77b0fa36897f652df990aa0a8c4eb278efaddcd604be00fc8d99";
-          revision = "1";
-          editedCabalFile = "15mqdimbgrq5brqljjl7dbxkyrxppap06q53cp7ml7w3l08v5mx8";
+          revision = "2";
+          editedCabalFile = "0r2knfcq0b4s652vlvlnfwxlc2mkc2ra9kl8bp4zdn1awmfy0ia5";
           libraryHaskellDepends = [
             base
             deepseq
@@ -8072,8 +8169,8 @@ self: {
           pname = "vector";
           version = "0.12.0.1";
           sha256 = "b100ee79b9da2651276278cd3e0f08a3c152505cc52982beda507515af173d7b";
-          revision = "1";
-          editedCabalFile = "1xjv8876kx9vh86w718vdaaai40pwnsiw8368c5h88ch8iqq10qb";
+          revision = "2";
+          editedCabalFile = "0vzr8kra73anchp86knkmkq2afkd1hw6hirldn9vn69frynb1n6y";
           libraryHaskellDepends = [
             base
             deepseq

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -388,8 +388,8 @@ self: {
           pname = "active";
           version = "0.2.0.13";
           sha256 = "5d9a141d58bcefbf699ed233a22309ded671c25ed64bcee11a663d00731280fb";
-          revision = "3";
-          editedCabalFile = "0jm8kkqa5k9nppis3jdx11nmds6w0x62rmnv5bn5q3b75llhnlc1";
+          revision = "2";
+          editedCabalFile = "1ml42hbvfhqzpdi1y5q6dqp4wq6zqb30f15r34n9ip9iv44qjwwf";
           libraryHaskellDepends = [
             base
             lens
@@ -4941,8 +4941,8 @@ self: {
           pname = "insert-ordered-containers";
           version = "0.2.1.0";
           sha256 = "d71d126bf455898492e1d2ba18b2ad04453f8b0e4daff3926a67f0560a712298";
-          revision = "4";
-          editedCabalFile = "0ls5rm5hg2lqp2m6bfssa30y72x8xyyl7izvwr3w804dpa9fvwrm";
+          revision = "3";
+          editedCabalFile = "0ik4n32rvamxvlp80ixjrbhskivynli7b89s4hk6401bcy3ykp3g";
           libraryHaskellDepends = [
             aeson
             base
@@ -4958,7 +4958,7 @@ self: {
           doHaddock = false;
           doCheck = false;
           homepage = "https://github.com/phadej/insert-ordered-containers#readme";
-          description = "Associative containers retaining insertion order for traversals";
+          description = "Associative containers retating insertion order for traversals";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       integer-gmp = callPackage ({ ghc-prim, mkDerivation, stdenv }:
@@ -5059,8 +5059,6 @@ self: {
           pname = "json-sop";
           version = "0.2.0.3";
           sha256 = "3065f11df636f9b72d988247bcc1273de9155255d8b31ed9105929e2ab67c22b";
-          revision = "1";
-          editedCabalFile = "1bvmfl6fqdr8fklv8zai5jgzlnv1jf9xy8i656lfz1ys95q9yr48";
           libraryHaskellDepends = [
             aeson
             base

--- a/scripts/auxx/dump_blockchain.sh
+++ b/scripts/auxx/dump_blockchain.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
-TOPOLOGY_FILE=/tmp/topology-mainnet.yaml
 CLUSTER=mainnet
-RELAY=relays.cardano-mainnet.iohk.io
+TOPOLOGY_FILE=/tmp/topology-$CLUSTER.yaml
 OUTPATH=/tmp/cardano-$CLUSTER-blockchain_$(date +%Y-%m-%d_%H-%M-%S)
 
+RELAY=relays.cardano-mainnet.iohk.io
+
+# Parse output of `nslookup` and extract IP addresses of the bootstrap nodes,
+# then format them into `--peer <IP>:3000` arguments.
 PEERS=$(\
     nslookup $RELAY | \
-    awk '/^Address: / { print "--peer", $2 }' | \
+    awk '/^Address: / { print "--peer", $2 ":3000" }' | \
     paste -sd ' ')
 
 echo "\
@@ -24,15 +27,18 @@ if [[ $1 == '--nowait' ]]; then
 	echo "Auxx does not support waiting for synchronization."
 	echo "The blockchain will be dumped without waiting until"
 	echo "it is downloaded completely."
+  echo ""
 elif [[ $1 == '--wait' ]]; then
-	EXECMODE="repl"
-	echo "Auxx does not support waiting for synchronization."
-	echo "As soon as the logs show that the node is synched,"
-	echo "execute the following command:"
-	echo ""
-	echo "    dump $OUTPATH"
+  EXECMODE="repl"
+  echo "Auxx does not support waiting for synchronization."
+  echo "As soon as the logs show that the node is synched,"
+  echo "execute the following command:"
+  echo ""
+  echo "    dump $OUTPATH"
+  echo ""
 else
 	echo "Usage: $0 [--wait|--nowait]"
+  exit
 fi;
 
 stack exec -- cardano-auxx --mode=with-node               \

--- a/scripts/auxx/dump_blockchain.sh
+++ b/scripts/auxx/dump_blockchain.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+TOPOLOGY_FILE=/tmp/topology-mainnet.yaml
+CLUSTER=mainnet
+RELAY=relays.cardano-mainnet.iohk.io
+OUTPATH=/tmp/cardano-$CLUSTER-blockchain_$(date +%Y-%m-%d_%H-%M-%S)
+
+PEERS=$(\
+    nslookup $RELAY | \
+    awk '/^Address: / { print "--peer", $2 }' | \
+    paste -sd ' ')
+
+echo "\
+wallet:
+  relays: [[{ host: $RELAY }]]
+  valency: 1
+  fallbacks: 7
+" > $TOPOLOGY_FILE
+
+EXECMODE=""
+
+if [[ $1 == '--nowait' ]]; then
+	EXECMODE="cmd --commands=\"dump $OUTPATH\""
+	echo "Auxx does not support waiting for synchronization."
+	echo "The blockchain will be dumped without waiting until"
+	echo "it is downloaded completely."
+elif [[ $1 == '--wait' ]]; then
+	EXECMODE="repl"
+	echo "Auxx does not support waiting for synchronization."
+	echo "As soon as the logs show that the node is synched,"
+	echo "execute the following command:"
+	echo ""
+	echo "    dump $OUTPATH"
+else
+	echo "Usage: $0 [--wait|--nowait]"
+fi;
+
+stack exec -- cardano-auxx --mode=with-node               \
+  $EXECMODE                                               \
+  --no-ntp                                                \
+  --topology $TOPOLOGY_FILE                               \
+  $PEERS                                                  \
+  --log-config ./scripts/log-templates/log-config-qa.yaml \
+  --logs-prefix "logs/$CLUSTER"                           \
+  --db-path "db-$CLUSTER"                                 \
+  --keyfile secret-$CLUSTER.key                           \
+  --configuration-file ./lib/configuration.yaml           \
+  --configuration-key mainnet_full

--- a/scripts/auxx/dump_blockchain.sh
+++ b/scripts/auxx/dump_blockchain.sh
@@ -17,7 +17,7 @@ EXECMODE=""
 PEERS=""
 
 if [[ $1 == '--nowait' ]]; then
-  EXECMODE="--mode=with-config cmd --commands=\"dump $OUTPATH\""
+  EXECMODE="--mode=with-config cmd --commands=\"dump-blockchain $OUTPATH\""
   echo "Current state of the blockchain will be dumped."
   echo "No downloading will occur."
   echo ""
@@ -35,7 +35,7 @@ elif [[ $1 == '--wait' ]]; then
   echo "As soon as the logs show that the node is synced,"
   echo "execute the following command:"
   echo ""
-  echo "    dump $OUTPATH"
+  echo "    dump-blockchain $OUTPATH"
   echo ""
 else
 	echo "Usage: $0 [--wait|--nowait]"

--- a/scripts/auxx/dump_blockchain.sh
+++ b/scripts/auxx/dump_blockchain.sh
@@ -18,8 +18,8 @@ PEERS=""
 
 if [[ $1 == '--nowait' ]]; then
   EXECMODE="--mode=with-config cmd --commands=\"dump $OUTPATH\""
-  echo "Current state of the blockchain will be dumped. No"
-  echo "downloading will occur."
+  echo "Current state of the blockchain will be dumped."
+  echo "No downloading will occur."
   echo ""
 elif [[ $1 == '--wait' ]]; then
   EXECMODE="--mode=with-node repl"

--- a/stack.yaml
+++ b/stack.yaml
@@ -134,6 +134,7 @@ extra-deps:
 - servant-docs-0.11.1             # needed for servant-0.12
 - servant-swagger-1.1.4           # needed for servant-0.12
 - servant-swagger-ui-0.2.4.3.4.0  # needed for servant-0.12
+- servant-blaze-0.7.1             # needed for servant-0.12
 - servant-quickcheck-0.0.4
 - ether-0.5.1.0
 - pipes-interleave-1.1.1
@@ -155,6 +156,9 @@ extra-deps:
 - json-sop-0.2.0.3
 - servant-generic-0.1.0.1
 - lzma-0.0.0.3
+- conduit-combinators-1.1.2
+- optparse-applicative-0.14.0.0   # to get nicer 'strOptions'
+- diagrams-svg-1.4.1.1            # because of optparse-applicative bump
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/stack.yaml
+++ b/stack.yaml
@@ -154,6 +154,7 @@ extra-deps:
 - lens-sop-0.2.0.2
 - json-sop-0.2.0.3
 - servant-generic-0.1.0.1
+- lzma-0.0.0.3
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -260,6 +260,7 @@ executable cardano-addr-convert
                      , ansi-wl-pprint
                      , cardano-sl
                      , cardano-sl-core
+                     , cardano-sl-util
                      , neat-interpolation
                      , optparse-applicative
                      , text

--- a/tools/src/addr-convert/Main.hs
+++ b/tools/src/addr-convert/Main.hs
@@ -15,6 +15,7 @@ import           Text.PrettyPrint.ANSI.Leijen (Doc)
 import           Paths_cardano_sl (version)
 import           Pos.Aeson.Genesis (fromAvvmPk)
 import           Pos.Core (makeRedeemAddress)
+import           Pos.Util (textOption)
 
 data AddrConvertOptions = AddrConvertOptions
     { address :: !(Maybe Text)
@@ -28,8 +29,6 @@ optionsParser = do
         <> help    "Address to convert. It must be in base64(url) format."
         <> metavar "STRING"
     return AddrConvertOptions{..}
-    where
-      textOption = option (toText <$> readerAsk)
 
 getAddrConvertOptions :: IO AddrConvertOptions
 getAddrConvertOptions = execParser programInfo

--- a/tools/src/addr-convert/Main.hs
+++ b/tools/src/addr-convert/Main.hs
@@ -7,15 +7,13 @@ import           Universum
 import           Data.Version (showVersion)
 import           NeatInterpolation (text)
 import           Options.Applicative (Parser, execParser, footerDoc, fullDesc, header, help, helper,
-                                      info, infoOption, long, metavar, option, optional, progDesc,
-                                      short)
-import           Options.Applicative.Types (readerAsk)
+                                      info, infoOption, long, metavar, optional, progDesc, short,
+                                      strOption)
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import           Paths_cardano_sl (version)
 import           Pos.Aeson.Genesis (fromAvvmPk)
 import           Pos.Core (makeRedeemAddress)
-import           Pos.Util (textOption)
 
 data AddrConvertOptions = AddrConvertOptions
     { address :: !(Maybe Text)
@@ -23,7 +21,7 @@ data AddrConvertOptions = AddrConvertOptions
 
 optionsParser :: Parser AddrConvertOptions
 optionsParser = do
-    address <- optional $ textOption $
+    address <- optional $ strOption $
            short   'a'
         <> long    "address"
         <> help    "Address to convert. It must be in base64(url) format."

--- a/tools/src/genupdate/Main.hs
+++ b/tools/src/genupdate/Main.hs
@@ -17,7 +17,6 @@ import           Formatting (Format, format, mapf, text, (%))
 import qualified NeatInterpolation as NI (text)
 import           Options.Applicative (Parser, execParser, footerDoc, fullDesc, header, help, helper,
                                       info, infoOption, long, metavar, option, progDesc, short)
-import           Options.Applicative.Types (readerAsk)
 import           System.Exit (ExitCode (ExitFailure))
 import           System.FilePath (normalise, takeFileName, (<.>), (</>))
 import qualified System.PosixCompat as PosixCompat
@@ -25,7 +24,7 @@ import           System.Process (readProcess)
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import           Paths_cardano_sl (version)
-import           Pos.Util (directory, ls, withTempDir)
+import           Pos.Util (directory, ls, textOption, withTempDir)
 
 data UpdateGenOptions = UpdateGenOptions
     { oldDir    :: !Text
@@ -49,8 +48,6 @@ optionsParser = do
         <> metavar "PATH"
         <> help    "Path to output .tar-file with diff."
     pure UpdateGenOptions{..}
-    where
-      textOption = option (toText <$> readerAsk)
 
 getUpdateGenOptions :: IO UpdateGenOptions
 getUpdateGenOptions = execParser programInfo

--- a/tools/src/genupdate/Main.hs
+++ b/tools/src/genupdate/Main.hs
@@ -16,7 +16,7 @@ import           Data.Version (showVersion)
 import           Formatting (Format, format, mapf, text, (%))
 import qualified NeatInterpolation as NI (text)
 import           Options.Applicative (Parser, execParser, footerDoc, fullDesc, header, help, helper,
-                                      info, infoOption, long, metavar, option, progDesc, short)
+                                      info, infoOption, long, metavar, progDesc, short, strOption)
 import           System.Exit (ExitCode (ExitFailure))
 import           System.FilePath (normalise, takeFileName, (<.>), (</>))
 import qualified System.PosixCompat as PosixCompat
@@ -24,7 +24,7 @@ import           System.Process (readProcess)
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import           Paths_cardano_sl (version)
-import           Pos.Util (directory, ls, textOption, withTempDir)
+import           Pos.Util (directory, ls, withTempDir)
 
 data UpdateGenOptions = UpdateGenOptions
     { oldDir    :: !Text
@@ -34,15 +34,15 @@ data UpdateGenOptions = UpdateGenOptions
 
 optionsParser :: Parser UpdateGenOptions
 optionsParser = do
-    oldDir <- textOption $
+    oldDir <- strOption $
            long    "old"
         <> metavar "PATH"
         <> help    "Path to directory with old program."
-    newDir <- textOption $
+    newDir <- strOption $
            long    "new"
         <> metavar "PATH"
         <> help    "Path to directory with new program."
-    outputTar <- textOption $
+    outputTar <- strOption $
            short   'o'
         <> long    "output"
         <> metavar "PATH"

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -26,9 +26,9 @@ import           Data.Time.Units (Second, convertUnit)
 import           Data.Version (showVersion)
 import           Formatting (int, sformat, shown, stext, (%))
 import qualified NeatInterpolation as Q (text)
-import           Options.Applicative (Mod, OptionFields, Parser, auto, execParser, footerDoc,
-                                      fullDesc, header, help, helper, info, infoOption, long,
-                                      metavar, option, progDesc, short, strOption, switch)
+import           Options.Applicative (Parser, auto, execParser, footerDoc, fullDesc, header, help,
+                                      helper, info, infoOption, long, metavar, option, progDesc,
+                                      short, strOption, switch)
 import           System.Directory (createDirectoryIfMissing, doesFileExist, removeFile)
 import           System.Environment (getExecutablePath)
 import           System.Exit (ExitCode (..))
@@ -69,7 +69,7 @@ import           Pos.Reporting.Methods (compressLogs, retrieveLogFiles, sendRepo
 import           Pos.ReportServer.Report (ReportType (..))
 import           Pos.Update (installerHash)
 import           Pos.Update.DB.Misc (affirmUpdateInstalled)
-import           Pos.Util (HasLens (..), directory, postfixLFields, sleep, textOption)
+import           Pos.Util (HasLens (..), directory, postfixLFields, sleep)
 import           Pos.Util.CompileInfo (HasCompileInfo, retrieveCompileTimeInfo, withCompileInfo)
 
 data LauncherOptions = LO
@@ -103,11 +103,11 @@ data Executable = EWallet | ENode | EUpdater
 optionsParser :: Parser LauncherOptions
 optionsParser = do
     -- Node-related args
-    loNodePath <- textOption $
+    loNodePath <- strOption $
         long    "node" <>
         help    "Path to the node executable." <>
         metavar "PATH"
-    loNodeArgs <- many $ textOption $
+    loNodeArgs <- many $ strOption $
         short   'n' <>
         help    "An argument to be passed to the node." <>
         metavar "ARG"
@@ -115,21 +115,21 @@ optionsParser = do
         long    "db-path" <>
         metavar "FILEPATH" <>
         help    "Path to directory with all DBs used by the node."
-    loNodeLogConfig <- optional $ textOption $
+    loNodeLogConfig <- optional $ strOption $
         long    "node-log-config" <>
         help    "Path to log config that will be used by the node." <>
         metavar "PATH"
-    loNodeLogPath <- optional $ textOption $
+    loNodeLogPath <- optional $ strOption $
         long    "node-log-path" <>
         help    "File where node stdout/err will be redirected " <>
         metavar "PATH"
 
     -- Wallet-related args
-    loWalletPath <- optional $ textOption $
+    loWalletPath <- optional $ strOption $
         long    "wallet" <>
         help    "Path to the wallet frontend executable (e. g. Daedalus)." <>
         metavar "PATH"
-    loWalletArgs <- many $ textOption $
+    loWalletArgs <- many $ strOption $
         short   'w' <>
         help    "An argument to be passed to the wallet frontend executable." <>
         metavar "ARG"
@@ -137,24 +137,24 @@ optionsParser = do
         long    "wlogging" <>
         help    "Bool that determines if wallet should log to stdout"
 
-    loWalletLogPath <- optional $ textOption $
+    loWalletLogPath <- optional $ strOption $
         long    "wallet-log-path" <>
         help    "File where wallet stdout/err will be redirected " <>
         metavar "PATH"
     -- Update-related args
-    loUpdaterPath <- textOption $
+    loUpdaterPath <- strOption $
         long    "updater" <>
         help    "Path to the updater executable." <>
         metavar "PATH"
-    loUpdaterArgs <- many $ textOption $
+    loUpdaterArgs <- many $ strOption $
         short   'u' <>
         help    "An argument to be passed to the updater." <>
         metavar "ARG"
-    loUpdateArchive <- optional $ textOption $
+    loUpdateArchive <- optional $ strOption $
         long    "update-archive" <>
         help    "Path to the update archive, it will be passed to the updater." <>
         metavar "PATH"
-    loUpdateWindowsRunner <- optional $ textOption $
+    loUpdateWindowsRunner <- optional $ strOption $
         long    "updater-windows-runner" <>
         help    "Path to write the Windows batch file executing updater" <>
         metavar "PATH"

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -69,7 +69,7 @@ import           Pos.Reporting.Methods (compressLogs, retrieveLogFiles, sendRepo
 import           Pos.ReportServer.Report (ReportType (..))
 import           Pos.Update (installerHash)
 import           Pos.Update.DB.Misc (affirmUpdateInstalled)
-import           Pos.Util (HasLens (..), directory, postfixLFields, sleep)
+import           Pos.Util (HasLens (..), directory, postfixLFields, sleep, textOption)
 import           Pos.Util.CompileInfo (HasCompileInfo, retrieveCompileTimeInfo, withCompileInfo)
 
 data LauncherOptions = LO
@@ -102,9 +102,6 @@ data Executable = EWallet | ENode | EUpdater
 
 optionsParser :: Parser LauncherOptions
 optionsParser = do
-    let textOption :: IsString a => Mod OptionFields String -> Parser a
-        textOption = fmap fromString . strOption
-
     -- Node-related args
     loNodePath <- textOption $
         long    "node" <>

--- a/tools/src/post-mortem/Options.hs
+++ b/tools/src/post-mortem/Options.hs
@@ -25,7 +25,7 @@ overviewOptions = Overview <$> (toProb <$> argument auto
                                 )))
 
 focusedOptions :: Parser Options
-focusedOptions = Focus <$> (toText <$> argument str
+focusedOptions = Focus <$> (argument str
                                 (  metavar "FOCUS"
                                 <> help "transaction hash to focus on"
                                 ))

--- a/util/Pos/Util/Util.hs
+++ b/util/Pos/Util/Util.hs
@@ -47,7 +47,6 @@ module Pos.Util.Util
        , (<//>)
        , divRoundUp
        , sleep
-       , textOption
 
        ) where
 
@@ -72,8 +71,6 @@ import           Data.Time.Units (Microsecond, toMicroseconds)
 import qualified Ether
 import           Ether.Internal (HasLens (..))
 import qualified Language.Haskell.TH as TH
-import           Options.Applicative (option)
-import           Options.Applicative.Types (readerAsk)
 import qualified Prelude
 import           Serokell.Util.Exceptions ()
 import           System.Wlog (LoggerName, logError, usingLoggerName)
@@ -270,6 +267,3 @@ median l = NE.sort l NE.!! middle
 -}
 sleep :: MonadIO m => NominalDiffTime -> m ()
 sleep n = liftIO (threadDelay (truncate (n * 10^(6::Int))))
-
--- | A CLI option that is parsed as text.
-textOption = option (toText <$> readerAsk)

--- a/util/Pos/Util/Util.hs
+++ b/util/Pos/Util/Util.hs
@@ -47,6 +47,7 @@ module Pos.Util.Util
        , (<//>)
        , divRoundUp
        , sleep
+       , textOption
 
        ) where
 
@@ -71,6 +72,8 @@ import           Data.Time.Units (Microsecond, toMicroseconds)
 import qualified Ether
 import           Ether.Internal (HasLens (..))
 import qualified Language.Haskell.TH as TH
+import           Options.Applicative (option)
+import           Options.Applicative.Types (readerAsk)
 import qualified Prelude
 import           Serokell.Util.Exceptions ()
 import           System.Wlog (LoggerName, logError, usingLoggerName)
@@ -267,3 +270,6 @@ median l = NE.sort l NE.!! middle
 -}
 sleep :: MonadIO m => NominalDiffTime -> m ()
 sleep n = liftIO (threadDelay (truncate (n * 10^(6::Int))))
+
+-- | A CLI option that is parsed as text.
+textOption = option (toText <$> readerAsk)

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -47,8 +47,9 @@ library
                      , base
                      , bytestring
                      , cardano-sl-networking
-                     , containers
                      , concurrent-extra
+                     , conduit-combinators
+                     , containers
                      , cryptonite
                      , data-default
                      , deepseq
@@ -64,6 +65,7 @@ library
                      , mmorph
                      , mtl
                      , parsec
+                     , primitive
                      , process
                      , quickcheck-instances
                      , random

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -63,7 +63,6 @@ library
                      , lrucache
                      , mmorph
                      , mtl
-                     , optparse-applicative
                      , parsec
                      , process
                      , quickcheck-instances

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -63,6 +63,7 @@ library
                      , lrucache
                      , mmorph
                      , mtl
+                     , optparse-applicative
                      , parsec
                      , process
                      , quickcheck-instances


### PR DESCRIPTION
This is a WIP implementation of an `auxx` command which traverses the blockchain starting from the tip and dumps each epoch to a separate CBOR file.

Currently there is a problem which may imply that I misunderstand how we store blocks. The algorithm this command executes is the following:

1. Set `start` = current tip.
2. Traverse blockchain from `start` to the nearest ancestor `G` which is a genesis block.
3. Dump all blocks from `start` to `G` to a file.
4. If `G` matches `genesisHash`, stop. Otherwise, set `start` = parent of G and goto 2.

This assumes that if a block is in the DB, then either it is the very first genesis block, or its parent is in the DB too. However, I've tested this patch and it seems that this is not the case.

```
$ scripts/launch/auxx.sh --mode=with-node repl
... lots of output ...
auxx> dump /tmp/cardano-blockchain
Command failed: 
DB contains block but not its parent
CallStack (from HasCallStack):
  error, called at src/Debug.hs:43:11 in universum-0.9.0-7P9sY0yY1Bo8ubfcEspjCA:Debug
...
```

Apparently, my understanding is incorrect and help would be appreciated.