### PR TITLE
[CSM-500] Remember pending transaction from the very beginning

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -74,6 +74,7 @@ txIdToCTxId = mkCTxId . sformat hashHexF
 
 ptxCondToCPtxCond :: Maybe PtxCondition -> CPtxCondition
 ptxCondToCPtxCond = maybe CPtxNotTracked $ \case
+    PtxCreating{}       -> CPtxCreating
     PtxApplying{}       -> CPtxApplying
     PtxInNewestBlocks{} -> CPtxInBlocks
     PtxPersisted{}      -> CPtxInBlocks

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -261,7 +261,8 @@ data CTxMeta = CTxMeta
 -- @PtxInNewestBlocks@ and @PtxPersisted@ states are merged into one
 -- not to provide information which conflicts with 'ctConfirmations'.
 data CPtxCondition
-    = CPtxApplying
+    = CPtxCreating  -- not for displaying to frontend
+    | CPtxApplying
     | CPtxInBlocks
     | CPtxWontApply
     | CPtxNotTracked  -- ^ tx was made not in this life

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -69,6 +69,7 @@ module Pos.Wallet.Web.State.Acidic
        , RemoveFromHistoryCache (..)
        , SetPtxCondition (..)
        , CasPtxCondition (..)
+       , RemoveOnlyCreatingPtx (..)
        , PtxUpdateMeta (..)
        , AddOnlyNewPendingTx (..)
        , ResetFailedPtxs (..)
@@ -179,6 +180,7 @@ makeAcidic ''WalletStorage
     , 'WS.removeFromHistoryCache
     , 'WS.setPtxCondition
     , 'WS.casPtxCondition
+    , 'WS.removeOnlyCreatingPtx
     , 'WS.ptxUpdateMeta
     , 'WS.addOnlyNewPendingTx
     , 'WS.resetFailedPtxs

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -79,6 +79,7 @@ module Pos.Wallet.Web.State.State
        , setWalletUtxo
        , setPtxCondition
        , casPtxCondition
+       , removeOnlyCreatingPtx
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , resetFailedPtxs
@@ -343,6 +344,11 @@ casPtxCondition
     :: WebWalletModeDB ctx m
     => CId Wal -> TxId -> PtxCondition -> PtxCondition -> m Bool
 casPtxCondition = updateDisk ... A.CasPtxCondition
+
+removeOnlyCreatingPtx
+    :: WebWalletModeDB ctx m
+    => CId Wal -> TxId -> m Bool
+removeOnlyCreatingPtx = updateDisk ... A.RemoveOnlyCreatingPtx
 
 ptxUpdateMeta
     :: WebWalletModeDB ctx m

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -79,6 +79,7 @@ module Pos.Wallet.Web.State.Storage
        , removeFromHistoryCache
        , setPtxCondition
        , casPtxCondition
+       , removeOnlyCreatingPtx
        , ptxUpdateMeta
        , addOnlyNewPendingTx
        , resetFailedPtxs
@@ -88,16 +89,18 @@ module Pos.Wallet.Web.State.Storage
 
 import           Universum
 
-import           Control.Lens                   (at, ix, makeClassy, makeLenses, non', to,
-                                                 toListOf, traversed, (%=), (+=), (.=),
-                                                 (<<.=), (?=), _Empty, _head)
-import           Control.Monad.State.Class      (put)
+import           Control.Lens                   (at, has, ix, makeClassy, makeLenses, non',
+                                                 to, toListOf, traversed, (%=), (+=), (.=),
+                                                 (<<.=), (?=), _Empty, _Just, _head)
+import           Control.Monad.State.Class      (get, put)
+import qualified Control.Monad.State.Lazy       as LS
 import           Data.Default                   (Default, def)
 import qualified Data.HashMap.Strict            as HM
 import qualified Data.Map                       as M
 import           Data.SafeCopy                  (Migrate (..), base, deriveSafeCopySimple,
                                                  extension)
 import           Data.Time.Clock.POSIX          (POSIXTime)
