### PR TITLE
[CSL-2087] Don't do extra work for change address creation

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -45,7 +45,7 @@ import           Pos.Wallet.Web.Account           (GenSeed (..), getSKByAddressP
                                                    getSKById)
 import           Pos.Wallet.Web.ClientTypes       (AccountId (..), Addr, CCoin, CId,
                                                    CTx (..), CWAddressMeta (..), Wal,
-                                                   addrMetaToAccount, cadId, mkCCoin)
+                                                   addrMetaToAccount, mkCCoin)
 import           Pos.Wallet.Web.Error             (WalletError (..))
 import           Pos.Wallet.Web.Methods.History   (addHistoryTx, constructCTx,
                                                    getCurChainDifficulty)
@@ -141,8 +141,8 @@ instance
   where
     type AddrData Pos.Wallet.Web.Mode.WalletWebMode = (AccountId, PassPhrase)
     getNewAddress (accId, passphrase) = do
-        clientAddress <- L.newAddress RandomSeed passphrase accId
-        decodeCTypeOrFail (cadId clientAddress)
+        cAddrMeta <- L.newAddress_ RandomSeed passphrase accId
+        decodeCTypeOrFail (cwamId cAddrMeta)
 
 sendMoney
     :: MonadWalletWebMode m


### PR DESCRIPTION
Backport of https://github.com/input-output-hk/cardano-sl/pull/2148, with a twist.

Whilst working on that, I discovered with horror that we overrode @pva701 's patch on [speeding up newAddress creation](https://github.com/input-output-hk/cardano-sl/commit/c051069710478f85b95891070372f2306e8c72c9#diff-419688e9990639ef3c3e43d0e9ca9b28) because we had to merge [this commit](https://github.com/input-output-hk/cardano-sl/commit/ce4adfce2820e3c0db9df53efd4214298ca96b3e#diff-419688e9990639ef3c3e43d0e9ca9b28) which was effectively a building block this PR and #2295 (😰 ).

Anyway, I have restored @pva701 's speedups, but we should carefully benchmark if `newAddress` is still fast or not. I can easily do this using `dbgen` and report back. 