### PR TITLE
Initial work for single DB reads in the wallet 

### DIFF
--- a/auxx/src/Command/Run.hs
+++ b/auxx/src/Command/Run.hs
@@ -30,13 +30,13 @@ import           Pos.Crypto                 (emptyPassphrase, encToPublic,
                                              safeCreatePsk, withSafeSigner)
 import           Pos.Launcher.Configuration (HasConfigurations)
 import           Pos.Util.UserSecret        (readUserSecret, usKeys, usPrimKey)
-import           Pos.Wallet                 (addSecretKey, getBalance, getSecretKeysPlain)
+import           Pos.Wallet                 (addSecretKey, getSecretKeysPlain)
 
 import qualified Command.Rollback           as Rollback
 import qualified Command.Tx                 as Tx
 import           Command.Types              (Command (..))
 import qualified Command.Update             as Update
-import           Mode                       (AuxxMode, CmdCtx (..), getCmdCtx)
+import           Mode                       (AuxxMode, CmdCtx (..), getCmdCtx, getBalance)
 
 
 helpMsg :: Text

--- a/node/src/Pos/Client/Txp/Balances.hs
+++ b/node/src/Pos/Client/Txp/Balances.hs
@@ -1,50 +1,28 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Pos.Client.Txp.Balances
-       ( MonadBalances(..)
-       , getOwnUtxo
-       , getBalanceFromUtxo
-       , getOwnUtxosDefault
-       , getBalanceDefault
+       ( getOwnUtxos
        , getOwnUtxoForPk
+       , getBalanceFromUtxo
        ) where
 
 import           Universum
 
-import           Control.Monad.Trans  (MonadTrans)
-import qualified Data.HashMap.Strict  as HM
 import qualified Data.HashSet         as HS
 import           Data.List            (partition)
 import qualified Data.Map             as M
 
 import           Pos.Core             (Address (..), Coin, IsBootstrapEraAddr (..),
-                                       isRedeemAddress, makePubKeyAddress, mkCoin)
+                                       isRedeemAddress, makePubKeyAddress)
 import           Pos.Crypto           (PublicKey)
 import           Pos.DB               (MonadDBRead, MonadGState, MonadRealDB)
 import           Pos.Txp              (MonadTxpMem, Utxo, addrBelongsToSet,
-                                       applyUtxoModToAddrCoinMap, getUtxoModifier)
+                                       getUtxoModifier)
 import qualified Pos.Txp.DB           as DB
 import           Pos.Txp.Toil.Utxo    (getTotalCoinsInUtxo)
 import qualified Pos.Util.Modifier    as MM
 import           Pos.Wallet.Web.State (WebWalletModeDB)
 import qualified Pos.Wallet.Web.State as WS
-
--- | A class which have the methods to get state of address' balance
-class Monad m => MonadBalances m where
-    getOwnUtxos :: [Address] -> m Utxo
-    getBalance :: Address -> m Coin
-    -- TODO: add a function to get amount of stake (it's different from
-    -- balance because of distributions)
-
-instance {-# OVERLAPPABLE #-}
-    (MonadBalances m, MonadTrans t, Monad (t m)) =>
-        MonadBalances (t m)
-  where
-    getOwnUtxos = lift . getOwnUtxos
-    getBalance = lift . getBalance
-
-getBalanceFromUtxo :: MonadBalances m => Address -> m Coin
-getBalanceFromUtxo addr = getTotalCoinsInUtxo <$> getOwnUtxo addr
 
 type BalancesEnv ext ctx m =
     ( MonadRealDB ctx m
@@ -54,8 +32,8 @@ type BalancesEnv ext ctx m =
     , MonadMask m
     , MonadTxpMem ext ctx m)
 
-getOwnUtxosDefault :: BalancesEnv ext ctx m => [Address] -> m Utxo
-getOwnUtxosDefault addrs = do
+getOwnUtxos :: BalancesEnv ext ctx m => [Address] -> m Utxo
+getOwnUtxos addrs = do
     let (redeemAddrs, commonAddrs) = partition isRedeemAddress addrs
 
     updates <- getUtxoModifier
@@ -68,19 +46,8 @@ getOwnUtxosDefault addrs = do
         addrsSet = HS.fromList addrs
     pure $ M.filter (`addrBelongsToSet` addrsSet) allUtxo
 
--- | `BalanceDB` isn't used here anymore, because
--- 1) It doesn't represent actual balances of addresses, but it represents _stakes_
--- 2) Local utxo is now cached, and deriving balances from it is not
---    so bad for performance now
-getBalanceDefault :: BalancesEnv ext ctx m => Address -> m Coin
-getBalanceDefault addr = do
-    balancesAndUtxo <- WS.getWalletBalancesAndUtxo
-    fromMaybe (mkCoin 0) .
-        HM.lookup addr .
-        flip applyUtxoModToAddrCoinMap balancesAndUtxo <$> getUtxoModifier
-
-getOwnUtxo :: MonadBalances m => Address -> m Utxo
-getOwnUtxo = getOwnUtxos . one
+getBalanceFromUtxo :: Functor m => ([Address] -> m Utxo) -> Address -> m Coin
+getBalanceFromUtxo getOwnUtxos' = fmap getTotalCoinsInUtxo . getOwnUtxos' . one
 
 -- | Sometimes we want to get utxo for all addresses which we «own»,
 -- i. e. can spend funds from them. We can't get all such addresses
@@ -88,8 +55,9 @@ getOwnUtxo = getOwnUtxos . one
 -- from an address. And we can't enumerate all possible addresses for
 -- a public key. So we only consider two addresses: one with bootstrap
 -- era distribution and another one with single key distribution.
-getOwnUtxoForPk :: MonadBalances m => PublicKey -> m Utxo
-getOwnUtxoForPk ourPk = getOwnUtxos ourAddresses
+getOwnUtxoForPk :: ([Address] -> m Utxo)
+                -> PublicKey -> m Utxo
+getOwnUtxoForPk getOwnUtxos' ourPk = getOwnUtxos' ourAddresses
   where
     ourAddresses :: [Address]
     ourAddresses =

--- a/node/src/Pos/Communication/Tx.hs
+++ b/node/src/Pos/Communication/Tx.hs
@@ -18,8 +18,7 @@ import           Universum
 
 import           Pos.Binary                 ()
 import           Pos.Client.Txp.Addresses   (MonadAddresses (..))
