### PR TITLE
[CSL-2154]+ [CSL-2165] 'getHistory' improvements

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -49,8 +49,8 @@ import           Pos.Wallet.Web.ClientTypes.Types     (AccountId (..), ApiVersio
                                                        CWallet, CWalletAssurance,
                                                        CWalletInit (..), CWalletMeta (..),
                                                        CWalletRedeem (..),
-                                                       ClientInfo (..), ScrollLimit (..),
-                                                       ScrollOffset (..),
+                                                       ClientInfo (..), SinceTime (..),
+                                                       ScrollLimit (..), ScrollOffset (..),
                                                        SyncProgress (..))
 import           Pos.Wallet.Web.Pending.Types         (PtxCondition)
 
@@ -238,6 +238,9 @@ instance Buildable CInitialized where
 instance Buildable (SecureLog CInitialized) where
     build = buildUnsecure
 
+instance Buildable (SecureLog SinceTime) where
+    build = buildUnsecure
+
 instance Buildable (SecureLog ScrollOffset) where
     build = buildUnsecure
 
@@ -343,6 +346,9 @@ instance FromHttpApiData CTxId where
 
 instance FromHttpApiData CPassPhrase where
     parseUrlPiece = pure . CPassPhrase
+
+instance FromHttpApiData SinceTime where
+    parseUrlPiece = fmap SinceTime . parseUrlPiece
 
 instance FromHttpApiData ScrollOffset where
     parseUrlPiece = fmap ScrollOffset . parseUrlPiece

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -37,6 +37,7 @@ module Pos.Wallet.Web.ClientTypes.Types
       , CElectronCrashReport (..)
       , Wal (..)
       , Addr (..)
+      , SinceTime (..)
       , ScrollOffset (..)
       , ScrollLimit (..)
       , CFilePath (..)
@@ -366,6 +367,10 @@ data CElectronCrashReport = CElectronCrashReport
 ----------------------------------------------------------------------------
 -- Misc
 ----------------------------------------------------------------------------
+
+newtype SinceTime = SinceTime Word
+    deriving (Eq, Ord, Show, Enum, Num, Real, Integral, Generic, Typeable,
+              Buildable)
 
 newtype ScrollOffset = ScrollOffset Word
     deriving (Eq, Ord, Show, Enum, Num, Real, Integral, Generic, Typeable,

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -97,7 +97,7 @@ import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccoun
                                              CId, CInitialized, CPaperVendWalletRedeem,
                                              CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
                                              CUpdateInfo, CWallet, CWalletInit,
-                                             CWalletMeta, CWalletRedeem, ScrollLimit,
+                                             CWalletMeta, CWalletRedeem, ScrollLimit, SinceTime,
                                              ScrollOffset, NewBatchPayment,
                                              SyncProgress, Wal)
 import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
@@ -331,6 +331,7 @@ type GetHistory =
     :> QueryParam "walletId" (CId Wal)
     :> CQueryParam "accountId" CAccountId
     :> QueryParam "address" (CId Addr)
+    :> QueryParam "since" SinceTime
     :> QueryParam "skip" ScrollOffset
     :> QueryParam "limit" ScrollLimit
     :> WRes Get ([CTx], Word)

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -51,7 +51,7 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccount (..),
                                              CWalletMeta (..), Wal, addrMetaToAccount,
                                              encToCId, mkCCoin)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddr)
+import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdToAddr)
 import           Pos.Wallet.Web.State       (AddressLookupMode (Existing), AddressInfo (..),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              addWAddress, createAccount, createWallet,
@@ -93,7 +93,7 @@ getWAddressBalanceWithMod
     -> m Coin
 getWAddressBalanceWithMod balancesAndUtxo accMod addr =
     getBalanceWithMod balancesAndUtxo accMod
-        <$> convertCIdTOAddr (cwamId addr)
+        <$> convertCIdToAddr (cwamId addr)
 
 -- BE CAREFUL: this function has complexity O(number of used and change addresses)
 getWAddress

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -58,7 +58,7 @@ import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs,
                                                    getPendingAddresses, rewrapTxError,
                                                    submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
-                                                   convertCIdTOAddrs)
+                                                   convertCIdToAddrs)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
 import           Pos.Wallet.Web.State             (AddressLookupMode (Ever, Existing), AddressInfo (..))
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
@@ -194,7 +194,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     addrMetas <- nonEmpty addrMetas' `whenNothing`
         throwM (RequestError "Given money source has no addresses!")
 
