### PR TITLE
[CSL-2135] Tricks with resubmission logic

### DIFF
--- a/infra/Pos/StateLock.hs
+++ b/infra/Pos/StateLock.hs
@@ -13,6 +13,7 @@ module Pos.StateLock
        ( Priority (..)
        , StateLock (..)
        , newStateLock
+       , MonadStateLock
 
        , StateLockMetrics (..)
        , ignoreStateLockMetrics

--- a/node/cardano-sl.cabal
+++ b/node/cardano-sl.cabal
@@ -134,6 +134,7 @@ library
                         Pos.Wallet.Web.Error.Util
                         Pos.Wallet.Web.Pending.Types
                         Pos.Wallet.Web.Pending.Updates
+                        Pos.Wallet.Web.Pending.Functions
                         Pos.Wallet.Web.State
                         Pos.Wallet.Web.State.Acidic
                         Pos.Wallet.Web.State.State

--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -307,7 +307,7 @@ mainnet_base: &mainnet_base
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
-    walletProductionApi: false
+    walletProductionApi: true
     walletTxCreationDisabled: false
 
 

--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -118,6 +118,8 @@ dev: &dev
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
+    walletProductionApi: false
+    walletTxCreationDisabled: false
 
 
 ##############################################################################
@@ -305,6 +307,8 @@ mainnet_base: &mainnet_base
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
+    walletProductionApi: false
+    walletTxCreationDisabled: false
 
 
 ##############################################################################

--- a/node/src/Pos/Configuration.hs
+++ b/node/src/Pos/Configuration.hs
@@ -26,8 +26,10 @@ module Pos.Configuration
        -- * Malicious activity detection constants
        , mdNoBlocksSlotThreshold
 
-       -- * Transaction resubmition constants
+       -- * Wallet constants
        , pendingTxResubmitionPeriod
+       , walletProductionApi
+       , walletTxCreationDisabled
        ) where
 
 import           Universum
@@ -76,6 +78,11 @@ data NodeConfiguration = NodeConfiguration
       -- ^ InvMsg propagation queue capacity
     , ccPendingTxResubmissionPeriod :: !Int
       -- ^ Minimal delay between pending transactions resubmission
+    , ccWalletProductionApi         :: !Bool
+      -- ^ Whether hazard wallet endpoint should be disabled
+    , ccWalletTxCreationDisabled    :: !Bool
+      -- ^ Disallow transaction creation or re-submission of
+      -- pending transactions by the wallet
     } deriving (Show, Generic)
 
 instance FromJSON NodeConfiguration where
@@ -148,8 +155,18 @@ mdNoBlocksSlotThreshold :: (HasNodeConfiguration, Integral i) => i
 mdNoBlocksSlotThreshold = fromIntegral . ccMdNoBlocksSlotThreshold $ nodeConfiguration
 
 ----------------------------------------------------------------------------
--- Transactions resubmition
+-- Wallet parameters
 ----------------------------------------------------------------------------
 
 pendingTxResubmitionPeriod :: HasNodeConfiguration => Second
 pendingTxResubmitionPeriod = fromIntegral . ccPendingTxResubmissionPeriod $ nodeConfiguration
+
+-- | If 'True', some dangerous endpoints, like one which resets wallet state,
+-- should throw exception if used.
+walletProductionApi :: HasNodeConfiguration => Bool
+walletProductionApi = ccWalletProductionApi $ nodeConfiguration
+
+-- | If 'True', wallet should *not* create new transactions or re-submit
+-- existing pending transactions.
+walletTxCreationDisabled :: HasNodeConfiguration => Bool
+walletTxCreationDisabled = ccWalletTxCreationDisabled $ nodeConfiguration

--- a/node/src/Pos/DB/Block.hs
+++ b/node/src/Pos/DB/Block.hs
@@ -53,6 +53,11 @@ module Pos.DB.Block
        , dbGetUndoSscSumDefault
        , dbGetHeaderSscSumDefault
        , dbPutBlundSumDefault
+
+       -- * Internals
+       , getBlundThrow
+       , getBlockThrow
+       , getHeaderThrow
        ) where
 
 import           Universum