-import           Pos.Client.Txp.Balances    (MonadBalances (..), getOwnUtxo,
-                                             getOwnUtxoForPk)
+import           Pos.Client.Txp.Balances    (getOwnUtxoForPk)
 import           Pos.Client.Txp.History     (MonadTxHistory (..))
 import           Pos.Client.Txp.Util        (InputSelectionPolicy, PendingAddresses (..),
                                              TxCreateMode, TxError (..), createMTx,
@@ -35,6 +34,7 @@ import           Pos.Crypto                 (RedeemSecretKey, SafeSigner, hash,
 import           Pos.DB.Class               (MonadGState)
 import           Pos.Txp.Core               (TxAux (..), TxId, TxOut (..), TxOutAux (..),
                                              txaF)
+import           Pos.Txp.Toil.Types         (Utxo)
 import           Pos.Txp.Network.Types      (TxMsgContents (..))
 import           Pos.Util.Util              (eitherToThrow)
 import           Pos.WorkMode.Class         (MinWorkMode)
@@ -42,7 +42,6 @@ import           Pos.WorkMode.Class         (MinWorkMode)
 
 type TxMode ssc m
     = ( MinWorkMode m
-      , MonadBalances m
       , MonadTxHistory ssc m
       , MonadMockable m
       , MonadMask m
@@ -62,14 +61,15 @@ submitAndSave enqueue txAux@TxAux {..} = do
 -- | Construct Tx using multiple secret keys and given list of desired outputs.
 prepareMTx
     :: TxMode ssc m
-    => (Address -> SafeSigner)
+    => ([Address] -> m Utxo)
+    -> (Address -> SafeSigner)
     -> PendingAddresses
     -> InputSelectionPolicy
     -> NonEmpty Address
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-prepareMTx hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData = do
+prepareMTx getOwnUtxos hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData = do
     utxo <- getOwnUtxos (toList addrs)
     eitherToThrow =<< createMTx pendingAddrs inputSelectionPolicy utxo hdwSigners outputs addrData
 
@@ -77,26 +77,28 @@ prepareMTx hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData =
 submitTx
     :: TxMode ssc m
     => EnqueueMsg m
+    -> ([Address] -> m Utxo)
     -> PendingAddresses
     -> SafeSigner
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-submitTx enqueue pendingAddrs ss outputs addrData = do
+submitTx enqueue getOwnUtxos pendingAddrs ss outputs addrData = do
     let ourPk = safeToPublic ss
-    utxo <- getOwnUtxoForPk ourPk
+    utxo <- getOwnUtxoForPk getOwnUtxos ourPk
     txWSpendings <- eitherToThrow =<< createTx pendingAddrs utxo ss outputs addrData
     txWSpendings <$ submitAndSave enqueue (fst txWSpendings)
 
 -- | Construct redemption Tx using redemption secret key and a output address
 prepareRedemptionTx
     :: TxMode ssc m
-    => RedeemSecretKey
+    => ([Address] -> m Utxo)
+    -> RedeemSecretKey
     -> Address
     -> m (TxAux, Address, Coin)
-prepareRedemptionTx rsk output = do
+prepareRedemptionTx getOwnUtxos rsk output = do
     let redeemAddress = makeRedeemAddress $ redeemToPublic rsk
-    utxo <- getOwnUtxo redeemAddress
+    utxo <- getOwnUtxos [redeemAddress]
     let addCoin c = unsafeAddCoin c . txOutValue . toaOut
         redeemBalance = foldl' addCoin (mkCoin 0) utxo
         txOuts = one $

--- a/node/src/Pos/Wallet/WalletMode.hs
+++ b/node/src/Pos/Wallet/WalletMode.hs
@@ -3,8 +3,7 @@
 -- | 'MonadWallet' constraint. Like `WorkMode`, but for wallet.
 
 module Pos.Wallet.WalletMode
-       ( MonadBalances (..)
-       , MonadTxHistory (..)
+       ( MonadTxHistory (..)
        , MonadBlockchainInfo (..)
        , MonadUpdates (..)
        , MonadWallet
@@ -15,7 +14,6 @@ import           Universum
 import           Control.Monad.Trans     (MonadTrans)
 import           Data.Time.Units         (Millisecond)
 
-import           Pos.Client.Txp.Balances (MonadBalances (..))
 import           Pos.Client.Txp.History  (MonadTxHistory (..))
 import           Pos.Communication       (TxMode)
 import           Pos.Core                (ChainDifficulty)

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -11,34 +11,15 @@ module Pos.Wallet.Web.State.Acidic
        , tidyState
        , update
 
-       , GetProfile (..)
+         -- * Only query transaction
+       , GetWalletStorage (..)
+
+         -- * All the update transactions
        , DoesAccountExist (..)
-       , GetAccountIds (..)
-       , GetAccountMetas (..)
-       , GetAccountMeta (..)
-       , GetAccountAddrMaps (..)
-       , GetWalletMetas (..)
-       , GetWalletMeta (..)
-       , GetWalletMetaIncludeUnready (..)
-       , GetWalletPassLU (..)
-       , GetWalletSyncTip (..)
-       , GetWalletAddresses (..)
-       , GetWalletUtxo (..)
-       , GetWalletBalancesAndUtxo (..)
        , UpdateWalletBalancesAndUtxo (..)
        , SetWalletUtxo (..)
-       , GetAccountWAddresses (..)
        , DoesWAddressExist (..)
-       , GetTxMeta (..)
-       , GetUpdates (..)
-       , GetNextUpdate (..)
        , TestReset (..)
-       , GetHistoryCache (..)
-       , GetCustomAddresses (..)
-       , GetCustomAddress (..)
-       , GetPendingTxs (..)
-       , GetWalletPendingTxs (..)
-       , GetPendingTx (..)
        , AddCustomAddress (..)
        , CreateAccount (..)
        , AddWAddress (..)
@@ -53,7 +34,6 @@ module Pos.Wallet.Web.State.Acidic
        , SetWalletTxMeta (..)
        , AddOnlyNewTxMetas (..)
        , SetWalletTxHistory (..)
-       , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
        , RemoveWallet (..)
        , RemoveTxMetas (..)
@@ -73,7 +53,6 @@ module Pos.Wallet.Web.State.Acidic
        , AddOnlyNewPendingTx (..)
        , CancelApplyingPtxs (..)
        , CancelSpecificApplyingPtx (..)
-       , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
        , UpdateHistoryCache (..)
@@ -120,33 +99,10 @@ tidyState = tidyExtendedState
 makeAcidic ''WalletStorage
     [
       'WS.testReset
-    , 'WS.getProfile
     , 'WS.doesAccountExist
-    , 'WS.getAccountIds
-    , 'WS.getAccountMetas
-    , 'WS.getAccountMeta
-    , 'WS.getAccountAddrMaps
-    , 'WS.getWalletMetas
-    , 'WS.getWalletMeta
-    , 'WS.getWalletMetaIncludeUnready
-    , 'WS.getWalletPassLU
-    , 'WS.getWalletSyncTip
-    , 'WS.getWalletAddresses
-    , 'WS.getWalletUtxo
-    , 'WS.getWalletBalancesAndUtxo
     , 'WS.updateWalletBalancesAndUtxo
     , 'WS.setWalletUtxo
-    , 'WS.getAccountWAddresses
     , 'WS.doesWAddressExist
-    , 'WS.getTxMeta
-    , 'WS.getUpdates
-    , 'WS.getNextUpdate
-    , 'WS.getHistoryCache
-    , 'WS.getCustomAddresses
-    , 'WS.getCustomAddress
-    , 'WS.getPendingTxs
-    , 'WS.getWalletPendingTxs
-    , 'WS.getPendingTx
     , 'WS.addCustomAddress
     , 'WS.removeCustomAddress
     , 'WS.createAccount
@@ -162,7 +118,6 @@ makeAcidic ''WalletStorage
     , 'WS.setWalletTxMeta
     , 'WS.addOnlyNewTxMetas
     , 'WS.setWalletTxHistory
-    , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta
     , 'WS.removeWallet
     , 'WS.removeTxMetas

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Rank2Types   #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Pos.Wallet.Web.State.State
@@ -13,10 +14,12 @@ module Pos.Wallet.Web.State.State
        , closeState
 
        , AddressLookupMode (..)
-       , CustomAddressType (..)
        , CurrentAndRemoved (..)
+       , CustomAddressType (..)
 
        -- * Getters
+       , WalletSnapshot
+       , getWalletSnapshot
        , getProfile
        , doesAccountExist
        , getAccountIds
@@ -82,7 +85,6 @@ module Pos.Wallet.Web.State.State
        , addOnlyNewPendingTx
        , cancelApplyingPtxs
        , cancelSpecificApplyingPtx
-       , getWalletStorage
        , flushWalletStorage
        ) where
 
@@ -106,9 +108,9 @@ import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition)
 import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
+import qualified Pos.Wallet.Web.State.Storage as S
 import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMode (..),
-                                               CurrentAndRemoved (..),
-                                               CustomAddressType (..),
+                                               CAddresses, CurrentAndRemoved(..) , CustomAddressType (..),
                                                PtxMetaUpdate (..), WalletBalances,
                                                WalletStorage, WalletTip (..))
 
@@ -129,11 +131,17 @@ type WebWalletModeDB ctx m =
     , HasConfiguration
     )
 
+type WalletSnapshot = WalletStorage
+
 queryDisk
     :: (EventState event ~ WalletStorage, QueryEvent event,
         MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 queryDisk e = getWalletWebState >>= flip A.query e
+
+queryValue
+    :: WalletStorage -> S.Query a -> a
+queryValue ws q = runReader q ws
 
 updateDisk
     :: (EventState event ~ WalletStorage, UpdateEvent event,
@@ -141,86 +149,95 @@ updateDisk
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
 
-doesAccountExist :: WebWalletModeDB ctx m => AccountId -> m Bool
-doesAccountExist = queryDisk . A.DoesAccountExist
+-- | All queries work by doing a /single/ read of the DB state and then
+-- by using pure functions to extract the relevant information. A single read
+-- guarantees that we see a self-consistent snapshot of the wallet state.
+--
+getWalletSnapshot :: WebWalletModeDB ctx m => m WalletSnapshot
+getWalletSnapshot = queryDisk A.GetWalletStorage
 
-getAccountIds :: WebWalletModeDB ctx m => m [AccountId]
-getAccountIds = queryDisk A.GetAccountIds
+doesAccountExist :: WalletSnapshot -> AccountId -> Bool
+doesAccountExist ws accid = queryValue ws (S.doesAccountExist accid)
 
-getAccountMetas :: WebWalletModeDB ctx m => m [CAccountMeta]
-getAccountMetas = queryDisk A.GetAccountMetas
+getAccountIds :: WalletSnapshot -> [AccountId]
+getAccountIds ws = queryValue ws S.getAccountIds
 
-getAccountMeta :: WebWalletModeDB ctx m => AccountId -> m (Maybe CAccountMeta)
-getAccountMeta = queryDisk . A.GetAccountMeta
+getAccountMetas :: WalletSnapshot -> [CAccountMeta]
+getAccountMetas ws = queryValue ws S.getAccountMetas
 
-getAccountAddrMaps
-    :: WebWalletModeDB ctx m
-    => AccountId -> m (CurrentAndRemoved (HashMap (CId Addr) AddressInfo))
-getAccountAddrMaps = queryDisk . A.GetAccountAddrMaps
+getAccountMeta :: WalletSnapshot -> AccountId -> Maybe CAccountMeta
+getAccountMeta ws accid = queryValue ws (S.getAccountMeta accid)
 
-getWalletAddresses :: WebWalletModeDB ctx m => m [CId Wal]
-getWalletAddresses = queryDisk A.GetWalletAddresses
+getAccountAddrMaps :: WalletSnapshot -> AccountId -> CurrentAndRemoved CAddresses
+getAccountAddrMaps ws accid = queryValue ws (S.getAccountAddrMaps accid)
 
-getWalletMeta :: WebWalletModeDB ctx m => CId Wal -> m (Maybe CWalletMeta)
-getWalletMeta = queryDisk . A.GetWalletMeta
+getWalletAddresses :: WalletSnapshot -> [CId Wal]
+getWalletAddresses ws = queryValue ws S.getWalletAddresses
 
-getWalletMetaIncludeUnready :: WebWalletModeDB ctx m => Bool -> CId Wal -> m (Maybe CWalletMeta)
-getWalletMetaIncludeUnready includeReady = queryDisk . A.GetWalletMetaIncludeUnready includeReady
+getWalletMeta :: WalletSnapshot -> CId Wal -> Maybe CWalletMeta
+getWalletMeta ws wid = queryValue ws (S.getWalletMeta wid)
 
-getWalletMetas :: WebWalletModeDB ctx m => m ([CWalletMeta])
-getWalletMetas = queryDisk A.GetWalletMetas
+getWalletMetaIncludeUnready
+    :: WalletSnapshot -> Bool -> CId Wal -> Maybe CWalletMeta
+getWalletMetaIncludeUnready ws includeReady wid =
+    queryValue ws (S.getWalletMetaIncludeUnready includeReady wid)
 
-getWalletPassLU :: WebWalletModeDB ctx m => CId Wal -> m (Maybe PassPhraseLU)
-getWalletPassLU = queryDisk . A.GetWalletPassLU
+getWalletMetas :: WalletSnapshot -> [CWalletMeta]
+getWalletMetas ws = queryValue ws S.getWalletMetas
 
-getWalletSyncTip :: WebWalletModeDB ctx m => CId Wal -> m (Maybe WalletTip)
-getWalletSyncTip = queryDisk . A.GetWalletSyncTip
+getWalletPassLU :: WalletSnapshot -> CId Wal -> Maybe PassPhraseLU
+getWalletPassLU ws wid = queryValue ws (S.getWalletPassLU wid)
+
+getWalletSyncTip :: WalletSnapshot -> CId Wal -> Maybe WalletTip
+getWalletSyncTip ws wid = queryValue ws (S.getWalletSyncTip wid)
 
 getAccountWAddresses
-    :: WebWalletModeDB ctx m
-    => AddressLookupMode -> AccountId -> m (Maybe [AddressInfo])
-getAccountWAddresses mode ai = queryDisk $ A.GetAccountWAddresses mode ai
+    :: WalletSnapshot -> AddressLookupMode -> AccountId -> Maybe [AddressInfo]
+getAccountWAddresses ws mode wid =
+    queryValue ws (S.getAccountWAddresses mode wid)
 
 doesWAddressExist
-    :: WebWalletModeDB ctx m
-    => AddressLookupMode -> CWAddressMeta -> m Bool
-doesWAddressExist mode = queryDisk . A.DoesWAddressExist mode
+    :: WalletSnapshot -> AddressLookupMode -> CWAddressMeta -> Bool
+doesWAddressExist ws mode addr = queryValue ws (S.doesWAddressExist mode addr)
 
-getProfile :: WebWalletModeDB ctx m => m CProfile
-getProfile = queryDisk A.GetProfile
+getProfile :: WalletSnapshot -> CProfile
+getProfile ws = queryValue ws S.getProfile
 
-getTxMeta :: WebWalletModeDB ctx m => CId Wal -> CTxId -> m (Maybe CTxMeta)
-getTxMeta cWalId = queryDisk . A.GetTxMeta cWalId
+getTxMeta :: WalletSnapshot -> CId Wal -> CTxId -> Maybe CTxMeta
+getTxMeta ws wid txid = queryValue ws (S.getTxMeta wid txid)
 
-getWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [CTxMeta])
-getWalletTxHistory = queryDisk . A.GetWalletTxHistory
+getWalletTxHistory :: WalletSnapshot -> CId Wal -> Maybe [CTxMeta]
+getWalletTxHistory ws wid = queryValue ws (S.getWalletTxHistory wid)
 
-getUpdates :: WebWalletModeDB ctx m => m [CUpdateInfo]
-getUpdates = queryDisk A.GetUpdates
+getUpdates :: WalletSnapshot -> [CUpdateInfo]
+getUpdates ws = queryValue ws S.getUpdates
 
-getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
-getNextUpdate = queryDisk A.GetNextUpdate
+getNextUpdate :: WalletSnapshot -> Maybe CUpdateInfo
+getNextUpdate ws = queryValue ws S.getNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe (Map TxId TxHistoryEntry))
-getHistoryCache = queryDisk . A.GetHistoryCache
+getHistoryCache :: WalletSnapshot -> CId Wal -> Maybe (Map TxId TxHistoryEntry)
+getHistoryCache ws wid = queryValue ws (S.getHistoryCache wid)
 
-getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]
-getCustomAddresses = queryDisk ... A.GetCustomAddresses
+getCustomAddresses :: WalletSnapshot -> CustomAddressType -> [CId Addr]
+getCustomAddresses ws addrtype = queryValue ws (S.getCustomAddresses addrtype)
 
-getCustomAddress :: WebWalletModeDB ctx m => CustomAddressType -> CId Addr -> m (Maybe HeaderHash)
-getCustomAddress = queryDisk ... A.GetCustomAddress
+getCustomAddress
+    :: WalletSnapshot -> CustomAddressType -> CId Addr -> Maybe HeaderHash
+getCustomAddress ws addrtype addrid =
+    queryValue ws (S.getCustomAddress addrtype addrid)
 
-isCustomAddress :: WebWalletModeDB ctx m => CustomAddressType -> CId Addr -> m Bool
-isCustomAddress = fmap isJust . queryDisk ... A.GetCustomAddress
+isCustomAddress :: WalletSnapshot -> CustomAddressType -> CId Addr -> Bool
+isCustomAddress ws addrtype addrid =
+    isJust (getCustomAddress ws addrtype addrid)
 
-getPendingTxs :: WebWalletModeDB ctx m => m [PendingTx]
-getPendingTxs = queryDisk ... A.GetPendingTxs
+getPendingTxs :: WalletSnapshot -> [PendingTx]
+getPendingTxs ws = queryValue ws S.getPendingTxs
 
-getWalletPendingTxs :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [PendingTx])
-getWalletPendingTxs = queryDisk ... A.GetWalletPendingTxs
+getWalletPendingTxs :: WalletSnapshot -> CId Wal -> Maybe [PendingTx]
+getWalletPendingTxs ws wid = queryValue ws (S.getWalletPendingTxs wid)
 
