### PR TITLE
Incorrect cardano static binary/attribute name

### DIFF
--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -56,7 +56,7 @@ Two steps remain, then:
 2.  Actually building the Cardano SL node (or, most likely, simply obtaining it
     from the IOHK's binary caches) can be performed by building the attribute `cardano-sl-node-static`:
 
-        $ nix-build -A cardano-sl-node-static --cores 0 --max-jobs 2 --no-build-output --out-link master
+        $ nix-build -A cardano-sl-static --cores 0 --max-jobs 2 --no-build-output --out-link master
 
     The build output directory will be symlinked as `master` (as specified by the command), and it will contain:
 


### PR DESCRIPTION
Followed exact directions on Centos 7.4 to build cardano bin. It fails unless the bin name is changed to 'cardano-sl-static'.

[martin@macedonia cardano-sl]$ nix-build -A cardano-sl-node-static --cores 0 --max-jobs 2 --no-build-output --out-link master
error: attribute ‘cardano-sl-node-static’ in selection path ‘cardano-sl-node-static’ not found
[martin@macedonia cardano-sl]$

'cardano-sl-node-static' may have been valid at some point, but no longer.
  