### PR TITLE
[CSL-2135] Add endpoint to remove all canceled transactions from pending list

### DIFF
--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -74,6 +74,7 @@ module Pos.Wallet.Web.State.Acidic
        , ResetFailedPtxs (..)
        , CancelApplyingPtxs (..)
        , CancelSpecificApplyingPtx (..)
+       , RemovePtx (..)
        , RemoveCanceledPtxs (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
@@ -185,6 +186,7 @@ makeAcidic ''WalletStorage
     , 'WS.resetFailedPtxs
     , 'WS.cancelApplyingPtxs
     , 'WS.cancelSpecificApplyingPtx
+    , 'WS.removePtx
     , 'WS.removeCanceledPtxs
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -74,6 +74,7 @@ module Pos.Wallet.Web.State.Acidic
        , ResetFailedPtxs (..)
        , CancelApplyingPtxs (..)
        , CancelSpecificApplyingPtx (..)
+       , RemoveCanceledPtxs (..)
        , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
@@ -184,6 +185,7 @@ makeAcidic ''WalletStorage
     , 'WS.resetFailedPtxs
     , 'WS.cancelApplyingPtxs
     , 'WS.cancelSpecificApplyingPtx
+    , 'WS.removeCanceledPtxs
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     ]

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -85,43 +85,47 @@ module Pos.Wallet.Web.State.State
        , cancelApplyingPtxs
        , cancelSpecificApplyingPtx
        , reevaluateUncertainPtxs
+       , removeCanceledPtxs
        , getWalletStorage
        , flushWalletStorage
        ) where
 
-import           Control.Lens                 (ifor_)
-import           Data.Acid                    (EventResult, EventState, QueryEvent,
-                                               UpdateEvent)
-import qualified Data.Map                     as Map
-import qualified Data.HashMap.Strict          as HM
-import           Ether.Internal               (HasLens (..))
-import           Mockable                     (MonadMockable)
-import           System.Wlog (WithLogger)
+import           Control.Lens                     (ifor_)
+import           Data.Acid                        (EventResult, EventState, QueryEvent,
+                                                   UpdateEvent)
+import qualified Data.HashMap.Strict              as HM
+import qualified Data.Map                         as Map
+import           Ether.Internal                   (HasLens (..))
+import           Mockable                         (MonadMockable)
+import           System.Wlog                      (WithLogger)
 import           Universum
 
-import           Pos.Client.Txp.History       (TxHistoryEntry)
-import           Pos.Core.Configuration       (HasConfiguration)
-import           Pos.DB.Block                 (MonadBlockDB)
-import           Pos.Wallet.SscType           (WalletSscType)
-import           Pos.StateLock                (MonadStateLock)
-import           Pos.Txp                      (TxId, Utxo, UtxoModifier, MonadUtxoRead)
-import           Pos.Types                    (HeaderHash, SlotId)
-import           Pos.Util.Servant             (encodeCType)
-import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CId,
-                                               CProfile, CTxId, CTxMeta, CUpdateInfo,
-                                               CWAddressMeta, CWalletMeta, PassPhraseLU,
-                                               Wal)
-import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition,
-                                               ptxWallet, ptxCond, ptxTxId)
+import           Pos.Client.Txp.History           (TxHistoryEntry)
+import           Pos.Core.Configuration           (HasConfiguration)
+import           Pos.DB.Block                     (MonadBlockDB)
+import           Pos.StateLock                    (MonadStateLock)
+import           Pos.Txp                          (MonadUtxoRead, TxId, Utxo,
+                                                   UtxoModifier)
+import           Pos.Types                        (HeaderHash, SlotId)
+import           Pos.Util.Servant                 (encodeCType)
+import           Pos.Wallet.SscType               (WalletSscType)
+import           Pos.Wallet.Web.ClientTypes       (AccountId, Addr, CAccountMeta, CId,
+                                                   CProfile, CTxId, CTxMeta, CUpdateInfo,
+                                                   CWAddressMeta, CWalletMeta,
+                                                   PassPhraseLU, Wal)
 import qualified Pos.Wallet.Web.Pending.Functions as F
-import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
-                                               openState)
-import           Pos.Wallet.Web.State.Acidic  as A
-import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMode (..),
-                                               CurrentAndRemoved (..),
-                                               CustomAddressType (..), NeedSorting (..),
-                                               PtxMetaUpdate (..), WalletBalances,
-                                               WalletStorage, WalletTip (..))
+import           Pos.Wallet.Web.Pending.Types     (PendingTx (..), PtxCondition, ptxCond,
+                                                   ptxTxId, ptxWallet)
+import           Pos.Wallet.Web.State.Acidic      (WalletState, closeState, openMemState,
+                                                   openState)
+import           Pos.Wallet.Web.State.Acidic      as A
+import           Pos.Wallet.Web.State.Storage     (AddressInfo (..),
+                                                   AddressLookupMode (..),
+                                                   CurrentAndRemoved (..),
+                                                   CustomAddressType (..),
+                                                   NeedSorting (..), PtxMetaUpdate (..),
+                                                   WalletBalances, WalletStorage,
+                                                   WalletTip (..))
 
 -- | MonadWalletWebDB stands for monad which is able to get web wallet state
 type MonadWalletWebDB ctx m =
