### PR TITLE
Remove Travis CI status badge

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,6 +1,6 @@
 # Cardano SL
 
-[![Build Status](https://travis-ci.org/input-output-hk/cardano-sl.svg)](https://travis-ci.org/input-output-hk/cardano-sl)
+[![Build status](https://badge.buildkite.com/9c3141d21214ff3ea95d0a38a0e1dab59b206159d2841dee44.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-sl)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/jagajaga/cardano-sl)
 [![Release](https://img.shields.io/github/release/input-output-hk/cardano-sl.svg)](https://github.com/input-output-hk/cardano-sl/releases)
 


### PR DESCRIPTION
Since Travis CI is no longer used in 'cardano-sl' (having been replaced
by Buildkite) this PR updates the CI status badge shown in the
'README.md' to point to the latest build in the latter service instead.