-getPendingTx :: WebWalletModeDB ctx m => CId Wal -> TxId -> m (Maybe PendingTx)
-getPendingTx = queryDisk ... A.GetPendingTx
+getPendingTx :: WalletSnapshot -> CId Wal -> TxId -> Maybe PendingTx
+getPendingTx ws wid txid = queryValue ws (S.getPendingTx wid txid)
 
 createAccount :: WebWalletModeDB ctx m => AccountId -> CAccountMeta -> m ()
 createAccount accId = updateDisk . A.CreateAccount accId
@@ -266,11 +283,11 @@ addOnlyNewTxMetas cWalId cTxMetas = updateDisk (A.AddOnlyNewTxMetas cWalId cTxMe
 setWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
 setWalletTxHistory cWalId = updateDisk . A.SetWalletTxHistory cWalId
 
-getWalletUtxo :: WebWalletModeDB ctx m => m Utxo
-getWalletUtxo = queryDisk A.GetWalletUtxo
+getWalletUtxo :: WalletSnapshot -> Utxo
+getWalletUtxo ws = queryValue ws S.getWalletUtxo
 
-getWalletBalancesAndUtxo :: WebWalletModeDB ctx m => m (WalletBalances, Utxo)
-getWalletBalancesAndUtxo = queryDisk A.GetWalletBalancesAndUtxo
+getWalletBalancesAndUtxo :: WalletSnapshot -> (WalletBalances, Utxo)
+getWalletBalancesAndUtxo ws = queryValue ws S.getWalletBalancesAndUtxo
 
 updateWalletBalancesAndUtxo :: WebWalletModeDB ctx m => UtxoModifier -> m ()
 updateWalletBalancesAndUtxo = updateDisk . A.UpdateWalletBalancesAndUtxo
@@ -356,5 +373,3 @@ cancelSpecificApplyingPtx txid = updateDisk ... A.CancelSpecificApplyingPtx txid
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage
 
-getWalletStorage :: WebWalletModeDB ctx m => m WalletStorage
-getWalletStorage = queryDisk A.GetWalletStorage

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -116,22 +116,28 @@ import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMo
 type MonadWalletWebDB ctx m =
     ( MonadReader ctx m
     , HasLens WalletState ctx WalletState
-    , HasConfiguration
     )
 
 getWalletWebState :: MonadWalletWebDB ctx m => m WalletState
 getWalletWebState = view (lensOf @WalletState)
 
 -- | Constraint for working with web wallet DB
-type WebWalletModeDB ctx m = (MonadWalletWebDB ctx m, MonadIO m, MonadMockable m)
+type WebWalletModeDB ctx m =
+    ( MonadWalletWebDB ctx m
+    , MonadIO m
+    , MonadMockable m
+    , HasConfiguration
+    )
 
 queryDisk
-    :: (EventState event ~ WalletStorage, QueryEvent event, WebWalletModeDB ctx m)
+    :: (EventState event ~ WalletStorage, QueryEvent event,
+        MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 queryDisk e = getWalletWebState >>= flip A.query e
 
 updateDisk
-    :: (EventState event ~ WalletStorage, UpdateEvent event, WebWalletModeDB ctx m)
+    :: (EventState event ~ WalletStorage, UpdateEvent event,
+        MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
 

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -9,6 +9,7 @@ module Pos.Wallet.Web.State.Storage
        , AccountInfo (..)
        , AddressInfo (..)
        , AddressLookupMode (..)
+       , CAddresses
        , CustomAddressType (..)
        , CurrentAndRemoved (..)
        , WalletBalances

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -33,53 +33,54 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
 
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode(..), AddressInfo (..),
-                                             CurrentAndRemoved (..),
-                                             WebWalletModeDB, getAccountAddrMaps, getAccountIds,
+                                             CurrentAndRemoved (getCurrent, getRemoved),
+                                             WalletSnapshot,
+                                             getAccountAddrMaps, getAccountIds,
                                              getAccountWAddresses, getWalletMeta,
                                              getAccountMeta)
 
-getAccountMetaOrThrow :: (WebWalletModeDB ctx m, MonadThrow m) => AccountId -> m CAccountMeta
-getAccountMetaOrThrow accId = getAccountMeta accId >>= maybeThrow noAccount
+getAccountMetaOrThrow :: MonadThrow m => WalletSnapshot -> AccountId -> m CAccountMeta
+getAccountMetaOrThrow ws accId = maybeThrow noAccount (getAccountMeta ws accId)
   where
     noAccount =
         RequestError $ sformat ("No account with id "%build%" found") accId
 
-getWalletAccountIds :: WebWalletModeDB ctx m => CId Wal -> m [AccountId]
-getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getAccountIds
+getWalletAccountIds :: WalletSnapshot -> CId Wal -> [AccountId]
+getWalletAccountIds ws cWalId = filter ((== cWalId) . aiWId) (getAccountIds ws)
 
-getAccountAddrsOrThrow
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> AccountId -> m [AddressInfo]
-getAccountAddrsOrThrow mode accId =
-    getAccountWAddresses mode accId >>= maybeThrow noWallet
+getAccountAddrsOrThrow :: MonadThrow m
+                       => WalletSnapshot
+                       -> AddressLookupMode
+                       -> AccountId
+                       -> m [AddressInfo]
+getAccountAddrsOrThrow ws mode accId = maybeThrow noWallet (getAccountWAddresses ws mode accId)
   where
     noWallet =
         RequestError $
         sformat ("No account with id "%build%" found") accId
 
 getWalletAddrMetas
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m [CWAddressMeta]
-getWalletAddrMetas lookupMode cWalId = do
-    accountIds <- getWalletAccountIds cWalId
-    map adiCWAddressMeta <$> concatMapM (getAccountAddrsOrThrow lookupMode) accountIds
+    :: MonadThrow m
+    => WalletSnapshot
+    -> AddressLookupMode
+    -> CId Wal
+    -> m [CWAddressMeta]
+getWalletAddrMetas ws lookupMode cWalId = do
+    let accountIds = getWalletAccountIds ws cWalId
+    map adiCWAddressMeta <$> concatMapM (getAccountAddrsOrThrow ws lookupMode) accountIds
 
-getWalletAddrs
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m [CId Addr]
-getWalletAddrs mode wid = cwamId <<$>> getWalletAddrMetas mode wid
+getWalletAddrs :: MonadThrow m => WalletSnapshot -> AddressLookupMode -> CId Wal -> m [CId Addr]
+getWalletAddrs ws mode wid = fmap cwamId <$> getWalletAddrMetas ws mode wid
 
-getWalletAddrsDetector
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m (CId Addr -> Bool)
-getWalletAddrsDetector lookupMode cWalId = do
-    accIds <- getWalletAccountIds cWalId
-    accAddrMaps <- mapM getAccountAddrMaps accIds
+getWalletAddrsDetector :: WalletSnapshot -> AddressLookupMode -> CId Wal -> (CId Addr -> Bool)
+getWalletAddrsDetector ws lookupMode cWalId = do
+    let accIds = getWalletAccountIds ws cWalId
+    let accAddrMaps = map (getAccountAddrMaps ws) accIds
     let lookupExisting addr = any (HM.member addr . getCurrent) accAddrMaps
         lookupDeleted  addr = any (HM.member addr . getRemoved) accAddrMaps
         lookupEver     addr = lookupExisting addr
                            || lookupDeleted  addr
-    return $ case lookupMode of
+    case lookupMode of
         Existing -> lookupExisting
         Deleted  -> lookupDeleted
         Ever     -> lookupEver
@@ -87,12 +88,10 @@ getWalletAddrsDetector lookupMode cWalId = do
 decodeCTypeOrFail :: (MonadThrow m, FromCType c) => c -> m (OriginType c)
 decodeCTypeOrFail = either (throwM . DecodeError) pure . decodeCType
 
-getWalletAssuredDepth
-    :: (WebWalletModeDB ctx m)
-    => CId Wal -> m (Maybe BlockCount)
-getWalletAssuredDepth wid =
-    assuredBlockDepth HighAssurance . cwAssurance <<$>>
-    getWalletMeta wid
+getWalletAssuredDepth :: WalletSnapshot -> CId Wal -> Maybe BlockCount
+getWalletAssuredDepth ws wid =
+    assuredBlockDepth HighAssurance . cwAssurance <$>
+    getWalletMeta ws wid
 
 testOnlyEndpoint :: (HasNodeConfiguration, MonadThrow m) => m a -> m a
 testOnlyEndpoint action

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -33,7 +33,7 @@ import           Pos.Wallet.SscType   (WalletSscType)
 import           Pos.Wallet.Web       (WalletWebMode, bracketWalletWS, bracketWalletWebDB,
                                        getSKById, runWRealMode, syncWalletsWithGState,
                                        walletServeWebFull, walletServerOuts)
-import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage,
+import           Pos.Wallet.Web.State (getWalletSnapshot, cleanupAcidStatePeriodically, flushWalletStorage,
                                        getWalletAddresses)
 import           Pos.Web              (serveWebGT)
 import           Pos.WorkMode         (WorkMode)
@@ -65,7 +65,8 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
     convPlugins = (, mempty) . map (\act -> ActionSpec $ \__vI __sA -> act)
     syncWallets :: WalletWebMode ()
     syncWallets = do
-        sks <- getWalletAddresses >>= mapM getSKById
+        ws  <- getWalletSnapshot
+        sks <- mapM getSKById (getWalletAddresses ws)
         syncWalletsWithGState @WalletSscType sks
     plugins :: HasConfigurations => ([WorkerSpec WalletWebMode], OutSpecs)
     plugins = mconcat [ convPlugins (pluginsGT wArgs)

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -34,14 +34,13 @@ import           Pos.Util.BackupPhrase (BackupPhrase, safeKeysFromPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
                                              addrMetaToAccount, addressToCId, encToCId)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), WebWalletModeDB,
+import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), WalletSnapshot,
                                              doesWAddressExist, getAccountMeta)
 
 type AccountMode ctx m =
     ( MonadCatch m
     , WithLogger m
     , MonadKeys ctx m
-    , WebWalletModeDB ctx m
     )
 
 myRootAddresses :: MonadKeys ctx m => m [CId Wal]