--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -21,7 +21,8 @@ import           Servant.Multipart                    (FromMultipart (..), looku
 
 import           Pos.Core                             (Address, Coin, decodeTextAddress,
                                                        mkCoin)
-import           Pos.Crypto                           (PassPhrase, passphraseLength)
+import           Pos.Crypto                           (PassPhrase, decodeHash,
+                                                       passphraseLength)
 import           Pos.Txp.Core.Types                   (TxId)
 import           Pos.Util.Servant                     (FromCType (..),
                                                        HasTruncateLogPolicy (..),
@@ -35,11 +36,12 @@ import           Pos.Wallet.Web.ClientTypes.Types     (AccountId (..), CAccount 
                                                        CAccountMeta (..), CAddress (..),
                                                        CCoin (..),
                                                        CElectronCrashReport (..),
-                                                       CId (..), CInitialized (..),
+                                                       CHash (..), CId (..),
+                                                       CInitialized (..),
                                                        CPaperVendWalletRedeem (..),
                                                        CPassPhrase (..), CProfile (..),
                                                        CPtxCondition, CTx (..),
-                                                       CTxId (..), CTxId, CTxMeta (..),
+                                                       CTxId (..), CTxMeta (..),
                                                        CUpdateInfo (..), CWallet (..),
                                                        CWallet, CWalletAssurance,
                                                        CWalletInit (..), CWalletMeta (..),
@@ -261,6 +263,8 @@ type instance OriginType CTxId = TxId
 instance ToCType CTxId where
     encodeCType = txIdToCTxId
 
+instance FromCType CTxId where
+    decodeCType (CTxId (CHash h)) = decodeHash h
 
 type instance OriginType CPtxCondition = Maybe PtxCondition
 

--- a/node/src/Pos/Wallet/Web/Pending/Functions.hs
+++ b/node/src/Pos/Wallet/Web/Pending/Functions.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Pos.Wallet.Web.Pending.Functions
+    ( reevaluateUncertainPtxs
+    , mkHashMap
+    ) where
+
+import           Universum
+
+import           Control.Lens                 (has, to, folded, _Right)
+import qualified Data.HashMap.Strict          as HM
+import qualified Data.HashSet                 as HS
+import           Formatting                   (sformat, (%))
+import           Serokell.Util                (listJson)
+import           System.Wlog                  (logInfo, WithLogger)
+
+import           Pos.Block.Core               (Block, mainBlockTxPayload)
+import           Pos.Crypto                   (WithHash (..), hash)
+import           Pos.Core.Configuration       (HasConfiguration, genesisHash)
+import           Pos.Core.Types               (ChainDifficulty)
+import           Pos.Core.Class               (difficultyL, headerHash, prevBlockL)
+import qualified Pos.DB.DB                    as DB
+import qualified Pos.DB.Block                 as DB
+import           Pos.StateLock                (withStateLock, Priority (..), MonadStateLock)
+import           Pos.Txp.Core                 (Tx, TxId, topsortTxs, taTx, txpTxs)
+import           Pos.Txp.Toil.Class           (MonadUtxoRead)
+import           Pos.Txp.Toil.Trans           (evalToilTEmpty)
+import           Pos.Txp.Toil.Failure         (ToilVerFailure)
+import           Pos.Txp.Toil.Utxo.Functions  (VTxContext (..), verifyTxUtxo,
+                                               applyTxToUtxo)
+import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..),
+                                               ptxCond, _PtxApplying, _PtxWontApply,
+                                               ptxTxAux, ptxTxId)
+import           Pos.Util.Util                (getKeys)
+
+
+-- | Reevaluate all pending txs (in 'PtxApplying' and 'PtxWontApply' states):
+--
+--   * 'PtxInNewestBlocks' for ones that are already in the blockchain
+--     (at any depth)
+--   * 'PtxWontApply' for ones that can't be applied
+--   * 'PtxApplying' to ones that can be applied either directly or after
+--     applying some other transactions
+--
+reevaluateUncertainPtxs
+    :: forall ssc ctx m.
+       ( DB.MonadBlockDB ssc m
+       , MonadStateLock ctx m
+       , HasConfiguration
+       , MonadUtxoRead m
+       , WithLogger m
+       , MonadIO m
+       )
+    => HashMap TxId PendingTx -> m (HashMap TxId PendingTx)
+reevaluateUncertainPtxs ptxs =  withStateLock LowPriority "reevaluateUncertainPtxs" $ \__tip -> do
+    -- Get all transactions we're uncertain about
+    let isUncertain ptx = has (ptxCond . _PtxApplying)  ptx ||
+                          has (ptxCond . _PtxWontApply) ptx
+    let (uncertain, certain) = partitionHashMap isUncertain ptxs
+    -- Find those that are already in blocks; they'll be marked as
+    -- 'PtxInNewestBlocks'
+    presentIds <- getTxsBlockStatus @ssc (getKeys uncertain)
+    let present :: HashMap TxId (PendingTx, ChainDifficulty)
+        present = HM.intersectionWith (,) uncertain presentIds
+    let missing :: HashMap TxId PendingTx
+        missing = HM.difference uncertain presentIds
+    -- Topsort the rest ('missing'), go one by one and either add to UTXO or
+    -- mark as 'PtxWontApply'
+    (missingInvalid, missingValid) <- evalToilTEmpty $ do
+        let sorted = fromMaybe (error "Pending transactions couldn't be topsorted") $
+                     topsortTxs ptxWithHash (toList missing)
+        fmap partitionEithers $ forM sorted $ \ptx -> do
+            let vtc = VTxContext True     -- TODO: is it necessarily 'True'?
+            runExceptT (verifyTxUtxo vtc (ptx ^. ptxTxAux)) >>= \case
+                Left err -> pure (Left (ptx, err))
+                Right _  -> applyTxToUtxo (ptxWithHash ptx) >>
+                            pure (Right ptx)
+
+    logInfo $ sformat ("These transactions are certain and won't be affected: "
+                       %listJson) (HM.keys certain)
+    logInfo $ sformat ("These transactions are present in blocks: "
+                       %listJson) (HM.keys present)
+    logInfo $ sformat ("These transactions are not in blocks and invalid: "
+                       %listJson) (map (view ptxTxId . fst) missingInvalid)
+    logInfo $ sformat ("These transactions are not in blocks and valid: "
+                       %listJson) (map (view ptxTxId) missingValid)
+
+
+    pure $ mconcat
+        [ certain                          -- certain = do nothing
+        , map setInNewestBlocks present    -- present = PtxInNewestBlocks
+        , mkHashMap (view ptxTxId) $       -- invalid = PtxWontApply
+            map setWontApply missingInvalid
+        , mkHashMap (view ptxTxId) $       -- valid = PtxApplying
+            map setApplying missingValid
+        ]
+
+----------------------------------------------------------------------------
+-- General utilities
+----------------------------------------------------------------------------
+
+-- | Create a 'HashMap' by deriving a key from each value.
+mkHashMap
+    :: (Eq k, Hashable k)
+    => (v -> k) -> [v] -> HashMap k v
+mkHashMap f = HM.fromList . map (f &&& identity)
+
+-- | Partition a 'HashMap'.
+partitionHashMap
+    :: (v -> Bool) -> HashMap k v -> (HashMap k v, HashMap k v)
+partitionHashMap p hm = (HM.filter p hm, HM.filter (not . p) hm)
+
+----------------------------------------------------------------------------
+-- Utilities for pending transactions
+----------------------------------------------------------------------------
+
+-- | Mark a transaction with 'PtxInNewestBlocks'.
+setInNewestBlocks :: (PendingTx, ChainDifficulty) -> PendingTx
+setInNewestBlocks (ptx, difficulty) = ptx & ptxCond %~ \case
+    PtxApplying _    -> PtxInNewestBlocks difficulty
+    PtxWontApply _ _ -> PtxInNewestBlocks difficulty
+    other            -> other
+
+-- | Cancel an __uncertain__ transaction by setting its status to
+-- 'PtxWontApply' with the given cancellation reason.
+setWontApply :: (PendingTx, ToilVerFailure) -> PendingTx
+setWontApply (ptx, err) = ptx & ptxCond %~ \case
+    PtxApplying    poolInfo -> PtxWontApply (pretty err) poolInfo
+    PtxWontApply _ poolInfo -> PtxWontApply (pretty err) poolInfo
+    other                   -> other
+
+-- | Schedule an __uncertain__ transaction for resubmission by setting its
+-- status to 'PtxApplying'.
+setApplying :: PendingTx -> PendingTx
+setApplying ptx = ptx & ptxCond %~ \case
+    PtxWontApply _ poolInfo -> PtxApplying poolInfo
+    other                   -> other
+
+-- | Get tx and hash out of a pending transaction.
+ptxWithHash :: PendingTx -> WithHash Tx
+ptxWithHash ptx =
+    WithHash { whData = ptx ^. ptxTxAux . to taTx
+             , whHash = ptx ^. ptxTxId
+             }
+
+----------------------------------------------------------------------------
+-- Utilities for traversing the blockchain
+----------------------------------------------------------------------------
+
+-- | Get status of several transactions – for ones that are in the
+-- blockchain, say in what block they are.
+getTxsBlockStatus
+    :: forall ssc m. DB.MonadBlockDB ssc m
+    => HashSet TxId
+    -> m (HashMap TxId ChainDifficulty)
+getTxsBlockStatus txs = foldMapBlocks @ssc $ \block -> do
+    let blockTxs   = block ^.. _Right . mainBlockTxPayload . txpTxs . folded
+        blockTxIds = HS.fromList $ map hash blockTxs
+        blockDiff  = block ^. difficultyL
+    pure $ fmap (const blockDiff) $ HS.toMap $ HS.intersection txs blockTxIds
+
+-- | Traverse all blocks in the blockchain (starting from the newest one)
+-- and concatenate the results.
+foldMapBlocks
+    :: forall ssc m a. (DB.MonadBlockDB ssc m, Monoid a)
+    => (Block ssc -> m a) -> m a
+foldMapBlocks f = do
+    tip <- headerHash <$> DB.getTipHeader @ssc
+    go tip mempty
+  where
+    go h !acc
+        | h == genesisHash = pure acc
+        | otherwise = do
+              block <- DB.getBlockThrow @ssc h
+              val <- f block
+              go (block ^. prevBlockL) (acc <> val)

--- a/node/src/Pos/Wallet/Web/Pending/Updates.hs
+++ b/node/src/Pos/Wallet/Web/Pending/Updates.hs
@@ -5,6 +5,7 @@ module Pos.Wallet.Web.Pending.Updates
     ( mkPtxSubmitTiming
     , incPtxSubmitTimingPure
     , ptxMarkAcknowledgedPure
+    , resetFailedPtx
     ) where
 
 import           Universum
@@ -14,9 +15,9 @@ import           Control.Lens                 ((%=), (+=), (+~), (<<*=), (<<.=))
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Core.Slotting            (flatSlotId)
 import           Pos.Core.Types               (FlatSlotId, SlotId)
-import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxSubmitTiming (..),
-                                               pstNextDelay, pstNextSlot, ptxPeerAck,
-                                               ptxSubmitTiming)
+import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..),
+                                               PtxSubmitTiming (..), pstNextDelay,
+                                               pstNextSlot, ptxPeerAck, ptxSubmitTiming)
 
 
 mkPtxSubmitTiming :: HasConfiguration => SlotId -> PtxSubmitTiming
