### PR TITLE
[CSL-2185] Add dbgen to tools.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,7 +47,7 @@ let
         ];
       });
 
-      cardano-sl-wallet = justStaticExecutables super.cardano-sl-wallet;
+      cardano-sl-wallet-static = justStaticExecutables super.cardano-sl-wallet;
       cardano-sl-networking = dontCheck super.cardano-sl-networking;
       cardano-sl-tools = justStaticExecutables (overrideCabal super.cardano-sl-tools (drv: {
         # waiting on load-command size fix in dyld

--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -79,7 +79,7 @@ NOTE: the various other Cardano components can be obtained through other attribu
    - `cardano-explorer`, `cardano-explorer-swagger`, `cardano-explorer-mock`
 -  `cardano-sl-tools-static`:
    - `cardano-analyzer`, `cardano-dht-keygen`, `cardano-genupdate`, `cardano-keygen`, `cardano-launcher`, `cardano-addr-convert`, `cardano-cli-docs`, `cardano-block-gen`, `cardano-post-mortem`
--  `cardano-sl-wallet`:
+-  `cardano-sl-wallet-static`:
    - `cardano-node`, `cardano-swagger`
 
 In general, for any given cabal `PACKAGE` provided by Cardano, there is a

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2369,18 +2369,18 @@ inherit (pkgs.xorg) libXrender;};
         ({ mkDerivation, attoparsec, base, base-compat, bytestring
          , containers, deepseq, dlist, ghc-prim, hashable, scientific
          , stdenv, tagged, template-haskell, text, time, time-locale-compat
-         , unordered-containers, uuid-types, vector
+         , unordered-containers, vector
          }:
          mkDerivation {
            pname = "aeson";
-           version = "1.1.2.0";
-           sha256 = "37488cfbf6ecf65c4d63164d760c1a0f3bcc3371a35a50e5c4a3c0fd2ffac5ff";
+           version = "1.0.2.1";
+           sha256 = "e0a66fba0a9996063d0e241b0b868c6271b6aeb457821a78bfcaac5d84c89066";
            revision = "1";
-           editedCabalFile = "06acsik1qcn5r1z1y3n7iw5h8x0h3hdcjii0bq9nf9ncvc71h1d4";
+           editedCabalFile = "1wfplxb4bppx2bqxbwprl09w9h9bfwn4ak97g8nrdrm30xfqv16g";
            libraryHaskellDepends = [
              attoparsec base base-compat bytestring containers deepseq dlist
              ghc-prim hashable scientific tagged template-haskell text time
-             time-locale-compat unordered-containers uuid-types vector
+             time-locale-compat unordered-containers vector
            ];
            doHaddock = false;
            doCheck = false;
@@ -7242,18 +7242,20 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.mit;
          }) {};
       "cardano-sl-tools" = callPackage
-        ({ mkDerivation, aeson, ansi-wl-pprint, array, async, attoparsec
-         , base, base58-bytestring, bytestring, canonical-json
-         , cardano-report-server, cardano-sl, cardano-sl-core, cardano-sl-db
-         , cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp
-         , Chart, Chart-diagrams, containers, cpphs, cryptonite
-         , data-default, directory, ed25519, ether, fgl, filepath, foldl
-         , formatting, Glob, graphviz, kademlia, lens, lifted-async
-         , log-warper, MonadRandom, mtl, neat-interpolation, node-sketch
-         , optparse-applicative, parsec, pipes, pipes-bytestring
-         , pipes-interleave, pipes-safe, process, QuickCheck, random
-         , random-shuffle, safe-exceptions, serokell-util, silently, stdenv
-         , stm, system-filepath, tar, text, text-format, time, time-units
+        ({ mkDerivation, acid-state, aeson, ansi-terminal, ansi-wl-pprint
+         , array, async, attoparsec, base, base58-bytestring, bytestring
+         , canonical-json, cardano-report-server, cardano-sl
+         , cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-lrc
+         , cardano-sl-ssc, cardano-sl-txp, cardano-sl-wallet, Chart
+         , Chart-diagrams, containers, cpphs, cryptonite, data-default
+         , dhall, directory, ed25519, ether, fgl, filepath, foldl
+         , formatting, Glob, graphviz, haskoin-core, kademlia, lens
+         , lifted-async, log-warper, MonadRandom, mtl, neat-interpolation
+         , node-sketch, optparse-applicative, optparse-generic, parsec
+         , pipes, pipes-bytestring, pipes-interleave, pipes-safe, process
+         , QuickCheck, random, random-shuffle, safe-exceptions
+         , serokell-util, silently, stdenv, stm, string-conv
+         , system-filepath, tar, text, text-format, time, time-units
          , universum, unix, unix-compat, unordered-containers, vector, yaml
          }:
          mkDerivation {
@@ -7263,16 +7265,18 @@ inherit (pkgs) mesa;};
            isLibrary = false;
            isExecutable = true;
            executableHaskellDepends = [
-             aeson ansi-wl-pprint array async attoparsec base base58-bytestring
-             bytestring canonical-json cardano-report-server cardano-sl
-             cardano-sl-core cardano-sl-db cardano-sl-infra cardano-sl-lrc
-             cardano-sl-ssc cardano-sl-txp Chart Chart-diagrams containers
-             cryptonite data-default directory ed25519 ether fgl filepath foldl
-             formatting Glob graphviz kademlia lens lifted-async log-warper
-             MonadRandom mtl neat-interpolation node-sketch optparse-applicative
-             parsec pipes pipes-bytestring pipes-interleave pipes-safe process
-             QuickCheck random random-shuffle safe-exceptions serokell-util
-             silently stm system-filepath tar text text-format time time-units
+             acid-state aeson ansi-terminal ansi-wl-pprint array async
+             attoparsec base base58-bytestring bytestring canonical-json
+             cardano-report-server cardano-sl cardano-sl-core cardano-sl-db
+             cardano-sl-infra cardano-sl-lrc cardano-sl-ssc cardano-sl-txp
+             cardano-sl-wallet Chart Chart-diagrams containers cryptonite
+             data-default dhall directory ed25519 ether fgl filepath foldl
+             formatting Glob graphviz haskoin-core kademlia lens lifted-async
+             log-warper MonadRandom mtl neat-interpolation node-sketch
+             optparse-applicative optparse-generic parsec pipes pipes-bytestring
+             pipes-interleave pipes-safe process QuickCheck random
+             random-shuffle safe-exceptions serokell-util silently stm
+             string-conv system-filepath tar text text-format time time-units
              universum unix unix-compat unordered-containers vector yaml
            ];
            executableToolDepends = [ cpphs ];
@@ -10508,6 +10512,35 @@ inherit (pkgs) mesa;};
            doCheck = false;
            homepage = "https://github.com/chrisdone/descriptive";
            description = "Self-describing consumers/parsers; forms, cmd-line args, JSON, etc";
+           license = stdenv.lib.licenses.bsd3;
+         }) {};
+      "dhall" = callPackage
+        ({ mkDerivation, ansi-wl-pprint, base, base16-bytestring
+         , bytestring, case-insensitive, charset, containers, contravariant
+         , cryptohash, exceptions, http-client, http-client-tls, lens
+         , optparse-generic, parsers, prettyprinter, stdenv, system-fileio
+         , system-filepath, text, text-format, transformers, trifecta
+         , unordered-containers, vector
+         }:
+         mkDerivation {
+           pname = "dhall";
+           version = "1.8.2";
+           sha256 = "520184b58a70e4ac5dc3dc0b39bee64c279b5cdebd2b178aee6934cbb30899d2";
+           isLibrary = true;
+           isExecutable = true;
+           libraryHaskellDepends = [
+             ansi-wl-pprint base base16-bytestring bytestring case-insensitive
+             charset containers contravariant cryptohash exceptions http-client
+             http-client-tls lens parsers prettyprinter system-fileio
+             system-filepath text text-format transformers trifecta
+             unordered-containers vector
+           ];
+           executableHaskellDepends = [
+             base optparse-generic prettyprinter system-filepath text trifecta
+           ];
+           doHaddock = false;
+           doCheck = false;
+           description = "A configuration language guaranteed to terminate";
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "diagrams" = callPackage
@@ -18115,6 +18148,29 @@ inherit (pkgs) which;};
            homepage = "http://daniel-diaz.github.io/projects/haskintex";
            description = "Haskell Evaluation inside of LaTeX code";
            license = stdenv.lib.licenses.bsd3;
+         }) {};
+      "haskoin-core" = callPackage
+        ({ mkDerivation, aeson, base, base16-bytestring, byteable
+         , bytestring, cereal, conduit, containers, cryptohash, deepseq
+         , either, entropy, largeword, mtl, murmur3, network, pbkdf
+         , QuickCheck, secp256k1, split, stdenv, string-conversions, text
+         , time, vector
+         }:
+         mkDerivation {
+           pname = "haskoin-core";
+           version = "0.4.2";
+           sha256 = "f35bce54c208c7445fa0588eb945c207a2eeff3cb1c5e1ae854afa876752d45b";
+           libraryHaskellDepends = [
+             aeson base base16-bytestring byteable bytestring cereal conduit
+             containers cryptohash deepseq either entropy largeword mtl murmur3
+             network pbkdf QuickCheck secp256k1 split string-conversions text
+             time vector
+           ];
+           doHaddock = false;
+           doCheck = false;
+           homepage = "http://github.com/haskoin/haskoin";
+           description = "Implementation of the core Bitcoin protocol features";
+           license = stdenv.lib.licenses.publicDomain;
          }) {};
       "hasmin" = callPackage
         ({ mkDerivation, attoparsec, base, bytestring, containers, gitrev
@@ -26421,6 +26477,19 @@ inherit (pkgs) which;};
            description = "MurmurHash2 implementation for Haskell";
            license = stdenv.lib.licenses.bsd3;
          }) {};