-    srcAddrs <- convertCIdTOAddrs $ map cwamId addrMetas
+    srcAddrs <- convertCIdToAddrs $ map cwamId addrMetas
 
     logDebug "sendMoney: processed addrs"
 
@@ -240,7 +240,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     srcWalletAddrsDetector <- getWalletAddrsDetector Ever srcWallet
 
     logDebug "sendMoney: constructing response"
-    fst <$> constructCTx srcWallet srcWalletAddrsDetector diff th
+    constructCTx srcWallet srcWalletAddrsDetector diff th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -112,4 +112,4 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     addHistoryTx cWalId th
     cWalAddrsDetector <- getWalletAddrsDetector Ever cWalId
     diff <- getCurChainDifficulty
-    fst <$> constructCTx cWalId cWalAddrsDetector diff th
+    constructCTx cWalId cWalAddrsDetector diff th

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -7,8 +7,8 @@ module Pos.Wallet.Web.Mode
        , WalletWebModeContextTag
        , WalletWebModeContext(..)
        , MonadWalletWebMode
-       , convertCIdTOAddrs
-       , convertCIdTOAddr
+       , convertCIdToAddrs
+       , convertCIdToAddr
        , AddrCIdHashes(AddrCIdHashes)
        ) where
 
@@ -108,8 +108,8 @@ makeLensesWith postfixLFields ''WalletWebModeContext
 instance HasLens AddrCIdHashes WalletWebModeContext AddrCIdHashes where
     lensOf = wwmcHashes_L
 
-convertCIdTOAddr :: (MonadWalletWebMode m) => CId Addr -> m Address
-convertCIdTOAddr i@(CId id) = do
+convertCIdToAddr :: MonadWalletWebMode m => CId Addr -> m Address
+convertCIdToAddr i@(CId id) = do
     hmRef <- unAddrCIdHashes <$> view (lensOf @AddrCIdHashes)
     maddr <- atomicModifyIORef' hmRef $ \hm ->
       case id `M.lookup` hm of
@@ -120,8 +120,8 @@ convertCIdTOAddr i@(CId id) = do
                       Left  err  -> (hm,                  Left err)
     either (throwM . DecodeError) pure maddr
 
-convertCIdTOAddrs :: (MonadWalletWebMode m, Traversable t) => t (CId Addr) -> m (t Address)
-convertCIdTOAddrs cids = do
+convertCIdToAddrs :: (MonadWalletWebMode m, Traversable t) => t (CId Addr) -> m (t Address)
+convertCIdToAddrs cids = do
     hmRef <- unAddrCIdHashes <$> view (lensOf @AddrCIdHashes)
     maddrs <- atomicModifyIORef' hmRef $ \hm ->
       let lookups = map (\cid@(CId h) -> (h, M.lookup h hm, cIdToAddress cid)) cids

--- a/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
@@ -83,6 +83,7 @@ instance ToSchema      InputSelectionPolicy
 instance ToSchema      BlockVersion
 instance ToSchema      BackupPhrase
 instance ToParamSchema CT.CPassPhrase
+instance ToParamSchema CT.SinceTime
 instance ToParamSchema CT.ScrollOffset
 instance ToParamSchema CT.ScrollLimit
 instance ToSchema      CT.CFilePath


### PR DESCRIPTION
This PR:
1. Speeds up 'getHistoryLimited'. Now we construct `CTx` only for response history entries
2. Adds 'since' parameter to `/api/txs/histories` enpoint, which accepts time in seconds

TESTED