@@ -360,6 +364,9 @@ cancelApplyingPtxs = updateDisk ... A.CancelApplyingPtxs
 
 cancelSpecificApplyingPtx :: WebWalletModeDB ctx m => TxId -> m ()
 cancelSpecificApplyingPtx txid = updateDisk ... A.CancelSpecificApplyingPtx txid
+
+removeCanceledPtxs :: WebWalletModeDB ctx m => m ()
+removeCanceledPtxs = updateDisk A.RemoveCanceledPtxs
 
 -- TODO: we might also want to give out a list of transactions that we've
 -- failed to update

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -86,6 +86,7 @@ module Pos.Wallet.Web.State.State
        , cancelSpecificApplyingPtx
        , reevaluateUncertainPtxs
        , removeCanceledPtxs
+       , removePtx
        , getWalletStorage
        , flushWalletStorage
        ) where
@@ -367,6 +368,9 @@ cancelSpecificApplyingPtx txid = updateDisk ... A.CancelSpecificApplyingPtx txid
 
 removeCanceledPtxs :: WebWalletModeDB ctx m => m ()
 removeCanceledPtxs = updateDisk A.RemoveCanceledPtxs
+
+removePtx :: WebWalletModeDB ctx m => TxId -> m ()
+removePtx = updateDisk . A.RemovePtx
 
 -- TODO: we might also want to give out a list of transactions that we've
 -- failed to update

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -80,6 +80,7 @@ module Pos.Wallet.Web.State.Storage
        , setPtxCondition
        , casPtxCondition
        , ptxUpdateMeta
+       , removePtx
        , removeCanceledPtxs
        , addOnlyNewPendingTx
        , resetFailedPtxs
@@ -535,6 +536,10 @@ cancelSpecificApplyingPtx :: TxId -> Update ()
 cancelSpecificApplyingPtx txId =
     wsWalletInfos . traversed .
     wsPendingTxs . ix txId %= cancelApplyingPtx
+
+removePtx :: TxId -> Update ()
+removePtx txId =
+    wsWalletInfos . traversed . wsPendingTxs . at txId .= Nothing
 
 removeCanceledPtxs :: Update ()
 removeCanceledPtxs =

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -45,6 +45,7 @@ module Pos.Wallet.Web.Api
        , CancelApplyingPtxs
        , CancelSpecificApplyingPtx
        , ReevaluateUncertainPtxs
+       , DeleteCanceledPtxs
        , UpdateTx
        , GetHistory
        , GetPendingTxsSummary
@@ -323,6 +324,12 @@ type ReevaluateUncertainPtxs =
     :> "reevaluate"
     :> WRes Post ()
 
+type DeleteCanceledPtxs =
+       "txs"
+    :> "pending"
+    :> "canceled"
+    :> WRes Delete ()
+
 type GetHistory =
        "txs"
     :> "histories"
@@ -499,6 +506,8 @@ type WalletApi = ApiPrefix :> (
      CancelSpecificApplyingPtx
     :<|>
      ReevaluateUncertainPtxs
+    :<|>
+     DeleteCanceledPtxs
     :<|>
       -- FIXME: Should capture the URL parameters in the payload.
      UpdateTx

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -45,6 +45,7 @@ module Pos.Wallet.Web.Api
        , CancelApplyingPtxs
        , CancelSpecificApplyingPtx
        , ReevaluateUncertainPtxs
+       , DeletePtx
        , DeleteCanceledPtxs
        , UpdateTx
        , GetHistory
@@ -324,6 +325,13 @@ type ReevaluateUncertainPtxs =
     :> "reevaluate"
     :> WRes Post ()
 
+type DeletePtx =
+       "txs"
+    :> "pending"
+    :> "any"
+    :> CCapture "transaction" CTxId
+    :> WRes Delete ()
+
 type DeleteCanceledPtxs =
        "txs"
     :> "pending"
@@ -506,6 +514,8 @@ type WalletApi = ApiPrefix :> (
      CancelSpecificApplyingPtx
     :<|>
      ReevaluateUncertainPtxs
+    :<|>
+     DeletePtx
     :<|>
      DeleteCanceledPtxs
     :<|>

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -25,6 +25,7 @@ module Pos.Wallet.Web.Methods.Misc
        , cancelAllApplyingPtxs
        , cancelOneApplyingPtx
        , reevaluateAllUncertainPtxs
+       , deletePtx
        , deleteCanceledPtxs
        ) where
 
@@ -65,7 +66,8 @@ import           Pos.Wallet.Web.State         (cancelApplyingPtxs,
                                                getPendingTxs, getProfile,
                                                getWalletStorage, reevaluateUncertainPtxs,
                                                removeCanceledPtxs, removeNextUpdate,
-                                               resetFailedPtxs, setProfile, testReset)
+                                               removePtx, resetFailedPtxs, setProfile,
+                                               testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoint)
 
