### PR TITLE
[CSL-2135] Add a newly created tx to the mempool before submitting it

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3905,6 +3905,8 @@ self: {
           pname = "http-api-data";
           version = "0.3.7.1";
           sha256 = "1zbmf0kkfsw7pfznisi205gh7jd284gfarxsyiavd2iw26akwqwc";
+          revision = "1";
+          editedCabalFile = "0g57k71bssf81yba6xf9fcxlys8m5ax5kvrs4gvckahf5ihdxds6";
           setupHaskellDepends = [
             base
             Cabal

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -43,7 +43,7 @@ import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAddressP
                                                    getSKById)
 import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CCoin, CId,
                                                    CTx (..), CWAddressMeta (..), Wal,
-                                                   addrMetaToAccount, cadId, mkCCoin)
+                                                   addrMetaToAccount, mkCCoin)
 import           Pos.Wallet.Web.Error             (WalletError (..))
 import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
                                                    getCurChainDifficulty)

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -116,9 +116,9 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
                       _ptxTxId
        | otherwise -> do
            saveTx (_ptxTxId, _ptxTxAux) `catches` handlers
+           addOnlyNewPendingTx ptx
            ack <- submitTxRaw enqueue _ptxTxAux
            reportSubmitted ack
-           addOnlyNewPendingTx ptx
            when ack $ ptxUpdateMeta _ptxWallet _ptxTxId PtxMarkAcknowledged
   where
     handlers =

--- a/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Submission.hs
@@ -39,7 +39,7 @@ data PtxSubmissionHandlers m = PtxSubmissionHandlers
       -- Exception is not specified explicitely to prevent a wish
       -- to disassemble the cases - it's already done.
       pshOnNonReclaimable  :: forall e. (Exception e, Buildable e)
-                           => Bool -> e -> m ()
+                           => e -> m ()
       -- | When minor error occurs, which means that transaction has
       -- a chance to be applied later.
     , pshOnMinor           :: SomeException -> m ()
@@ -50,27 +50,18 @@ ptxFirstSubmissionHandler
     => PtxSubmissionHandlers m
 ptxFirstSubmissionHandler =
     PtxSubmissionHandlers
-    { pshOnNonReclaimable = \peerAck e ->
-        if peerAck
-        then reportPeerApplied
-        else throwM e
+    { pshOnNonReclaimable = throwM
     , pshOnMinor = \_ -> pass
     }
-  where
-     reportPeerApplied =
-        logInfo "Some peer applied new tx, while we didn't - considering \
-                \transaction made"
 
 ptxResubmissionHandler
     :: MonadWalletWebMode m
     => PendingTx -> PtxSubmissionHandlers m
 ptxResubmissionHandler PendingTx{..} =
     PtxSubmissionHandlers
-    { pshOnNonReclaimable = \peerAck e ->
+    { pshOnNonReclaimable = \e ->
         if | _ptxPeerAck ->
              reportPeerAppliedEarlier
-           | peerAck ->
-             reportPeerApplied
            | PtxApplying poolInfo <- _ptxCond -> do
              cancelPtx poolInfo e
              throwM e
@@ -90,11 +81,6 @@ ptxResubmissionHandler PendingTx{..} =
     reportPeerAppliedEarlier =
         logInfo $
         sformat ("Some peer applied tx #"%build%" earlier - continuing \
-            \tracking")
-            _ptxTxId
-    reportPeerApplied =
-        logInfo $
-        sformat ("Peer applied tx #"%build%", while we didn't - continuing \
             \tracking")
             _ptxTxId
     reportCanceled =
@@ -129,17 +115,17 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
                       \the 1h time limit was exceeded")
                       _ptxTxId
        | otherwise -> do
+           saveTx (_ptxTxId, _ptxTxAux) `catches` handlers
            ack <- submitTxRaw enqueue _ptxTxAux
            reportSubmitted ack
-           saveTx (_ptxTxId, _ptxTxAux) `catches` handlers ack
            addOnlyNewPendingTx ptx
            when ack $ ptxUpdateMeta _ptxWallet _ptxTxId PtxMarkAcknowledged
   where
-    handlers accepted =
+    handlers =
         [ Handler $ \e ->
             if isReclaimableFailure e
                 then minorError "reclaimable" (SomeException e)
-                else nonReclaimableError accepted (SomeException e)
+                else nonReclaimableError (SomeException e)
 
         , Handler $ \e@SomeException{} ->
             -- I don't know where this error can came from,
@@ -150,9 +136,9 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
     minorError desc e = do
         reportError desc e ", but was given another chance"
         pshOnMinor e
-    nonReclaimableError accepted e = do
+    nonReclaimableError e = do
         reportError "fatal" e ""
-        pshOnNonReclaimable accepted e
+        pshOnNonReclaimable e
 
     reportError desc e outcome =
         logInfo $
@@ -162,4 +148,3 @@ submitAndSavePtx PtxSubmissionHandlers{..} enqueue ptx@PendingTx{..} = do
         logDebug $
         sformat ("submitAndSavePtx: transaction submitted with confirmation?: "
                 %build) ack
-


### PR DESCRIPTION
This is done in order to revent race condition when we receive our transaction
as part of a block before we use 'saveTx' (in which case 'saveTx' fails).
More elaborate explanation will be provided by @pva701.

@pva701's explanation:
In this PR we reorder sending a transaction to network and saving it at the `submitAndSave` and `submitAndSavePtx` functions.

Previously it might cause a situation when a transaction was sent to network, then appeared in a block, block came to the wallet and the transaction was considered as invalid because the block with this transaction had been already applied.

Now we save a tx to mempool first and then send it to network to avoid such situation.



As part of this PR we describe wallet-db and mempool changes. There are three things which can be changed:

1. wallet-db's utxo. It can be changed only when new block comes. Transactions from a block which belong to our wallets affect this utxo.

2. wallet-db's pending transactions. We add to this list each transaction which we are going to send to network and we add a tx to list **before** sending to network.

3. node's mempool. We add tx here before sending tx to network.

The first and the second things are persisted and stored on the disk. The third thing is in-memory only and can be modified when new block comes.