### PR TITLE
add nix enable flag into stack config file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -94,6 +94,7 @@ packages:
   extra-dep: true
 
 nix:
+  enable: true
   shell-file: shell.nix
 
 extra-deps:


### PR DESCRIPTION
without the flag setting build process doesn't work properly.
The PR solves the issue #2223