+import           Serokell.Util                  (zoom')
 
 import           Pos.Client.Txp.History         (TxHistoryEntry, txHistoryListToMap)
 import           Pos.Core.Configuration         (HasConfiguration)
@@ -115,7 +118,7 @@ import           Pos.Wallet.Web.ClientTypes     (AccountId, Addr, CAccountMeta, 
                                                  PassPhraseLU, Wal, addrMetaToAccount)
 import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition,
                                                  PtxSubmitTiming (..), ptxCond,
-                                                 ptxSubmitTiming)
+                                                 ptxSubmitTiming, _PtxCreating)
 import           Pos.Wallet.Web.Pending.Updates (cancelApplyingPtx,
                                                  incPtxSubmitTimingPure,
                                                  mkPtxSubmitTiming,
@@ -494,14 +497,29 @@ setPtxCondition :: CId Wal -> TxId -> PtxCondition -> Update ()
 setPtxCondition wid txId cond =
     wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond .= cond
 
+-- | Conditional modifier.
+-- Returns 'True' if pending transaction existed and modification was applied.
+checkAndSmthPtx
+    :: CId Wal
+    -> TxId
+    -> (Maybe PtxCondition -> Bool)
+    -> LS.State (Maybe PendingTx) ()
+    -> Update Bool
+checkAndSmthPtx wid txId whetherModify modifier =
+    fmap getAny $ zoom' (wsWalletInfos . ix wid . wsPendingTxs . at txId) $ do
+        matches <- whetherModify . fmap _ptxCond <$> get
+        when matches modifier
+        return (Any matches)
+
 -- | Compare-and-set version of 'setPtxCondition'.
--- Returns 'True' if transaction existed and modification was applied.
 casPtxCondition :: CId Wal -> TxId -> PtxCondition -> PtxCondition -> Update Bool
-casPtxCondition wid txId expectedCond newCond = do
-    oldCond <- preuse $ wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond
-    let success = oldCond == Just expectedCond
-    when success $ setPtxCondition wid txId newCond
-    return success
+casPtxCondition wid txId expectedCond newCond =
+    checkAndSmthPtx wid txId (== Just expectedCond) (_Just . ptxCond .= newCond)
+
+-- | Removes pending transaction, if its status is 'PtxCreating'.
+removeOnlyCreatingPtx :: CId Wal -> TxId -> Update Bool
+removeOnlyCreatingPtx wid txId =
+    checkAndSmthPtx wid txId (has (_Just . _PtxCreating)) (put Nothing)
 
 data PtxMetaUpdate
     = PtxIncSubmitTiming

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2252,8 +2252,8 @@ self: {
           pname = "comonad";
           version = "5.0.2";
           sha256 = "115pai560rllsmym76bj787kwz5xx19y8bl6262005nddqwzxc0v";
-          revision = "1";
-          editedCabalFile = "1lnsnx8p3wlfhd1xfc68za3b00vq77z2m6b0vqiw2laqmpj9akcw";
+          revision = "2";
+          editedCabalFile = "1ngks9bym68rw0xdq43n14nay4kxdxv2n7alwfd9wcpismfz009g";
           setupHaskellDepends = [
             base
             Cabal
@@ -4744,8 +4744,8 @@ self: {
           pname = "natural-transformation";
           version = "0.4";
           sha256 = "1by8xwjc23l6pa9l4iv7zp82dykpll3vc3hgxk0pgva724n8xhma";
-          revision = "2";
-          editedCabalFile = "1j90pd1zznr18966axskad5w0kx4dvqg62r65rmw1ihqwxm1ndix";
+          revision = "3";
+          editedCabalFile = "0z6vmdgz9r2fbgzh2xvrw6cy5h7m1jv911jah615s6xgr52smhrf";
           libraryHaskellDepends = [
             base
           ];

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -13,7 +13,7 @@ module Pos.Wallet.Web.Pending.Submission
 
 import           Universum
 
-import           Control.Monad.Catch          (Handler (..), catches)
+import           Control.Monad.Catch          (Handler (..), catches, onException)
 import           Formatting                   (build, sformat, shown, stext, (%))
 import           System.Wlog                  (WithLogger, logDebug, logInfo, logWarning)
 import           Serokell.Util                (hour)
@@ -22,14 +22,16 @@ import           Pos.Client.Txp.History       (saveTx, thTimestamp)
 import           Pos.Communication            (EnqueueMsg, submitTxRaw)
 import           Pos.Configuration            (walletTxCreationDisabled)
 import           Pos.Core                     (getCurrentTimestamp, diffTimestamp)
+import           Pos.Util.Util                (maybeThrow)
 import           Pos.Wallet.Web.Error         (WalletError (..))
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition (..),
                                                PtxPoolInfo)
-import           Pos.Wallet.Web.Pending.Util  (isReclaimableFailure)
+import           Pos.Wallet.Web.Pending.Util  (isReclaimableFailure, ptxPoolInfo,
+                                               usingPtxCoords)
 import           Pos.Wallet.Web.State         (PtxMetaUpdate (PtxMarkAcknowledged),
                                                addOnlyNewPendingTx, casPtxCondition,
-                                               ptxUpdateMeta)
+                                               ptxUpdateMeta, removeOnlyCreatingPtx)
 
 -- | Handers used for to procees various pending transaction submission
 -- errors.
@@ -115,10 +117,15 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
                       \the 1h time limit was exceeded")
                       _ptxTxId
        | otherwise -> do
-           saveTx (_ptxTxId, _ptxTxAux) `catches` handlers
+           (saveTx (_ptxTxId, _ptxTxAux)
+               `catches` handlers)
+               `onException` creationFailedHandler
            addOnlyNewPendingTx ptx
            ack <- submitTxRaw enqueue _ptxTxAux
            reportSubmitted ack
+
+           poolInfo <- badInitPtxCondition `maybeThrow` ptxPoolInfo _ptxCond
+           _ <- usingPtxCoords casPtxCondition ptx _ptxCond (PtxApplying poolInfo)
            when ack $ ptxUpdateMeta _ptxWallet _ptxTxId PtxMarkAcknowledged
   where
     handlers =
@@ -132,7 +139,6 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
             -- but it's better to try with tx again than to regret, right?
             minorError "unknown error" e
         ]
-
     minorError desc e = do
         reportError desc e ", but was given another chance"
         pshOnMinor e
@@ -148,3 +154,11 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
         logDebug $
         sformat ("submitAndSavePtx: transaction submitted with confirmation?: "
                 %build) ack
+
+    creationFailedHandler =
+        -- tx creation shouldn't fail if any of peers accepted our tx, but still,
+        -- if transaction was detected in blocks and its state got updated by tracker
+        -- while transaction creation failed, due to protocol error or bug,
+        -- then we better not remove this pending transaction
+        void $ usingPtxCoords removeOnlyCreatingPtx ptx
+    badInitPtxCondition = InternalError "Expected PtxCreating as initial pending condition"

--- a/wallet/src/Pos/Wallet/Web/Pending/Util.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Util.hs
@@ -5,6 +5,7 @@
 
 module Pos.Wallet.Web.Pending.Util
     ( ptxPoolInfo
+    , isPtxActive
     , isPtxInBlocks
     , sortPtxsChrono
     , mkPendingTx
@@ -32,9 +33,16 @@ import           Pos.Wallet.Web.Pending.Updates (mkPtxSubmitTiming)
 import           Pos.Wallet.Web.State           (getWalletMeta)
 
 ptxPoolInfo :: PtxCondition -> Maybe PtxPoolInfo
-ptxPoolInfo (PtxApplying i)    = Just i
-ptxPoolInfo (PtxWontApply _ i) = Just i
-ptxPoolInfo _                  = Nothing
+ptxPoolInfo (PtxCreating i)     = Just i
+ptxPoolInfo (PtxApplying i)     = Just i
+ptxPoolInfo (PtxWontApply _ i)  = Just i
+ptxPoolInfo PtxInNewestBlocks{} = Nothing
+ptxPoolInfo PtxPersisted{}      = Nothing
+
+-- | Whether transaction is claimed to be once created.
+isPtxActive :: PtxCondition -> Bool
+isPtxActive PtxCreating{} = False
+isPtxActive _             = True
 
 isPtxInBlocks :: PtxCondition -> Bool
 isPtxInBlocks = isNothing . ptxPoolInfo
@@ -53,7 +61,7 @@ mkPendingTx wid _ptxTxId _ptxTxAux th = do
     _ptxCreationSlot <- getCurrentSlotInaccurate
     CWalletMeta{..} <- maybeThrow noWallet =<< getWalletMeta wid
     return PendingTx
-        { _ptxCond = PtxApplying th
+        { _ptxCond = PtxCreating th
         , _ptxWallet = wid
         , _ptxPeerAck = False
         , _ptxSubmitTiming = mkPtxSubmitTiming _ptxCreationSlot


### PR DESCRIPTION
This is important, because if we add transaction to pending list once transaction creation is done,
then creation and addition to pending list may complete only after the moment when transaction gets to
blocks, so on this "transaction detected in blocks" nothing effectively happens. (and adding transaction to pending list once it detected in block is problematic, because there are many meta info to be stored along with pending transaction which may be not accessible from block tracker context)

Solution is to add new pending transaction status, `PtxCreating`, in which
transaction is not displayed to frontend, and such transaction may be safely removed if
full cycle of transaction creation finishes with fatal error (unlike
`PtxApplying`).
Transaction remembered with this status still caries all pending meta info,
so blocks tracker can successfully update status of that transaction.

(cherry picked from commit 2c1cfa3290af33e4b34f6f6ebfe46315af1ce2cb)
  