+      "murmur3" = callPackage
+        ({ mkDerivation, base, bytestring, cereal, stdenv }:
+         mkDerivation {
+           pname = "murmur3";
+           version = "1.0.3";
+           sha256 = "102c81e0e6ae604f51bccced6d2d493f4de0b65e856cd0492a17f9f8e4d51f2a";
+           libraryHaskellDepends = [ base bytestring cereal ];
+           doHaddock = false;
+           doCheck = false;
+           homepage = "http://github.com/plaprade/murmur3";
+           description = "Pure Haskell implementation of the MurmurHash3 x86_32 algorithm";
+           license = stdenv.lib.licenses.publicDomain;
+         }) {};
       "mushu" = callPackage
         ({ mkDerivation, base, brick, bytestring, classy-prelude
          , connection, containers, data-default, directory, filepath, fuzzy
@@ -28613,6 +28682,23 @@ inherit (pkgs) which;};
            description = "Arrows for Pretty Printing";
            license = stdenv.lib.licenses.mit;
          }) {};
+      "pbkdf" = callPackage
+        ({ mkDerivation, base, binary, byteable, bytedump, bytestring
+         , cryptohash, stdenv, utf8-string
+         }:
+         mkDerivation {
+           pname = "pbkdf";
+           version = "1.1.1.1";
+           sha256 = "ddc5755cc895b00af47cadf70f71c0a97675659754a137c403200e62d54476d9";
+           libraryHaskellDepends = [
+             base binary byteable bytedump bytestring cryptohash utf8-string
+           ];
+           doHaddock = false;
+           doCheck = false;
+           homepage = "https://github.com/cdornan/pbkdf";
+           description = "Haskell implementation of the PBKDF functions from RFC-2898";
+           license = stdenv.lib.licenses.bsd3;
+         }) {};
       "pcre-heavy" = callPackage
         ({ mkDerivation, base, base-compat, bytestring, pcre-light
          , semigroups, stdenv, string-conversions, template-haskell
@@ -30335,10 +30421,10 @@ inherit (pkgs) which;};
         ({ mkDerivation, base, ghc-prim, stdenv, transformers }:
          mkDerivation {
            pname = "primitive";
-           version = "0.6.2.0";
-           sha256 = "b8e8d70213e22b3fab0e0d11525c02627489618988fdc636052ca0adce282ae1";
+           version = "0.6.1.0";
+           sha256 = "93731fa72eaf74e8e83453f080828e18cec9fbc82bee91b49ba8b61c043d38c8";
            revision = "1";
-           editedCabalFile = "0d61g8ppsdajdqykl2kc46kq00aamsf12v60ilgrf58dbji9sz56";
+           editedCabalFile = "0gb8lcn6bd6ilfln7ah9jmqq6324vgkrgdsnz1qvlyj3bi2w5ivf";
            libraryHaskellDepends = [ base ghc-prim transformers ];
            doHaddock = false;
            doCheck = false;
@@ -33134,6 +33220,25 @@ inherit (pkgs) which;};
            homepage = "https://github.com/devonhollowood/search-algorithms#readme";
            description = "Common graph search algorithms";
            license = stdenv.lib.licenses.bsd3;
+         }) {};
+      "secp256k1" = callPackage
+        ({ mkDerivation, base, base16-bytestring, binary, bytestring, Cabal
+         , entropy, largeword, mtl, QuickCheck, stdenv, string-conversions
+         }:
+         mkDerivation {
+           pname = "secp256k1";
+           version = "0.4.8";
+           sha256 = "13fb455af6874fb9a52adb85a52bfcfbcab5e80eb18b410fa088a92cabd3db4a";
+           setupHaskellDepends = [ base Cabal ];
+           libraryHaskellDepends = [
+             base base16-bytestring binary bytestring entropy largeword mtl
+             QuickCheck string-conversions
+           ];
+           doHaddock = false;
+           doCheck = false;
+           homepage = "http://github.com/haskoin/secp256k1-haskell#readme";
+           description = "Bindings for secp256k1 library from Bitcoin Core";
+           license = stdenv.lib.licenses.publicDomain;
          }) {};
       "securemem" = callPackage
         ({ mkDerivation, base, byteable, bytestring, ghc-prim, memory
@@ -40143,18 +40248,14 @@ inherit (pkgs) which;};
            license = "GPL";
          }) {};
       "vector" = callPackage