@@ -122,7 +121,7 @@ type AddrGenSeed = GenSeed Word32   -- with derivation index
 
 generateUnique
     :: (MonadIO m, MonadThrow m)
-    => Text -> AddrGenSeed -> (Word32 -> m b) -> (Word32 -> b -> m Bool) -> m b
+    => Text -> AddrGenSeed -> (Word32 -> m b) -> (Word32 -> b -> Bool) -> m b
 generateUnique desc RandomSeed generator isDuplicate = loop (100 :: Int)
   where
     loop 0 = throwM . RequestError $
@@ -131,45 +130,46 @@ generateUnique desc RandomSeed generator isDuplicate = loop (100 :: Int)
     loop i = do
         rand  <- liftIO $ randomRIO (firstHardened, maxBound)
         value <- generator rand
-        isDup <- isDuplicate rand value
-        if isDup then
+        if isDuplicate rand value then
             loop (i - 1)
         else
             return value
 generateUnique desc (DeterminedSeed seed) generator notFit = do
     value <- generator (fromIntegral seed)
-    whenM (notFit seed value) $
+    when (notFit seed value) $
         throwM . InternalError $
         sformat (build%": this index is already taken")
         desc
     return value
 
 genUniqueAccountId
-    :: AccountMode ctx m
-    => AddrGenSeed
+    :: (MonadIO m, MonadThrow m)
+    => WalletSnapshot
+    -> AddrGenSeed
     -> CId Wal
     -> m AccountId