@@ -39,3 +40,16 @@ ptxMarkAcknowledgedPure :: PendingTx -> PendingTx
 ptxMarkAcknowledgedPure = execState $ do
     wasAcked <- ptxPeerAck <<.= True
     unless wasAcked $ ptxSubmitTiming . pstNextDelay %= (* 8)
+
+-- | If given transaction is in 'PtxWontApply' condition, sets its condition
+-- to 'PtxApplying'. This allows "stuck" transactions to be resubmitted
+-- again.
+--
+-- Has no effect for transactions in other conditions.
+resetFailedPtx :: HasConfiguration => SlotId -> PendingTx -> PendingTx
+resetFailedPtx curSlot ptx@PendingTx{..}
+    | PtxWontApply _ poolInfo <- _ptxCond =
+          ptx { _ptxCond = PtxApplying poolInfo
+              , _ptxSubmitTiming = mkPtxSubmitTiming curSlot
+              }
+    | otherwise = ptx

--- a/node/src/Pos/Wallet/Web/Pending/Updates.hs
+++ b/node/src/Pos/Wallet/Web/Pending/Updates.hs
@@ -60,6 +60,7 @@ cancelApplyingPtx :: HasConfiguration => PendingTx -> PendingTx
 cancelApplyingPtx ptx@PendingTx{..}
     | PtxApplying poolInfo <- _ptxCond =
           ptx { _ptxCond = PtxWontApply reason poolInfo
+              , _ptxPeerAck = False
               }
     | otherwise = ptx
   where

--- a/node/src/Pos/Wallet/Web/Pending/Updates.hs
+++ b/node/src/Pos/Wallet/Web/Pending/Updates.hs
@@ -6,6 +6,7 @@ module Pos.Wallet.Web.Pending.Updates
     , incPtxSubmitTimingPure
     , ptxMarkAcknowledgedPure
     , resetFailedPtx
+    , cancelApplyingPtx
     ) where
 
 import           Universum
@@ -41,7 +42,7 @@ ptxMarkAcknowledgedPure = execState $ do
     wasAcked <- ptxPeerAck <<.= True
     unless wasAcked $ ptxSubmitTiming . pstNextDelay %= (* 8)
 
--- | If given transaction is in 'PtxWontApply' condition, sets its condition
+-- | If given transaction has been canceled, sets its condition
 -- to 'PtxApplying'. This allows "stuck" transactions to be resubmitted
 -- again.
 --
@@ -53,3 +54,13 @@ resetFailedPtx curSlot ptx@PendingTx{..}
               , _ptxSubmitTiming = mkPtxSubmitTiming curSlot
               }
     | otherwise = ptx
+
+-- | If given pending transaction is not yet confirmed, cancels it.
+cancelApplyingPtx :: HasConfiguration => PendingTx -> PendingTx
+cancelApplyingPtx ptx@PendingTx{..}
+    | PtxApplying poolInfo <- _ptxCond =
+          ptx { _ptxCond = PtxWontApply reason poolInfo
+              }
+    | otherwise = ptx
+  where
+    reason = "Canceled manually"

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -72,6 +72,7 @@ module Pos.Wallet.Web.State.Acidic
        , AddOnlyNewPendingTx (..)
        , ResetFailedPtxs (..)
        , CancelApplyingPtxs (..)
