### PR TITLE
[CSL-2195] Add option to get info about single address

### DIFF
--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -32,6 +32,7 @@ module Pos.Wallet.Web.Api
        , DeleteAccount
        , NewAccount
 
+       , GetAddress
        , NewAddress
 
        , IsValidAddress
@@ -83,25 +84,25 @@ import           Servant.Swagger.UI          (SwaggerSchemaUI)
 import           Universum
 
 -------
-import           Pos.Client.Txp.Util        (InputSelectionPolicy)
-import           Pos.Types                  (Coin, SoftwareVersion)
-import           Pos.Util.Servant           (ApiLoggingConfig, CCapture, CQueryParam,
-                                             CReqBody, DCQueryParam, DReqBody,
-                                             HasLoggingServer (..), LoggingApi,
-                                             ModifiesApiRes (..), ReportDecodeError (..),
-                                             VerbMod, WithTruncatedLog (..),
-                                             applyLoggingToHandler, inRouteServer,
-                                             serverHandlerL')
-import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit,
-                                             CAccountMeta, CAddress, CCoin, CFilePath, ClientInfo,
-                                             CId, CInitialized, CPaperVendWalletRedeem,
-                                             CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
-                                             CUpdateInfo, CWallet, CWalletInit,
-                                             CWalletMeta, CWalletRedeem, ScrollLimit,
-                                             ScrollOffset, NewBatchPayment,
-                                             SyncProgress, Wal)
-import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
-                                             catchEndpointErrors)
+import           Pos.Client.Txp.Util         (InputSelectionPolicy)
+import           Pos.Types                   (Coin, SoftwareVersion)
+import           Pos.Util.Servant            (ApiLoggingConfig, CCapture, CQueryParam,
+                                              CReqBody, DCQueryParam, DReqBody,
+                                              HasLoggingServer (..), LoggingApi,
+                                              ModifiesApiRes (..), ReportDecodeError (..),
+                                              VerbMod, WithTruncatedLog (..),
+                                              applyLoggingToHandler, inRouteServer,
+                                              serverHandlerL')
+import           Pos.Wallet.Web.ClientTypes  (Addr, CAccount, CAccountId, CAccountInit,
+                                              CAccountMeta, CAddress, CCoin, CFilePath,
+                                              CId, CInitialized, CPaperVendWalletRedeem,
+                                              CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
+                                              CUpdateInfo, CWallet, CWalletInit,
+                                              CWalletMeta, CWalletRedeem, ClientInfo,
+                                              NewBatchPayment, ScrollLimit, ScrollOffset,
+                                              SyncProgress, Wal)
+import           Pos.Wallet.Web.Error        (WalletError (DecodeError),
+                                              catchEndpointErrors)
 import           Pos.Wallet.Web.Methods.Misc (PendingTxsSummary, WalletStateSnapshot)
 
 -- | Common prefix for all endpoints.
@@ -244,6 +245,12 @@ type DeleteAccount =
 -------------------------------------------------------------------------
 -- Wallet addresses
 -------------------------------------------------------------------------
+
+type GetAddress =
+       "addresses"
+    :> CCapture "accountId" CAccountId
+    :> Capture "address" (CId Addr)
+    :> WRes Get CAddress
 
 type NewAddress =
        "addresses"
@@ -477,6 +484,8 @@ type WalletApi = ApiPrefix :> (
      -------------------------------------------------------------------------
      -- Walllet addresses
      -------------------------------------------------------------------------
+     GetAddress
+    :<|>
      NewAddress
     :<|>
      -------------------------------------------------------------------------

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -56,6 +56,8 @@ servantHandlers sendActions =
      M.deleteAccount
     :<|>
 
+     M.getWAddressSingle
+    :<|>
      M.newAddress RandomSeed
     :<|>
 

--- a/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Description.hs
@@ -111,6 +111,11 @@ instance HasCustomSwagger DeleteAccount where
         \account in wallet)."
 
 
+instance HasCustomSwagger GetAddress where
+    swaggerModifier = modifyDescription
+        "Get info about address with given ID. \
+        \Note, this method may display address belatedly."
+
 instance HasCustomSwagger NewAddress where
     swaggerModifier = modifyDescription
         "Create a new address in given account."


### PR DESCRIPTION
Added GET `api/addresses/<accountId>/<addressId>` endpoint so that one can get info about single address.

Example:
`https://127.0.0.1:8090/api/addresses/Ae2tdPwUPEZEK5DvxPMtnTnUfQg8coWAAbNfLEvQ4GqWTe9h8d6AEkBDMce@2147483648/DdzFFzCqrhsg9ngNRhHEa49se7qEMKyubT9tcE13Fkvh8QC82trpTDsNvdQV7mg9SCZiuENkf77zrtwPXrTyGMNznUsSinPC1gb2ZCqK`

```
{
    "Right": {
        "cadId": "DdzFFzCqrhsg9ngNRhHEa49se7qEMKyubT9tcE13Fkvh8QC82trpTDsNvdQV7mg9SCZiuENkf77zrtwPXrTyGMNznUsSinPC1gb2ZCqK",
        "cadAmount": {
            "getCCoin": "37499999999166"
        },
        "cadIsUsed": false,
        "cadIsChange": false
    }
}
```