-genUniqueAccountId genSeed wsCAddr =
+genUniqueAccountId ws genSeed wsCAddr =
     generateUnique
         "account generation"
         genSeed
         (return . AccountId wsCAddr)
         notFit
   where
-    notFit _idx addr = isJust <$> getAccountMeta addr
+    notFit _idx addr = isJust $ getAccountMeta ws addr
 
 genUniqueAddress
     :: AccountMode ctx m
-    => AddrGenSeed
+    => WalletSnapshot
+    -> AddrGenSeed
     -> PassPhrase
     -> AccountId
     -> m CWAddressMeta
-genUniqueAddress genSeed passphrase wCAddr@AccountId{..} =
+genUniqueAddress ws genSeed passphrase wCAddr@AccountId{..} =
     generateUnique "address generation" genSeed mkAddress notFit
   where
     mkAddress cwamAddressIndex =
         deriveAddress passphrase wCAddr cwamAddressIndex
-    notFit _idx addr = doesWAddressExist Ever addr
+    notFit _idx addr = doesWAddressExist ws Ever addr
 
 deriveAddressSK
     :: AccountMode ctx m

--- a/wallet/src/Pos/Wallet/Web/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Backup.hs
@@ -18,7 +18,7 @@ import           Pos.Wallet.Web.Account     (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountMeta (..), CId,
                                              CWalletMeta (..), Wal)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (getAccountMeta, getWalletMeta)
+import           Pos.Wallet.Web.State       (WalletSnapshot, getAccountMeta, getWalletMeta)
 import           Pos.Wallet.Web.Util        (getWalletAccountIds)
 
 currentBackupFormatVersion :: V.Version
@@ -35,15 +35,18 @@ data WalletBackup = WalletBackup
 
 data TotalBackup = TotalBackup WalletBackup
 
-getWalletBackup :: AccountMode ctx m => CId Wal -> m WalletBackup
-getWalletBackup wId = do
+getWalletBackup :: AccountMode ctx m
+                => WalletSnapshot
+                -> CId Wal
+                -> m WalletBackup
+getWalletBackup ws wId = do
     sk <- getSKById wId
-    meta <- maybeThrow (InternalError "Wallet have no meta") =<<
-            getWalletMeta wId
-    accountIds <- getWalletAccountIds wId
-    accountMetas <- forM accountIds $
-        maybeThrow (InternalError "Account have no meta") <=<
-        getAccountMeta
+    meta <- maybeThrow (InternalError "Wallet have no meta") $
+            getWalletMeta ws wId
+    let accountIds = getWalletAccountIds ws wId
+    accountMetas <- forM accountIds $ \accid ->
+        maybeThrow (InternalError "Account have no meta") $
+        getAccountMeta ws accid
 
     let accountsMap = HM.fromList $ zip
             (map (fromInteger . fromIntegral . aiIndex) accountIds)

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -27,13 +27,14 @@ import           Pos.Wallet.Web.ClientTypes   (CFilePath (..), CId, CWallet, Wal
 import           Pos.Wallet.Web.Error         (WalletError (..))
 import qualified Pos.Wallet.Web.Methods.Logic as L
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
-import           Pos.Wallet.Web.State         (createAccount, getWalletMeta)
+import           Pos.Wallet.Web.State         (createAccount, getWalletMeta, getWalletSnapshot)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
 restoreWalletFromBackup :: MonadWalletWebMode m => WalletBackup -> m CWallet
 restoreWalletFromBackup WalletBackup {..} = do
+    ws <- getWalletSnapshot
     let wId = encToCId wbSecretKey
-    wExists <- isJust <$> getWalletMeta wId
+        wExists = isJust $ getWalletMeta ws wId
 
     if wExists
         then do
@@ -48,7 +49,7 @@ restoreWalletFromBackup WalletBackup {..} = do
             for_ accList $ \(idx, meta) -> do
                 let aIdx = fromInteger $ fromIntegral idx
                     seedGen = DeterminedSeed aIdx
-                accId <- genUniqueAccountId seedGen wId
+                accId <- genUniqueAccountId ws seedGen wId
                 createAccount accId meta
             -- Restoring a wallet from backup may take a long time.
             -- Hence we mark the wallet as "not ready" until `syncWalletOnImport` completes.
@@ -70,5 +71,6 @@ importWalletJSON (CFilePath (toString -> fp)) = do
 
 exportWalletJSON :: MonadWalletWebMode m => CId Wal -> CFilePath -> m ()
 exportWalletJSON wid (CFilePath (toString -> fp)) = do
-    wBackup <- TotalBackup <$> getWalletBackup wid
+    ws <- getWalletSnapshot
+    wBackup <- TotalBackup <$> getWalletBackup ws wid
     liftIO $ BSL.writeFile fp $ A.encode wBackup

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -13,7 +13,6 @@ module Pos.Wallet.Web.Methods.Logic
        , newAccountIncludeUnready
        , newAddress
        , newAddress_
-       , markWalletReady
 
        , deleteWallet
        , deleteAccount
@@ -52,18 +51,18 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccount (..),
                                              encToCId, mkCCoin)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddr)