+       , CancelSpecificApplyingPtx (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
@@ -180,6 +181,7 @@ makeAcidic ''WalletStorage
     , 'WS.addOnlyNewPendingTx
     , 'WS.resetFailedPtxs
     , 'WS.cancelApplyingPtxs
+    , 'WS.cancelSpecificApplyingPtx
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -70,6 +70,7 @@ module Pos.Wallet.Web.State.Acidic
        , CasPtxCondition (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
+       , ResetFailedPtxs (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
@@ -176,6 +177,7 @@ makeAcidic ''WalletStorage
     , 'WS.casPtxCondition
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
+    , 'WS.resetFailedPtxs
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -71,6 +71,7 @@ module Pos.Wallet.Web.State.Acidic
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , ResetFailedPtxs (..)
+       , CancelApplyingPtxs (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
@@ -178,6 +179,7 @@ makeAcidic ''WalletStorage
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
     , 'WS.resetFailedPtxs
+    , 'WS.cancelApplyingPtxs
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -79,6 +79,7 @@ module Pos.Wallet.Web.State.State
        , addOnlyNewPendingTx
        , resetFailedPtxs
        , cancelApplyingPtxs
+       , cancelSpecificApplyingPtx
        , getWalletStorage
        , flushWalletStorage
        ) where
@@ -337,6 +338,9 @@ resetFailedPtxs = updateDisk ... A.ResetFailedPtxs
 
 cancelApplyingPtxs :: WebWalletModeDB ctx m => m ()
 cancelApplyingPtxs = updateDisk ... A.CancelApplyingPtxs
+
+cancelSpecificApplyingPtx :: WebWalletModeDB ctx m => TxId -> m ()
+cancelSpecificApplyingPtx txid = updateDisk ... A.CancelSpecificApplyingPtx txid
 
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -77,6 +77,7 @@ module Pos.Wallet.Web.State.State
        , casPtxCondition
        , ptxUpdateMeta
        , addOnlyNewPendingTx
+       , resetFailedPtxs
        , getWalletStorage
        , flushWalletStorage
        ) where
@@ -91,7 +92,7 @@ import           Universum
 import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Txp                      (TxId, Utxo, UtxoModifier)
-import           Pos.Types                    (HeaderHash)
+import           Pos.Types                    (HeaderHash, SlotId)
 import           Pos.Util.Servant             (encodeCType)
 import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
                                                CProfile, CTxId, CTxMeta, CUpdateInfo,
@@ -329,6 +330,9 @@ ptxUpdateMeta = updateDisk ... A.PtxUpdateMeta
 
 addOnlyNewPendingTx :: WebWalletModeDB ctx m => PendingTx -> m ()
 addOnlyNewPendingTx = updateDisk ... A.AddOnlyNewPendingTx
+
+resetFailedPtxs :: WebWalletModeDB ctx m => SlotId -> m ()
+resetFailedPtxs = updateDisk ... A.ResetFailedPtxs
 
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -78,6 +78,7 @@ module Pos.Wallet.Web.State.State
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , resetFailedPtxs
+       , cancelApplyingPtxs
        , getWalletStorage
        , flushWalletStorage
        ) where
@@ -333,6 +334,9 @@ addOnlyNewPendingTx = updateDisk ... A.AddOnlyNewPendingTx
 
 resetFailedPtxs :: WebWalletModeDB ctx m => SlotId -> m ()
 resetFailedPtxs = updateDisk ... A.ResetFailedPtxs
+
+cancelApplyingPtxs :: WebWalletModeDB ctx m => m ()
+cancelApplyingPtxs = updateDisk ... A.CancelApplyingPtxs
 
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -80,6 +80,7 @@ module Pos.Wallet.Web.State.Storage
        , addOnlyNewPendingTx
        , resetFailedPtxs
        , cancelApplyingPtxs
+       , cancelSpecificApplyingPtx
        ) where
 
 import           Universum
@@ -503,6 +504,11 @@ cancelApplyingPtxs :: Update ()
 cancelApplyingPtxs =
     wsWalletInfos . traversed .
     wsPendingTxs . traversed %= cancelApplyingPtx
+
+cancelSpecificApplyingPtx :: TxId -> Update ()
+cancelSpecificApplyingPtx txId =
+    wsWalletInfos . traversed .
+    wsPendingTxs . ix txId %= cancelApplyingPtx
 
 addOnlyNewPendingTx :: PendingTx -> Update ()
 addOnlyNewPendingTx ptx =

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -78,6 +78,7 @@ module Pos.Wallet.Web.State.Storage
        , casPtxCondition
        , ptxUpdateMeta
        , addOnlyNewPendingTx
+       , resetFailedPtxs
        ) where
 
 import           Universum
@@ -112,7 +113,7 @@ import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition,
                                                  ptxSubmitTiming)
 import           Pos.Wallet.Web.Pending.Updates (incPtxSubmitTimingPure,
                                                  mkPtxSubmitTiming,
-                                                 ptxMarkAcknowledgedPure)
+                                                 ptxMarkAcknowledgedPure, resetFailedPtx)
 
 type AddressSortingKey = Int
 
@@ -490,6 +491,11 @@ ptxUpdateMeta wid txId updType =
                 ptxSubmitTiming .~ mkPtxSubmitTiming curSlot
             PtxMarkAcknowledged ->
                 ptxMarkAcknowledgedPure
+
+resetFailedPtxs :: SlotId -> Update ()
+resetFailedPtxs curSlot =
+    wsWalletInfos . traversed .
+    wsPendingTxs . traversed %= resetFailedPtx curSlot
 
 addOnlyNewPendingTx :: PendingTx -> Update ()
 addOnlyNewPendingTx ptx =

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -79,6 +79,7 @@ module Pos.Wallet.Web.State.Storage
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , resetFailedPtxs
+       , cancelApplyingPtxs
        ) where
 
 import           Universum
@@ -111,7 +112,8 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId, Addr, CAccountMeta, 
 import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition,
                                                  PtxSubmitTiming (..), ptxCond,
                                                  ptxSubmitTiming)
-import           Pos.Wallet.Web.Pending.Updates (incPtxSubmitTimingPure,
+import           Pos.Wallet.Web.Pending.Updates (cancelApplyingPtx,
+                                                 incPtxSubmitTimingPure,
                                                  mkPtxSubmitTiming,
                                                  ptxMarkAcknowledgedPure, resetFailedPtx)
 
@@ -496,6 +498,11 @@ resetFailedPtxs :: SlotId -> Update ()
 resetFailedPtxs curSlot =
     wsWalletInfos . traversed .
     wsPendingTxs . traversed %= resetFailedPtx curSlot
+
+cancelApplyingPtxs :: Update ()
+cancelApplyingPtxs =
+    wsWalletInfos . traversed .
+    wsPendingTxs . traversed %= cancelApplyingPtx
 
 addOnlyNewPendingTx :: PendingTx -> Update ()
 addOnlyNewPendingTx ptx =

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -10,22 +10,23 @@ module Pos.Wallet.Web.Util
     , getWalletAddrsSet
     , decodeCTypeOrFail
     , getWalletAssuredDepth
+    , testOnlyEndpoint
     ) where
 
 import           Universum
 
 import qualified Data.Set                   as S
 import           Formatting                 (build, sformat, (%))
+import           Servant.Server             (err405, errReasonPhrase)
 
+import           Pos.Configuration          (HasNodeConfiguration, walletProductionApi)
 import           Pos.Core                   (BlockCount)
 import           Pos.Util.Servant           (FromCType (..), OriginType)
 import           Pos.Util.Util              (maybeThrow)
 import           Pos.Wallet.Web.Assurance   (AssuranceLevel (HighAssurance),
                                              assuredBlockDepth)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
-                                             CWAddressMeta (..), Wal,
-                                             cwAssurance)
-
+                                             CWAddressMeta (..), Wal, cwAssurance)
 
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode, WebWalletModeDB,
@@ -72,3 +73,11 @@ getWalletAssuredDepth
 getWalletAssuredDepth wid =
     assuredBlockDepth HighAssurance . cwAssurance <<$>>
     getWalletMeta wid
