### PR TITLE
[CSL-2196] Mempool consistency

### DIFF
--- a/node/src/Pos/Block/Logic/Internal.hs
+++ b/node/src/Pos/Block/Logic/Internal.hs
@@ -58,7 +58,7 @@ import           Pos.Ssc.Extra           (MonadSscMem, sscApplyBlocks, sscNormal
                                           sscRollbackBlocks)
 import           Pos.Ssc.Util            (toSscBlock)
 import           Pos.Txp.Core            (TxPayload)
-import           Pos.Txp.MemState        (MonadTxpMem)
+import           Pos.Txp.MemState        (MonadTxpMem, getMemPoolSnapshot)
 import           Pos.Txp.Settings        (TxpBlock, TxpBlund, TxpGlobalSettings (..))
 import           Pos.Update.Context      (UpdateContext)
 import           Pos.Update.Core         (UpdateBlock, UpdatePayload)
@@ -135,14 +135,15 @@ normalizeMempool
     :: forall ssc ctx m . (MonadMempoolNormalization ssc ctx m)
     => m ()
 normalizeMempool = do
+    mps <- getMemPoolSnapshot
     -- We normalize all mempools except the delegation one.
     -- That's because delegation mempool normalization is harder and is done
     -- within block application.
     sscNormalize @ssc
 #ifdef WITH_EXPLORER
-    eTxNormalize
+    eTxNormalize mps
 #else
-    txNormalize
+    txNormalize mps
 #endif
     usNormalize
 

--- a/node/src/Pos/Client/Txp/Balances.hs
+++ b/node/src/Pos/Client/Txp/Balances.hs
@@ -16,8 +16,8 @@ import           Pos.Core             (Address (..), Coin, IsBootstrapEraAddr (.
                                        isRedeemAddress, makePubKeyAddress)
 import           Pos.Crypto           (PublicKey)
 import           Pos.DB               (MonadDBRead)
-import           Pos.Txp              (MonadTxpMem, Utxo, addrBelongsToSet,
-                                       getUtxoModifier)
+import           Pos.Txp              (MemPoolSnapshot, MonadTxpMem, Utxo,
+                                       addrBelongsToSet, getUtxoModifier)
 import qualified Pos.Txp.DB           as DB
 import           Pos.Txp.Toil.Utxo    (getTotalCoinsInUtxo)
 import qualified Pos.Util.Modifier    as MM
@@ -25,11 +25,14 @@ import           Pos.Wallet.Web.State (WalletSnapshot)
 import qualified Pos.Wallet.Web.State as WS
 
 getOwnUtxos :: (MonadIO m, MonadDBRead m, MonadTxpMem ext ctx m)
-            => WalletSnapshot -> [Address] -> m Utxo
-getOwnUtxos ws addrs = do
+            => WalletSnapshot
+            -> MemPoolSnapshot
+            -> [Address]
+            -> m Utxo
+getOwnUtxos ws mps addrs = do
     let (redeemAddrs, commonAddrs) = partition isRedeemAddress addrs
 
-    updates <- getUtxoModifier
+    let updates = getUtxoModifier mps
     let commonUtxo = if null commonAddrs then mempty
                      else WS.getWalletUtxo ws
     redeemUtxo <- if null redeemAddrs then pure mempty

--- a/node/src/Pos/Generator/Block/Payload.hs
+++ b/node/src/Pos/Generator/Block/Payload.hs
@@ -42,6 +42,7 @@ import           Pos.Explorer.Txp.Local     (eTxProcessTransactionNoLock)
 #else
 import           Pos.Txp.Logic              (txProcessTransactionNoLock)
 #endif
+import           Pos.Txp.MemState           (getMemPoolSnapshot)
 import           Pos.Txp.Toil.Class         (MonadUtxo (..), MonadUtxoRead (..))
 import           Pos.Txp.Toil.Types         (Utxo)
 import qualified Pos.Txp.Toil.Utxo          as Utxo
@@ -224,10 +225,11 @@ genTxPayload = do
         let tx = taTx txAux
         let txId = hash tx
         let txIns = _txInputs tx
+        mps <- getMemPoolSnapshot
 #ifdef WITH_EXPLORER
-        res <- lift . lift $ eTxProcessTransactionNoLock (txId, txAux)
+        res <- lift . lift $ eTxProcessTransactionNoLock mps (txId, txAux)
 #else
-        res <- lift . lift $ txProcessTransactionNoLock (txId, txAux)
+        res <- lift . lift $ txProcessTransactionNoLock mps (txId, txAux)
 #endif
         case res of
             Left e  -> error $ "genTransaction@txProcessTransaction: got left: " <> pretty e

--- a/node/src/Pos/Web/Server.hs
+++ b/node/src/Pos/Web/Server.hs
@@ -31,6 +31,7 @@ import           Servant.Utils.Enter             ((:~>) (NT), enter)
 
 import qualified Network.Broadcast.OutboundQueue as OQ
 import           Pos.Aeson.Txp                   ()
+import           Pos.Aeson.Types                 ()
 import           Pos.Context                     (HasNodeContext (..), HasSscContext (..),
                                                   NodeContext, getOurPublicKey)
 import           Pos.Core                        (EpochIndex (..), SlotLeaders)
@@ -44,7 +45,7 @@ import           Pos.Ssc.Class                   (SscConstraint)
 import           Pos.Ssc.GodTossing              (SscGodTossing, gtcParticipateSsc)
 import           Pos.Txp                         (TxOut (..), toaOut)
 import           Pos.Txp.MemState                (GenericTxpLocalData, askTxpMem,
-                                                  getLocalTxs)
+                                                  getLocalTxs, getMemPoolSnapshot)
 import           Pos.Web.Mode                    (WebMode, WebModeContext (..))
 import           Pos.WorkMode                    (OQ)
 import           Pos.WorkMode.Class              (TxpExtra_TMP, WorkMode)