-import           Pos.Wallet.Web.State       (AddressLookupMode (Existing), AddressInfo (..),
+import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (Existing), AddressInfo (..),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              addWAddress, createAccount, createWallet,
                                              getAccountIds, doesAccountExist,
                                              getWalletAddresses,
                                              getWalletBalancesAndUtxo,
                                              getWalletMetaIncludeUnready, getWalletPassLU,
+                                             getWalletSnapshot,
                                              isCustomAddress, removeAccount,
                                              removeHistoryCache, removeTxMetas,
                                              removeWallet, setAccountMeta, setWalletMeta,
-                                             setWalletPassLU, setWalletReady)
-import           Pos.Wallet.Web.State.Storage (WalBalancesAndUtxo)
+                                             setWalletPassLU)
 import           Pos.Wallet.Web.Tracking     (CAccModifier (..), CachedCAccModifier,
                                               fixCachedAccModifierFor,
                                               fixingCachedAccModifier, sortedInsertions)
@@ -79,52 +78,55 @@ import           Pos.Wallet.Web.Util         (decodeCTypeOrFail, getAccountAddrs
 sumCCoin :: MonadThrow m => [CCoin] -> m CCoin
 sumCCoin ccoins = mkCCoin . unsafeIntegerToCoin . sumCoins <$> mapM decodeCTypeOrFail ccoins
 
-getBalanceWithMod :: WalBalancesAndUtxo -> CachedCAccModifier -> Address -> Coin
-getBalanceWithMod balancesAndUtxo accMod addr =
+getBalanceWithMod :: WalletSnapshot -> CachedCAccModifier -> Address -> Coin
+getBalanceWithMod ws accMod addr =
     fromMaybe (mkCoin 0) .
     HM.lookup addr $
     flip applyUtxoModToAddrCoinMap balancesAndUtxo (camUtxo accMod)
+  where
+    balancesAndUtxo = getWalletBalancesAndUtxo ws
 
 getWAddressBalanceWithMod
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo
+    => WalletSnapshot
     -> CachedCAccModifier
     -> CWAddressMeta
     -> m Coin
-getWAddressBalanceWithMod balancesAndUtxo accMod addr =
-    getBalanceWithMod balancesAndUtxo accMod
+getWAddressBalanceWithMod ws accMod addr =
+    getBalanceWithMod ws accMod
         <$> convertCIdTOAddr (cwamId addr)
 
 -- BE CAREFUL: this function has complexity O(number of used and change addresses)
 getWAddress
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo -> CachedCAccModifier -> CWAddressMeta -> m CAddress
-getWAddress balancesAndUtxo cachedAccModifier cAddr = do
+    => WalletSnapshot
+    -> CachedCAccModifier -> CWAddressMeta -> m CAddress
+getWAddress ws cachedAccModifier cAddr = do
     let aId = cwamId cAddr
-    balance <- getWAddressBalanceWithMod balancesAndUtxo cachedAccModifier cAddr
+    balance <- getWAddressBalanceWithMod ws cachedAccModifier cAddr
 
-    let getFlag customType accessMod = do
-            checkDB <- isCustomAddress customType (cwamId cAddr)
-            let checkMempool = elem aId . map (fst . fst) . toList $
+    let getFlag customType accessMod =
+            let checkDB = isCustomAddress ws customType (cwamId cAddr)
+                checkMempool = elem aId . map (fst . fst) . toList $
                                MM.insertions $ accessMod cachedAccModifier
-            return (checkDB || checkMempool)
-    isUsed   <- getFlag UsedAddr camUsed
-    isChange <- getFlag ChangeAddr camChange
+             in checkDB || checkMempool
+        isUsed   = getFlag UsedAddr camUsed
+        isChange = getFlag ChangeAddr camChange
     return $ CAddress aId (mkCCoin balance) isUsed isChange
 
 getAccountMod
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo
+    => WalletSnapshot
     -> CachedCAccModifier
     -> AccountId
     -> m CAccount
-getAccountMod balAndUtxo accMod accId = do
-    dbAddrs    <- map adiCWAddressMeta . sortOn adiSortingKey <$> getAccountAddrsOrThrow Existing accId
+getAccountMod ws accMod accId = do
+    dbAddrs    <- map adiCWAddressMeta . sortOn adiSortingKey <$> getAccountAddrsOrThrow ws Existing accId
     let allAddrIds = gatherAddresses (camAddresses accMod) dbAddrs
-    allAddrs <- mapM (getWAddress balAndUtxo accMod) allAddrIds
+    allAddrs <- mapM (getWAddress ws accMod) allAddrIds
     balance <- mkCCoin . unsafeIntegerToCoin . sumCoins <$>
                mapM (decodeCTypeOrFail . cadAmount) allAddrs
-    meta <- getAccountMetaOrThrow accId
+    meta <- getAccountMetaOrThrow ws accId
     pure $ CAccount (encodeCType accId) meta allAddrs balance
   where
     gatherAddresses addrModifier dbAddrs = do
@@ -136,23 +138,25 @@ getAccountMod balAndUtxo accMod accId = do
 
 getAccount :: MonadWalletWebMode m => AccountId -> m CAccount
 getAccount accId = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    fixingCachedAccModifier (getAccountMod balAndUtxo) accId
+    ws <- getWalletSnapshot
+    fixingCachedAccModifier ws (getAccountMod ws) accId
 
 getAccountsIncludeUnready
     :: MonadWalletWebMode m
-    => Bool -> Maybe (CId Wal) -> m [CAccount]
-getAccountsIncludeUnready includeUnready mCAddr = do
-    whenJust mCAddr $ \cAddr -> getWalletMetaIncludeUnready includeUnready cAddr `whenNothingM_` noWallet cAddr
-    accIds <- maybe getAccountIds getWalletAccountIds mCAddr
+    => WalletSnapshot
+    -> Bool -> Maybe (CId Wal) -> m [CAccount]
+getAccountsIncludeUnready ws includeUnready mCAddr = do
+    whenJust mCAddr $ \cAddr ->
+      void $ maybeThrow (noWallet cAddr) $
+        getWalletMetaIncludeUnready ws includeUnready cAddr
+    let accIds = maybe (getAccountIds ws) (getWalletAccountIds ws) mCAddr
     let groupedAccIds = fmap reverse $ HM.fromListWith mappend $
                         accIds <&> \acc -> (aiWId acc, [acc])
-    balAndUtxo <- getWalletBalancesAndUtxo
     concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) ->
-         fixCachedAccModifierFor wid $ \accMod ->
-             mapM (getAccountMod balAndUtxo accMod) walAccIds
+         fixCachedAccModifierFor ws wid $ \accMod ->
+             mapM (getAccountMod ws accMod) walAccIds
   where
-    noWallet cAddr = throwM . RequestError $
+    noWallet cAddr = RequestError $
         -- TODO No WALLET with id ...
         -- dunno whether I can fix and not break compatible w/ daedalus
         sformat ("No account with id "%build%" found") cAddr
@@ -160,26 +164,33 @@ getAccountsIncludeUnready includeUnready mCAddr = do
 getAccounts
     :: MonadWalletWebMode m
     => Maybe (CId Wal) -> m [CAccount]
-getAccounts = getAccountsIncludeUnready False
+getAccounts mCAddr = do
+    ws <- getWalletSnapshot
+    getAccountsIncludeUnready ws False mCAddr
 
