### PR TITLE
Fix connect-to-mainnet generator

### DIFF
--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -63,7 +63,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
 
   echo "Launching a node connected to '${environment}' ..."
   ${ifWallet ''
-  if [ ! -d ${stateDir}tls ]; then
+  if [ ! -d ${stateDir}/tls ]; then
     mkdir ${stateDir}/tls/
     ${pkgs.openssl}/bin/openssl req -x509 -newkey rsa:2048 -keyout ${stateDir}/tls/server.key -out ${stateDir}/tls/server.cert -days 3650 -nodes -subj "/CN=localhost"
   fi


### PR DESCRIPTION
A typo in the check for existence of the TLS certificate directory
causes the server cert to be re-generated every time the script is
called. This little patch fixes the situation.