@@ -167,7 +168,7 @@ getUtxo :: HasConfiguration => WebMode ssc [TxOut]
 getUtxo = map toaOut . toList <$> GS.getAllPotentiallyHugeUtxo
 
 getLocalTxsNum :: WebMode ssc Word
-getLocalTxsNum = fromIntegral . length <$> getLocalTxs
+getLocalTxsNum = fromIntegral . length . getLocalTxs <$> getMemPoolSnapshot
 
 ----------------------------------------------------------------------------
 -- HealthCheck handlers

--- a/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
@@ -21,6 +21,7 @@ import           Pos.Client.Txp.Util        (InputSelectionPolicy (..),
                                              PendingAddresses (..), isCheckedTxError)
 import           Pos.Core.Types             (Coin)
 import           Pos.Txp                    (TxOut (..), TxOutAux (..))
+import           Pos.Txp.MemState.Class     (MemPoolSnapshot)
 import           Pos.Wallet.Web.ClientTypes (Addr, CId)
 import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletError)
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
@@ -55,8 +56,9 @@ coinDistrToOutputs distr = do
 -- by the time of resubmission.
 submitAndSaveNewPtx
     :: MonadWalletWebMode m
-    => EnqueueMsg m -> PendingTx -> m ()
-submitAndSaveNewPtx = submitAndSavePtx ptxFirstSubmissionHandler
+    => MemPoolSnapshot -> EnqueueMsg m -> PendingTx -> m ()
+submitAndSaveNewPtx mps enqueue pendingTx = do
+    submitAndSavePtx mps ptxFirstSubmissionHandler enqueue pendingTx
 
 -- | With regard to tx creation policy which is going to be used,
 -- get addresses which are refered by some yet unconfirmed transaction outputs.


### PR DESCRIPTION
This PR builds on top of `alfredo/cbr-5-single-db-read` to explicitly pass the mempool all along, in order to improve the consistency of wallet's endpoints.