-getWalletIncludeUnready :: MonadWalletWebMode m => Bool -> CId Wal -> m CWallet
-getWalletIncludeUnready includeUnready cAddr = do
-    meta       <- getWalletMetaIncludeUnready includeUnready cAddr >>= maybeThrow noWallet
-    accounts   <- getAccountsIncludeUnready includeUnready (Just cAddr)
+getWalletIncludeUnready :: MonadWalletWebMode m
+                        => WalletSnapshot -> Bool -> CId Wal -> m CWallet
+getWalletIncludeUnready ws includeUnready cAddr = do
+    meta       <- maybeThrow noWallet $ getWalletMetaIncludeUnready ws includeUnready cAddr
+    accounts   <- getAccountsIncludeUnready ws includeUnready (Just cAddr)
     let accountsNum = length accounts
     balance    <- sumCCoin (map caAmount accounts)
     hasPass    <- isNothing . checkPassMatches emptyPassphrase <$> getSKById cAddr
-    passLU     <- getWalletPassLU cAddr >>= maybeThrow noWallet
+    passLU     <- maybeThrow noWallet (getWalletPassLU ws cAddr)
     pure $ CWallet cAddr meta accountsNum balance hasPass passLU
   where
     noWallet = RequestError $
         sformat ("No wallet with address "%build%" found") cAddr
 
 getWallet :: MonadWalletWebMode m => CId Wal -> m CWallet
-getWallet = getWalletIncludeUnready False
+getWallet wid = do
+    ws <- getWalletSnapshot
+    getWalletIncludeUnready ws False wid
 
 getWallets :: MonadWalletWebMode m => m [CWallet]
-getWallets = getWalletAddresses >>= mapM getWallet
+getWallets = do
+    ws <- getWalletSnapshot
+    mapM (getWalletIncludeUnready ws False) (getWalletAddresses ws)
 
 ----------------------------------------------------------------------------
 -- Creators
@@ -187,16 +198,17 @@ getWallets = getWalletAddresses >>= mapM getWallet
 
 newAddress_
     :: MonadWalletWebMode m
-    => AddrGenSeed
+    => WalletSnapshot
+    -> AddrGenSeed
     -> PassPhrase
     -> AccountId
     -> m CWAddressMeta
-newAddress_ addGenSeed passphrase accId = do
+newAddress_ ws addGenSeed passphrase accId = do
     -- check whether account exists
-    parentExists <- doesAccountExist accId
+    let parentExists = doesAccountExist ws accId
     unless parentExists $ throwM noAccount
 
-    cAccAddr <- genUniqueAddress addGenSeed passphrase accId
+    cAccAddr <- genUniqueAddress ws addGenSeed passphrase accId
     addWAddress cAccAddr
     return cAccAddr
   where
@@ -210,24 +222,30 @@ newAddress
     -> AccountId
     -> m CAddress
 newAddress addGenSeed passphrase accId = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    cwAddrMeta <- newAddress_ addGenSeed passphrase accId
-    fixCachedAccModifierFor accId $ \accMod -> do
-        getWAddress balAndUtxo accMod cwAddrMeta
+    ws <- getWalletSnapshot
+    cwAddrMeta <- newAddress_ ws addGenSeed passphrase accId
+    fixCachedAccModifierFor ws accId $ \accMod -> do
+        getWAddress ws accMod cwAddrMeta
 
 newAccountIncludeUnready
     :: MonadWalletWebMode m
     => Bool -> AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
 newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    fixCachedAccModifierFor caInitWId $ \accMod -> do
+    ws <- getWalletSnapshot
+    fixCachedAccModifierFor ws caInitWId $ \accMod -> do
         -- check wallet exists
-        _ <- getWalletIncludeUnready includeUnready caInitWId
+        _ <- getWalletIncludeUnready ws includeUnready caInitWId
 
-        cAddr <- genUniqueAccountId addGenSeed caInitWId
+        cAddr <- genUniqueAccountId ws addGenSeed caInitWId
         createAccount cAddr caInitMeta
+        -- NOTE(adinapoli): 'newAddres' re-reads the DB here.
         () <$ newAddress addGenSeed passphrase cAddr
-        getAccountMod balAndUtxo accMod cAddr
+
+        -- NOTE(adinapoli): Is it correct doing the new read within a
+        -- 'fixCachedAccModifierFor' block?
+        -- Re-read DB after the update.
+        ws' <- getWalletSnapshot
+        getAccountMod ws' accMod cAddr
 
 newAccount
     :: MonadWalletWebMode m
@@ -239,23 +257,14 @@ createWalletSafe
     => CId Wal -> CWalletMeta -> Bool -> m CWallet
 createWalletSafe cid wsMeta isReady = do
     -- Disallow duplicate wallets (including unready wallets)
-    wSetExists <- isJust <$> getWalletMetaIncludeUnready True cid
+    ws <- getWalletSnapshot
+    let wSetExists = isJust $ getWalletMetaIncludeUnready ws True cid
     when wSetExists $
         throwM $ RequestError "Wallet with that mnemonics already exists"
     curTime <- liftIO getPOSIXTime
     createWallet cid wsMeta isReady curTime
     -- Return the newly created wallet irrespective of whether it's ready yet