+
+testOnlyEndpoint :: (HasNodeConfiguration, MonadThrow m) => m a -> m a
+testOnlyEndpoint action
+    | walletProductionApi = throwM err405{ errReasonPhrase = errReason }
+    | otherwise = action
+  where
+    errReason = "Disabled in production, switch 'walletProductionApi' \
+                \parameter in config if you want to use this endpoint"

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -32,7 +32,7 @@ import           Pos.Util.UserSecret  (usVss)
 import           Pos.Wallet.SscType   (WalletSscType)
 import           Pos.Wallet.Web       (WalletWebMode, bracketWalletWS, bracketWalletWebDB,
                                        getSKById, runWRealMode, syncWalletsWithGState,
-                                       walletServeWebFull, walletServerOuts)
+                                       walletServeWebFull, walletServerOuts, dumpPendingTxsSummary)
 import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage,
                                        getWalletAddresses)
 import           Pos.Web              (serveWebGT)
@@ -54,6 +54,7 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
                     (mainAction nr)
   where
     mainAction = runNodeWithInit $ do
+        whenJust walletDumpPending dumpPendingTxsSummary
         when (walletFlushDb) $ do
             putText "Flushing wallet db..."
             flushWalletStorage

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -12,14 +12,15 @@ module Main
 import           Universum            hiding (over)
 
 import           Data.Maybe           (fromJust)
-import           Formatting           (sformat, shown, (%))
+import           Formatting           (build, sformat, shown, (%))
 import           Mockable             (Production, currentTime, runProduction)
-import           System.Wlog          (modifyLoggerName)
+import           System.Wlog          (logInfo, modifyLoggerName)
 
 import           Pos.Binary           ()
 import           Pos.Client.CLI       (CommonNodeArgs (..))
 import qualified Pos.Client.CLI       as CLI
 import           Pos.Communication    (ActionSpec (..), OutSpecs, WorkerSpec, worker)
+import           Pos.Configuration    (walletProductionApi, walletTxCreationDisabled)
 import           Pos.Context          (HasNodeContext)
 import           Pos.Core             (Timestamp (..), gdStartTime, genesisData)
 import           Pos.Launcher         (HasConfigurations, NodeParams (..),
@@ -78,7 +79,12 @@ acidCleanupWorker WalletArgs{..} =
     cleanupAcidStatePeriodically walletAcidInterval
 
 walletProd :: HasConfigurations => WalletArgs -> ([WorkerSpec WalletWebMode], OutSpecs)
-walletProd WalletArgs {..} = first one $ worker walletServerOuts $ \sendActions ->
+walletProd WalletArgs {..} = first one $ worker walletServerOuts $ \sendActions -> do
+    logInfo $ sformat ("Production mode for API: "%build)
+        walletProductionApi
+    logInfo $ sformat ("Transaction submission disabled: "%build)
+        walletTxCreationDisabled
+
     walletServeWebFull
         sendActions
         walletDebug

--- a/wallet/node/NodeOptions.hs
+++ b/wallet/node/NodeOptions.hs
@@ -36,6 +36,7 @@ data WalletArgs = WalletArgs
     , walletAcidInterval :: !Minute
     , walletDebug        :: !Bool
     , walletFlushDb      :: !Bool
+    , walletDumpPending  :: !(Maybe FilePath)
     } deriving Show
 
 walletArgsParser :: Parser WalletNodeArgs
@@ -70,6 +71,9 @@ walletArgsParser = do
         long "flush-wallet-db" <>
         help "Flushes all blockchain-recoverable data from DB \
               \(everything excluding wallets/accounts/addresses, metadata)"
+    walletDumpPending <- optional $ strOption $
+        long "wallet-dump-pending" <>
+        help "Dump summary of all pending transactions to given file path"
 
     pure $ WalletNodeArgs commonNodeArgs WalletArgs{..}
 

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -43,6 +43,7 @@ module Pos.Wallet.Web.Api
        , TxFee
        , ResetFailedPtxs
        , CancelApplyingPtxs
+       , CancelSpecificApplyingPtx
        , UpdateTx
        , GetHistory
        , GetPendingTxsSummary
@@ -308,6 +309,13 @@ type CancelApplyingPtxs =
     :> "cancel"
     :> WRes Get ()
 
+type CancelSpecificApplyingPtx =
+       "txs"
+    :> "resubmission"
+    :> "cancelsingle"
+    :> Capture "transaction" CTxId
+    :> WRes Get ()
+
 type GetHistory =
        "txs"
     :> "histories"
