### PR TITLE
[CSL-2113] Binance new address performance improvement

### DIFF
--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -3,7 +3,8 @@
 -- | Different utils for wallets
 
 module Pos.Wallet.Web.Util
-    ( getWalletAccountIds
+    ( getAccountMetaOrThrow
+    , getWalletAccountIds
     , getAccountAddrsOrThrow
     , getWalletAddrMetas
     , getWalletAddrs
@@ -23,14 +24,21 @@ import           Pos.Util.Util              (maybeThrow)
 import           Pos.Wallet.Web.Assurance   (AssuranceLevel (HighAssurance),
                                              assuredBlockDepth)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
-                                             CWAddressMeta (..), Wal,
+                                             CWAddressMeta (..), Wal, CAccountMeta,
                                              cwAssurance)
 
 
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode, WebWalletModeDB,
                                              getAccountIds, getAccountWAddresses,
-                                             getWalletMeta)
+                                             getWalletMeta, getAccountMeta)
+
+
+getAccountMetaOrThrow :: (WebWalletModeDB ctx m, MonadThrow m) => AccountId -> m CAccountMeta
+getAccountMetaOrThrow accId = getAccountMeta accId >>= maybeThrow noAccount
+  where
+    noAccount =
+        RequestError $ sformat ("No account with id "%build%" found") accId
 
 getWalletAccountIds :: WebWalletModeDB ctx m => CId Wal -> m [AccountId]
 getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getAccountIds

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -18,21 +18,19 @@ module Pos.Wallet.Web.Account
        , MonadKeySearch (..)
        ) where
 
-import           Control.Monad.Except       (MonadError (throwError), runExceptT)
-import           Data.List                  (elemIndex)
-import           Formatting                 (build, sformat, (%))
-import           System.Random              (randomIO)
-import           System.Wlog                (WithLogger)
+import           Control.Monad.Except (MonadError (throwError), runExceptT)
+import           Data.List (elemIndex)
+import           Formatting (build, sformat, (%))
+import           System.Random (randomRIO)
+import           System.Wlog (WithLogger)
 import           Universum
 
-import           Pos.Core                   (Address (..), IsBootstrapEraAddr (..),
-                                             deriveLvl2KeyPair)
-import           Pos.Crypto                 (EncryptedSecretKey, PassPhrase,
-                                             ShouldCheckPassphrase (..), isHardened)
-import           Pos.Util                   (eitherToThrow, maybeThrow)
-import           Pos.Util.BackupPhrase      (BackupPhrase, safeKeysFromPhrase)
-import           Pos.Wallet.KeyStorage      (AllUserSecrets (..), MonadKeys, addSecretKey,
-                                             getSecretKeys, getSecretKeysPlain)
+import           Pos.Wallet.KeyStorage (AllUserSecrets (..), MonadKeys, MonadKeys, addSecretKey,
+                                        getSecretKeys, getSecretKeysPlain)
+import           Pos.Core (Address (..), IsBootstrapEraAddr (..), deriveLvl2KeyPair)
+import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..), firstHardened)
+import           Pos.Util (eitherToThrow, maybeThrow)
+import           Pos.Util.BackupPhrase (BackupPhrase, safeKeysFromPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
                                              addrMetaToAccount, addressToCId, encToCId)
 import           Pos.Wallet.Web.Error       (WalletError (..))
@@ -131,15 +129,13 @@ generateUnique desc RandomSeed generator isDuplicate = loop (100 :: Int)
              sformat (build%": generation of unique item seems too difficult, \
                       \you are approaching the limit") desc
     loop i = do
-        rand  <- liftIO randomIO
+        rand  <- liftIO $ randomRIO (firstHardened, maxBound)
         value <- generator rand
-        bad   <- orM
-            [ isDuplicate rand value
-            , pure $ isHardened rand  -- using hardened keys only for now
-            ]
-        if bad
-            then loop (i - 1)
-            else return value
+        isDup <- isDuplicate rand value
+        if isDup then
+            loop (i - 1)
+        else
+            return value
 generateUnique desc (DeterminedSeed seed) generator notFit = do
     value <- generator (fromIntegral seed)
     whenM (notFit seed value) $


### PR DESCRIPTION
There are two improvements:
1. Checking existence of an account in `newAddress` is done much faster. Previously it was done by calling `getAccount`, which collects all addresses, deserialize them and it's extremely slow.
2. Generating unique address is optimized. For each generated address we derived it even this address already existed in db or was hardened, now we check it at first and then derive

I haven't generated 80k addresses like binance contains, but for 1k addresses, the first improvement showed much better performance