-        ({ mkDerivation, base, deepseq, ghc-prim, primitive, semigroups
-         , stdenv
-         }:
+        ({ mkDerivation, base, deepseq, ghc-prim, primitive, stdenv }:
          mkDerivation {
            pname = "vector";
-           version = "0.12.0.1";
-           sha256 = "b100ee79b9da2651276278cd3e0f08a3c152505cc52982beda507515af173d7b";
-           revision = "1";
-           editedCabalFile = "1xjv8876kx9vh86w718vdaaai40pwnsiw8368c5h88ch8iqq10qb";
-           libraryHaskellDepends = [
-             base deepseq ghc-prim primitive semigroups
-           ];
+           version = "0.11.0.0";
+           sha256 = "0a5320ed44c3f2b04b7f61e0f63f4fcd5b337524e601e01d5813ace3f5a432e4";
+           revision = "2";
+           editedCabalFile = "1kjafhgsyjqlvrpfv2vj17hipyv0zw56a2kbl6khzn5li9szvyib";
+           libraryHaskellDepends = [ base deepseq ghc-prim primitive ];
            doHaddock = false;
            doCheck = false;
            homepage = "https://github.com/haskell/vector";

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -4,7 +4,7 @@
 # regenerate the `pkgs/default.nix` file based on the current contents of cardano-sl.cabal and stack.yaml
 
 function runInShell {
-  nix-shell -j 4 -p nix cabal2nix glibcLocales --pure --run "LANG=en_US.utf-8 NIX_REMOTE=daemon NIX_PATH=$NIX_PATH $*"
+  nix-shell -j 4 -p nix cabal2nix glibcLocales --pure --run "LANG=en_US.utf-8 NIX_REMOTE=$NIX_REMOTE NIX_PATH=$NIX_PATH $*"
 }
 
 set -xe

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -11,7 +11,7 @@ if [[ ("$OS_NAME" == "linux") && ("$BUILDKITE_BRANCH" == "master") ]];
   else with_haddock=false
 fi
 
-targets="cardano-sl cardano-sl-auxx cardano-sl-tools cardano-sl-wallet"
+targets="cardano-sl cardano-sl-auxx cardano-sl-tools cardano-sl-wallet-static"
 
 # There are no macOS explorer devs atm and it's only deployed on linux
 if [[ "$OS_NAME" == "linux" ]]; then
@@ -50,7 +50,7 @@ done
   #./update-haddock.sh
 #fi
 
-./cardano-sl-wallet.root/bin/cardano-wallet-hs2purs
+./cardano-sl-wallet-static.root/bin/cardano-wallet-hs2purs
 
 # Generate daedalus-bridge
 pushd daedalus
@@ -60,7 +60,7 @@ pushd daedalus
   cp ../node/configuration.yaml .
   cp ../node/*genesis*.json .
   cp ../cardano-sl-tools.root/bin/cardano-launcher .
-  cp ../cardano-sl-wallet.root/bin/cardano-node .
+  cp ../cardano-sl-wallet-static.root/bin/cardano-node .
   # check that binaries exit with 0
   ./cardano-node --help > /dev/null
   ./cardano-launcher --help > /dev/null

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -29,7 +29,7 @@ let
     };
   };
   executables =  {
-    wallet = "${iohkPkgs.cardano-sl-wallet}/bin/cardano-node";
+    wallet = "${iohkPkgs.cardano-sl-wallet-static}/bin/cardano-node";
     explorer = "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
   };
   ifWallet = localLib.optionalString (executable == "wallet");

--- a/stack.yaml
+++ b/stack.yaml
@@ -121,6 +121,15 @@ extra-deps:
 - ekg-statsd-0.2.2.0
 # https://github.com/fpco/lts-haskell/issues/70
 - fgl-5.5.3.1
+# dbgen deps
+- aeson-1.0.2.1
+- dhall-1.8.2
+- haskoin-core-0.4.2
+- murmur3-1.0.3
+- pbkdf-1.1.1.1
+- secp256k1-0.4.8
+- vector-0.11.0.0
+- primitive-0.6.1.0
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -22,6 +22,86 @@ Flag for-installer
   description: Build a reduced set of components (only what is needed for the
                installer)
 
+executable dbgen
+  hs-source-dirs:      src/dbgen
+  main-is:             Main.hs
+  other-modules:       CLI
+                     , Lib
+                     , Rendering
+                     , Stats
+                     , Types
+                     , QueryMethods
+  if !flag(for-installer)
+   build-depends:      base >= 4.7 && < 5
+                     , acid-state
+                     , ansi-terminal
+                     , unordered-containers
+                     , containers
+                     , serokell-util
+                     , dhall
+                     , text
+                     , time
+                     , QuickCheck
+                     , bytestring
+                     , string-conv
+                     , mtl
+                     , lens
+                     , optparse-generic
+                     , optparse-applicative
+                     , haskoin-core
+                     , cardano-sl
+                     , cardano-sl-core
+                     , cardano-sl-db
+                     , cardano-sl-ssc
+                     , cardano-sl-infra
+                     , cardano-sl-wallet
+                     , optparse-generic
+                     , optparse-applicative
+                     , node-sketch
+                     , mtl
+                     , log-warper
+                     , data-default
+                     , lens
+                     , universum >= 0.1.11
+  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts
+                       -Wall
+                       -fno-warn-orphans
+                       -O2
+
+  -- linker speed up for linux
+  if os(linux)
+    ghc-options:       -optl-fuse-ld=gold
+    ld-options:        -fuse-ld=gold
+
+  default-extensions:   DeriveDataTypeable
+                        DeriveGeneric
+                        GeneralizedNewtypeDeriving
+                        StandaloneDeriving
+                        FlexibleContexts
+                        FlexibleInstances
+                        MultiParamTypeClasses
+                        FunctionalDependencies
+                        DefaultSignatures
+                        NoImplicitPrelude
+                        OverloadedStrings
+                        RecordWildCards
+                        TypeApplications
+                        TupleSections
+                        ViewPatterns
+                        LambdaCase
+                        MultiWayIf
+                        ConstraintKinds
+                        UndecidableInstances
+                        BangPatterns
+                        ScopedTypeVariables
+
+  build-tools: cpphs >= 1.19
+  ghc-options: -pgmP cpphs -optP --cpp
+
+  if flag(for-installer)
+    buildable: False
+
 executable cardano-analyzer
   hs-source-dirs:      src/analyzer
   main-is:             Main.hs

--- a/tools/src/dbgen/CLI.hs
+++ b/tools/src/dbgen/CLI.hs
@@ -1,0 +1,75 @@
+
+module CLI where
+
+import           Prelude
+import           Data.Monoid
+import           Data.String.Conv
+import           Options.Applicative
+import           Options.Generic
+import           Pos.Util.Servant
+import           Pos.Wallet.Web.ClientTypes.Instances ()
+import           Pos.Wallet.Web.ClientTypes.Types
+import           Text.Read                            (readMaybe)
+import           Types                                (Method)
+
+data CLI = CLI
+    { config            :: FilePath
+    -- ^ The path to the config file
+    , nodePath          :: FilePath
+    -- ^ The path to a valid rocksdb database.
+    , secretKeyPath     :: FilePath
+    -- ^ The path to the secret key from the database.
+    , walletPath        :: FilePath
+    -- ^ The path to a valid acid-state database.
+    , addTo             :: Maybe AccountId
+    -- ^ If specified, only append addresses to the
+    -- given <wallet_id@account_id>
+    , configurationPath :: FilePath
+    -- ^ The path to a valid cardano-sl configuration.
+    , configurationProf :: String
+    -- ^ The configuration profile to use.
+    , systemStart       :: Maybe Int
+    -- ^ The systemStart for the application
+    , showStats         :: Bool
+    -- ^ If true, print the stats for the `wallet-db`
+    , queryMethod       :: Maybe Method
+    -- ^ If true, generate a DB targeting mainnet.
+    , genFakeUtxo       :: Bool
+    }
+
+
+instance ParseRecord CLI where
+  parseRecord = CLI
+              <$> (strOption (long "config" <> metavar "CONFIG.DHALL"
+                             <> help "A path to a Dhall file."
+                                      ))
+              <*> (strOption (long "nodeDB" <> metavar "rocksdb-path"
+                             <> help "A path to a valid rocksdb database."
+                                      ))
+              <*> (strOption (long "secretKey" <> metavar "secret-key-path"
+                             <> help "A path to a valid secreate key for the database."
+                                      ))
+              <*> (strOption (long "walletDB" <> metavar "acidstate-path"
+                             <> help "A path to a valid acidstate database."
+                                      ))
+              <*> (optional (option (eitherReader readAccountId)
+                            (long "add-to" <> metavar "walletId@accountId"
+                                           <> help "Append to an existing wallet & account."
+              )))
+              <*> (strOption (long "configPath" <> metavar "configuration-path"
+                             <> help "A path to a valid cardano-sl configuration."
+                                      ))
+              <*> (strOption (long "configProf" <> metavar "configuration-profile"
+                             <> help "A valid cardano-sl configuration profile to use."
+                                      ))
+              <*> optional (option auto (long "systemStart"
+                             <> help "A valid node system start to use."))
+              <*> switch (long "stats" <> help "Show stats for this wallet.")
+              <*> ((readMaybe =<<) <$> (optional (strOption (long "query" <> help "Query a predefined endpoint."))))
+              <*> switch (long "genFakeUtxo" <> help "Generate fake UTXO for the wallet. Fake as-in doesn't exist in node DB.")
+
+
+readAccountId :: String -> Either String AccountId
+readAccountId str' = case decodeCType (CAccountId (toS str')) of
+  Left e  -> Left (toS e)
+  Right x -> Right x

--- a/tools/src/dbgen/Lib.hs
+++ b/tools/src/dbgen/Lib.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ViewPatterns        #-}
+module Lib where
+
+import           Prelude
+import           CLI
+import           Types (UberMonad)
+import           Control.Concurrent
+import           Control.Lens                         (view)
+import           Control.Monad
+import           Control.Monad.IO.Class
+import qualified Data.ByteString                      as B
+import           Data.Monoid
+import           Data.String.Conv
+import qualified Data.Text                            as T
+import           Data.Time
+import           Dhall
+import           GHC.Generics                         (Generic)
+import           Network.Haskoin.Crypto
+import           Pos.Crypto.Random
+import           Pos.DB.GState.Common                 (getTip)
+import           Pos.StateLock
+import           Pos.Util.BackupPhrase
+import           Pos.Util.Servant
+import           Pos.Util.Util                        (lensOf)
+import           Pos.Wallet.Web.Account
+import           Pos.Wallet.Web.ClientTypes
+import           Pos.Wallet.Web.ClientTypes.Instances ()
+import           Pos.Wallet.Web.Methods.Logic
+import           Pos.Wallet.Web.Methods.Restore
+import           Rendering
+import           Text.Printf
+
+--
+-- Types
+--
+
+data GenSpec = GenSpec {
+    wallets       :: !Integer
+    -- ^ How many wallets to create
+    , wallet_spec :: WalletSpec
+    -- ^ The specification for each wallet.
+    } deriving (Show, Eq, Generic)
+
+instance Interpret GenSpec
+
+data WalletSpec = WalletSpec {
+    accounts       :: !Integer
+    -- ^ How many accounts to generate
+    , account_spec :: AccountSpec
+    -- ^ How specification for each account.
+    } deriving (Show, Eq, Generic)
+
+instance Interpret WalletSpec
+
+data AccountSpec = AccountSpec {
+    addresses :: !Integer
+    -- How many addresses to generate.
+    } deriving (Show, Eq, Generic)
+
+instance Interpret AccountSpec
+
+--
+-- Functions
+--
+
+-- | Load the 'GenSpec' from an input file.
+loadGenSpec :: FilePath -> IO GenSpec
+loadGenSpec = input auto . toS
+
+-- | Run an action and report the time it took.
+timed :: MonadIO m => m a -> m a
+timed action = do
+    before <- liftIO getCurrentTime
+    res <- action
+    after <- liftIO getCurrentTime
+    -- NOTE: Mind the `fromEnum` overflow.
+    let diff = fromEnum $ after `diffUTCTime` before
+    liftIO $ putStrLn $ printf "Action took %f seconds." (fromIntegral diff / (1000000000000 :: Double))
+    return res
+
+fakeSync :: UberMonad ()
+fakeSync = do
+    say "Faking StateLock syncing..."
+    tip <- getTip
+    (StateLock mvar _) <- view (lensOf @StateLock)
+    () <$ liftIO (tryPutMVar mvar tip)
+
+-- | The main entry point.
+generate :: CLI -> GenSpec -> UberMonad ()
+generate CLI{..} spec@GenSpec{..} = do
+    fakeSync
+    -- If `addTo` is not mempty, skip the generation
+    -- but append the requested addresses to the input
+    -- CAccountId.
+    case addTo of
+        Just accId -> addAddressesTo accId spec
+        Nothing -> do
+            say $ printf "Generating %d wallets..." wallets
+            wallets' <- timed (forM [1..wallets] genWallet)
+            forM_ (zip [1..] wallets') (genAccounts spec)
+    say $ green "OK."
+
+addAddressesTo :: AccountId -> GenSpec -> UberMonad ()
+addAddressesTo cid spec = genAddresses spec cid
+
+genAccounts :: GenSpec -> (Int, CWallet) -> UberMonad ()
+genAccounts spec@(wallet_spec -> wspec) (idx, wallet) = do
+    let accs = accounts wspec
+    say $ printf "Generating %d accounts for Wallet %d..." accs idx
+    cAccounts <- timed (forM [1..accs] (genAccount wallet))
+    let cids = map toAccountId cAccounts
+    forM_ cids (genAddresses spec)
+
+toAccountId :: CAccount -> AccountId
+toAccountId CAccount{..} = either (error . toS) id (decodeCType caId)
+
+genAddresses :: GenSpec -> AccountId -> UberMonad ()
+genAddresses (account_spec . wallet_spec -> aspec) cid = do
+    let addrs = addresses aspec
+    say $ printf "Generating %d addresses for Account %s..." addrs (renderAccountId cid)
+    timed (forM_ [1..addrs] (const $ genAddress cid))
+
+
+-- | Creates a new 'CWallet'.
+genWallet :: Integer -> UberMonad CWallet
+genWallet walletNum = do
+    entropy   <- randomNumber walletNum
+    mnemonic  <- newRandomMnemonic (toEntropy entropy)
+    r         <- newWallet mempty (walletInit mnemonic)
+    return r
+  where
+    walletInit :: BackupPhrase -> CWalletInit
+    walletInit backupPhrase = CWalletInit {
+      cwInitMeta      = CWalletMeta
+          { cwName      = toS $ "Wallet #" <> show walletNum
+          , cwAssurance = CWANormal
+          , cwUnit      = 0
+        }
+      , cwBackupPhrase  = backupPhrase
+      }
+
+-- | Generates some 'Entropy' from an 'Integer'. Due to the fact
+-- Haskoin accepts only multiple of 4 bytes, we pad the input with
+-- zeros. It leads to quite crappy 12-words mnemonic, but as long as
+-- they don't clash with each other, we are happy.
+toEntropy :: Integer -> Entropy
+toEntropy x =
+    let packs = B.unpack (toS $ show x)
+        len   = length packs
+    in B.pack $ case len < 16 of
+      True  -> packs <> replicate (16 - len) 0x0
+      False -> take (len - (len `mod` 16)) packs
+
+-- | Generates a new 'BackupPhrase' piggybacking on @Haskoin@ for
+-- the BIP-39 words list.
+newRandomMnemonic :: MonadIO m => Entropy -> m BackupPhrase
+newRandomMnemonic entropy = case toMnemonic entropy of
+    Left e  -> error ("Error: " <> e)
+    Right x -> pure (mkBackupPhrase12 (T.words $ toS x))
+
+-- | Creates a new 'CAccount'.
+genAccount :: CWallet -> Integer -> UberMonad CAccount
+genAccount CWallet{..} accountNum = do
+    newAccountIncludeUnready True RandomSeed mempty accountInit
+  where
+    accountInit :: CAccountInit
+    accountInit = CAccountInit {
+      caInitMeta = CAccountMeta {
+          caName = toS $ "Account Number #" <> show accountNum
+          }
+      , caInitWId  = cwId
+      }
+
+-- | Creates a new 'CAddress'.
+genAddress :: AccountId -> UberMonad CAddress
+genAddress cid = do
+    let (walletId, addrNum) = (aiWId cid, aiIndex cid)
+    newAddress RandomSeed mempty (AccountId walletId addrNum)
+

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+module Main where
+
+import           Prelude
+import           CLI
+import           Types
+import           Rendering                   (say, bold)
+import           Control.Lens
+import           Control.Monad.Reader
+import           Serokell.Util               (sec)
+import           Data.Text                   (pack)
+import           Data.Default                (def)
+import           Data.Maybe                  (fromJust, isJust)
+import           Data.IORef                  (newIORef)
+import           GHC.Conc
+import           Lib
+import           Mockable                    (Production, runProduction)
+import           Options.Generic
+import           Pos.Client.CLI              (CommonArgs (..), CommonNodeArgs (..),
+                                              NodeArgs (..), getNodeParams, gtSscParams)
+import           Pos.Core                    (Timestamp (..))
+import           Pos.DB.Rocks.Functions
+import           Pos.DB.Rocks.Types
+import           Pos.Launcher
+import           Pos.Network.CLI
+import           Pos.Network.Types
+import           Pos.Ssc.SscAlgo
+import           Pos.Util.JsonLog
+import           Pos.Util.UserSecret         (usVss)
+import           Pos.Wallet.SscType          (WalletSscType)
+import           Pos.Wallet.Web.Mode
+import           Pos.Wallet.Web.State.Acidic
+import           Pos.Wallet.Web.State.State  (WalletState)
+import           Pos.WorkMode
+import           Stats                       (showStatsAndExit, showStatsData)
+import           System.IO
+import           System.Wlog.LoggerName
+import           System.Wlog.LoggerNameBox
+
+newRealModeContext
+    :: HasConfigurations
+    => NodeDBs
+    -> ConfigurationOptions
+    -> FilePath
+    -> Production (RealModeContext WalletSscType)
+newRealModeContext dbs confOpts secretKeyPath = do
+    let nodeArgs = NodeArgs {
+      sscAlgo            = GodTossingAlgo
+    , behaviorConfigPath = Nothing
+    }
+    let networkOps = NetworkConfigOpts {
+          networkConfigOptsTopology = Nothing
+        , networkConfigOptsKademlia = Nothing
+        , networkConfigOptsSelf     = Nothing
+        , networkConfigOptsPort     = 3030
+        , networkConfigOptsPolicies = Nothing
+        }
+    let cArgs@CommonNodeArgs {..} = CommonNodeArgs {
+           dbPath                 = "node-db"
+         , rebuildDB              = True
+         , devSpendingGenesisI    = Nothing
+         , devVssGenesisI         = Nothing
+         , keyfilePath            = secretKeyPath
+         , backupPhrase           = Nothing
+         , externalAddress        = Nothing
+         , bindAddress            = Nothing
+         , peers                  = mempty
+         , networkConfigOpts      = networkOps
+         , jlPath                 = Nothing
+         , kademliaDumpPath       = "kademlia.dump"
+         , commonArgs             = CommonArgs {
+               logConfig            = Nothing
+             , logPrefix            = Nothing
+             , reportServers        = mempty
+             , updateServers        = mempty
+             , configurationOptions = confOpts
+             }
+         , updateLatestPath       = "update"
+         , updateWithPackage      = False
+         , noNTP                  = True
+         , route53Params          = Nothing
+         , enableMetrics          = False
+         , ekgParams              = Nothing
+         , statsdParams           = Nothing
+         , cnaDumpGenesisDataPath = Nothing
+         }
+    nodeParams <- getNodeParams cArgs nodeArgs
+    let vssSK = fromJust $ npUserSecret nodeParams ^. usVss
+    let gtParams = gtSscParams cArgs vssSK (npBehaviorConfig nodeParams)
+    bracketNodeResources @WalletSscType @IO nodeParams gtParams $ \NodeResources{..} ->
+        RealModeContext <$> pure dbs
+                        <*> pure nrSscState
+                        <*> pure nrTxpState
+                        <*> pure nrDlgState
+                        <*> jsonLogConfigFromHandle stdout
+                        <*> pure (LoggerName "dbgen")
+                        <*> pure nrContext
+                        <*> initQueue (defaultNetworkConfig (TopologyAuxx mempty)) Nothing
+
+
+walletRunner
+    :: HasConfigurations
+    => ConfigurationOptions
+    -> NodeDBs
+    -> FilePath
+    -> WalletState
+    -> UberMonad a
+    -> IO a
+walletRunner confOpts dbs secretKeyPath ws act = runProduction $ do
+    wwmc <- WalletWebModeContext <$> pure ws
+                                 <*> liftIO (newTVarIO def)
+                                 <*> liftIO (AddrCIdHashes <$> (newIORef mempty))
+                                 <*> newRealModeContext dbs confOpts secretKeyPath
+    runReaderT act wwmc
+
+newWalletState :: (MonadIO m, HasConfigurations) => Bool -> FilePath -> m WalletState
+newWalletState recreate walletPath =
+    -- If the user passed the `--add-to` option, it means we don't have
+    -- to rebuild the DB, but rather append stuff into it.
+    liftIO $ openState (not recreate) walletPath
+
+instance HasLoggerName IO where
+    getLoggerName = pure $ LoggerName "dbgen"
+    modifyLoggerName _ x = x
+
+-- TODO(ks): Fix according to Pos.Client.CLI.Options
+newConfig :: CLI -> ConfigurationOptions
+newConfig CLI{..} = defaultConfigurationOptions {
+      cfoSystemStart  = Timestamp . sec <$> systemStart
+    , cfoFilePath     = configurationPath
+    , cfoKey          = pack configurationProf
+    }
+
+-- stack exec dbgen -- --config ./tools/src/dbgen/config.dhall --nodeDB db-mainnet --walletDB wdb-mainnet --configPath node/configuration.yaml --secretKey secret-mainnet.key --configProf mainnet_full
+main :: IO ()
+main = do
+
+    cli@CLI{..} <- getRecord "DBGen"
+    let cfg = newConfig cli
+
+    withConfigurations cfg $ do
+        when showStats (showStatsAndExit walletPath)
+
+        say $ bold "Starting the modification of the wallet..."
+
+        showStatsData "before" walletPath
+
+        dbs  <- openNodeDBs False nodePath -- Do not recreate!
+        spec <- loadGenSpec config
+        ws   <- newWalletState (isJust addTo) walletPath -- Recreate or not
+
+        let generatedWallet = generate cli spec
+        walletRunner cfg dbs secretKeyPath ws generatedWallet
+        closeState ws
+
+        showStatsData "after" walletPath

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -5,18 +5,14 @@
 {-# LANGUAGE TypeApplications    #-}
 module Main where
 
-import           Prelude
+import           Universum
+
 import           CLI
 import           Types
 import           Rendering                   (say, bold)
-import           Control.Lens
-import           Control.Monad.Reader
 import           Serokell.Util               (sec)
-import           Data.Text                   (pack)
 import           Data.Default                (def)
 import           Data.Maybe                  (fromJust, isJust)
-import           Data.IORef                  (newIORef)
-import           GHC.Conc
 import           Lib
 import           Mockable                    (Production, runProduction)
 import           Options.Generic
@@ -37,7 +33,6 @@ import           Pos.Wallet.Web.State.Acidic
 import           Pos.Wallet.Web.State.State  (WalletState)
 import           Pos.WorkMode
 import           Stats                       (showStatsAndExit, showStatsData)
-import           System.IO
 import           System.Wlog.LoggerName
 import           System.Wlog.LoggerNameBox
 
@@ -112,8 +107,8 @@ walletRunner
     -> IO a
 walletRunner confOpts dbs secretKeyPath ws act = runProduction $ do
     wwmc <- WalletWebModeContext <$> pure ws
-                                 <*> liftIO (newTVarIO def)
-                                 <*> liftIO (AddrCIdHashes <$> (newIORef mempty))
+                                 <*> newTVarIO def
+                                 <*> (AddrCIdHashes <$> (newIORef mempty))
                                  <*> newRealModeContext dbs confOpts secretKeyPath
     runReaderT act wwmc
 
@@ -132,7 +127,7 @@ newConfig :: CLI -> ConfigurationOptions
 newConfig CLI{..} = defaultConfigurationOptions {
       cfoSystemStart  = Timestamp . sec <$> systemStart
     , cfoFilePath     = configurationPath
-    , cfoKey          = pack configurationProf
+    , cfoKey          = toText configurationProf
     }
 
 -- stack exec dbgen -- --config ./tools/src/dbgen/config.dhall --nodeDB db-mainnet --walletDB wdb-mainnet --configPath node/configuration.yaml --secretKey secret-mainnet.key --configProf mainnet_full

--- a/tools/src/dbgen/QueryMethods.hs
+++ b/tools/src/dbgen/QueryMethods.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE RankNTypes #-}
+module QueryMethods where
+
+import           Prelude
+import           Lib
+import           Pos.Wallet.Web.Methods.Logic (getWallets)
+import           Rendering                    (say)
+import           Text.Printf
+import           Types
+
+queryMethods :: Maybe Method -> UberMonad ()
+queryMethods Nothing = say "No valid method read from the CLI."
+queryMethods (Just method) = case method of
+  GetWallets -> queryGetWallets
+
+
+queryGetWallets :: UberMonad ()
+queryGetWallets = do
+  wallets <- timed getWallets
+  case wallets of
+    [] -> say "No wallets returned."
+    _  -> say $ printf "%d wallets found." (length wallets)
+

--- a/tools/src/dbgen/README.md
+++ b/tools/src/dbgen/README.md
@@ -1,0 +1,93 @@
+# dbgen
+
+This is a simple program to generate valid `wallet-db` databases, starting from a specification
+stored in a `Dhall` config file.
+
+In order for the program to work correctly, it must be provided with a non-empty RocksDB generated
+with the same configuration this program is invoked with, or the DB-content deserialisation will
+fail with the "wrong magic" error.
+
+## Usage
+
+First compile `dbgen` against the same revision of Cardano you want it to generate the `wallet-db` for.
+At the moment the program has been tested with `release/1.0.4`
+(SHA: `6e53bf599097aa0b55738a454115f76f69c9489e`). Then edit the `config.dhall` file to specify the number
+of wallets, accounts and addresses to generate. For example, the following config will generate 10 wallets,
+each wallet with 1 account and 100 addresses underneath:
+
+```
+{ wallet_spec = { account_spec = { addresses = 100 }, accounts = 1 }
+, wallets     = 10
+}
+```
+
+Once you are ready, you can invoke `dbgen`:
+
+```
+Usage: dbgen [--config CONFIG.DHALL] [--dbPath rocksdb-path]
+```
+
+If all is well, the program will generate a new `wallet-db` filled with synthetic but valid data,
+together with stats about how much time it took to generate those:
+
+```
+dbgen --dbPath ../cardano-sl/run/node-db0
+Faking StateLock syncing...
+Generating 1 wallets...
+Action took 0.13194 seconds.
+Generating 1 accounts for Wallet 1...
+Action took 0.083039 seconds.
+Generating 10 addresses for Account CAccountId "Ae2tdPwUPEZGwUVR8meJ6mgbHeiC16TNyM3wTDYRYwDBMeCHUXdMVLHKupC@793406314"...
+Action took 0.739177 seconds.
+OK.
+```
+
+## Printing statistics
+
+If `dbgen` is invoked with the `--stats` option, it will print a bunch of useful stats, namely the wallets,
+their accounts and the number of addresses:
+
+<img width="1440" alt="screen shot 2018-01-01 at 16 36 22" src="https://user-images.githubusercontent.com/29383371/34468858-1756d7e8-ef12-11e7-9d15-6b615adc24fb.png">
+
+## Adding Addresses to an existing wallet
+
+If the `--add-to` option is passed, along with a valid string of the form `walletId@accountIndex`, then
+instead of rebuild the DB from scratch, new addresses (which number can be controlled from the `config.dhall`
+file) will be added. For example, the following two commands first create a DB with a single wallet, a single
+account and 10 addresses, then it appends extra 100 to it:
+
+```
+stack exec dbgen -- --nodeDB ../cardano-sl/run/node-db0 --walletDB wallet-db
+# now grab the account id by printing --stats
+stack exec dbgen -- --nodeDB ../cardano-sl/run/node-db0 --walletDB wallet-db --stats               
+Wallets: 1
+
+- Wallet #1, ready, Synced[AbstractHash 6e5377d2c78b8ba69644bc17caa8c05131d9dd32ed95e8da7a2c3babcad90e6e], PendingTxs: 0
+
+Accounts: 2
+
+- Initial account, Ae2tdPwUPEZGwUVR8meJ6mgbHeiC16TNyM3wTDYRYwDBMeCHUXdMVLHKupC@2147483648, addresses: 1, removed: 0
+- Account Number #1, Ae2tdPwUPEZGwUVR8meJ6mgbHeiC16TNyM3wTDYRYwDBMeCHUXdMVLHKupC@75378469, addresses: 111, removed: 0
+
+Number of used addresses: 0
+Number of change addresses: 0
+
+# Now add more addresses..
+stack exec dbgen -- --nodeDB ../cardano-sl/run/node-db0 --walletDB wallet-db --add-to Ae2tdPwUPEZGwUVR8meJ6mgbHeiC16TNyM3wTDYRYwDBMeCHUXdMVLHKupC@75378469
+```
+
+## Pitfalls
+
+- Not passing an external RocksDB path would result in a segmentation fault (due to invalid FFI code
+  usage in the `rocksdb-haskell` library)
+
+- Faking `StakeLock` sync to avoid the relevant `MVar` from deadlocking.
+
+- By default, the current version of the wallet creates with each new wallet a default account and a default
+  address.
+
+## To implement
+
+- @Ilya Peresadin - probably we also should add option for `dbgen` which generates ton of history entries (https://input-output-rnd.slack.com/archives/C7DRYGPT8/p1515507443000578)
+
+- @Ilya Peresadin and @George Agapov - add fake utxo entries to local db (https://input-output-rnd.slack.com/archives/C7DRYGPT8/p1515493184000042)

--- a/tools/src/dbgen/README.md
+++ b/tools/src/dbgen/README.md
@@ -88,6 +88,5 @@ stack exec dbgen -- --nodeDB ../cardano-sl/run/node-db0 --walletDB wallet-db --a
 
 ## To implement
 
-- @Ilya Peresadin - probably we also should add option for `dbgen` which generates ton of history entries (https://input-output-rnd.slack.com/archives/C7DRYGPT8/p1515507443000578)
-
-- @Ilya Peresadin and @George Agapov - add fake utxo entries to local db (https://input-output-rnd.slack.com/archives/C7DRYGPT8/p1515493184000042)
+- https://iohk.myjetbrains.com/youtrack/issue/CSL-2210
+- https://iohk.myjetbrains.com/youtrack/issue/CSL-2208

--- a/tools/src/dbgen/Rendering.hs
+++ b/tools/src/dbgen/Rendering.hs
@@ -1,0 +1,75 @@
+
+module Rendering where
+
+import           Prelude
+import           Control.Monad.IO.Class
+import qualified Data.HashMap.Strict              as HM
+import           Data.Monoid
+import qualified Data.Text                        as T
+import           Pos.Wallet.Web.ClientTypes.Types
+import           Pos.Wallet.Web.State.Storage
+import           System.Console.ANSI
+import           Text.Printf
+
+renderWallet :: WalletInfo -> T.Text
+renderWallet WalletInfo{..} = T.pack $
+  printf "%s, %s, %s, PendingTxs: %s" (bold $ T.unpack $ cwName _wiMeta)
+                                      (renderReady _wiIsReady)
+                                      (renderSync _wiSyncTip)
+                                      (renderPendingTxs _wsPendingTxs)
+
+renderAccount :: (AccountId, AccountInfo) -> T.Text
+renderAccount (cid, AccountInfo{..}) = T.pack $
+  printf "%s, %s, addresses: %s, removed: %s" (bold $ T.unpack $ caName _aiMeta)
+                                              (renderAccountId cid)
+                                              (cyan $ show $ HM.size _aiAddresses)
+                                              (cyan $ show $ HM.size _aiRemovedAddresses)
+
+renderSync :: WalletTip -> String
+renderSync wt = case wt of
+  NotSynced    -> red "NotSynced"
+  SyncedWith h -> green "Synced" <> printf "[%s]" (show h)
+
+renderPendingTxs :: HM.HashMap a b -> String
+renderPendingTxs m = case HM.size m of
+  0 -> green "0"
+  x -> yellow (show x)
+
+colored :: Color -> String -> String
+colored col txt = setSGRCode [Reset, SetColor Foreground Dull col] <> txt <> setSGRCode [Reset]
+
+red :: String -> String
+red = colored Red
+
+bold :: String -> String
+bold txt = setSGRCode [Reset, SetConsoleIntensity BoldIntensity] <> txt <> setSGRCode [Reset]
+
+yellow :: String -> String
+yellow = colored Red
+
+green :: String -> String
+green = colored Green
+
+cyan :: String -> String
+cyan = colored Cyan
+
+renderReady :: Bool -> String
+renderReady True  = green "ready"
+renderReady False = yellow "restoring"
+
+listOf :: [T.Text] -> IO ()
+listOf = putStrLn . T.unpack . mappend "\n- " . T.intercalate "\n- "
+
+blankLine :: IO ()
+blankLine = say "\n"
+
+-- | Log on stdout.
+say :: MonadIO m => String -> m ()
+say = liftIO . putStrLn
+
+renderAccountId :: AccountId -> String
+renderAccountId AccountId{..} = printf "%s@%s" (renderWId aiWId) (cyan (show aiIndex))
+
+renderWId :: CId Wal -> String
+renderWId (CId (CHash hash)) = cyan (T.unpack hash)
+

--- a/tools/src/dbgen/Rendering.hs
+++ b/tools/src/dbgen/Rendering.hs
@@ -1,10 +1,9 @@
 
 module Rendering where
 
-import           Prelude
-import           Control.Monad.IO.Class
+import           Universum
+
 import qualified Data.HashMap.Strict              as HM
-import           Data.Monoid
 import qualified Data.Text                        as T
 import           Pos.Wallet.Web.ClientTypes.Types
 import           Pos.Wallet.Web.State.Storage
@@ -12,23 +11,29 @@ import           System.Console.ANSI
 import           Text.Printf
 
 renderWallet :: WalletInfo -> T.Text
-renderWallet WalletInfo{..} = T.pack $
-  printf "%s, %s, %s, PendingTxs: %s" (bold $ T.unpack $ cwName _wiMeta)
-                                      (renderReady _wiIsReady)
-                                      (renderSync _wiSyncTip)
-                                      (renderPendingTxs _wsPendingTxs)
+renderWallet WalletInfo{..} = toText renderWalletString
+  where
+    renderWalletString :: String
+    renderWalletString = printf "%s, %s, %s, PendingTxs: %s"
+                              (bold $ toString $ cwName _wiMeta)
+                              (renderReady _wiIsReady)
+                              (renderSync _wiSyncTip)
+                              (renderPendingTxs _wsPendingTxs)
 
 renderAccount :: (AccountId, AccountInfo) -> T.Text
-renderAccount (cid, AccountInfo{..}) = T.pack $
-  printf "%s, %s, addresses: %s, removed: %s" (bold $ T.unpack $ caName _aiMeta)
-                                              (renderAccountId cid)
-                                              (cyan $ show $ HM.size _aiAddresses)
-                                              (cyan $ show $ HM.size _aiRemovedAddresses)
+renderAccount (cid, AccountInfo{..}) = toText accountRenderString
+  where
+    accountRenderString :: String
+    accountRenderString = printf "%s, %s, addresses: %s, removed: %s"
+                              (bold $ toString $ caName _aiMeta)
+                              (renderAccountId cid)
+                              (cyan $ show $ HM.size _aiAddresses)
+                              (cyan $ show $ HM.size _aiRemovedAddresses)
 
 renderSync :: WalletTip -> String
 renderSync wt = case wt of
   NotSynced    -> red "NotSynced"
-  SyncedWith h -> green "Synced" <> printf "[%s]" (show h)
+  SyncedWith h -> green "Synced" <> printf "[%s]" (show h :: String)
 
 renderPendingTxs :: HM.HashMap a b -> String
 renderPendingTxs m = case HM.size m of
@@ -58,7 +63,7 @@ renderReady True  = green "ready"
 renderReady False = yellow "restoring"
 
 listOf :: [T.Text] -> IO ()
-listOf = putStrLn . T.unpack . mappend "\n- " . T.intercalate "\n- "
+listOf = putStrLn . toString . mappend "\n- " . T.intercalate "\n- "
 
 blankLine :: IO ()
 blankLine = say "\n"
@@ -71,5 +76,5 @@ renderAccountId :: AccountId -> String
 renderAccountId AccountId{..} = printf "%s@%s" (renderWId aiWId) (cyan (show aiIndex))
 
 renderWId :: CId Wal -> String
-renderWId (CId (CHash hash)) = cyan (T.unpack hash)
+renderWId (CId (CHash hash)) = cyan (toString hash)
 

--- a/tools/src/dbgen/Stats.hs
+++ b/tools/src/dbgen/Stats.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE TypeFamilies #-}
+module Stats where
+
+import           Prelude
+import           Control.Exception
+import           Control.Monad.IO.Class
+import qualified Data.HashMap.Strict              as HM
+import           Data.Monoid
+import           Pos.Launcher.Configuration
+import           Pos.Wallet.Web.State.Acidic
+import           Pos.Wallet.Web.State.Storage
+import           Rendering
+import           Serokell.AcidState.ExtendedState
+import           System.Exit
+import           Text.Printf
+
+{- For reference:
+
+data WalletStorage = WalletStorage
+    { _wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
+    , _wsAccountInfos    :: !(HashMap AccountId AccountInfo)
+    , _wsProfile         :: !CProfile
+    , _wsReadyUpdates    :: [CUpdateInfo]
+    , _wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
+    , _wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
+    , _wsUtxo            :: !Utxo
+    -- @_wsBalances@ depends on @_wsUtxo@,
+    -- it's forbidden to update @_wsBalances@ without @_wsUtxo@
+    , _wsBalances        :: !WalletBalances
+    , _wsUsedAddresses   :: !CustomAddresses
+    , _wsChangeAddresses :: !CustomAddresses
+    }
+-}
+
+-- type Utxo = Map TxIn TxOutAux
+
+
+showStats :: HasConfigurations => WalletStorage -> IO ()
+showStats WalletStorage{..} = do
+    let wallets  = HM.elems _wsWalletInfos
+    let accounts = HM.toList _wsAccountInfos
+    -- let txsIn    = elems _wsUtxo
+    say $ bold "Wallets:" <> printf " %d"  (length wallets)
+    listOf (map renderWallet wallets)
+    blankLine
+    say $ bold "Accounts:" <> printf " %d" (length accounts)
+    listOf (map renderAccount accounts)
+    blankLine
+    say $ printf "Number of used addresses: %d" (length _wsUsedAddresses)
+    say $ printf "Number of change addresses: %d" (length _wsChangeAddresses)
+
+showStatsAndExit :: HasConfigurations => FilePath -> IO ()
+showStatsAndExit walletPath = do
+    bracket (openState False walletPath) (\x -> closeState x >> exitSuccess) $ \db -> do
+        walletStorage <- getStorage db
+        showStats walletStorage
+
+showStatsNoExit :: HasConfigurations => FilePath -> IO ()
+showStatsNoExit walletPath = do
+  bracket (openState False walletPath) (\x -> closeState x) $ \db -> do
+        walletStorage <- getStorage db
+        showStats walletStorage
+
+showStatsData :: HasConfigurations => String -> FilePath -> IO ()
+showStatsData mark walletPath = do
+    blankLine
+    say $ red $ "The stats " <> mark <> " modification:"
+    showStatsNoExit walletPath
+    blankLine
+
+getStorage :: ExtendedState WalletStorage -> IO WalletStorage
+getStorage db = liftIO (query db GetWalletStorage)
+

--- a/tools/src/dbgen/Types.hs
+++ b/tools/src/dbgen/Types.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE RankNTypes       #-}
+module Types where
+
+import           Prelude
+import           Data.Map            (Map)
+import           Pos.Wallet.Web.Mode
+
+type UberMonad a = MonadWalletWebMode WalletWebMode => WalletWebMode a
+
+data Method  =
+  GetWallets
+  deriving (Show, Read)
+
+type Methods = MonadWalletWebMode WalletWebMode => Map Method (WalletWebMode ())
+

--- a/tools/src/dbgen/config.dhall
+++ b/tools/src/dbgen/config.dhall
@@ -1,0 +1,3 @@
+{ wallet_spec = { account_spec = { addresses = 100 }, accounts = 1 }
+, wallets     = 1
+}


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/CSL-2185

Adding https://github.com/adinapoli-iohk/dbgen to `cardano-sl` because of the GHC linker bug https://ghc.haskell.org/trac/ghc/ticket/13810

Example usage: `stack exec dbgen -- --config ./tools/src/dbgen/config.dhall --nodeDB db-mainnet --walletDB wdb-mainnet --configPath node/configuration.yaml --secretKey secret-mainnet.key --configProf mainnet_full`

Using current `mainnet.sh` script on `cardano-sl` root:
```
#!/usr/bin/env bash
set -eo pipefail

readonly CLUSTER=mainnet

if [[ "$1" == "-c" ]]; then
  shift
  rm -Rf                \
    db-${CLUSTER}       \
    wdb-${CLUSTER}      \
    secret-$CLUSTER.key \
    logs/$CLUSTER
fi

echo "Launch a single node and connect it to '${CLUSTER}' cluster..."

readonly TMP_TOPOLOGY_YAML=/tmp/topology.yaml
printf "wallet:
    relays: [[{ host: relays.cardano-mainnet.iohk.io }]]
    valency: 1
    fallbacks: 7" > "${TMP_TOPOLOGY_YAML}"

stack exec -- cardano-node                                  \
    --tlscert ./scripts/tls-files/server.crt                \
    --tlskey ./scripts/tls-files/server.key                 \
    --tlsca ./scripts/tls-files/ca.crt                      \
    --web                                                   \
    --no-ntp                                                \
    --topology "${TMP_TOPOLOGY_YAML}"                       \
    --log-config scripts/log-templates/log-config-qa.yaml   \
    --logs-prefix "logs/${CLUSTER}"                         \
    --db-path db-${CLUSTER}                                 \
    --wallet-db-path wdb-${CLUSTER}                         \
    --keyfile secret-$CLUSTER.key                           \
    --configuration-key mainnet_full
```