### PR TITLE
[CSL-2135] Add options to disable tx creation and hazard endpoints

### DIFF
--- a/node/configuration.yaml
+++ b/node/configuration.yaml
@@ -118,6 +118,8 @@ dev: &dev
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
+    walletProductionApi: false
+    walletTxCreationDisabled: false
 
 
 ##############################################################################
@@ -305,6 +307,8 @@ mainnet_base: &mainnet_base
     blockRetrievalQueueSize: 100
     propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
+    walletProductionApi: true
+    walletTxCreationDisabled: false
 
 
 ##############################################################################

--- a/node/src/Pos/Configuration.hs
+++ b/node/src/Pos/Configuration.hs
@@ -26,8 +26,10 @@ module Pos.Configuration
        -- * Malicious activity detection constants
        , mdNoBlocksSlotThreshold
 
-       -- * Transaction resubmition constants
+       -- * Wallet constants
        , pendingTxResubmitionPeriod
+       , walletProductionApi
+       , walletTxCreationDisabled
        ) where
 
 import           Universum
@@ -76,6 +78,11 @@ data NodeConfiguration = NodeConfiguration
       -- ^ InvMsg propagation queue capacity
     , ccPendingTxResubmissionPeriod :: !Int
       -- ^ Minimal delay between pending transactions resubmission
+    , ccWalletProductionApi         :: !Bool
+      -- ^ Whether hazard wallet endpoint should be disabled
+    , ccWalletTxCreationDisabled    :: !Bool
+      -- ^ Disallow transaction creation or re-submission of
+      -- pending transactions by the wallet
     } deriving (Show, Generic)
 
 instance FromJSON NodeConfiguration where
@@ -148,8 +155,18 @@ mdNoBlocksSlotThreshold :: (HasNodeConfiguration, Integral i) => i
 mdNoBlocksSlotThreshold = fromIntegral . ccMdNoBlocksSlotThreshold $ nodeConfiguration
 
 ----------------------------------------------------------------------------
--- Transactions resubmition
+-- Wallet parameters
 ----------------------------------------------------------------------------
 
 pendingTxResubmitionPeriod :: HasNodeConfiguration => Second
 pendingTxResubmitionPeriod = fromIntegral . ccPendingTxResubmissionPeriod $ nodeConfiguration
+
+-- | If 'True', some dangerous endpoints, like one which resets wallet state,
+-- should throw exception if used.
+walletProductionApi :: HasNodeConfiguration => Bool
+walletProductionApi = ccWalletProductionApi $ nodeConfiguration
+
+-- | If 'True', wallet should *not* create new transactions or re-submit
+-- existing pending transactions.
+walletTxCreationDisabled :: HasNodeConfiguration => Bool
+walletTxCreationDisabled = ccWalletTxCreationDisabled $ nodeConfiguration

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -11,13 +11,16 @@ module Pos.Wallet.Web.Util
     , getWalletAddrsSet
     , decodeCTypeOrFail
     , getWalletAssuredDepth
+    , testOnlyEndpoint
     ) where
 
 import           Universum
 
 import qualified Data.Set                   as S
 import           Formatting                 (build, sformat, (%))
+import           Servant.Server             (err405, errReasonPhrase)
 
+import           Pos.Configuration          (HasNodeConfiguration, walletProductionApi)
 import           Pos.Core                   (BlockCount)
 import           Pos.Util.Servant           (FromCType (..), OriginType)
 import           Pos.Util.Util              (maybeThrow)
@@ -80,3 +83,11 @@ getWalletAssuredDepth
 getWalletAssuredDepth wid =
     assuredBlockDepth HighAssurance . cwAssurance <<$>>
     getWalletMeta wid
+
+testOnlyEndpoint :: (HasNodeConfiguration, MonadThrow m) => m a -> m a
+testOnlyEndpoint action
+    | walletProductionApi = throwM err405{ errReasonPhrase = errReason }
+    | otherwise = action
+  where
+    errReason = "Disabled in production, switch 'walletProductionApi' \
+                \parameter in config if you want to use this endpoint"

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -12,14 +12,15 @@ module Main
 import           Universum            hiding (over)
 
 import           Data.Maybe           (fromJust)