-    getWalletIncludeUnready True cid
-
-markWalletReady
-  :: MonadWalletWebMode m
-  => CId Wal -> Bool -> m ()
-markWalletReady cid isReady = do
-    _ <- getWalletMetaIncludeUnready True cid >>= maybeThrow noWallet
-    setWalletReady cid isReady
-  where
-    noWallet = RequestError $
-        sformat ("No wallet with that id "%build%" found") cid
+    getWalletIncludeUnready ws True cid
 
 
 ----------------------------------------------------------------------------

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -215,7 +215,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     (th, dstAddrs) <-
         rewrapTxError "Cannot send transaction" $ do
             (txAux, inpTxOuts') <-
-                prepareMTx getSigner pendingAddrs policy srcAddrs outputs (relatedAccount, passphrase)
+                prepareMTx getOwnUtxos getSigner pendingAddrs policy srcAddrs outputs (relatedAccount, passphrase)
 
             ts <- Just <$> getCurrentTimestamp
             let tx = taTx txAux

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -15,6 +15,7 @@ import qualified Serokell.Util.Base64           as B64
 import           Pos.Aeson.ClientTypes          ()
 import           Pos.Aeson.WalletBackup         ()
 import           Pos.Client.Txp.Addresses       (MonadAddresses)
+import           Pos.Client.Txp.Balances        (getOwnUtxos)
 import           Pos.Client.Txp.History         (TxHistoryEntry (..))
 import           Pos.Communication              (SendActions (..), prepareRedemptionTx)
 import           Pos.Core                       (getCurrentTimestamp)
@@ -95,7 +96,7 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
                L.newAddress RandomSeed passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
-                prepareRedemptionTx redeemSK dstAddr
+                prepareRedemptionTx getOwnUtxos redeemSK dstAddr
 
         ts <- Just <$> getCurrentTimestamp
         let tx = taTx txAux

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -41,7 +41,7 @@ import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
-import           Pos.Wallet.Web.State         (createAccount, removeHistoryCache,
+import           Pos.Wallet.Web.State         (getWalletSnapshot, createAccount, removeHistoryCache,
                                                setWalletSyncTip)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
@@ -124,7 +124,8 @@ importWalletSecret passphrase WalletUserSecret{..} = do
     for_ _wusAccounts $ \(walletIndex, walletName) -> do
         let accMeta = def{ caName = walletName }
             seedGen = DeterminedSeed walletIndex
-        cAddr <- genUniqueAccountId seedGen wid
+        ws <- getWalletSnapshot
+        cAddr <- genUniqueAccountId ws seedGen wid
         createAccount cAddr accMeta
 
     for_ _wusAddrs $ \(walletIndex, accountIndex) -> do

--- a/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
@@ -26,7 +26,7 @@ import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletErr
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending     (PendingTx, allPendingAddresses,
                                              ptxFirstSubmissionHandler, submitAndSavePtx)
-import           Pos.Wallet.Web.State       (getPendingTxs)
+import           Pos.Wallet.Web.State       (WalletSnapshot, getPendingTxs)
 import           Pos.Wallet.Web.Util        (decodeCTypeOrFail)
 
 
@@ -60,13 +60,13 @@ submitAndSaveNewPtx = submitAndSavePtx ptxFirstSubmissionHandler
 
 -- | With regard to tx creation policy which is going to be used,
 -- get addresses which are refered by some yet unconfirmed transaction outputs.
-getPendingAddresses :: MonadWalletWebMode m => InputSelectionPolicy -> m PendingAddresses
-getPendingAddresses = \case
+getPendingAddresses :: WalletSnapshot -> InputSelectionPolicy -> PendingAddresses
+getPendingAddresses ws = \case
     OptimizeForSecurity ->
         -- NOTE (int-index) The pending transactions are ignored when we optimize
         -- for security, so it is faster to not get them. In case they start being
         -- used for other purposes, this shortcut must be removed.
-        return mempty
+        mempty
     OptimizeForHighThroughput ->
-        allPendingAddresses <$> getPendingTxs
+        allPendingAddresses (getPendingTxs ws)
 

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -45,8 +45,6 @@ import           Pos.DB.Rocks                     (dbDeleteDefault, dbGetDefault
                                                    dbIterSourceDefault, dbPutDefault,
                                                    dbWriteBatchDefault)
 
-import           Pos.Client.Txp.Balances          (MonadBalances (..), getBalanceDefault,
-                                                   getOwnUtxosDefault)
 import           Pos.Client.Txp.History           (MonadTxHistory (..),
                                                    getBlockHistoryDefault,
                                                    getLocalHistoryDefault, saveTxDefault)
@@ -262,10 +260,6 @@ instance (HasConfiguration, HasGtConfiguration, HasInfraConfiguration) => MonadB
     localChainDifficulty = localChainDifficultyWebWallet
     connectedPeers = connectedPeersWebWallet
     blockchainSlotDuration = blockchainSlotDurationWebWallet
-
-instance HasConfiguration => MonadBalances WalletWebMode where
-    getOwnUtxos = getOwnUtxosDefault
-    getBalance = getBalanceDefault
 
 instance (HasConfiguration, HasGtConfiguration, HasInfraConfiguration) => MonadTxHistory WalletSscType WalletWebMode where
     getBlockHistory = getBlockHistoryDefault @WalletSscType

--- a/wallet/src/Pos/Wallet/Web/Pending/Util.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Util.hs
@@ -35,7 +35,7 @@ import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition (..),
                                                  PtxPoolInfo)
 import           Pos.Wallet.Web.Pending.Updates (mkPtxSubmitTiming)
-import           Pos.Wallet.Web.State           (getWalletMeta)
+import           Pos.Wallet.Web.State           (WalletSnapshot, getWalletMeta)
 
 ptxPoolInfo :: PtxCondition -> Maybe PtxPoolInfo
 ptxPoolInfo (PtxApplying i)    = Just i
@@ -54,10 +54,11 @@ sortPtxsChrono = OldestFirst . sortWith _ptxCreationSlot . tryTopsort
 
 mkPendingTx
     :: MonadWalletWebMode m
-    => CId Wal -> TxId -> TxAux -> TxHistoryEntry -> m PendingTx
-mkPendingTx wid _ptxTxId _ptxTxAux th = do
+    => WalletSnapshot
+    -> CId Wal -> TxId -> TxAux -> TxHistoryEntry -> m PendingTx
+mkPendingTx ws wid _ptxTxId _ptxTxAux th = do
     _ptxCreationSlot <- getCurrentSlotInaccurate
-    CWalletMeta{..} <- maybeThrow noWallet =<< getWalletMeta wid
+    CWalletMeta{..} <- maybeThrow noWallet (getWalletMeta ws wid)
     return PendingTx
         { _ptxCond = PtxApplying th
         , _ptxWallet = wid

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -42,6 +42,7 @@ import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningW
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
 import qualified Pos.Wallet.Web.State             as WS
+import           Pos.Wallet.Web.State             (WalletSnapshot, WebWalletModeDB)
 import           Pos.Wallet.Web.Tracking.Modifier (CAccModifier (..))
 import           Pos.Wallet.Web.Tracking.Sync     (applyModifierToWallet,
                                                    rollbackModifierFromWallet,
@@ -49,13 +50,13 @@ import           Pos.Wallet.Web.Tracking.Sync     (applyModifierToWallet,
 import           Pos.Wallet.Web.Util              (getWalletAddrMetas)
 
 walletGuard ::
-    ( AccountMode ctx m
-    )
-    => HeaderHash
+       (WithLogger m, MonadIO m)
+    => WalletSnapshot
+    -> HeaderHash
     -> CId Wal
     -> m ()
     -> m ()
-walletGuard curTip wAddr action = WS.getWalletSyncTip wAddr >>= \case
+walletGuard ws curTip wAddr action = case WS.getWalletSyncTip ws wAddr of
     Nothing -> logWarningS $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
     Just WS.NotSynced    -> logInfoS $ sformat ("Wallet #"%build%" hasn't been synced yet") wAddr
     Just (WS.SyncedWith wTip)
@@ -70,6 +71,7 @@ onApplyTracking
     :: forall ssc ctx m .
     ( SscHelpersClass ssc
     , AccountMode ctx m
+    , WebWalletModeDB ctx m
     , MonadSlotsData ctx m
     , MonadDBRead m
     , MonadReporting ctx m
@@ -77,12 +79,13 @@ onApplyTracking
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
 onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
+    ws <- WS.getWalletSnapshot
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
     currentTipHH <- GS.getTip
-    mapM_ (catchInSync "apply" $ syncWallet currentTipHH newTipH txsWUndo)
-       =<< WS.getWalletAddresses
+    mapM_ (catchInSync "apply" $ syncWallet ws currentTipHH newTipH txsWUndo)
+          (WS.getWalletAddresses ws)
 
     -- It's silly, but when the wallet is migrated to RocksDB, we can write
     -- something a bit more reasonable.
@@ -90,14 +93,15 @@ onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
   where
 
     syncWallet
-        :: HeaderHash
+        :: WalletSnapshot
+        -> HeaderHash
         -> BlockHeader ssc
         -> [(TxAux, TxUndo, BlockHeader ssc)]
         -> CId Wal
         -> m ()
-    syncWallet curTip newTipH blkTxsWUndo wAddr = walletGuard curTip wAddr $ do
+    syncWallet ws curTip newTipH blkTxsWUndo wAddr = walletGuard ws curTip wAddr $ do
         blkHeaderTs <- blkHeaderTsGetter
-        allAddresses <- getWalletAddrMetas WS.Ever wAddr
+        allAddresses <- getWalletAddrMetas ws WS.Ever wAddr
         encSK <- getSKById wAddr
         let mapModifier =
                 trackingApplyTxs encSK allAddresses gbDiff blkHeaderTs ptxBlkInfo blkTxsWUndo
@@ -111,6 +115,7 @@ onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
 onRollbackTracking
     :: forall ssc ctx m .
     ( AccountMode ctx m
+    , WebWalletModeDB ctx m
     , MonadDBRead m
     , MonadSlots ctx m
     , SscHelpersClass ssc
@@ -119,25 +124,27 @@ onRollbackTracking
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
 onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
+    ws <- WS.getWalletSnapshot
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
     currentTipHH <- GS.getTip
-    mapM_ (catchInSync "rollback" $ syncWallet currentTipHH newTip txs)
-        =<< WS.getWalletAddresses
+    mapM_ (catchInSync "rollback" $ syncWallet ws currentTipHH newTip txs)
+          (WS.getWalletAddresses ws)
 
     -- It's silly, but when the wallet is migrated to RocksDB, we can write
     -- something a bit more reasonable.
     pure mempty
   where
     syncWallet
-        :: HeaderHash
+        :: WalletSnapshot
+        -> HeaderHash
         -> HeaderHash
         -> [(TxAux, TxUndo, BlockHeader ssc)]
         -> CId Wal
         -> m ()
-    syncWallet curTip newTip txs wid = walletGuard curTip wid $ do
-        allAddresses <- getWalletAddrMetas WS.Ever wid
+    syncWallet ws curTip newTip txs wid = walletGuard ws curTip wid $ do
+        allAddresses <- getWalletAddrMetas ws WS.Ever wid
         encSK <- getSKById wid
         blkHeaderTs <- blkHeaderTsGetter
 


### PR DESCRIPTION
This PR includes the first batch of changes necessary to switch to a `WalletSnapshot`-centric API for the wallet, where we read the DB once and pass it all along as a normal function argument.

This allows us to maintain a consistent view of the DB during most wallet's operations.