@@ -480,6 +488,8 @@ type WalletApi = ApiPrefix :> (
      ResetFailedPtxs
     :<|>
      CancelApplyingPtxs
+    :<|>
+     CancelSpecificApplyingPtx
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -44,6 +44,7 @@ module Pos.Wallet.Web.Api
        , ResetFailedPtxs
        , CancelApplyingPtxs
        , CancelSpecificApplyingPtx
+       , ReevaluateUncertainPtxs
        , UpdateTx
        , GetHistory
        , GetPendingTxsSummary
@@ -316,6 +317,12 @@ type CancelSpecificApplyingPtx =
     :> Capture "transaction" CTxId
     :> WRes Get ()
 
+type ReevaluateUncertainPtxs =
+       "txs"
+    :> "resubmission"
+    :> "reevaluate"
+    :> WRes Post ()
+
 type GetHistory =
        "txs"
     :> "histories"
@@ -327,7 +334,7 @@ type GetHistory =
     :> WRes Get ([CTx], Word)
 
 type GetPendingTxsSummary =
-        "txs"
+       "txs"
     :> "pending"
     :> "summary"
     :> WRes Get [PendingTxsSummary]
@@ -490,6 +497,8 @@ type WalletApi = ApiPrefix :> (
      CancelApplyingPtxs
     :<|>
      CancelSpecificApplyingPtx
+    :<|>
+     ReevaluateUncertainPtxs
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -43,6 +43,7 @@ module Pos.Wallet.Web.Api
        , TxFee
        , UpdateTx
        , GetHistory
+       , GetPendingTxsSummary
 
        , NextUpdate
        , PostponeUpdate
@@ -65,35 +66,35 @@ module Pos.Wallet.Web.Api
        ) where
 
 
-import           Control.Lens               (from)
-import           Control.Monad.Catch        (try)
-import           Data.Reflection            (Reifies (..))
-import           Servant.API                ((:<|>), (:>), Capture, Delete, Get, JSON,
-                                             Post, Put, QueryParam, ReflectMethod (..),
-                                             ReqBody, Verb)
-import           Servant.Server             (HasServer (..))
-import           Servant.Swagger.UI         (SwaggerSchemaUI)
-import           Servant.API.ContentTypes   (OctetStream)
+import           Control.Lens                (from)
+import           Control.Monad.Catch         (try)
+import           Data.Reflection             (Reifies (..))
+import           Servant.API                 ((:<|>), (:>), Capture, Delete, Get, JSON,
+                                              Post, Put, QueryParam, ReflectMethod (..),
+                                              ReqBody, Verb)
+import           Servant.API.ContentTypes    (OctetStream)
+import           Servant.Server              (HasServer (..))
+import           Servant.Swagger.UI          (SwaggerSchemaUI)
 import           Universum
 
-import           Pos.Types                  (Coin, SoftwareVersion)
-import           Pos.Util.Servant           (ApiLoggingConfig, CCapture, CQueryParam,
-                                             CReqBody, DCQueryParam,
-                                             HasLoggingServer (..), LoggingApi,
-                                             ModifiesApiRes (..), ReportDecodeError (..),
-                                             VerbMod, WithTruncatedLog (..),
-                                             applyLoggingToHandler, inRouteServer,
-                                             serverHandlerL')
-import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit,
-                                             CAccountMeta, CAddress, CCoin, CId,
-                                             CInitialized, CPaperVendWalletRedeem,
-                                             CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
-                                             CUpdateInfo, CWallet, CWalletInit,
-                                             CWalletMeta, CWalletRedeem, SyncProgress,
-                                             Wal)
-import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
-                                             catchEndpointErrors)
-import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot)
+import           Pos.Types                   (Coin, SoftwareVersion)
+import           Pos.Util.Servant            (ApiLoggingConfig, CCapture, CQueryParam,
+                                              CReqBody, DCQueryParam,
+                                              HasLoggingServer (..), LoggingApi,
+                                              ModifiesApiRes (..), ReportDecodeError (..),
+                                              VerbMod, WithTruncatedLog (..),
+                                              applyLoggingToHandler, inRouteServer,
+                                              serverHandlerL')
+import           Pos.Wallet.Web.ClientTypes  (Addr, CAccount, CAccountId, CAccountInit,
+                                              CAccountMeta, CAddress, CCoin, CId,
+                                              CInitialized, CPaperVendWalletRedeem,
+                                              CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
+                                              CUpdateInfo, CWallet, CWalletInit,
+                                              CWalletMeta, CWalletRedeem, SyncProgress,
+                                              Wal)
+import           Pos.Wallet.Web.Error        (WalletError (DecodeError),
+                                              catchEndpointErrors)
+import           Pos.Wallet.Web.Methods.Misc (PendingTxsSummary, WalletStateSnapshot)
 
 -- | Common prefix for all endpoints.
 type ApiPrefix = "api"
@@ -303,6 +304,12 @@ type GetHistory =
     :> QueryParam "limit" Word
     :> WRes Get ([CTx], Word)
 
+type GetPendingTxsSummary =
+        "txs"
+    :> "pending"
+    :> "summary"
+    :> WRes Get [PendingTxsSummary]
+
 -------------------------------------------------------------------------
 -- Updates
 -------------------------------------------------------------------------
@@ -460,6 +467,8 @@ type WalletApi = ApiPrefix :> (
      UpdateTx
     :<|>
      GetHistory
+    :<|>
+     GetPendingTxsSummary
     :<|>
      -------------------------------------------------------------------------
      -- Updates

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -42,6 +42,7 @@ module Pos.Wallet.Web.Api
        , NewPayment
        , TxFee
        , ResetFailedPtxs
+       , CancelApplyingPtxs
        , UpdateTx
        , GetHistory
        , GetPendingTxsSummary
@@ -301,6 +302,12 @@ type ResetFailedPtxs =
     :> "reset"
     :> WRes Get ()
 
+type CancelApplyingPtxs =
+       "txs"
+    :> "resubmission"
+    :> "cancel"
+    :> WRes Get ()
+
 type GetHistory =
        "txs"
     :> "histories"
@@ -471,6 +478,8 @@ type WalletApi = ApiPrefix :> (
      TxFee
     :<|>
      ResetFailedPtxs
+    :<|>
+     CancelApplyingPtxs
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -41,6 +41,7 @@ module Pos.Wallet.Web.Api
 
        , NewPayment
        , TxFee
+       , ResetFailedPtxs
        , UpdateTx
        , GetHistory
        , GetPendingTxsSummary
@@ -294,6 +295,12 @@ type UpdateTx =
     :> ReqBody '[JSON] CTxMeta
     :> WRes Post ()
 
+type ResetFailedPtxs =
+       "txs"
+    :> "resubmission"
+    :> "reset"
+    :> WRes Get ()
+
 type GetHistory =
        "txs"
     :> "histories"
@@ -462,6 +469,8 @@ type WalletApi = ApiPrefix :> (
      NewPayment
     :<|>
      TxFee
+    :<|>
+     ResetFailedPtxs
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -20,6 +20,7 @@ module Pos.Wallet.Web.Methods.Misc
 
        , PendingTxsSummary (..)
        , gatherPendingTxsSummary
+       , dumpPendingTxsSummary
        , resetAllFailedPtxs
        , cancelAllApplyingPtxs
        , cancelOneApplyingPtx
@@ -29,6 +30,7 @@ import           Universum
 
 import           Data.Aeson                   (encode)
 import           Data.Aeson.TH                (defaultOptions, deriveJSON)
+import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.Text.Buildable
 import           Formatting                   (bprint, build, (%))
 import           Serokell.Util.Text           (listJson)
@@ -199,6 +201,11 @@ gatherPendingTxsSummary =
             , ptiOutputs = _txOutputs tx
             , ptiTxId = hash tx
             }
+
+dumpPendingTxsSummary :: MonadWalletWebMode m => FilePath -> m ()
+dumpPendingTxsSummary path = do
+    summary <- gatherPendingTxsSummary
+    liftIO $ BSL.writeFile path (encode summary)
 
 resetAllFailedPtxs :: MonadWalletWebMode m => m ()
 resetAllFailedPtxs =

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -24,6 +24,7 @@ module Pos.Wallet.Web.Methods.Misc
        , resetAllFailedPtxs
        , cancelAllApplyingPtxs
        , cancelOneApplyingPtx
+       , reevaluateAllUncertainPtxs
        ) where
 
 import           Universum
@@ -61,7 +62,8 @@ import           Pos.Wallet.Web.Pending       (PendingTx (..), isPtxInBlocks,
 import           Pos.Wallet.Web.State         (cancelApplyingPtxs,
                                                cancelSpecificApplyingPtx, getNextUpdate,
                                                getPendingTxs, getProfile,
-                                               getWalletStorage, removeNextUpdate,
+                                               getWalletStorage, reevaluateUncertainPtxs,
+                                               removeNextUpdate,
                                                resetFailedPtxs, setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoint)
@@ -218,3 +220,6 @@ cancelOneApplyingPtx :: MonadWalletWebMode m => CTxId -> m ()
 cancelOneApplyingPtx cTxId = do
     txId <- decodeCTypeOrFail cTxId
     testOnlyEndpoint (cancelSpecificApplyingPtx txId)
+
+reevaluateAllUncertainPtxs :: MonadWalletWebMode m => m ()
+reevaluateAllUncertainPtxs = testOnlyEndpoint reevaluateUncertainPtxs

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -43,6 +43,7 @@ import           Pos.Wallet.Web.State         (getNextUpdate, getProfile,
                                                getWalletStorage, removeNextUpdate,
                                                setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
+import           Pos.Wallet.Web.Util          (testOnlyEndpoint)
 
 
 ----------------------------------------------------------------------------
@@ -106,7 +107,7 @@ syncProgress =
 ----------------------------------------------------------------------------
 
 testResetAll :: MonadWalletWebMode m => m ()
-testResetAll = deleteAllKeys >> testReset
+testResetAll = testOnlyEndpoint $ deleteAllKeys >> testReset
   where
     deleteAllKeys = do
         keyNum <- length <$> getSecretKeys

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -21,6 +21,7 @@ module Pos.Wallet.Web.Methods.Misc
        , PendingTxsSummary (..)
        , gatherPendingTxsSummary
        , resetAllFailedPtxs
+       , cancelAllApplyingPtxs
        ) where
 
 import           Universum
@@ -53,7 +54,8 @@ import           Pos.Wallet.Web.Error         (WalletError (..))
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending       (PendingTx (..), isPtxInBlocks,
                                                sortPtxsChrono)
-import           Pos.Wallet.Web.State         (getNextUpdate, getPendingTxs, getProfile,
+import           Pos.Wallet.Web.State         (cancelApplyingPtxs, getNextUpdate,
+                                               getPendingTxs, getProfile,
                                                getWalletStorage, removeNextUpdate,
                                                resetFailedPtxs, setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
@@ -194,3 +196,6 @@ gatherPendingTxsSummary =
 resetAllFailedPtxs :: MonadWalletWebMode m => m ()
 resetAllFailedPtxs =
     testOnlyEndpoint $ getCurrentSlotBlocking >>= resetFailedPtxs
+
+cancelAllApplyingPtxs :: MonadWalletWebMode m => m ()
+cancelAllApplyingPtxs = testOnlyEndpoint cancelApplyingPtxs

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -22,6 +22,7 @@ module Pos.Wallet.Web.Methods.Misc
        , gatherPendingTxsSummary
        , resetAllFailedPtxs
        , cancelAllApplyingPtxs
+       , cancelOneApplyingPtx
        ) where
 
 import           Universum
@@ -48,18 +49,19 @@ import           Pos.Wallet.KeyStorage        (deleteSecretKey, getSecretKeys)
 import           Pos.Wallet.WalletMode        (applyLastUpdate, connectedPeers,
                                                localChainDifficulty,
                                                networkChainDifficulty)
-import           Pos.Wallet.Web.ClientTypes   (CProfile (..), CPtxCondition,
+import           Pos.Wallet.Web.ClientTypes   (CProfile (..), CPtxCondition, CTxId (..),
                                                CUpdateInfo (..), SyncProgress (..))
 import           Pos.Wallet.Web.Error         (WalletError (..))
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending       (PendingTx (..), isPtxInBlocks,
                                                sortPtxsChrono)
-import           Pos.Wallet.Web.State         (cancelApplyingPtxs, getNextUpdate,
+import           Pos.Wallet.Web.State         (cancelApplyingPtxs,
+                                               cancelSpecificApplyingPtx, getNextUpdate,
                                                getPendingTxs, getProfile,
                                                getWalletStorage, removeNextUpdate,
                                                resetFailedPtxs, setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
-import           Pos.Wallet.Web.Util          (testOnlyEndpoint)
+import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoint)
 
 
 ----------------------------------------------------------------------------
@@ -199,3 +201,8 @@ resetAllFailedPtxs =
 
 cancelAllApplyingPtxs :: MonadWalletWebMode m => m ()
 cancelAllApplyingPtxs = testOnlyEndpoint cancelApplyingPtxs
+
+cancelOneApplyingPtx :: MonadWalletWebMode m => CTxId -> m ()
+cancelOneApplyingPtx cTxId = do
+    txId <- decodeCTypeOrFail cTxId
+    testOnlyEndpoint (cancelSpecificApplyingPtx txId)

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -63,6 +63,8 @@ import           Pos.Slotting.Impl.Sum            (currentTimeSlottingSum,
 import           Pos.Slotting.MemState            (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Ssc.Class.Types              (HasSscContext (..), SscBlock)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
+import           Pos.Txp.DB.Utxo                  (getTxOut)
+import           Pos.Txp.Toil.Class               (MonadUtxoRead (..))
 import           Pos.Update.Configuration         (HasUpdateConfiguration)
 import           Pos.Util                         (Some (..))
 import           Pos.Util.JsonLog                 (HasJsonLogConfig (..), jsonLogDefault)
@@ -223,6 +225,9 @@ instance HasConfiguration => MonadDB WalletWebMode where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
+
+instance HasConfiguration => MonadUtxoRead WalletWebMode where
+    utxoGet = getTxOut
 
 instance (HasConfiguration, HasGtConfiguration) =>
          MonadBlockDBGenericWrite (BlockHeader WalletSscType) (Block WalletSscType) Undo WalletWebMode where

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -19,6 +19,8 @@ import           System.Wlog                  (WithLogger, logDebug, logInfo, lo
 
 import           Pos.Client.Txp.History       (saveTx)
 import           Pos.Communication            (EnqueueMsg, submitTxRaw)
+import           Pos.Configuration            (walletTxCreationDisabled)
+import           Pos.Wallet.Web.Error         (WalletError (..))
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..),
                                                PtxPoolInfo)
@@ -110,6 +112,10 @@ submitAndSavePtx
     :: MonadWalletWebMode m
     => PtxSubmissionHandlers m -> EnqueueMsg m -> PendingTx -> m ()
 submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
+    -- this should've been checked before, but just in case
+    when walletTxCreationDisabled $
+        throwM $ InternalError "Transaction creation is disabled by configuration!"
+
     ack <- submitTxRaw enqueue _ptxTxAux
     reportSubmitted ack
     saveTx (_ptxTxId, _ptxTxAux) `catches` handlers ack

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -15,11 +15,13 @@ import           Data.Time.Units                   (Microsecond, Second, convert
 import           Formatting                        (build, sformat, (%))
 import           Mockable                          (delay, fork)
 import           Serokell.Util.Text                (listJson)
-import           System.Wlog                       (logInfo, modifyLoggerName)
+import           System.Wlog                       (logDebug, logInfo, modifyLoggerName)
 
 import           Pos.Client.Txp.Addresses          (MonadAddresses)
 import           Pos.Communication.Protocol        (SendActions (..))
-import           Pos.Configuration                 (HasNodeConfiguration, pendingTxResubmitionPeriod)
+import           Pos.Configuration                 (HasNodeConfiguration,
+                                                    pendingTxResubmitionPeriod,
+                                                    walletTxCreationDisabled)
 import           Pos.Core                          (ChainDifficulty (..), SlotId (..),
                                                     difficultyL)
 import           Pos.Core.Configuration            (HasConfiguration)
@@ -125,7 +127,10 @@ processPtxs
     => SendActions m -> SlotId -> [PendingTx] -> m ()
 processPtxs sendActions curSlot ptxs = do
     mapM_ processPtxInNewestBlocks ptxs
-    processPtxsToResubmit sendActions curSlot ptxs
+
+    if walletTxCreationDisabled
+    then logDebug "Transaction resubmission is disabled"
+    else processPtxsToResubmit sendActions curSlot ptxs
 
 processPtxsOnSlot
     :: MonadPendings m

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -99,11 +99,12 @@ resubmitPtxsDuringSlot sendActions ptxs = do
 processPtxsToResubmit
     :: MonadPendings m
     => SendActions m -> SlotId -> [PendingTx] -> m ()
-processPtxsToResubmit sendActions curSlot ptxs = do
+processPtxsToResubmit sendActions _curSlot ptxs = do
     ptxsPerSlotLimit <- evalPtxsPerSlotLimit
     let toResubmit =
-            take ptxsPerSlotLimit $
-            filter ((curSlot >=) . view ptxNextSubmitSlot) $
+            take (min 1 ptxsPerSlotLimit) $  -- for now the limit will be 1,
+                                             -- though properly “min 1”
+                                             -- shouldn't be needed
             filter (has _PtxApplying . _ptxCond) $
             ptxs
     logInfo $ sformat fmt (map _ptxTxId toResubmit)

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -77,6 +77,8 @@ servantHandlers sendActions =
     :<|>
      M.cancelOneApplyingPtx
     :<|>
+     M.reevaluateAllUncertainPtxs
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -75,6 +75,8 @@ servantHandlers sendActions =
     :<|>
      M.cancelAllApplyingPtxs
     :<|>
+     M.cancelOneApplyingPtx
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -73,6 +73,8 @@ servantHandlers sendActions =
     :<|>
      M.resetAllFailedPtxs
     :<|>
+     M.cancelAllApplyingPtxs
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -71,6 +71,8 @@ servantHandlers sendActions =
     :<|>
      M.getTxFee
     :<|>
+     M.resetAllFailedPtxs
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -75,6 +75,8 @@ servantHandlers sendActions =
     :<|>
      M.getHistoryLimited
     :<|>
+     M.gatherPendingTxsSummary
+    :<|>
 
      M.nextUpdate
     :<|>

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -143,6 +143,12 @@ instance HasCustomSwagger UpdateTx where
     swaggerModifier = modifyDescription
         "Update payment transaction."
 
+instance HasCustomSwagger ResetFailedPtxs where
+    swaggerModifier = modifyDescription
+        "For all transactions in CPtxWontApply condition, \
+        \reset them to CPtxApplying condition so that they will \
+        \be passed to resubmition"
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -157,6 +157,11 @@ instance HasCustomSwagger CancelSpecificApplyingPtx where
     swaggerModifier = modifyDescription
         "Cancels specific transaction in CPtxApplying condition."
 
+instance HasCustomSwagger ReevaluateUncertainPtxs where
+    swaggerModifier = modifyDescription
+        "Reevaluates the status of all transactions in CPtxApplying \
+        \or CPtxWontApply conditions."
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -153,6 +153,10 @@ instance HasCustomSwagger CancelApplyingPtxs where
     swaggerModifier = modifyDescription
         "Cancels all transactions in CPtxApplying condition (unconfirmed)."
 
+instance HasCustomSwagger CancelSpecificApplyingPtx where
+    swaggerModifier = modifyDescription
+        "Cancels specific transaction in CPtxApplying condition."
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -149,6 +149,10 @@ instance HasCustomSwagger ResetFailedPtxs where
         \reset them to CPtxApplying condition so that they will \
         \be passed to resubmition"
 
+instance HasCustomSwagger CancelApplyingPtxs where
+    swaggerModifier = modifyDescription
+        "Cancels all transactions in CPtxApplying condition (unconfirmed)."
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -147,6 +147,10 @@ instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."
 
+instance HasCustomSwagger GetPendingTxsSummary where
+    swaggerModifier = modifyDescription
+        "Get list of all unconfirmed transactions, newest first, with details."
+
 
 instance HasCustomSwagger NextUpdate where
     swaggerModifier = modifyDescription

--- a/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
@@ -28,7 +28,7 @@ import qualified Pos.Wallet.Web.ClientTypes  as CT
 import qualified Pos.Wallet.Web.Error.Types  as ET
 
 import           Pos.Aeson.Storage           ()
-import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot)
+import           Pos.Wallet.Web.Methods.Misc (PendingTxsSummary, WalletStateSnapshot)
 
 -- | Instances we need to build Swagger-specification for 'walletApi':
 -- 'ToParamSchema' - for types in parameters ('Capture', etc.),
@@ -81,6 +81,9 @@ instance ToParamSchema CT.CPassPhrase
 
 instance ToSchema WalletStateSnapshot where
     declareNamedSchema _ = pure $ NamedSchema (Just "WalletStateSnapshot") mempty
+
+instance ToSchema PendingTxsSummary where
+    declareNamedSchema _ = pure $ NamedSchema (Just "PendingTxsSummary") mempty
 
 instance ToSchema FileData where
     declareNamedSchema _ = do


### PR DESCRIPTION
**a,b.** Added options to config to disable hazard endpoints and disable transactions creation. Log values at beginning of wallet run.
**c.** Added endpoint to see pending (or canceled) transactions summary
Example of output: ~https://pastebin.com/Y72HTs2H~ https://pastebin.com/80Bp1Uya
**d.** Cherry-picked `fea9971` with endpoint to reset pending transaction (from CSL-2020) and added endpoint to cancel unconfirmed transactions
**5a.** Add endpoint to reform cancelled transactions

Correctness testing:
* [x] a, b
* [x] c
* [x] d
* [x] 5a