-import           Formatting           (sformat, shown, (%))
+import           Formatting           (build, sformat, shown, (%))
 import           Mockable             (Production, currentTime, runProduction)
-import           System.Wlog          (modifyLoggerName)
+import           System.Wlog          (logInfo, modifyLoggerName)
 
 import           Pos.Binary           ()
 import           Pos.Client.CLI       (CommonNodeArgs (..))
 import qualified Pos.Client.CLI       as CLI
 import           Pos.Communication    (ActionSpec (..), OutSpecs, WorkerSpec, worker)
+import           Pos.Configuration    (walletProductionApi, walletTxCreationDisabled)
 import           Pos.Context          (HasNodeContext)
 import           Pos.Core             (Timestamp (..), gdStartTime, genesisData)
 import           Pos.Launcher         (HasConfigurations, NodeParams (..),
@@ -78,7 +79,12 @@ acidCleanupWorker WalletArgs{..} =
     cleanupAcidStatePeriodically walletAcidInterval
 
 walletProd :: HasConfigurations => WalletArgs -> ([WorkerSpec WalletWebMode], OutSpecs)
-walletProd WalletArgs {..} = first one $ worker walletServerOuts $ \sendActions ->
+walletProd WalletArgs {..} = first one $ worker walletServerOuts $ \sendActions -> do
+    logInfo $ sformat ("Production mode for API: "%build)
+        walletProductionApi
+    logInfo $ sformat ("Transaction submission disabled: "%build)
+        walletTxCreationDisabled
+
     walletServeWebFull
         sendActions
         walletDebug

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -43,6 +43,7 @@ import           Pos.Wallet.Web.State         (getNextUpdate, getProfile,
                                                getWalletStorage, removeNextUpdate,
                                                setProfile, testReset)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
+import           Pos.Wallet.Web.Util          (testOnlyEndpoint)
 
 
 ----------------------------------------------------------------------------
@@ -104,7 +105,7 @@ syncProgress =
 ----------------------------------------------------------------------------
 
 testResetAll :: MonadWalletWebMode m => m ()
-testResetAll = deleteAllKeys >> testReset
+testResetAll = testOnlyEndpoint $ deleteAllKeys >> testReset
   where
     deleteAllKeys = do
         keyNum <- length <$> getSecretKeys

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -15,12 +15,13 @@ import           Data.Time.Units                   (Microsecond, Second, convert
 import           Formatting                        (build, sformat, (%))
 import           Mockable                          (delay, fork)
 import           Serokell.Util.Text                (listJson)
-import           System.Wlog                       (logInfo, modifyLoggerName)
+import           System.Wlog                       (logDebug, logInfo, modifyLoggerName)
 
 import           Pos.Client.Txp.Addresses          (MonadAddresses)
 import           Pos.Communication.Protocol        (SendActions (..))
 import           Pos.Configuration                 (HasNodeConfiguration,
-                                                    pendingTxResubmitionPeriod)
+                                                    pendingTxResubmitionPeriod,
+                                                    walletTxCreationDisabled)
 import           Pos.Core                          (ChainDifficulty (..), SlotId (..),
                                                     difficultyL)
 import           Pos.Core.Configuration            (HasConfiguration)
@@ -129,7 +130,10 @@ processPtxs
     => SendActions m -> SlotId -> [PendingTx] -> m ()
 processPtxs sendActions curSlot ptxs = do
     mapM_ processPtxInNewestBlocks ptxs
-    processPtxsToResubmit sendActions curSlot ptxs
+
+    if walletTxCreationDisabled
+    then logDebug "Transaction resubmission is disabled"
+    else processPtxsToResubmit sendActions curSlot ptxs
 
 processPtxsOnSlot
     :: MonadPendings m


### PR DESCRIPTION
This is a backport to master of [this particular commit](https://github.com/input-output-hk/cardano-sl/pull/2213/commits/5d57aaa86ef4a76df75ea7df4ab78861b6a29ef5).

It has been cherry-picked and includes [this other commit](https://github.com/input-output-hk/cardano-sl/pull/2213/commits/f515bcb1e65ebc61df9fdf0a5d3020a26066b7b0) as well, as per plan.
  