### PR TITLE
[CSL-2184] Get rid of forks in NTP.Client

### DIFF
--- a/networking/src/NTP/Client.hs
+++ b/networking/src/NTP/Client.hs
@@ -1,47 +1,45 @@
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module implements functionality of NTP client.
 
 module NTP.Client
-    ( startNtpClient
+    ( NtpMonad
+    , spawnNtpClient
     , NtpClientSettings (..)
-    , NtpStopButton (..)
     , ntpSingleShot
     , hoistNtpClientSettings
     ) where
 
-import           Control.Concurrent.STM (atomically, modifyTVar')
-import           Control.Concurrent.STM.TVar (TVar, newTVarIO, readTVar, readTVarIO, writeTVar)
-import           Control.Exception.Safe (Exception, MonadMask, bracketOnError, catchAny, handleAny,
-                                         throwM)
+import           Universum
+
+import           Control.Concurrent.STM (modifyTVar')
+import           Control.Concurrent.STM.TVar (TVar, readTVar)
+import           Control.Exception.Safe (Exception, MonadMask, catchAny, handleAny)
 import           Control.Lens ((%=), (.=), _Just)
-import           Control.Monad (forM_, forever, unless, void, when)
+import           Control.Monad (forever)
 import           Control.Monad.State (gets)
-import           Control.Monad.Trans (MonadIO (..))
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Binary (decodeOrFail, encode)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Default (Default (..))
-import           Data.List (sortOn)
+import           Data.List (sortOn, (!!))
 import           Data.Maybe (catMaybes, isNothing)
-import           Data.Monoid ((<>))
-import           Data.Text (Text)
 import           Data.Time.Units (Microsecond, Second, toMicroseconds)
 import           Data.Typeable (Typeable)
 import           Formatting (sformat, shown, (%))
 import           Network.Socket (AddrInfo, SockAddr (..), Socket, addrAddress, addrFamily, close)
 import           Network.Socket.ByteString (recvFrom, sendTo)
-import           Prelude hiding (log)
 import           Serokell.Util.Concurrent (modifyTVarS, threadDelay)
-import           System.Wlog (LoggerName, Severity (..), WithLogger, logMessage, modifyLoggerName)
-import           Universum (whenJust)
+import           System.Wlog (LoggerName, WithLogger, logDebug, logError, logInfo, logWarning,
+                              modifyLoggerName)
 
 import           Mockable.Class (Mockable)
-import           Mockable.Concurrent (Delay, Fork, delay, fork)
+import           Mockable.Concurrent (Async, Concurrently, concurrently, forConcurrently, race)
 import           NTP.Packet (NtpPacket (..), evalClockOffset, mkCliNtpPacket, ntpPacketSize)
 import           NTP.Util (createAndBindSock, resolveNtpHost, selectIPv4, selectIPv6,
                            udpLocalAddresses, withSocketsDoLifted)
@@ -72,7 +70,6 @@ hoistNtpClientSettings f settings =
 data NtpClient m = NtpClient
     { ncSockets  :: TVar Sockets
     , ncState    :: TVar (Maybe [(Microsecond, Microsecond)])
-    , ncClosed   :: TVar Bool
     , ncSettings :: NtpClientSettings m
     }
 
@@ -80,7 +77,6 @@ mkNtpClient :: MonadIO m => NtpClientSettings m -> Sockets -> m (NtpClient m)
 mkNtpClient ncSettings sock = liftIO $ do
     ncSockets <- newTVarIO sock
     ncState  <- newTVarIO Nothing
-    ncClosed <- newTVarIO False
     return NtpClient{..}
 
 instance Monad m => Default (NtpClientSettings m) where
@@ -96,10 +92,6 @@ instance Monad m => Default (NtpClientSettings m) where
         , ntpMeanSelection   = \l -> let len = length l in (sortOn fst l) !! ((len - 1) `div` 2)
         }
 
-newtype NtpStopButton m = NtpStopButton
-    { pressNtpStopButton :: m ()
-    }
-
 data NoHostResolved = NoHostResolved
     deriving (Show, Typeable)
 
@@ -110,18 +102,9 @@ type NtpMonad m =
     , MonadBaseControl IO m
     , MonadMask m
     , WithLogger m
-    , Mockable Fork m
+    , Mockable Concurrently m
+    , Mockable Async m
     )
-
-log' :: NtpMonad m => NtpClientSettings m -> Severity -> Text -> m ()
-log' settings severity msg =
-    let logName = ntpLogName settings
-    in  modifyLoggerName (<> logName) $ logMessage severity msg
-
-log :: NtpMonad m => NtpClient m -> Severity -> Text -> m ()
-log cli severity msg = do
-    closed <- liftIO $ readTVarIO (ncClosed cli)
-    unless closed $ log' (ncSettings cli) severity msg
 
 handleCollectedResponses :: NtpMonad m => NtpClient m -> m ()
 handleCollectedResponses cli = do
@@ -129,17 +112,17 @@ handleCollectedResponses cli = do
     let selection = ntpMeanSelection (ncSettings cli)
         handler   = ntpHandler (ncSettings cli)
     case mres of
-        Nothing        -> log cli Error "Protocol error: responses are not awaited"
-        Just []        -> log cli Warning "No servers responded"
+        Nothing        -> logError "Protocol error: responses are not awaited"
+        Just []        -> logWarning "No servers responded"
         Just responses -> handleE `handleAny` do
             let time = selection responses
-            log cli Info $ sformat ("Evaluated clock offset "%shown%
+            logInfo $ sformat ("Evaluated clock offset "%shown%
                 " mcs for request at "%shown%" mcs")
                 (toMicroseconds $ fst time)
                 (toMicroseconds $ snd time)
             handler time
   where
-    handleE = log cli Error . sformat ("ntpMeanSelection: "%shown)
+    handleE = logError . sformat ("ntpMeanSelection: "%shown)
 
 doSend :: NtpMonad m => SockAddr -> NtpClient m -> m ()
 doSend addr cli = do
@@ -152,31 +135,27 @@ doSend addr cli = do
     sendDo a@(SockAddrInet6 _ _ _ _) (IPv6Sock sock) = sendTo' sock a
     sendDo a@(SockAddrInet6 _ _ _ _) (BothSock _ sock)  = sendTo' sock a
     sendDo a sks                                           =
-        error $ "SockAddr is " ++ show a ++ ", but sockets: " ++ show sks
+        error $ "SockAddr is " <> show a <> ", but sockets: " <> show sks
     sendTo' sock = flip (sendTo sock)
 
     -- just log; socket closure is handled by receiver
     handleE =
-        log cli Warning . sformat ("Failed to send to "%shown%": "%shown) addr
+        logWarning . sformat ("Failed to send to "%shown%": "%shown) addr
 
 startSend :: NtpMonad m => [SockAddr] -> NtpClient m -> m ()
 startSend addrs cli = do
     let timeout = ntpResponseTimeout (ncSettings cli)
     let poll    = ntpPollDelay (ncSettings cli)
-    closed <- liftIO $ readTVarIO (ncClosed cli)
-    unless closed $ do
-        log cli Debug "Sending requests"
-        liftIO . atomically . modifyTVarS (ncState cli) $ id .= Just []
-        forM_ addrs $
-            \addr -> fork $ doSend addr cli
-        liftIO $ threadDelay timeout
+    logDebug "Sending requests"
+    liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Just []
+    () <$ threadDelay timeout `race` forConcurrently addrs (flip doSend cli)
 
-        log cli Debug "Collecting responses"
-        handleCollectedResponses cli
-        liftIO . atomically . modifyTVarS (ncState cli) $ id .= Nothing
-        liftIO $ threadDelay (poll - timeout)
+    logDebug "Collecting responses"
+    handleCollectedResponses cli
+    liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Nothing
+    liftIO $ threadDelay (poll - timeout)
 
-        startSend addrs cli
+    startSend addrs cli
 
 -- Try to create IPv4 and IPv6 socket.
 mkSockets :: forall m . NtpMonad m => NtpClientSettings m -> m Sockets
@@ -189,11 +168,11 @@ mkSockets settings = do
         (Just sock1, Nothing)    -> pure $ IPv4Sock sock1
         (Nothing, Just sock2)    -> pure $ IPv6Sock sock2
         (_, _)                   -> do
-            log' settings Warning "Couldn't create both IPv4 and IPv6 socket, retrying in 5 sec..."
+            logWarning "Couldn't create both IPv4 and IPv6 socket, retrying in 5 sec..."
             liftIO $ threadDelay (5 :: Second)
             mkSockets settings
   where
-    logging (_, addrInfo) = log' settings Info $
+    logging (_, addrInfo) = logInfo $
         sformat ("Created socket (family/addr): "%shown%"/"%shown)
                 (addrFamily addrInfo) (addrAddress addrInfo)
     doMkSockets :: m (Maybe (Socket, AddrInfo), Maybe (Socket, AddrInfo))
@@ -202,7 +181,7 @@ mkSockets settings = do
         (,) <$> createAndBindSock selectIPv4 serveraddrs
             <*> createAndBindSock selectIPv6 serveraddrs
     handlerE e = do
-        log' settings Warning $
+        logWarning $
             sformat ("Failed to create sockets, retrying in 5 sec... (reason: "%shown%")")
             e
         liftIO $ threadDelay (5 :: Second)
@@ -210,18 +189,18 @@ mkSockets settings = do
 
 handleNtpPacket :: NtpMonad m => NtpClient m -> NtpPacket -> m ()
 handleNtpPacket cli packet = do
-    log cli Debug $ sformat ("Got packet "%shown) packet
+    logDebug $ sformat ("Got packet "%shown) packet
 
     clockOffset <- evalClockOffset packet
 
-    log cli Debug $ sformat ("Received time delta "%shown%" mcs")
+    logDebug $ sformat ("Received time delta "%shown%" mcs")
         (toMicroseconds clockOffset)
 
     late <- liftIO . atomically . modifyTVarS (ncState cli) $ do
         _Just %= ((clockOffset, ntpOriginTime packet) :)
         gets isNothing
     when late $
-        log cli Warning "Response was too late"
+        logWarning "Response was too late"
 
 doReceive :: NtpMonad m => Socket -> NtpClient m -> m ()
 doReceive sock cli = forever $ do
@@ -229,40 +208,37 @@ doReceive sock cli = forever $ do
     let eNtpPacket = decodeOrFail $ LBS.fromStrict received
     case eNtpPacket of
         Left  (_, _, err)    ->
-            log cli Warning $ sformat ("Error while receiving time: "%shown) err
+            logWarning $ sformat ("Error while receiving time: "%shown) err
         Right (_, _, packet) ->
             handleNtpPacket cli packet `catchAny` handleE
   where
-    handleE = log cli Warning . sformat ("Error while handle packet: "%shown)
+    handleE = logWarning . sformat ("Error while handle packet: "%shown)
 
 startReceive :: NtpMonad m => NtpClient m -> m ()
 startReceive cli = do
     sockets <- liftIO . atomically . readTVar $ ncSockets cli
     case sockets of
-        BothSock sIPv4 sIPv6 -> do
-            void $ fork $ runDoReceive True sIPv4
-            runDoReceive False sIPv6
+        BothSock sIPv4 sIPv6 ->
+            () <$ runDoReceive True sIPv4 `concurrently` runDoReceive False sIPv6
         IPv4Sock sIPv4 -> runDoReceive True sIPv4
         IPv6Sock sIPv6 -> runDoReceive False sIPv6
   where
     runDoReceive isIPv4 sock = doReceive sock cli `catchAny` handleE isIPv4 sock
     -- got error while receiving data, retrying in 5 sec
     handleE isIPv4 sock e = do
-        closed <- liftIO . readTVarIO $ ncClosed cli
-        unless closed $ do
-            log cli Debug $ sformat ("doReceive failed on socket"%shown%
-                                     ", reason: "%shown%
-                                     ", recreate socket in 5 sec") sock e
-            liftIO $ threadDelay (5 :: Second)
-            serveraddrs <- liftIO udpLocalAddresses
-            newSockMB <- liftIO $
-                if isIPv4 then
-                    traverse (overwriteSocket IPv4Sock . fst) =<< createAndBindSock selectIPv4 serveraddrs
-                else
-                    traverse (overwriteSocket IPv6Sock . fst) =<< createAndBindSock selectIPv6 serveraddrs
-            case newSockMB of
-                Nothing      -> log cli Warning "Recreating of socket failed" >> handleE isIPv4 sock e
-                Just newSock -> runDoReceive isIPv4 newSock
+        logDebug $ sformat ("doReceive failed on socket"%shown%
+                            ", reason: "%shown%
+                            ", recreate socket in 5 sec") sock e
+        liftIO $ threadDelay (5 :: Second)
+        serveraddrs <- liftIO udpLocalAddresses
+        newSockMB <- liftIO $
+            if isIPv4 then
+                traverse (overwriteSocket IPv4Sock . fst) =<< createAndBindSock selectIPv4 serveraddrs
+            else
+                traverse (overwriteSocket IPv6Sock . fst) =<< createAndBindSock selectIPv6 serveraddrs
+        case newSockMB of
+            Nothing      -> logWarning "Recreating of socket failed" >> handleE isIPv4 sock e
+            Just newSock -> runDoReceive isIPv4 newSock
     overwriteSocket constr sock = sock <$
         (liftIO .
          atomically .
@@ -270,53 +246,41 @@ startReceive cli = do
          flip mergeSockets .
          constr $ sock)
 
-stopNtpClient :: NtpMonad m => NtpClient m -> m ()
-stopNtpClient cli = do
-    log cli Info "Stopped"
-    sockets <- liftIO . atomically $ do
-        writeTVar (ncClosed cli) True
-        socketsToList <$> readTVar (ncSockets cli)
-
-    -- unblock receiving from socket in case no one replies
-    forM_ sockets $ \s -> liftIO (close s) `catchAny` (const $ pure ())
-
-startNtpClient :: NtpMonad m => NtpClientSettings m -> m (NtpStopButton m)
-startNtpClient settings =
+spawnNtpClient :: NtpMonad m => NtpClientSettings m -> m ()
+spawnNtpClient settings =
     withSocketsDoLifted $
-    bracketOnError (mkSockets settings) closeSockets $ \sock -> do
+    modifyLoggerName (<> ntpLogName settings) $
+    bracket (mkSockets settings) closeSockets $ \sock -> do
         cli <- mkNtpClient settings sock
 
-        addrs <- catMaybes <$> mapM (resolveHost cli $ socketsToBoolDescr sock)
+        addrs <- catMaybes <$> mapM (resolveHost $ socketsToBoolDescr sock)
                                     (ntpServers settings)
-        if null addrs then
-            throwM NoHostResolved
-        else do
-            void . fork . withSocketsDoLifted $ startReceive cli
-            void . fork . withSocketsDoLifted $ startSend addrs cli
-            log cli Info "Launched"
-
-        return $ NtpStopButton $ stopNtpClient cli
+        when (null addrs) $ throwM NoHostResolved
+        () <$ startReceive cli `concurrently`
+              startSend addrs cli `concurrently`
+              logInfo "Launched NTP client"
   where
-    closeSockets sockets = forM_ (socketsToList sockets) (liftIO . close)
-    resolveHost cli sockDescr host = do
+    closeSockets sockets = do
+        logInfo "NTP client is stopped"
+        forM_ (socketsToList sockets) (liftIO . close)
+    resolveHost sockDescr host = do
         maddr <- liftIO $ resolveNtpHost host sockDescr
         case maddr of
             Nothing   -> do
-                log cli Warning $ sformat ("Host "%shown%" is not resolved") host
+                logWarning $ sformat ("Host "%shown%" is not resolved") host
                 pure Nothing
             Just addr -> do
-                log cli Info $ sformat ("Host "%shown%" is resolved: "%shown) host addr
+                logInfo $ sformat ("Host "%shown%" is resolved: "%shown) host addr
                 pure $ Just addr
 
 -- | Start client, wait for a while so that most likely it ticks once
 -- and stop it.
 ntpSingleShot
-    :: (Mockable Delay m, NtpMonad m)
+    :: (NtpMonad m)
     => NtpClientSettings m -> m ()
-ntpSingleShot settings = do
-    stopButton <- startNtpClient settings
-    delay (ntpResponseTimeout settings)
-    pressNtpStopButton stopButton
+ntpSingleShot settings =
+    () <$ threadDelay (ntpResponseTimeout settings) `race`
+          spawnNtpClient settings
 
 -- Store created sockets.
 -- If system supports IPv6 and IPv4 we create socket for IPv4 and IPv6.

--- a/networking/src/NTP/Example.hs
+++ b/networking/src/NTP/Example.hs
@@ -10,20 +10,17 @@
 module NTP.Example
     ( NtpClientSettings (..)
     , runNtpClientIO
-    , def
-    -- there is no stop button, since `runNtpClientIO` does `initLogging`
     ) where
 
 import           Universum
 
 import           Control.Monad (void)
-import           Data.Default (def)
 import           System.Wlog (LoggerNameBox, Severity (..), defaultConfig, setupLogging,
                               severityPlus, termSeveritiesOutB, usingLoggerName)
 
 import           Mockable.Instances ()
 import           Mockable.Production (Production (..))
-import           NTP.Client (NtpClientSettings (..), startNtpClient)
+import           NTP.Client (NtpClientSettings (..), spawnNtpClient)
 
 type WorkMode = LoggerNameBox Production
 
@@ -33,4 +30,4 @@ runNtpClientIO settings = do
         defaultConfig "ntp-example" <> termSeveritiesOutB (severityPlus Debug)
     void $ runProduction $
         usingLoggerName "ntp-example" $
-        startNtpClient settings
+        spawnNtpClient settings


### PR DESCRIPTION
I slightly modified some logic to make it possible.
I think this code is still not perfect and there are other things
to improve, but within this issue I am only concerned about `forkIO` usages.
Notable changes (other than actual eliminating `forkIO`):
1. I removed stop button, because it's not needed anymore.
2. I removed `ncClosed`, because it seems to be not needed, because
 with current interface it seems to be impossible to access `NtpClient` after
 it's closed.
3. I moved `modifyLoggerName` to `spawnNtpClient` and it allowed to remove
ad-hoc `log` and `log'` functions.