### PR TITLE
[CSL-2083] High throughput policy for UTXO input selection

### DIFF
--- a/auxx/src/Command/Tx.hs
+++ b/auxx/src/Command/Tx.hs
@@ -146,7 +146,7 @@ sendToAllGenesis sendActions (SendToAllGenesisParams duration conc delay_ sendMo
                 | otherwise = (atomically $ tryReadTQueue txQueue) >>= \case
                       Just (key, txOuts, neighbours) -> do
                           utxo <- getOwnUtxoForPk $ safeToPublic (fakeSigner key)
-                          etx <- createTx utxo (fakeSigner key) txOuts (toPublic key)
+                          etx <- createTx mempty utxo (fakeSigner key) txOuts (toPublic key)
                           case etx of
                               Left err -> do
                                   addTxFailed tpsMVar
@@ -197,6 +197,7 @@ send sendActions idx outputs = do
         ss <- mss `whenNothing` throwError (toException $ AuxxException "Invalid passphrase")
         ExceptT $ try $ submitTx
             (immediateConcurrentConversations sendActions ccPeers)
+            mempty
             ss
             (map TxOutAux outputs)
             curPk

--- a/node/src/Pos/Client/Txp/Util.hs
+++ b/node/src/Pos/Client/Txp/Util.hs
@@ -8,6 +8,7 @@ module Pos.Client.Txp.Util
        (
        -- * Tx creation params
          InputSelectionPolicy (..)
+       , PendingAddresses (..)
 
        -- * Tx creation
        , TxCreateMode
@@ -44,10 +45,11 @@ import           Control.Monad.Except     (ExceptT, MonadError (throwError), run
 import           Data.Default             (Default (..))
 import           Data.Fixed               (Fixed, HasResolution)
 import qualified Data.HashSet             as HS
-import           Data.List                (tail)
+import           Data.List                (partition, tail)
 import qualified Data.List.NonEmpty       as NE
 import qualified Data.Map                 as M
 import qualified Data.Semigroup           as S
+import qualified Data.Set                 as Set
 import qualified Data.Text.Buildable
 import qualified Data.Vector              as V
 import           Formatting               (bprint, build, sformat, stext, (%))
@@ -80,6 +82,11 @@ type TxInputs = NonEmpty TxIn
 type TxOwnedInputs owner = NonEmpty (owner, TxIn)
 type TxOutputs = NonEmpty TxOutAux
 type TxWithSpendings = (TxAux, NonEmpty TxOut)
+
+-- | List of addresses which are refered by at least one output of transaction
+-- which is not yet confirmed i.e. detected in block.
+newtype PendingAddresses = PendingAddresses (Set Address)
+    deriving (Show, Monoid)
 
 instance Buildable TxWithSpendings where
     build (txAux, neTxOut) =
@@ -149,14 +156,14 @@ isCheckedTxError = \case
 
 -- | Specifies the way Uxtos are going to be grouped.
 data InputSelectionPolicy
-    = OptimizeForSecurity  -- ^ Spend everything from the address
-    | OptimizeForSize      -- ^ No grouping
+    = OptimizeForSecurity       -- ^ Spend everything from the address
+    | OptimizeForHighThroughput -- ^ No grouping, prefer confirmed addresses
     deriving (Show, Eq, Generic)
 
 instance Buildable InputSelectionPolicy where
     build = \case
-        OptimizeForSecurity -> "securely"
-        OptimizeForSize -> "simple"
+        OptimizeForSecurity       -> "securely"
+        OptimizeForHighThroughput -> "high throughput"
 
 instance Buildable (SecureLog InputSelectionPolicy) where
     build = buildUnsecure
@@ -291,13 +298,32 @@ makeLenses ''InputPickerState
 
 type InputPicker = StateT InputPickerState (Either TxError)
 
-plainInputPicker :: InputPickingWay
-plainInputPicker utxo _outputs moneyToSpent =
+plainInputPicker :: PendingAddresses -> InputPickingWay
+plainInputPicker (PendingAddresses pendingAddrs) utxo _outputs moneyToSpent =
     evalStateT (pickInputs []) (InputPickerState moneyToSpent sortedUnspent)
   where
-    allUnspent = M.toList utxo
-    sortedUnspent =
-        sortOn (Down . txOutValue . toaOut . snd) allUnspent
+    onlyConfirmedInputs :: Set.Set Address -> (TxIn, TxOutAux) -> Bool
+    onlyConfirmedInputs addrs (_, (TxOutAux (TxOut addr _))) = not (addr `Set.member` addrs)
+    --
+    -- NOTE (adinapoli, kantp) Under certain circumstances, it's still possible for the `confirmed` set
+    -- to be exhausted and for the utxo to be picked from the `unconfirmed`, effectively allowing for the
+    -- old "slow" behaviour which could create linear chains of dependent transactions which can then be
+    -- submitted to relays and possibly fail to be accepted if they arrive in an out-of-order fashion,
+    -- effectively piling up in the mempool of the edgenode and in need to be resubmitted.
+    -- However, this policy significantly reduce the likelyhood of such edge case to happen, as for exchanges
+    -- the `confirmed` set would tend to be quite big anyway.
+    -- We should revisit such policy and its implications during a proper rewrite.
+    --
+    -- NOTE (adinapoli, kantp) There is another subtle corner case which involves such partitioning; it's now
+    -- in theory (by absurd reasoning) for the `confirmed` set to contain only dust, which would yes involve a
+    -- "high throughput" Tx but also a quite large one, bringing it closely to the "Toil too large" error
+    -- (The same malady the @OptimiseForSecurity@ policy was affected by).
+    sortedUnspent = confirmed ++ unconfirmed
+
+    (confirmed, unconfirmed) =
+      -- Give precedence to "confirmed" addresses.
+      partition (onlyConfirmedInputs pendingAddrs)
+                (sortOn (Down . txOutValue . toaOut . snd) (M.toList utxo))
 
     pickInputs :: FlatUtxo -> InputPicker FlatUtxo
     pickInputs inps = do
@@ -417,16 +443,17 @@ prepareTxRawWithPicker inputPicker utxo outputs (TxFee fee) = do
 
 prepareTxRaw
     :: Monad m
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> TxOutputs
     -> TxFee
     -> TxCreator m TxRaw
-prepareTxRaw utxo outputs fee = do
+prepareTxRaw pendingTx utxo outputs fee = do
     inputSelectionPolicy <- view tcdInputSelectionPolicy
     let inputPicker =
           case inputSelectionPolicy of
-            OptimizeForSize     -> plainInputPicker
-            OptimizeForSecurity -> groupedInputPicker
+            OptimizeForHighThroughput -> plainInputPicker pendingTx
+            OptimizeForSecurity       -> groupedInputPicker
     prepareTxRawWithPicker inputPicker utxo outputs fee
 
 -- Returns set of tx outputs including change output (if it's necessary)
@@ -444,75 +471,81 @@ mkOutputsWithRem addrData TxRaw {..}
 
 prepareInpsOuts
     :: TxCreateMode m
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> TxOutputs
     -> AddrData m
     -> TxCreator m (TxOwnedInputs TxOut, TxOutputs)
-prepareInpsOuts utxo outputs addrData = do
-    txRaw@TxRaw {..} <- prepareTxWithFee utxo outputs
+prepareInpsOuts pendingTx utxo outputs addrData = do
+    txRaw@TxRaw {..} <- prepareTxWithFee pendingTx utxo outputs
     outputsWithRem <- mkOutputsWithRem addrData txRaw
     pure (trInputs, outputsWithRem)
 
 createGenericTx
     :: TxCreateMode m
-    => (TxOwnedInputs TxOut -> TxOutputs -> TxAux)
+    => PendingAddresses
+    -> (TxOwnedInputs TxOut -> TxOutputs -> TxAux)
     -> InputSelectionPolicy
     -> Utxo
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createGenericTx creator inputSelectionPolicy utxo outputs addrData =
+createGenericTx pendingTx creator inputSelectionPolicy utxo outputs addrData =
     runTxCreator inputSelectionPolicy $ do
-        (inps, outs) <- prepareInpsOuts utxo outputs addrData
+        (inps, outs) <- prepareInpsOuts pendingTx utxo outputs addrData
         pure (creator inps outs, map fst inps)
 
 createGenericTxSingle
     :: TxCreateMode m
-    => (TxInputs -> TxOutputs -> TxAux)
+    => PendingAddresses
+    -> (TxInputs -> TxOutputs -> TxAux)
     -> InputSelectionPolicy
     -> Utxo
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createGenericTxSingle creator = createGenericTx (creator . map snd)
+createGenericTxSingle pendingTx creator = createGenericTx pendingTx (creator . map snd)
 
 -- | Make a multi-transaction using given secret key and info for outputs.
 -- Currently used for HD wallets only, thus `HDAddressPayload` is required
 createMTx
     :: TxCreateMode m
-    => InputSelectionPolicy
+    => PendingAddresses
+    -> InputSelectionPolicy
     -> Utxo
     -> (Address -> SafeSigner)
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMTx groupInputs utxo hdwSigners outputs addrData =
-    createGenericTx (makeMPubKeyTxAddrs hdwSigners)
+createMTx pendingTx groupInputs utxo hdwSigners outputs addrData =
+    createGenericTx pendingTx (makeMPubKeyTxAddrs hdwSigners)
     groupInputs utxo outputs addrData
 
 -- | Make a multi-transaction using given secret key and info for
 -- outputs.
 createTx
     :: TxCreateMode m
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> SafeSigner
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createTx utxo ss outputs addrData =
-    createGenericTxSingle (makePubKeyTx ss)
+createTx pendingTx utxo ss outputs addrData =
+    createGenericTxSingle pendingTx (makePubKeyTx ss)
     OptimizeForSecurity utxo outputs addrData
 
 -- | Make a transaction, using M-of-N script as a source
 createMOfNTx
     :: TxCreateMode m
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> [(StakeholderId, Maybe SafeSigner)]
     -> TxOutputs
     -> AddrData m
     -> m (Either TxError TxWithSpendings)
-createMOfNTx utxo keys outputs addrData =
-    createGenericTxSingle (makeMOfNTx validator sks)
+createMOfNTx pendingTx utxo keys outputs addrData =
+    createGenericTxSingle pendingTx (makeMOfNTx validator sks)
     OptimizeForSecurity utxo outputs addrData
   where
     ids = map fst keys
@@ -529,12 +562,12 @@ createRedemptionTx
     -> m (Either TxError TxAux)
 createRedemptionTx utxo rsk outputs =
     runTxCreator whetherGroupedInputs $ do
-        TxRaw {..} <- prepareTxRaw utxo outputs (TxFee $ mkCoin 0)
+        TxRaw {..} <- prepareTxRaw mempty utxo outputs (TxFee $ mkCoin 0)
         let bareInputs = snd <$> trInputs
         pure $ makeRedemptionTx rsk bareInputs trOutputs
   where
     -- always spend redeem address fully
-    whetherGroupedInputs = OptimizeForSize
+    whetherGroupedInputs = OptimizeForSecurity
 
 -----------------------------------------------------------------------------
 -- Fees logic
@@ -554,21 +587,23 @@ withLinearFeePolicy action = view tcdFeePolicy >>= \case
 -- | Prepare transaction considering fees
 prepareTxWithFee
     :: (HasConfiguration, Monad m)
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> TxOutputs
     -> TxCreator m TxRaw
-prepareTxWithFee utxo outputs = withLinearFeePolicy $ \linearPolicy ->
-    stabilizeTxFee linearPolicy utxo outputs
+prepareTxWithFee pendingTx utxo outputs = withLinearFeePolicy $ \linearPolicy ->
+    stabilizeTxFee pendingTx linearPolicy utxo outputs
 
 -- | Compute, how much fees we should pay to send money to given
 -- outputs
 computeTxFee
     :: (HasConfiguration, Monad m)
-    => Utxo
+    => PendingAddresses
+    -> Utxo
     -> TxOutputs
     -> TxCreator m TxFee
-computeTxFee utxo outputs = do
-    TxRaw {..} <- prepareTxWithFee utxo outputs
+computeTxFee pendingTx utxo outputs = do
+    TxRaw {..} <- prepareTxWithFee pendingTx utxo outputs
     let outAmount = sumTxOutCoins trOutputs
         inAmount = sumCoins $ map (txOutValue . fst) trInputs
         remaining = coinToInteger trRemainingMoney
@@ -620,11 +655,12 @@ computeTxFee utxo outputs = do
 -- To possibly find better solutions we iterate for several times more.
 stabilizeTxFee
     :: forall m. (HasConfiguration, Monad m)
-    => TxSizeLinear
+    => PendingAddresses
+    -> TxSizeLinear
     -> Utxo
     -> TxOutputs
     -> TxCreator m TxRaw
-stabilizeTxFee linearPolicy utxo outputs = do
+stabilizeTxFee pendingTx linearPolicy utxo outputs = do
     minFee <- fixedToFee (txSizeLinearMinValue linearPolicy)
     mtx <- stabilizeTxFeeDo (False, firstStageAttempts) minFee
     case mtx of
@@ -639,7 +675,7 @@ stabilizeTxFee linearPolicy utxo outputs = do
                      -> TxCreator m $ Maybe (S.ArgMin TxFee TxRaw)
     stabilizeTxFeeDo (_, 0) _ = pure Nothing
     stabilizeTxFeeDo (isSecondStage, attempt) expectedFee = do
-        txRaw <- prepareTxRaw utxo outputs expectedFee
+        txRaw <- prepareTxRaw pendingTx utxo outputs expectedFee
         txMinFee <- txToLinearFee linearPolicy $
                     createFakeTxFromRawTx txRaw
 

--- a/node/src/Pos/Generator/Block/Payload.hs
+++ b/node/src/Pos/Generator/Block/Payload.hs
@@ -218,7 +218,7 @@ genTxPayload = do
             groupedInputs = OptimizeForSecurity
 
         eTx <- lift . lift $
-            createGenericTx makeTestTx groupedInputs ownUtxo txOutAuxs changeAddrData
+            createGenericTx mempty makeTestTx groupedInputs ownUtxo txOutAuxs changeAddrData
         (txAux, _) <- either (throwM . BGFailedToCreate . pretty) pure eTx
 
         let tx = taTx txAux

--- a/node/test/Test/Pos/Client/Txp/UtilSpec.hs
+++ b/node/test/Test/Pos/Client/Txp/UtilSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ExistentialQuantification #-}
 
 -- | Specification of Pos.Client.Txp.Util
 
@@ -93,16 +94,12 @@ getSignerFromList :: NonEmpty (SafeSigner, Address) -> (Address -> SafeSigner)
 getSignerFromList (HM.fromList . map swap . toList -> hm) =
     \addr -> fromMaybe (error "Requested signer for unknown address") $ HM.lookup addr hm
 
--- TODO [CSM-527] test with ungrouped inputs picking as well.
-useGroupedInputs :: InputSelectionPolicy
-useGroupedInputs = OptimizeForSecurity
-
 testCreateMTx
     :: HasTxpConfigurations
     => CreateMTxParams
     -> TxpTestProperty (Either TxError (TxAux, NonEmpty TxOut))
 testCreateMTx CreateMTxParams{..} =
-    createMTx useGroupedInputs cmpUtxo (getSignerFromList cmpSigners)
+    createMTx mempty cmpInputSelectionPolicy cmpUtxo (getSignerFromList cmpSigners)
     cmpOutputs cmpAddrData
 
 createMTxWorksWhenWeAreRichSpec :: HasTxpConfigurations => TxpTestProperty ()
@@ -182,7 +179,7 @@ redemptionSpec = do
 txWithRedeemOutputFailsSpec :: HasTxpConfigurations => TxpTestProperty ()
 txWithRedeemOutputFailsSpec = do
     txOrError <-
-        createMTx useGroupedInputs utxo (getSignerFromList signers) outputs addrData
+        createMTx mempty OptimizeForSecurity utxo (getSignerFromList signers) outputs addrData
     case txOrError of
         Left (OutputIsRedeem _) -> return ()
         Left err -> stopProperty $ pretty err
@@ -250,13 +247,15 @@ feeForManyAddressesSpec manyAddrs =
 
 -- | Container for parameters of `createMTx`.
 data CreateMTxParams = CreateMTxParams
-    { cmpUtxo     :: !Utxo
+    { cmpInputSelectionPolicy :: InputSelectionPolicy
+    -- ^ Input selection policy
+    , cmpUtxo                 :: !Utxo
     -- ^ Unspent transaction outputs.
-    , cmpSigners  :: !(NonEmpty (SafeSigner, Address))
+    , cmpSigners              :: !(NonEmpty (SafeSigner, Address))
     -- ^ Wrappers around secret keys for addresses in Utxo.
-    , cmpOutputs  :: !TxOutputs
+    , cmpOutputs              :: !TxOutputs
     -- ^ A (nonempty) list of desired tx outputs.
-    , cmpAddrData :: !(AddrData TxpTestMode)
+    , cmpAddrData             :: !(AddrData TxpTestMode)
     -- ^ Data that is normally used for creation of change addresses.
     -- In tests, it is always `()`.
     }
@@ -275,6 +274,7 @@ makeManyUtxoTo1Params numFrom amountEachFrom amountTo = CreateMTxParams {..}
             k <- [0..numFrom-1]]
     cmpSigners = one (fakeSigner sk, addr)
     cmpOutputs = one txOutAuxOutput
+    cmpInputSelectionPolicy = OptimizeForSecurity
     cmpAddrData = ()
 
 makeManyAddressesToManyParams :: Word8 -> Integer -> Word8 -> Integer -> CreateMTxParams
@@ -294,6 +294,7 @@ makeManyAddressesToManyParams numFrom amountEachFrom numTo amountEachTo = Create
     cmpUtxo = M.fromList [(TxInUtxo (unsafeIntegerToTxId $ fromIntegral k) 0, txOutAux) |
         (k, txOutAux) <- zip [0..numFrom-1] txOutAuxInputs]
     cmpOutputs = NE.fromList txOutAuxOutputs
+    cmpInputSelectionPolicy = OptimizeForSecurity
     cmpAddrData = ()
 
 makeManyAddressesTo1Params :: Word8 -> Integer -> Integer -> CreateMTxParams

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2281,8 +2281,8 @@ self: {
           pname = "comonad";
           version = "5.0.2";
           sha256 = "1bb0fe396ecd16008411862ee453e8bd7c3e0f3a7299537dd59466604a54b784";
-          revision = "1";
-          editedCabalFile = "1lnsnx8p3wlfhd1xfc68za3b00vq77z2m6b0vqiw2laqmpj9akcw";
+          revision = "2";
+          editedCabalFile = "1ngks9bym68rw0xdq43n14nay4kxdxv2n7alwfd9wcpismfz009g";
           setupHaskellDepends = [
             base
             Cabal

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -23,8 +23,8 @@ import           Pos.Aeson.WalletBackup           ()
 import           Pos.Client.Txp.Addresses         (MonadAddresses (..))
 import           Pos.Client.Txp.Balances          (getOwnUtxos)
 import           Pos.Client.Txp.History           (TxHistoryEntry (..))
-import           Pos.Client.Txp.Util              (InputSelectionPolicy, computeTxFee,
-                                                   runTxCreator)
+import           Pos.Client.Txp.Util              (InputSelectionPolicy (..),
+                                                   computeTxFee, runTxCreator)
 import           Pos.Communication                (SendActions (..), prepareMTx)
 import           Pos.Configuration                (HasNodeConfiguration,
                                                    walletTxCreationDisabled)
@@ -51,7 +51,8 @@ import           Pos.Wallet.Web.Error             (WalletError (..))
 import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
                                                    getCurChainDifficulty)
 import qualified Pos.Wallet.Web.Methods.Logic     as L
-import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs, rewrapTxError,
+import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs,
+                                                   getPendingAddresses, rewrapTxError,
                                                    submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
                                                    convertCIdTOAddrs)
@@ -86,10 +87,11 @@ getTxFee
      -> InputSelectionPolicy
      -> m CCoin
 getTxFee srcAccount dstAccount coin policy = do
+    pendingAddrs <- getPendingAddresses policy
     utxo <- getMoneySourceUtxo (AccountMoneySource srcAccount)
     outputs <- coinDistrToOutputs $ one (dstAccount, coin)
     TxFee fee <- rewrapTxError "Cannot compute transaction fee" $
-        eitherToThrow =<< runTxCreator policy (computeTxFee utxo outputs)
+        eitherToThrow =<< runTxCreator policy (computeTxFee pendingAddrs utxo outputs)
     pure $ mkCCoin fee
 
 data MoneySource
@@ -174,7 +176,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     let metasAndAdrresses = M.fromList $ zip (toList srcAddrs) (toList addrMetas)
     allSecrets <- getSecretKeys
 
-    let getSinger addr = runIdentity $ do
+    let getSigner addr = runIdentity $ do
           let addrMeta =
                   fromMaybe (error "Corresponding adress meta not found")
                             (M.lookup addr metasAndAdrresses)
@@ -184,10 +186,11 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
 
     relatedAccount <- getSomeMoneySourceAccount moneySource
     outputs <- coinDistrToOutputs dstDistr
+    pendingAddrs <- getPendingAddresses policy
     (th, dstAddrs) <-
         rewrapTxError "Cannot send transaction" $ do
             (txAux, inpTxOuts') <-
-                prepareMTx getSinger policy srcAddrs outputs (relatedAccount, passphrase)
+                prepareMTx getSigner pendingAddrs policy srcAddrs outputs (relatedAccount, passphrase)
 
             ts <- Just <$> getCurrentTimestamp
             let tx = taTx txAux

--- a/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
@@ -8,6 +8,7 @@ module Pos.Wallet.Web.Methods.Txp
     ( rewrapTxError
     , coinDistrToOutputs
     , submitAndSaveNewPtx
+    , getPendingAddresses
     ) where
 
 import           Universum
@@ -16,14 +17,16 @@ import qualified Data.List.NonEmpty         as NE
 import           Formatting                 (build, sformat, stext, (%))
 import           Pos.Communication          (EnqueueMsg)
 
-import           Pos.Client.Txp.Util        (isCheckedTxError)
+import           Pos.Client.Txp.Util        (InputSelectionPolicy (..),
+                                             PendingAddresses (..), isCheckedTxError)
 import           Pos.Core.Types             (Coin)
 import           Pos.Txp                    (TxOut (..), TxOutAux (..))
 import           Pos.Wallet.Web.ClientTypes (Addr, CId)
 import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletError)
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
-import           Pos.Wallet.Web.Pending     (PendingTx, ptxFirstSubmissionHandler,
-                                             submitAndSavePtx)
+import           Pos.Wallet.Web.Pending     (PendingTx, allPendingAddresses,
+                                             ptxFirstSubmissionHandler, submitAndSavePtx)
+import           Pos.Wallet.Web.State       (getPendingTxs)
 import           Pos.Wallet.Web.Util        (decodeCTypeOrFail)
 
 
@@ -54,4 +57,16 @@ submitAndSaveNewPtx
     :: MonadWalletWebMode m
     => EnqueueMsg m -> PendingTx -> m ()
 submitAndSaveNewPtx = submitAndSavePtx ptxFirstSubmissionHandler
+
+-- | With regard to tx creation policy which is going to be used,
+-- get addresses which are refered by some yet unconfirmed transaction outputs.
+getPendingAddresses :: MonadWalletWebMode m => InputSelectionPolicy -> m PendingAddresses
+getPendingAddresses = \case
+    OptimizeForSecurity ->
+        -- NOTE (int-index) The pending transactions are ignored when we optimize
+        -- for security, so it is faster to not get them. In case they start being
+        -- used for other purposes, this shortcut must be removed.
+        return mempty
+    OptimizeForHighThroughput ->
+        allPendingAddresses <$> getPendingTxs
 

--- a/wallet/src/Pos/Wallet/Web/Pending/Util.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Util.hs
@@ -10,19 +10,25 @@ module Pos.Wallet.Web.Pending.Util
     , mkPendingTx
     , isReclaimableFailure
     , usingPtxCoords
+    , allPendingAddresses
+    , nonConfirmedTransactions
     ) where
 
 import           Universum
 
+import qualified Data.Set                       as Set
 import           Formatting                     (build, sformat, (%))
 
 import           Pos.Client.Txp.History         (TxHistoryEntry)
+import           Pos.Client.Txp.Util            (PendingAddresses (..))
+import           Pos.Core.Types                 (Address)
 import           Pos.Crypto                     (WithHash (..))
 import           Pos.Slotting.Class             (getCurrentSlotInaccurate)
-import           Pos.Txp                        (ToilVerFailure (..), TxAux (..), TxId,
-                                                 topsortTxs)
+import           Pos.Txp                        (ToilVerFailure (..), Tx (..), TxAux (..),
+                                                 TxId, TxOut(..), topsortTxs)
 import           Pos.Util.Chrono                (OldestFirst (..))
 import           Pos.Util.Util                  (maybeThrow)
+
 import           Pos.Wallet.Web.ClientTypes     (CId, CWalletMeta (..), Wal, cwAssurance)
 import           Pos.Wallet.Web.Error           (WalletError (RequestError))
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
@@ -89,3 +95,27 @@ isReclaimableFailure = \case
 
 usingPtxCoords :: (CId Wal -> TxId -> a) -> PendingTx -> a
 usingPtxCoords f PendingTx{..} = f _ptxWallet _ptxTxId
+
+-- | Returns the full list of "pending addresses", which are @output@ addresses
+-- associated to transactions not yet persisted in the blockchain.
+allPendingAddresses :: [PendingTx] -> PendingAddresses
+allPendingAddresses =
+    PendingAddresses . Set.unions . map grabTxOutputs . nonConfirmedTransactions
+  where
+    grabTxOutputs :: PendingTx -> Set.Set Address
+    grabTxOutputs PendingTx{..} =
+        let (TxAux tx _) = _ptxTxAux
+            (UnsafeTx _ outputs _) = tx
+            in Set.fromList $ map (\(TxOut a _) -> a) (toList outputs)
+
+-- | Filters the input '[PendingTx]' to choose only the ones which are not
+-- yet persisted in the blockchain.
+nonConfirmedTransactions :: [PendingTx] -> [PendingTx]
+nonConfirmedTransactions = filter isPending
+  where
+    -- | Is this 'PendingTx' really pending?
+    isPending :: PendingTx -> Bool
+    isPending PendingTx{..} = case _ptxCond of
+        PtxInNewestBlocks _ -> False
+        PtxPersisted        -> False
+        _                   -> True


### PR DESCRIPTION
This is a backport of https://github.com/input-output-hk/cardano-sl/pull/2160 by cherry picking e6158e0f13774e985c832ac1bf5f02c8b8f662cd and rewriting the `FromJSON` and `ToJSON` instances to be lenient and backward compatible.

Note how this is still not enough; we probably want to incorporate @Martoon-00 's work on the "configurable input policy via configuration.yaml" and maybe that lenient "empty json body" which would allow an empty JSON body to yield a valid policy (which defaults to the one specified in the config file).