### PR TITLE
[CSL-2068] Fix 'PureToss' test

### DIFF
--- a/lib/test/Test/Pos/Ssc/Toss/PureSpec.hs
+++ b/lib/test/Test/Pos/Ssc/Toss/PureSpec.hs
@@ -128,7 +128,7 @@ property will cause it to fail.
 putDelCommitment :: HasConfiguration => SignedCommitment -> TossTestInfo -> Property
 putDelCommitment sc =
     let actionPrefixGen = arbitrary `suchThat` (\case
-            PutCommitment sc' -> sc /= sc'
+            PutCommitment sc' -> sc ^. _1 /= sc'^. _1
             _                 -> True)
     in ([PutCommitment sc, DelCommitment $ addressHash $ sc ^. _1] ==^ []) actionPrefixGen
 


### PR DESCRIPTION
This commit introduces a correction to a 'PureToss' test that caught a bug
(test failure here:
https://travis-ci.org/input-output-hk/cardano-sl/jobs/315346651)
in the way the generation of arbitrary sequences of actions in the
'PureToss' monad works.

In particular, the 'Test.Pos.Ssc.Toss.PureSpec.putDelCommitment' test
generates a prefix of 'PureToss' actions in which there are no actions
that insert the same signed commitment in the state (https://github.com/input-output-hk/cardano-sl/commit/d55ad660224b27b27540bcc659a61a8ecbc40053#diff-6687dba169eab6172cb5a6deaa9c433bR131)
as the one generated for the test (see the comment for an explanation).

The problem with the previous code is that a `SignedCommitment` is a
tuple, and comparing tuples for equality means only one of the components
has to be different, not necessarily the one that matters in this
case: the `PublicKey` which will serve as the key for insertion into
the `sgsCommitments` field of the `PureToss` state.

As such, this commit corrects the situation by making sure the action
prefix does not contain any `SignedCommitment` with the same `PublicKey`
as the commitment used for the test.