### PR TITLE
wrong url

### DIFF
--- a/ssc/Pos/Ssc.hs
+++ b/ssc/Pos/Ssc.hs
@@ -4,7 +4,7 @@
 -- delivery. Nodes exchange commitments, openings, and shares, and in the
 -- end arrive at a shared seed.
 --
--- See https://eprint.iacr.org/2015/889.pdf (“A Provably Secure
+-- See https://eprint.iacr.org/2016/889.pdf (“A Provably Secure
 -- Proof-of-Stake Blockchain Protocol”), section 4 for more details.
 
 {-# OPTIONS_GHC -F -pgmF autoexporter #-}


### PR DESCRIPTION
The documentation contains the wrong url,
the 2015 is wrong, should be 2016. 
https://eprint.iacr.org/2015/889.pdf is "Which Ring Based Somewhat Homomorphic Encryption Scheme is Best?" 
and 
https://eprint.iacr.org/2016/889.pdf is "Ouroboros: A Provably Secure Proof-of-Stake Blockchain Protocol"