@@ -227,3 +229,6 @@ reevaluateAllUncertainPtxs = testOnlyEndpoint reevaluateUncertainPtxs
 
 deleteCanceledPtxs :: MonadWalletWebMode m => m ()
 deleteCanceledPtxs = testOnlyEndpoint removeCanceledPtxs
+
+deletePtx :: MonadWalletWebMode m => TxId -> m ()
+deletePtx = removePtx

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -25,6 +25,7 @@ module Pos.Wallet.Web.Methods.Misc
        , cancelAllApplyingPtxs
        , cancelOneApplyingPtx
        , reevaluateAllUncertainPtxs
+       , deleteCanceledPtxs
        ) where
 
 import           Universum
@@ -40,9 +41,9 @@ import           Servant.API.ContentTypes     (MimeRender (..), OctetStream)
 import           Pos.Aeson.ClientTypes        ()
 import           Pos.Core                     (SlotId, SoftwareVersion (..),
                                                decodeTextAddress)
-import           Pos.Crypto                   (hashHexF, hash)
+import           Pos.Crypto                   (hash, hashHexF)
 import           Pos.Slotting                 (getCurrentSlotBlocking)
-import           Pos.Txp                      (Tx (..), TxAux (..), TxIn, TxOut, TxId)
+import           Pos.Txp                      (Tx (..), TxAux (..), TxId, TxIn, TxOut)
 import           Pos.Update.Configuration     (curSoftwareVersion)
 import           Pos.Util                     (maybeThrow)
 import           Pos.Util.Servant             (HasTruncateLogPolicy (..), encodeCType)
@@ -63,7 +64,7 @@ import           Pos.Wallet.Web.State         (cancelApplyingPtxs,
                                                cancelSpecificApplyingPtx, getNextUpdate,
                                                getPendingTxs, getProfile,
                                                getWalletStorage, reevaluateUncertainPtxs,
-                                               removeNextUpdate,
+                                               removeCanceledPtxs, removeNextUpdate,
                                                resetFailedPtxs, setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoint)
@@ -223,3 +224,6 @@ cancelOneApplyingPtx cTxId = do
 
 reevaluateAllUncertainPtxs :: MonadWalletWebMode m => m ()
 reevaluateAllUncertainPtxs = testOnlyEndpoint reevaluateUncertainPtxs
+
+deleteCanceledPtxs :: MonadWalletWebMode m => m ()
+deleteCanceledPtxs = testOnlyEndpoint removeCanceledPtxs

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -79,6 +79,8 @@ servantHandlers sendActions =
     :<|>
      M.reevaluateAllUncertainPtxs
     :<|>
+     M.deletePtx
+    :<|>
      M.deleteCanceledPtxs
     :<|>
      M.updateTransaction

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -79,6 +79,8 @@ servantHandlers sendActions =
     :<|>
      M.reevaluateAllUncertainPtxs
     :<|>
+     M.deleteCanceledPtxs
+    :<|>
      M.updateTransaction
     :<|>
      M.getHistoryLimited

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -162,6 +162,10 @@ instance HasCustomSwagger ReevaluateUncertainPtxs where
         "Reevaluates the status of all transactions in CPtxApplying \
         \or CPtxWontApply conditions."
 
+instance HasCustomSwagger DeleteCanceledPtxs where
+    swaggerModifier = modifyDescription
+        "Removes all canceled transactions from list tracked by resubmitter"
+
 instance HasCustomSwagger GetHistory where
     swaggerModifier = modifyDescription
         "Get the history of transactions."

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -162,6 +162,10 @@ instance HasCustomSwagger ReevaluateUncertainPtxs where
         "Reevaluates the status of all transactions in CPtxApplying \
         \or CPtxWontApply conditions."
 
+instance HasCustomSwagger DeletePtx where
+    swaggerModifier = modifyDescription
+        "Delete given transaction from resubmitter sight"
+
 instance HasCustomSwagger DeleteCanceledPtxs where
     swaggerModifier = modifyDescription
         "Removes all canceled transactions from list tracked by resubmitter"


### PR DESCRIPTION
Two endpoints:
* Bulk removal of canceled transactions - for a new version of plan.
* Removal of specific transaction - for old plan if occur to be needed

Tested with `Applying`, `InBlocks` and manually created `WontApply` transactions