### PR TITLE
Explicit DB reads and writes in the wallet

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
     WORK_DIR: "c:\\w"
     CACHE_S3_VERSION: v0.1.1
     AWS_REGION: us-west-1
-    S3_BUCKET: appveyor-ci-cache              
-    AWS_ACCESS_KEY_ID: 
+    S3_BUCKET: appveyor-ci-cache
+    AWS_ACCESS_KEY_ID:
       secure: 0OtMCUmJ4V7fNRPvKjzYxSO19I200rPG8WRW/qn1QPk=
     AWS_SECRET_ACCESS_KEY:
       secure: EmPAMpga8gjXxPMfJSsdq2sof8SLwyga1rrYuZDlPoriMS1iEFLvCNLA70JqHSna

--- a/auxx/src/Command/Run.hs
+++ b/auxx/src/Command/Run.hs
@@ -30,13 +30,13 @@ import           Pos.Crypto                 (emptyPassphrase, encToPublic,
                                              safeCreatePsk, withSafeSigner)
 import           Pos.Launcher.Configuration (HasConfigurations)
 import           Pos.Util.UserSecret        (readUserSecret, usKeys, usPrimKey)
-import           Pos.Wallet                 (addSecretKey, getBalance, getSecretKeysPlain)
+import           Pos.Wallet                 (addSecretKey, getSecretKeysPlain)
 
 import qualified Command.Rollback           as Rollback
 import qualified Command.Tx                 as Tx
 import           Command.Types              (Command (..))
 import qualified Command.Update             as Update
-import           Mode                       (AuxxMode, CmdCtx (..), getCmdCtx)
+import           Mode                       (AuxxMode, CmdCtx (..), getCmdCtx, getBalance)
 
 
 helpMsg :: Text

--- a/node/cardano-sl.cabal
+++ b/node/cardano-sl.cabal
@@ -139,6 +139,7 @@ library
                         Pos.Wallet.Web.State.Acidic
                         Pos.Wallet.Web.State.State
                         Pos.Wallet.Web.State.Storage
+                        Pos.Wallet.Web.State.Transactions
                         Pos.Wallet.Web.State.Util
                         Pos.Wallet.Web.Secret
                         Pos.Wallet.Web.Util

--- a/node/src/Pos/Client/Txp/Balances.hs
+++ b/node/src/Pos/Client/Txp/Balances.hs
@@ -1,50 +1,28 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Pos.Client.Txp.Balances
-       ( MonadBalances(..)
-       , getOwnUtxo
-       , getBalanceFromUtxo
-       , getOwnUtxosDefault
-       , getBalanceDefault
+       ( getOwnUtxos
        , getOwnUtxoForPk
+       , getBalanceFromUtxo
        ) where
 
 import           Universum
 
-import           Control.Monad.Trans  (MonadTrans)
-import qualified Data.HashMap.Strict  as HM
 import qualified Data.HashSet         as HS
 import           Data.List            (partition)
 import qualified Data.Map             as M
 
 import           Pos.Core             (Address (..), Coin, IsBootstrapEraAddr (..),
-                                       isRedeemAddress, makePubKeyAddress, mkCoin)
+                                       isRedeemAddress, makePubKeyAddress)
 import           Pos.Crypto           (PublicKey)
 import           Pos.DB               (MonadDBRead, MonadGState, MonadRealDB)
 import           Pos.Txp              (MonadTxpMem, Utxo, addrBelongsToSet,
-                                       applyUtxoModToAddrCoinMap, getUtxoModifier)
+                                       getUtxoModifier)
 import qualified Pos.Txp.DB           as DB
 import           Pos.Txp.Toil.Utxo    (getTotalCoinsInUtxo)
 import qualified Pos.Util.Modifier    as MM
 import           Pos.Wallet.Web.State (WebWalletModeDB)
 import qualified Pos.Wallet.Web.State as WS
-
--- | A class which have the methods to get state of address' balance
-class Monad m => MonadBalances m where
-    getOwnUtxos :: [Address] -> m Utxo
-    getBalance :: Address -> m Coin
-    -- TODO: add a function to get amount of stake (it's different from
-    -- balance because of distributions)
-
-instance {-# OVERLAPPABLE #-}
-    (MonadBalances m, MonadTrans t, Monad (t m)) =>
-        MonadBalances (t m)
-  where
-    getOwnUtxos = lift . getOwnUtxos
-    getBalance = lift . getBalance
-
-getBalanceFromUtxo :: MonadBalances m => Address -> m Coin
-getBalanceFromUtxo addr = getTotalCoinsInUtxo <$> getOwnUtxo addr
 
 type BalancesEnv ext ctx m =
     ( MonadRealDB ctx m
@@ -54,8 +32,8 @@ type BalancesEnv ext ctx m =
     , MonadMask m
     , MonadTxpMem ext ctx m)
 
-getOwnUtxosDefault :: BalancesEnv ext ctx m => [Address] -> m Utxo
-getOwnUtxosDefault addrs = do
+getOwnUtxos :: BalancesEnv ext ctx m => [Address] -> m Utxo
+getOwnUtxos addrs = do
     let (redeemAddrs, commonAddrs) = partition isRedeemAddress addrs
 
     updates <- getUtxoModifier
@@ -68,19 +46,8 @@ getOwnUtxosDefault addrs = do
         addrsSet = HS.fromList addrs
     pure $ M.filter (`addrBelongsToSet` addrsSet) allUtxo
 
--- | `BalanceDB` isn't used here anymore, because
--- 1) It doesn't represent actual balances of addresses, but it represents _stakes_
--- 2) Local utxo is now cached, and deriving balances from it is not
---    so bad for performance now
-getBalanceDefault :: BalancesEnv ext ctx m => Address -> m Coin
-getBalanceDefault addr = do
-    balancesAndUtxo <- WS.getWalletBalancesAndUtxo
-    fromMaybe (mkCoin 0) .
-        HM.lookup addr .
-        flip applyUtxoModToAddrCoinMap balancesAndUtxo <$> getUtxoModifier
-
-getOwnUtxo :: MonadBalances m => Address -> m Utxo
-getOwnUtxo = getOwnUtxos . one
+getBalanceFromUtxo :: Functor m => ([Address] -> m Utxo) -> Address -> m Coin
+getBalanceFromUtxo getOwnUtxos' = fmap getTotalCoinsInUtxo . getOwnUtxos' . one
 
 -- | Sometimes we want to get utxo for all addresses which we «own»,
 -- i. e. can spend funds from them. We can't get all such addresses
@@ -88,8 +55,9 @@ getOwnUtxo = getOwnUtxos . one
 -- from an address. And we can't enumerate all possible addresses for
 -- a public key. So we only consider two addresses: one with bootstrap
 -- era distribution and another one with single key distribution.
-getOwnUtxoForPk :: MonadBalances m => PublicKey -> m Utxo
-getOwnUtxoForPk ourPk = getOwnUtxos ourAddresses
+getOwnUtxoForPk :: ([Address] -> m Utxo)
+                -> PublicKey -> m Utxo
+getOwnUtxoForPk getOwnUtxos' ourPk = getOwnUtxos' ourAddresses
   where
     ourAddresses :: [Address]
     ourAddresses =

--- a/node/src/Pos/Communication/Tx.hs
+++ b/node/src/Pos/Communication/Tx.hs
@@ -18,8 +18,7 @@ import           Universum
 
 import           Pos.Binary                 ()
 import           Pos.Client.Txp.Addresses   (MonadAddresses (..))
-import           Pos.Client.Txp.Balances    (MonadBalances (..), getOwnUtxo,
-                                             getOwnUtxoForPk)
+import           Pos.Client.Txp.Balances    (getOwnUtxoForPk)
 import           Pos.Client.Txp.History     (MonadTxHistory (..))
 import           Pos.Client.Txp.Util        (InputSelectionPolicy, PendingAddresses (..),
                                              TxCreateMode, TxError (..), createMTx,
@@ -35,6 +34,7 @@ import           Pos.Crypto                 (RedeemSecretKey, SafeSigner, hash,
 import           Pos.DB.Class               (MonadGState)
 import           Pos.Txp.Core               (TxAux (..), TxId, TxOut (..), TxOutAux (..),
                                              txaF)
+import           Pos.Txp.Toil.Types         (Utxo)
 import           Pos.Txp.Network.Types      (TxMsgContents (..))
 import           Pos.Util.Util              (eitherToThrow)
 import           Pos.WorkMode.Class         (MinWorkMode)
@@ -42,7 +42,6 @@ import           Pos.WorkMode.Class         (MinWorkMode)
 
 type TxMode ssc m
     = ( MinWorkMode m
-      , MonadBalances m
       , MonadTxHistory ssc m
       , MonadMockable m
       , MonadMask m
@@ -62,14 +61,15 @@ submitAndSave enqueue txAux@TxAux {..} = do
 -- | Construct Tx using multiple secret keys and given list of desired outputs.
 prepareMTx
     :: TxMode ssc m
-    => (Address -> SafeSigner)
+    => ([Address] -> m Utxo)
+    -> (Address -> SafeSigner)
     -> PendingAddresses
     -> InputSelectionPolicy
     -> NonEmpty Address
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-prepareMTx hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData = do
+prepareMTx getOwnUtxos hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData = do
     utxo <- getOwnUtxos (toList addrs)
     eitherToThrow =<< createMTx pendingAddrs inputSelectionPolicy utxo hdwSigners outputs addrData
 
@@ -77,26 +77,28 @@ prepareMTx hdwSigners pendingAddrs inputSelectionPolicy addrs outputs addrData =
 submitTx
     :: TxMode ssc m
     => EnqueueMsg m
+    -> ([Address] -> m Utxo)
     -> PendingAddresses
     -> SafeSigner
     -> NonEmpty TxOutAux
     -> AddrData m
     -> m (TxAux, NonEmpty TxOut)
-submitTx enqueue pendingAddrs ss outputs addrData = do
+submitTx enqueue getOwnUtxos pendingAddrs ss outputs addrData = do
     let ourPk = safeToPublic ss
-    utxo <- getOwnUtxoForPk ourPk
+    utxo <- getOwnUtxoForPk getOwnUtxos ourPk
     txWSpendings <- eitherToThrow =<< createTx pendingAddrs utxo ss outputs addrData
     txWSpendings <$ submitAndSave enqueue (fst txWSpendings)
 
 -- | Construct redemption Tx using redemption secret key and a output address
 prepareRedemptionTx
     :: TxMode ssc m
-    => RedeemSecretKey
+    => ([Address] -> m Utxo)
+    -> RedeemSecretKey
     -> Address
     -> m (TxAux, Address, Coin)
-prepareRedemptionTx rsk output = do
+prepareRedemptionTx getOwnUtxos rsk output = do
     let redeemAddress = makeRedeemAddress $ redeemToPublic rsk
-    utxo <- getOwnUtxo redeemAddress
+    utxo <- getOwnUtxos [redeemAddress]
     let addCoin c = unsafeAddCoin c . txOutValue . toaOut
         redeemBalance = foldl' addCoin (mkCoin 0) utxo
         txOuts = one $

--- a/node/src/Pos/Wallet/WalletMode.hs
+++ b/node/src/Pos/Wallet/WalletMode.hs
@@ -3,8 +3,7 @@
 -- | 'MonadWallet' constraint. Like `WorkMode`, but for wallet.
 
 module Pos.Wallet.WalletMode
-       ( MonadBalances (..)
-       , MonadTxHistory (..)
+       ( MonadTxHistory (..)
        , MonadBlockchainInfo (..)
        , MonadUpdates (..)
        , MonadWallet
@@ -15,7 +14,6 @@ import           Universum
 import           Control.Monad.Trans     (MonadTrans)
 import           Data.Time.Units         (Millisecond)
 
-import           Pos.Client.Txp.Balances (MonadBalances (..))
 import           Pos.Client.Txp.History  (MonadTxHistory (..))
 import           Pos.Communication       (TxMode)
 import           Pos.Core                (ChainDifficulty)

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -57,6 +57,7 @@ module Pos.Wallet.Web.State.Acidic
        -- * Grouped transactions
        , CreateAccountWithAddress (..)
        , DeleteWallet (..)
+       , ApplyModifierToWallet (..)
        ) where
 
 import           Universum
@@ -141,4 +142,5 @@ makeAcidic ''WalletStorage
     , 'WS.getWalletStorage
     , 'WST.createAccountWithAddress
     , 'WST.deleteWallet
+    , 'WST.applyModifierToWallet
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -58,6 +58,7 @@ module Pos.Wallet.Web.State.Acidic
        , CreateAccountWithAddress (..)
        , DeleteWallet (..)
        , ApplyModifierToWallet (..)
+       , RollbackModifierFromWallet (..)
        ) where
 
 import           Universum
@@ -143,4 +144,5 @@ makeAcidic ''WalletStorage
     , 'WST.createAccountWithAddress
     , 'WST.deleteWallet
     , 'WST.applyModifierToWallet
+    , 'WST.rollbackModifierFromWallet
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -35,8 +35,6 @@ module Pos.Wallet.Web.State.Acidic
        , AddOnlyNewTxMetas (..)
        , SetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
-       , RemoveWallet (..)
-       , RemoveTxMetas (..)
        , RemoveWalletTxMetas (..)
        , RemoveHistoryCache (..)
        , RemoveAccount (..)
@@ -58,6 +56,7 @@ module Pos.Wallet.Web.State.Acidic
        , UpdateHistoryCache (..)
        -- * Grouped transactions
        , CreateAccountWithAddress (..)
+       , DeleteWallet (..)
        ) where
 
 import           Universum
@@ -122,8 +121,6 @@ makeAcidic ''WalletStorage
     , 'WS.addOnlyNewTxMetas
     , 'WS.setWalletTxHistory
     , 'WS.addOnlyNewTxMeta
-    , 'WS.removeWallet
-    , 'WS.removeTxMetas
     , 'WS.removeWalletTxMetas
     , 'WS.removeHistoryCache
     , 'WS.removeAccount
@@ -143,4 +140,5 @@ makeAcidic ''WalletStorage
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
     , 'WST.createAccountWithAddress
+    , 'WST.deleteWallet
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -3,7 +3,7 @@
 
 module Pos.Wallet.Web.State.Acidic
        (
-         WalletState
+         WalletDB
        , closeState
        , openMemState
        , openState
@@ -72,28 +72,28 @@ import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.State.Storage as WS
 
-type WalletState = ExtendedState WalletStorage
+type WalletDB = ExtendedState WalletStorage
 
 query
     :: (EventState event ~ WalletStorage, QueryEvent event, MonadIO m)
-    => WalletState -> event -> m (EventResult event)
+    => WalletDB -> event -> m (EventResult event)
 query = queryExtended
 
 update
     :: (EventState event ~ WalletStorage, UpdateEvent event, MonadIO m)
-    => WalletState -> event -> m (EventResult event)
+    => WalletDB -> event -> m (EventResult event)
 update = updateExtended
 
-openState :: (MonadIO m, HasConfiguration) => Bool -> FilePath -> m WalletState
+openState :: (MonadIO m, HasConfiguration) => Bool -> FilePath -> m WalletDB
 openState deleteIfExists fp = openLocalExtendedState deleteIfExists fp def
 
-openMemState :: (MonadIO m, HasConfiguration) => m WalletState
+openMemState :: (MonadIO m, HasConfiguration) => m WalletDB
 openMemState = openMemoryExtendedState def
 
-closeState :: MonadIO m => WalletState -> m ()
+closeState :: MonadIO m => WalletDB -> m ()
 closeState = closeExtendedState
 
-tidyState :: MonadIO m => WalletState -> m ()
+tidyState :: MonadIO m => WalletDB -> m ()
 tidyState = tidyExtendedState
 
 makeAcidic ''WalletStorage

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -56,6 +56,8 @@ module Pos.Wallet.Web.State.Acidic
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
        , UpdateHistoryCache (..)
+       -- * Grouped transactions
+       , CreateAccountWithAddress (..)
        ) where
 
 import           Universum
@@ -71,6 +73,7 @@ import           Serokell.AcidState           (ExtendedState, closeExtendedState
 import           Pos.Core.Configuration       (HasConfiguration)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.State.Storage as WS
+import           Pos.Wallet.Web.State.Transactions as WST
 
 type WalletDB = ExtendedState WalletStorage
 
@@ -139,4 +142,5 @@ makeAcidic ''WalletStorage
     , 'WS.cancelSpecificApplyingPtx
     , 'WS.flushWalletStorage
     , 'WS.getWalletStorage
+    , 'WST.createAccountWithAddress
     ]

--- a/node/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/node/src/Pos/Wallet/Web/State/Acidic.hs
@@ -11,34 +11,15 @@ module Pos.Wallet.Web.State.Acidic
        , tidyState
        , update
 
-       , GetProfile (..)
+         -- * Only query transaction
+       , GetWalletStorage (..)
+
+         -- * All the update transactions
        , DoesAccountExist (..)
-       , GetAccountIds (..)
-       , GetAccountMetas (..)
-       , GetAccountMeta (..)
-       , GetAccountAddrMaps (..)
-       , GetWalletMetas (..)
-       , GetWalletMeta (..)
-       , GetWalletMetaIncludeUnready (..)
-       , GetWalletPassLU (..)
-       , GetWalletSyncTip (..)
-       , GetWalletAddresses (..)
-       , GetWalletUtxo (..)
-       , GetWalletBalancesAndUtxo (..)
        , UpdateWalletBalancesAndUtxo (..)
        , SetWalletUtxo (..)
-       , GetAccountWAddresses (..)
        , DoesWAddressExist (..)
-       , GetTxMeta (..)
-       , GetUpdates (..)
-       , GetNextUpdate (..)
        , TestReset (..)
-       , GetHistoryCache (..)
-       , GetCustomAddresses (..)
-       , GetCustomAddress (..)
-       , GetPendingTxs (..)
-       , GetWalletPendingTxs (..)
-       , GetPendingTx (..)
        , AddCustomAddress (..)
        , CreateAccount (..)
        , AddWAddress (..)
@@ -53,7 +34,6 @@ module Pos.Wallet.Web.State.Acidic
        , SetWalletTxMeta (..)
        , AddOnlyNewTxMetas (..)
        , SetWalletTxHistory (..)
-       , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
        , RemoveWallet (..)
        , RemoveTxMetas (..)
@@ -73,7 +53,6 @@ module Pos.Wallet.Web.State.Acidic
        , AddOnlyNewPendingTx (..)
        , CancelApplyingPtxs (..)
        , CancelSpecificApplyingPtx (..)
-       , GetWalletStorage (..)
        , FlushWalletStorage (..)
        -- * No longer used, just here for migrations and backwards compatibility
        , UpdateHistoryCache (..)
@@ -120,33 +99,10 @@ tidyState = tidyExtendedState
 makeAcidic ''WalletStorage
     [
       'WS.testReset
-    , 'WS.getProfile
     , 'WS.doesAccountExist
-    , 'WS.getAccountIds
-    , 'WS.getAccountMetas
-    , 'WS.getAccountMeta
-    , 'WS.getAccountAddrMaps
-    , 'WS.getWalletMetas
-    , 'WS.getWalletMeta
-    , 'WS.getWalletMetaIncludeUnready
-    , 'WS.getWalletPassLU
-    , 'WS.getWalletSyncTip
-    , 'WS.getWalletAddresses
-    , 'WS.getWalletUtxo
-    , 'WS.getWalletBalancesAndUtxo
     , 'WS.updateWalletBalancesAndUtxo
     , 'WS.setWalletUtxo
-    , 'WS.getAccountWAddresses
     , 'WS.doesWAddressExist
-    , 'WS.getTxMeta
-    , 'WS.getUpdates
-    , 'WS.getNextUpdate
-    , 'WS.getHistoryCache
-    , 'WS.getCustomAddresses
-    , 'WS.getCustomAddress
-    , 'WS.getPendingTxs
-    , 'WS.getWalletPendingTxs
-    , 'WS.getPendingTx
     , 'WS.addCustomAddress
     , 'WS.removeCustomAddress
     , 'WS.createAccount
@@ -162,7 +118,6 @@ makeAcidic ''WalletStorage
     , 'WS.setWalletTxMeta
     , 'WS.addOnlyNewTxMetas
     , 'WS.setWalletTxHistory
-    , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta
     , 'WS.removeWallet
     , 'WS.removeTxMetas

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Rank2Types   #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Pos.Wallet.Web.State.State
@@ -13,10 +14,12 @@ module Pos.Wallet.Web.State.State
        , closeState
 
        , AddressLookupMode (..)
-       , CustomAddressType (..)
        , CurrentAndRemoved (..)
+       , CustomAddressType (..)
 
        -- * Getters
+       , WalletSnapshot
+       , getWalletSnapshot
        , getProfile
        , doesAccountExist
        , getAccountIds
@@ -82,7 +85,6 @@ module Pos.Wallet.Web.State.State
        , addOnlyNewPendingTx
        , cancelApplyingPtxs
        , cancelSpecificApplyingPtx
-       , getWalletStorage
        , flushWalletStorage
        ) where
 
@@ -106,9 +108,9 @@ import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition)
 import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
+import qualified Pos.Wallet.Web.State.Storage as S
 import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMode (..),
-                                               CurrentAndRemoved (..),
-                                               CustomAddressType (..),
+                                               CAddresses, CurrentAndRemoved(..) , CustomAddressType (..),
                                                PtxMetaUpdate (..), WalletBalances,
                                                WalletStorage, WalletTip (..))
 
@@ -129,11 +131,17 @@ type WebWalletModeDB ctx m =
     , HasConfiguration
     )
 
+type WalletSnapshot = WalletStorage
+
 queryDisk
     :: (EventState event ~ WalletStorage, QueryEvent event,
         MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 queryDisk e = getWalletWebState >>= flip A.query e
+
+queryValue
+    :: WalletStorage -> S.Query a -> a
+queryValue ws q = runReader q ws
 
 updateDisk
     :: (EventState event ~ WalletStorage, UpdateEvent event,
@@ -141,86 +149,95 @@ updateDisk
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
 
-doesAccountExist :: WebWalletModeDB ctx m => AccountId -> m Bool
-doesAccountExist = queryDisk . A.DoesAccountExist
+-- | All queries work by doing a /single/ read of the DB state and then
+-- by using pure functions to extract the relevant information. A single read
+-- guarantees that we see a self-consistent snapshot of the wallet state.
+--
+getWalletSnapshot :: WebWalletModeDB ctx m => m WalletSnapshot
+getWalletSnapshot = queryDisk A.GetWalletStorage
 
-getAccountIds :: WebWalletModeDB ctx m => m [AccountId]
-getAccountIds = queryDisk A.GetAccountIds
+doesAccountExist :: WalletSnapshot -> AccountId -> Bool
+doesAccountExist ws accid = queryValue ws (S.doesAccountExist accid)
 
-getAccountMetas :: WebWalletModeDB ctx m => m [CAccountMeta]
-getAccountMetas = queryDisk A.GetAccountMetas
+getAccountIds :: WalletSnapshot -> [AccountId]
+getAccountIds ws = queryValue ws S.getAccountIds
 
-getAccountMeta :: WebWalletModeDB ctx m => AccountId -> m (Maybe CAccountMeta)
-getAccountMeta = queryDisk . A.GetAccountMeta
+getAccountMetas :: WalletSnapshot -> [CAccountMeta]
+getAccountMetas ws = queryValue ws S.getAccountMetas
 
-getAccountAddrMaps
-    :: WebWalletModeDB ctx m
-    => AccountId -> m (CurrentAndRemoved (HashMap (CId Addr) AddressInfo))
-getAccountAddrMaps = queryDisk . A.GetAccountAddrMaps
+getAccountMeta :: WalletSnapshot -> AccountId -> Maybe CAccountMeta
+getAccountMeta ws accid = queryValue ws (S.getAccountMeta accid)
 
-getWalletAddresses :: WebWalletModeDB ctx m => m [CId Wal]
-getWalletAddresses = queryDisk A.GetWalletAddresses
+getAccountAddrMaps :: WalletSnapshot -> AccountId -> CurrentAndRemoved CAddresses
+getAccountAddrMaps ws accid = queryValue ws (S.getAccountAddrMaps accid)
 
-getWalletMeta :: WebWalletModeDB ctx m => CId Wal -> m (Maybe CWalletMeta)
-getWalletMeta = queryDisk . A.GetWalletMeta
+getWalletAddresses :: WalletSnapshot -> [CId Wal]
+getWalletAddresses ws = queryValue ws S.getWalletAddresses
 
-getWalletMetaIncludeUnready :: WebWalletModeDB ctx m => Bool -> CId Wal -> m (Maybe CWalletMeta)
-getWalletMetaIncludeUnready includeReady = queryDisk . A.GetWalletMetaIncludeUnready includeReady
+getWalletMeta :: WalletSnapshot -> CId Wal -> Maybe CWalletMeta
+getWalletMeta ws wid = queryValue ws (S.getWalletMeta wid)
 
-getWalletMetas :: WebWalletModeDB ctx m => m ([CWalletMeta])
-getWalletMetas = queryDisk A.GetWalletMetas
+getWalletMetaIncludeUnready
+    :: WalletSnapshot -> Bool -> CId Wal -> Maybe CWalletMeta
+getWalletMetaIncludeUnready ws includeReady wid =
+    queryValue ws (S.getWalletMetaIncludeUnready includeReady wid)
 
-getWalletPassLU :: WebWalletModeDB ctx m => CId Wal -> m (Maybe PassPhraseLU)
-getWalletPassLU = queryDisk . A.GetWalletPassLU
+getWalletMetas :: WalletSnapshot -> [CWalletMeta]
+getWalletMetas ws = queryValue ws S.getWalletMetas
 
-getWalletSyncTip :: WebWalletModeDB ctx m => CId Wal -> m (Maybe WalletTip)
-getWalletSyncTip = queryDisk . A.GetWalletSyncTip
+getWalletPassLU :: WalletSnapshot -> CId Wal -> Maybe PassPhraseLU
+getWalletPassLU ws wid = queryValue ws (S.getWalletPassLU wid)
+
+getWalletSyncTip :: WalletSnapshot -> CId Wal -> Maybe WalletTip
+getWalletSyncTip ws wid = queryValue ws (S.getWalletSyncTip wid)
 
 getAccountWAddresses
-    :: WebWalletModeDB ctx m
-    => AddressLookupMode -> AccountId -> m (Maybe [AddressInfo])
-getAccountWAddresses mode ai = queryDisk $ A.GetAccountWAddresses mode ai
+    :: WalletSnapshot -> AddressLookupMode -> AccountId -> Maybe [AddressInfo]
+getAccountWAddresses ws mode wid =
+    queryValue ws (S.getAccountWAddresses mode wid)
 
 doesWAddressExist
-    :: WebWalletModeDB ctx m
-    => AddressLookupMode -> CWAddressMeta -> m Bool
-doesWAddressExist mode = queryDisk . A.DoesWAddressExist mode
+    :: WalletSnapshot -> AddressLookupMode -> CWAddressMeta -> Bool
+doesWAddressExist ws mode addr = queryValue ws (S.doesWAddressExist mode addr)
 
-getProfile :: WebWalletModeDB ctx m => m CProfile
-getProfile = queryDisk A.GetProfile
+getProfile :: WalletSnapshot -> CProfile
+getProfile ws = queryValue ws S.getProfile
 
-getTxMeta :: WebWalletModeDB ctx m => CId Wal -> CTxId -> m (Maybe CTxMeta)
-getTxMeta cWalId = queryDisk . A.GetTxMeta cWalId
+getTxMeta :: WalletSnapshot -> CId Wal -> CTxId -> Maybe CTxMeta
+getTxMeta ws wid txid = queryValue ws (S.getTxMeta wid txid)
 
-getWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [CTxMeta])
-getWalletTxHistory = queryDisk . A.GetWalletTxHistory
+getWalletTxHistory :: WalletSnapshot -> CId Wal -> Maybe [CTxMeta]
+getWalletTxHistory ws wid = queryValue ws (S.getWalletTxHistory wid)
 
-getUpdates :: WebWalletModeDB ctx m => m [CUpdateInfo]
-getUpdates = queryDisk A.GetUpdates
+getUpdates :: WalletSnapshot -> [CUpdateInfo]
+getUpdates ws = queryValue ws S.getUpdates
 
-getNextUpdate :: WebWalletModeDB ctx m => m (Maybe CUpdateInfo)
-getNextUpdate = queryDisk A.GetNextUpdate
+getNextUpdate :: WalletSnapshot -> Maybe CUpdateInfo
+getNextUpdate ws = queryValue ws S.getNextUpdate
 
-getHistoryCache :: WebWalletModeDB ctx m => CId Wal -> m (Maybe (Map TxId TxHistoryEntry))
-getHistoryCache = queryDisk . A.GetHistoryCache
+getHistoryCache :: WalletSnapshot -> CId Wal -> Maybe (Map TxId TxHistoryEntry)
+getHistoryCache ws wid = queryValue ws (S.getHistoryCache wid)
 
-getCustomAddresses :: WebWalletModeDB ctx m => CustomAddressType -> m [CId Addr]
-getCustomAddresses = queryDisk ... A.GetCustomAddresses
+getCustomAddresses :: WalletSnapshot -> CustomAddressType -> [CId Addr]
+getCustomAddresses ws addrtype = queryValue ws (S.getCustomAddresses addrtype)
 
-getCustomAddress :: WebWalletModeDB ctx m => CustomAddressType -> CId Addr -> m (Maybe HeaderHash)
-getCustomAddress = queryDisk ... A.GetCustomAddress
+getCustomAddress
+    :: WalletSnapshot -> CustomAddressType -> CId Addr -> Maybe HeaderHash
+getCustomAddress ws addrtype addrid =
+    queryValue ws (S.getCustomAddress addrtype addrid)
 
-isCustomAddress :: WebWalletModeDB ctx m => CustomAddressType -> CId Addr -> m Bool
-isCustomAddress = fmap isJust . queryDisk ... A.GetCustomAddress
+isCustomAddress :: WalletSnapshot -> CustomAddressType -> CId Addr -> Bool
+isCustomAddress ws addrtype addrid =
+    isJust (getCustomAddress ws addrtype addrid)
 
-getPendingTxs :: WebWalletModeDB ctx m => m [PendingTx]
-getPendingTxs = queryDisk ... A.GetPendingTxs
+getPendingTxs :: WalletSnapshot -> [PendingTx]
+getPendingTxs ws = queryValue ws S.getPendingTxs
 
-getWalletPendingTxs :: WebWalletModeDB ctx m => CId Wal -> m (Maybe [PendingTx])
-getWalletPendingTxs = queryDisk ... A.GetWalletPendingTxs
+getWalletPendingTxs :: WalletSnapshot -> CId Wal -> Maybe [PendingTx]
+getWalletPendingTxs ws wid = queryValue ws (S.getWalletPendingTxs wid)
 
-getPendingTx :: WebWalletModeDB ctx m => CId Wal -> TxId -> m (Maybe PendingTx)
-getPendingTx = queryDisk ... A.GetPendingTx
+getPendingTx :: WalletSnapshot -> CId Wal -> TxId -> Maybe PendingTx
+getPendingTx ws wid txid = queryValue ws (S.getPendingTx wid txid)
 
 createAccount :: WebWalletModeDB ctx m => AccountId -> CAccountMeta -> m ()
 createAccount accId = updateDisk . A.CreateAccount accId
@@ -266,11 +283,11 @@ addOnlyNewTxMetas cWalId cTxMetas = updateDisk (A.AddOnlyNewTxMetas cWalId cTxMe
 setWalletTxHistory :: WebWalletModeDB ctx m => CId Wal -> [(CTxId, CTxMeta)] -> m ()
 setWalletTxHistory cWalId = updateDisk . A.SetWalletTxHistory cWalId
 
-getWalletUtxo :: WebWalletModeDB ctx m => m Utxo
-getWalletUtxo = queryDisk A.GetWalletUtxo
+getWalletUtxo :: WalletSnapshot -> Utxo
+getWalletUtxo ws = queryValue ws S.getWalletUtxo
 
-getWalletBalancesAndUtxo :: WebWalletModeDB ctx m => m (WalletBalances, Utxo)
-getWalletBalancesAndUtxo = queryDisk A.GetWalletBalancesAndUtxo
+getWalletBalancesAndUtxo :: WalletSnapshot -> (WalletBalances, Utxo)
+getWalletBalancesAndUtxo ws = queryValue ws S.getWalletBalancesAndUtxo
 
 updateWalletBalancesAndUtxo :: WebWalletModeDB ctx m => UtxoModifier -> m ()
 updateWalletBalancesAndUtxo = updateDisk . A.UpdateWalletBalancesAndUtxo
@@ -356,5 +373,3 @@ cancelSpecificApplyingPtx txid = updateDisk ... A.CancelSpecificApplyingPtx txid
 flushWalletStorage :: WebWalletModeDB ctx m => m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage
 
-getWalletStorage :: WebWalletModeDB ctx m => m WalletStorage
-getWalletStorage = queryDisk A.GetWalletStorage

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Pos.Wallet.Web.State.State
-       ( WalletState
+       ( WalletDB
        , WalletDbReader
        , WalletDbWriter
        , WalletTip (..)
        , PtxMetaUpdate (..)
        , AddressInfo (..)
-       , askWalletState
+       , askWalletDB
        , openState
        , openMemState
        , closeState
@@ -103,7 +103,7 @@ import           Pos.Wallet.Web.ClientTypes   (AccountId, Addr, CAccountMeta, CI
                                                CWAddressMeta, CWalletMeta, PassPhraseLU,
                                                Wal)
 import           Pos.Wallet.Web.Pending.Types (PendingTx (..), PtxCondition)
-import           Pos.Wallet.Web.State.Acidic  (WalletState, closeState, openMemState,
+import           Pos.Wallet.Web.State.Acidic  (WalletDB, closeState, openMemState,
                                                openState)
 import           Pos.Wallet.Web.State.Acidic  as A
 import qualified Pos.Wallet.Web.State.Storage as S
@@ -113,15 +113,15 @@ import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMo
                                                WalletStorage, WalletTip (..))
 
 -- | The 'WalletDbReader' constraint encapsulates the set of effects which
--- are able to read the 'WalletState'.
+-- are able to read the 'WalletDB'.
 type WalletDbReader ctx m =
     ( MonadReader ctx m
-    , HasLens WalletState ctx WalletState
+    , HasLens WalletDB ctx WalletDB
     )
 
--- | Reads the 'WalletState'.
-askWalletState :: WalletDbReader ctx m => m WalletState
-askWalletState = view (lensOf @WalletState)
+-- | Reads the 'WalletDB'.
+askWalletDB :: WalletDbReader ctx m => m WalletDB
+askWalletDB = view (lensOf @WalletDB)
 
 -- | The 'WalletDbWriter' constraint encapsulate the fact we can write an updated
 -- copy of the 'WalletStorage', but that we cannot read it back, if not as part
@@ -138,13 +138,13 @@ queryDisk
     :: (EventState event ~ WalletStorage, QueryEvent event,
         WalletDbReader ctx m, MonadIO m)
     => event -> m (EventResult event)
-queryDisk e = askWalletState >>= flip A.query e
+queryDisk e = askWalletDB >>= flip A.query e
 
 queryValue
     :: WalletStorage -> S.Query a -> a
 queryValue ws q = runReader q ws
 
-updateDisk :: WalletDbWriter event m => event -> WalletState -> m (EventResult event)
+updateDisk :: WalletDbWriter event m => event -> WalletDB -> m (EventResult event)
 updateDisk evt db = A.update db evt
 
 -- | All queries work by doing a /single/ read of the DB state and then
@@ -254,79 +254,80 @@ getWalletBalancesAndUtxo ws = queryValue ws S.getWalletBalancesAndUtxo
 
 createAccount :: ( WalletDbReader ctx m
                  , WalletDbWriter A.CreateAccount m
-                 ) => AccountId -> CAccountMeta -> m ()
+                 )
+              => AccountId -> CAccountMeta -> m ()
 createAccount accId accMeta =
-    askWalletState >>= updateDisk (A.CreateAccount accId accMeta)
+    askWalletDB >>= updateDisk (A.CreateAccount accId accMeta)
 
 createWallet :: ( WalletDbReader ctx m
                 , WalletDbWriter A.CreateWallet m
                 ) => CId Wal -> CWalletMeta -> Bool -> PassPhraseLU -> m ()
 createWallet cWalId cwMeta isReady lastUpdate =
-    askWalletState >>= updateDisk (A.CreateWallet cWalId cwMeta isReady lastUpdate)
+    askWalletDB >>= updateDisk (A.CreateWallet cWalId cwMeta isReady lastUpdate)
 
 addWAddress :: ( WalletDbReader ctx m
                , WalletDbWriter A.AddWAddress m
                ) => CWAddressMeta -> m ()
-addWAddress addr = askWalletState >>= updateDisk (A.AddWAddress addr)
+addWAddress addr = askWalletDB >>= updateDisk (A.AddWAddress addr)
 
 addCustomAddress :: ( WalletDbReader ctx m
                     , WalletDbWriter A.AddCustomAddress m
                     ) => CustomAddressType -> (CId Addr, HeaderHash) -> m Bool
 addCustomAddress customAddrType addrAndHash =
-    askWalletState >>= updateDisk (A.AddCustomAddress customAddrType addrAndHash)
+    askWalletDB >>= updateDisk (A.AddCustomAddress customAddrType addrAndHash)
 
 addRemovedAccount :: ( WalletDbReader ctx m
                      , WalletDbWriter A.AddRemovedAccount m
                      ) => CWAddressMeta -> m ()
 addRemovedAccount addrMeta =
-    askWalletState >>= updateDisk (A.AddRemovedAccount addrMeta)
+    askWalletDB >>= updateDisk (A.AddRemovedAccount addrMeta)
 
 setAccountMeta :: ( WalletDbReader ctx m
                   , WalletDbWriter A.SetAccountMeta m
                   ) => AccountId -> CAccountMeta -> m ()
 setAccountMeta accId accMeta =
-    askWalletState >>= updateDisk (A.SetAccountMeta accId accMeta)
+    askWalletDB >>= updateDisk (A.SetAccountMeta accId accMeta)
 
 setWalletMeta :: ( WalletDbReader ctx m
                  , WalletDbWriter A.SetWalletMeta m
                  ) => CId Wal -> CWalletMeta -> m ()
 setWalletMeta cWalId walletMeta =
-    askWalletState >>= updateDisk (A.SetWalletMeta cWalId walletMeta)
+    askWalletDB >>= updateDisk (A.SetWalletMeta cWalId walletMeta)
 
 setWalletReady :: ( WalletDbReader ctx m
                   , WalletDbWriter A.SetWalletReady m
                   ) => CId Wal -> Bool -> m ()
 setWalletReady cWalId isReady =
-    askWalletState >>= updateDisk (A.SetWalletReady cWalId isReady)
+    askWalletDB >>= updateDisk (A.SetWalletReady cWalId isReady)
 
 setWalletPassLU :: ( WalletDbReader ctx m
                    , WalletDbWriter A.SetWalletPassLU m
                    ) => CId Wal -> PassPhraseLU -> m ()
 setWalletPassLU cWalId lastUpdate =
-    askWalletState >>= updateDisk (A.SetWalletPassLU cWalId lastUpdate)
+    askWalletDB >>= updateDisk (A.SetWalletPassLU cWalId lastUpdate)
 
 setWalletSyncTip :: ( WalletDbReader ctx m
                     , WalletDbWriter A.SetWalletSyncTip m
                     ) => CId Wal -> HeaderHash -> m ()
 setWalletSyncTip cWalId headerHash =
-    askWalletState >>= updateDisk (A.SetWalletSyncTip cWalId headerHash)
+    askWalletDB >>= updateDisk (A.SetWalletSyncTip cWalId headerHash)
 
 setProfile :: ( WalletDbReader ctx m
               , WalletDbWriter A.SetProfile m
               ) => CProfile -> m ()
-setProfile cProfile = askWalletState >>= updateDisk (A.SetProfile cProfile)
+setProfile cProfile = askWalletDB >>= updateDisk (A.SetProfile cProfile)
 
 setWalletTxMeta :: ( WalletDbReader ctx m
                    , WalletDbWriter A.SetWalletTxMeta m
                    ) => CId Wal -> CTxId -> CTxMeta -> m ()
 setWalletTxMeta cWalId cTxId cTxMeta =
-    askWalletState >>= updateDisk (A.SetWalletTxMeta cWalId cTxId cTxMeta)
+    askWalletDB >>= updateDisk (A.SetWalletTxMeta cWalId cTxId cTxMeta)
 
 addOnlyNewTxMetas :: ( WalletDbReader ctx m
                      , WalletDbWriter A.AddOnlyNewTxMetas m
                      ) => CId Wal -> Map TxId CTxMeta -> m ()
 addOnlyNewTxMetas cWalId cTxMetas =
-    askWalletState >>= updateDisk (A.AddOnlyNewTxMetas cWalId cTxMetaList)
+    askWalletDB >>= updateDisk (A.AddOnlyNewTxMetas cWalId cTxMetaList)
     where
       cTxMetaList = [ (encodeCType txId, cTxMeta) | (txId, cTxMeta) <- Map.toList cTxMetas ]
 
@@ -334,98 +335,98 @@ setWalletTxHistory :: ( WalletDbReader ctx m
                       , WalletDbWriter A.SetWalletTxHistory m
                       ) => CId Wal -> [(CTxId, CTxMeta)] -> m ()
 setWalletTxHistory cWalId idsAndMetas =
-    askWalletState >>= updateDisk (A.SetWalletTxHistory cWalId idsAndMetas)
+    askWalletDB >>= updateDisk (A.SetWalletTxHistory cWalId idsAndMetas)
 
 updateWalletBalancesAndUtxo :: ( WalletDbReader ctx m
                                , WalletDbWriter A.UpdateWalletBalancesAndUtxo m
                                ) => UtxoModifier -> m ()
 updateWalletBalancesAndUtxo utxoModifier =
-    askWalletState >>= updateDisk (A.UpdateWalletBalancesAndUtxo utxoModifier)
+    askWalletDB >>= updateDisk (A.UpdateWalletBalancesAndUtxo utxoModifier)
 
 setWalletUtxo :: ( WalletDbReader ctx m
                  , WalletDbWriter A.SetWalletUtxo m
                  ) => Utxo -> m ()
-setWalletUtxo utxo = askWalletState >>= updateDisk (A.SetWalletUtxo utxo)
+setWalletUtxo utxo = askWalletDB >>= updateDisk (A.SetWalletUtxo utxo)
 
 addOnlyNewTxMeta :: ( WalletDbReader ctx m
                     , WalletDbWriter A.AddOnlyNewTxMeta m
                     ) => CId Wal -> CTxId -> CTxMeta -> m ()
 addOnlyNewTxMeta walletId txId txMeta =
-    askWalletState >>= updateDisk (A.AddOnlyNewTxMeta walletId txId txMeta)
+    askWalletDB >>= updateDisk (A.AddOnlyNewTxMeta walletId txId txMeta)
 
 removeWallet :: ( WalletDbReader ctx m
                 , WalletDbWriter A.RemoveWallet m
                 ) => CId Wal -> m ()
-removeWallet walletId = askWalletState >>= updateDisk (A.RemoveWallet walletId)
+removeWallet walletId = askWalletDB >>= updateDisk (A.RemoveWallet walletId)
 
 removeTxMetas :: ( WalletDbReader ctx m
                  , WalletDbWriter A.RemoveTxMetas m
                  ) => CId Wal -> m ()
-removeTxMetas walletId = askWalletState >>= updateDisk (A.RemoveTxMetas walletId)
+removeTxMetas walletId = askWalletDB >>= updateDisk (A.RemoveTxMetas walletId)
 
 removeWalletTxMetas :: ( WalletDbReader ctx m
                        , WalletDbWriter A.RemoveWalletTxMetas m)
                     => CId Wal -> [CTxId] -> m ()
 removeWalletTxMetas walletId txIds =
-    askWalletState >>= updateDisk (A.RemoveWalletTxMetas walletId txIds)
+    askWalletDB >>= updateDisk (A.RemoveWalletTxMetas walletId txIds)
 
 removeHistoryCache :: ( WalletDbReader ctx m
                       , WalletDbWriter A.RemoveHistoryCache m
                       ) => CId Wal -> m ()
-removeHistoryCache walletId = askWalletState >>= updateDisk (A.RemoveHistoryCache walletId)
+removeHistoryCache walletId = askWalletDB >>= updateDisk (A.RemoveHistoryCache walletId)
 
 removeAccount :: ( WalletDbReader ctx m
                  , WalletDbWriter A.RemoveAccount m
                  ) => AccountId -> m ()
-removeAccount accountId = askWalletState >>= updateDisk (A.RemoveAccount accountId)
+removeAccount accountId = askWalletDB >>= updateDisk (A.RemoveAccount accountId)
 
 removeWAddress :: ( WalletDbReader ctx m
                   , WalletDbWriter A.RemoveWAddress m
                   ) => CWAddressMeta -> m ()
-removeWAddress addrMeta = askWalletState >>= updateDisk (A.RemoveWAddress addrMeta)
+removeWAddress addrMeta = askWalletDB >>= updateDisk (A.RemoveWAddress addrMeta)
 
 totallyRemoveWAddress :: ( WalletDbReader ctx m
                          , WalletDbWriter A.TotallyRemoveWAddress m
                          ) => CWAddressMeta -> m ()
 totallyRemoveWAddress addrMeta =
-    askWalletState >>= updateDisk (A.TotallyRemoveWAddress addrMeta)
+    askWalletDB >>= updateDisk (A.TotallyRemoveWAddress addrMeta)
 
 removeCustomAddress
     :: ( WalletDbReader ctx m
        , WalletDbWriter A.RemoveCustomAddress m
        ) => CustomAddressType -> (CId Addr, HeaderHash) -> m Bool
 removeCustomAddress customAddrType aIdAndHeaderHash =
-    askWalletState >>= updateDisk (A.RemoveCustomAddress customAddrType aIdAndHeaderHash)
+    askWalletDB >>= updateDisk (A.RemoveCustomAddress customAddrType aIdAndHeaderHash)
 
 addUpdate :: ( WalletDbReader ctx m
              , WalletDbWriter A.AddUpdate m
              ) => CUpdateInfo -> m ()
 addUpdate updateInfo =
-    askWalletState >>= updateDisk (A.AddUpdate updateInfo)
+    askWalletDB >>= updateDisk (A.AddUpdate updateInfo)
 
 removeNextUpdate :: ( WalletDbReader ctx m
                     , WalletDbWriter A.RemoveNextUpdate m
                     ) => m ()
-removeNextUpdate = askWalletState >>= updateDisk A.RemoveNextUpdate
+removeNextUpdate = askWalletDB >>= updateDisk A.RemoveNextUpdate
 
 testReset :: ( WalletDbReader ctx m
              , WalletDbWriter A.TestReset m
              ) => m ()
-testReset = askWalletState >>= updateDisk A.TestReset
+testReset = askWalletDB >>= updateDisk A.TestReset
 
 insertIntoHistoryCache :: ( WalletDbReader ctx m
                           , WalletDbWriter A.InsertIntoHistoryCache m
                           ) => CId Wal -> Map TxId TxHistoryEntry -> m ()
 insertIntoHistoryCache cWalId cTxs
   | Map.null cTxs = return ()
-  | otherwise     = askWalletState >>= updateDisk (A.InsertIntoHistoryCache cWalId cTxs)
+  | otherwise     = askWalletDB >>= updateDisk (A.InsertIntoHistoryCache cWalId cTxs)
 
 removeFromHistoryCache :: ( WalletDbReader ctx m
                           , WalletDbWriter A.RemoveFromHistoryCache m
                           ) => CId Wal -> Map TxId a -> m ()
 removeFromHistoryCache cWalId cTxs
   | Map.null cTxs = return ()
-  | otherwise     = askWalletState >>= updateDisk (A.RemoveFromHistoryCache cWalId cTxs')
+  | otherwise     = askWalletDB >>= updateDisk (A.RemoveFromHistoryCache cWalId cTxs')
   where
     cTxs' :: Map TxId ()
     cTxs' = Map.map (const ()) cTxs
@@ -434,37 +435,37 @@ setPtxCondition :: ( WalletDbReader ctx m
                    , WalletDbWriter A.SetPtxCondition m
                    ) => CId Wal -> TxId -> PtxCondition -> m ()
 setPtxCondition walletId txId condition =
-    askWalletState >>= updateDisk (A.SetPtxCondition walletId txId condition)
+    askWalletDB >>= updateDisk (A.SetPtxCondition walletId txId condition)
 
 casPtxCondition :: ( WalletDbReader ctx m
                    , WalletDbWriter A.CasPtxCondition m
                    ) => CId Wal -> TxId -> PtxCondition -> PtxCondition -> m Bool
 casPtxCondition walletId txId old new =
-    askWalletState >>= updateDisk (A.CasPtxCondition walletId txId old new)
+    askWalletDB >>= updateDisk (A.CasPtxCondition walletId txId old new)
 
 ptxUpdateMeta :: ( WalletDbReader ctx m
                  , WalletDbWriter A.PtxUpdateMeta m
                  ) => CId Wal -> TxId -> PtxMetaUpdate -> m ()
 ptxUpdateMeta walletId txId metaUpdate =
-    askWalletState >>= updateDisk (A.PtxUpdateMeta walletId txId metaUpdate)
+    askWalletDB >>= updateDisk (A.PtxUpdateMeta walletId txId metaUpdate)
 
 addOnlyNewPendingTx :: ( WalletDbReader ctx m
                        , WalletDbWriter A.AddOnlyNewPendingTx m
                        ) => PendingTx -> m ()
-addOnlyNewPendingTx pendingTx = askWalletState >>= updateDisk (A.AddOnlyNewPendingTx pendingTx)
+addOnlyNewPendingTx pendingTx = askWalletDB >>= updateDisk (A.AddOnlyNewPendingTx pendingTx)
 
 cancelApplyingPtxs :: ( WalletDbReader ctx m
                       , WalletDbWriter A.CancelApplyingPtxs m
                       ) => m ()
-cancelApplyingPtxs = askWalletState >>= updateDisk A.CancelApplyingPtxs
+cancelApplyingPtxs = askWalletDB >>= updateDisk A.CancelApplyingPtxs
 
 cancelSpecificApplyingPtx :: ( WalletDbReader ctx m
                              , WalletDbWriter A.CancelSpecificApplyingPtx m
                              ) => TxId -> m ()
-cancelSpecificApplyingPtx txid = askWalletState >>= updateDisk (A.CancelSpecificApplyingPtx txid)
+cancelSpecificApplyingPtx txid = askWalletDB >>= updateDisk (A.CancelSpecificApplyingPtx txid)
 
 flushWalletStorage :: ( WalletDbReader ctx m
                       , WalletDbWriter A.FlushWalletStorage m
                       ) => m ()
-flushWalletStorage = askWalletState >>= updateDisk A.FlushWalletStorage
+flushWalletStorage = askWalletDB >>= updateDisk A.FlushWalletStorage
 

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -116,22 +116,28 @@ import           Pos.Wallet.Web.State.Storage (AddressInfo (..), AddressLookupMo
 type MonadWalletWebDB ctx m =
     ( MonadReader ctx m
     , HasLens WalletState ctx WalletState
-    , HasConfiguration
     )
 
 getWalletWebState :: MonadWalletWebDB ctx m => m WalletState
 getWalletWebState = view (lensOf @WalletState)
 
 -- | Constraint for working with web wallet DB
-type WebWalletModeDB ctx m = (MonadWalletWebDB ctx m, MonadIO m, MonadMockable m)
+type WebWalletModeDB ctx m =
+    ( MonadWalletWebDB ctx m
+    , MonadIO m
+    , MonadMockable m
+    , HasConfiguration
+    )
 
 queryDisk
-    :: (EventState event ~ WalletStorage, QueryEvent event, WebWalletModeDB ctx m)
+    :: (EventState event ~ WalletStorage, QueryEvent event,
+        MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 queryDisk e = getWalletWebState >>= flip A.query e
 
 updateDisk
-    :: (EventState event ~ WalletStorage, UpdateEvent event, WebWalletModeDB ctx m)
+    :: (EventState event ~ WalletStorage, UpdateEvent event,
+        MonadWalletWebDB ctx m, MonadIO m)
     => event -> m (EventResult event)
 updateDisk e = getWalletWebState >>= flip A.update e
 

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -88,6 +88,7 @@ module Pos.Wallet.Web.State.State
        , cancelApplyingPtxs
        , cancelSpecificApplyingPtx
        , flushWalletStorage
+       , applyModifierToWallet
        ) where
 
 import           Data.Acid                    (EventResult, EventState, QueryEvent,
@@ -516,3 +517,25 @@ flushWalletStorage :: ( WalletDbWriter A.FlushWalletStorage m)
                    => WalletDB
                    -> m ()
 flushWalletStorage = updateDisk A.FlushWalletStorage
+
+applyModifierToWallet
+  :: (WalletDbWriter A.ApplyModifierToWallet m)
+  => WalletDB
+  -> CId Wal
+  -> [CWAddressMeta] -- ^ Wallet addresses to add
+  -> [(S.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to add
+  -> UtxoModifier
+  -> [(CTxId, CTxMeta)] -- ^ Transaction metadata to add
+  -> Map TxId TxHistoryEntry -- ^ Entries for the history cache
+  -> [(TxId, PtxCondition)] -- ^ PTX Conditions
+  -> HeaderHash -- ^ New sync tip
+  -> m ()
+applyModifierToWallet db walId wAddrs custAddrs utxoMod
+                      txMetas historyEntries ptxConditions
+                      syncTip =
+    updateDisk
+      ( A.ApplyModifierToWallet
+          walId wAddrs custAddrs utxoMod
+          txMetas historyEntries ptxConditions syncTip
+      )
+      db

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -54,6 +54,7 @@ module Pos.Wallet.Web.State.State
        -- * Setters
        , testReset
        , createAccount
+       , createAccountWithAddress
        , createWallet
        , addRemovedAccount
        , addWAddress
@@ -275,6 +276,15 @@ createAccount :: (WalletDbWriter A.CreateAccount m)
               -> m ()
 createAccount db accId accMeta =
     updateDisk (A.CreateAccount accId accMeta) db
+
+createAccountWithAddress :: (WalletDbWriter A.CreateAccountWithAddress m)
+                         => WalletDB
+                         -> AccountId
+                         -> CAccountMeta
+                         -> CWAddressMeta
+                         -> m ()
+createAccountWithAddress db accId accMeta addrMeta =
+    updateDisk (A.CreateAccountWithAddress accId accMeta addrMeta) db
 
 createWallet :: (WalletDbWriter A.CreateWallet m)
              => WalletDB

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -71,7 +71,6 @@ module Pos.Wallet.Web.State.State
        , addOnlyNewTxMeta
        , removeWallet
        , removeWalletTxMetas
-       , removeTxMetas
        , removeHistoryCache
        , removeAccount
        , removeWAddress
@@ -379,13 +378,20 @@ addOnlyNewTxMeta :: (WalletDbWriter A.AddOnlyNewTxMeta m)
 addOnlyNewTxMeta db walletId txId txMeta =
     updateDisk (A.AddOnlyNewTxMeta walletId txId txMeta) db
 
-removeWallet :: (WalletDbWriter A.RemoveWallet m)
+-- | Remove a wallet and all associated data:
+--   - Associated accounts
+--   - Transaction metadata
+--   - History cache
+--
+--   Note that this functionality has changed - the old version of
+--   'removeWallet' did not used to remove the associated data.
+--   This functionality was not used anywhere and was therefore
+--   removed. Should it be needed again, one should add 'removeWallet'
+--   to the set of acidic updates and add a suitable function in this
+--   module to invoke it.
+removeWallet :: (WalletDbWriter A.DeleteWallet m)
              => WalletDB -> CId Wal  -> m ()
-removeWallet db walletId = updateDisk (A.RemoveWallet walletId) db
-
-removeTxMetas :: (WalletDbWriter A.RemoveTxMetas m)
-              => WalletDB -> CId Wal  -> m ()
-removeTxMetas db walletId = updateDisk (A.RemoveTxMetas walletId) db
+removeWallet db walletId = updateDisk (A.DeleteWallet walletId) db
 
 removeWalletTxMetas :: (WalletDbWriter A.RemoveWalletTxMetas m)
                     => WalletDB -> CId Wal -> [CTxId]  -> m ()

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -148,18 +148,6 @@ queryValue ws q = runReader q ws
 updateDisk :: WalletDbWriter event m => event -> WalletDB -> m (EventResult event)
 updateDisk evt db = A.update db evt
 
-updateDisk' :: forall m event. WalletDbWriter event m
-            => event
-            -> WalletDB
-            -> m (EventResult event, WalletSnapshot)
-updateDisk' evt db = do
-    result       <- A.update db evt
-    newSnapshot  <- readUpdatedDb
-    pure (result, newSnapshot)
-    where
-      readUpdatedDb :: m WalletSnapshot
-      readUpdatedDb = A.query db A.GetWalletStorage
-
 -- | All queries work by doing a /single/ read of the DB state and then
 -- by using pure functions to extract the relevant information. A single read
 -- guarantees that we see a self-consistent snapshot of the wallet state.
@@ -272,9 +260,9 @@ getWalletBalancesAndUtxo ws = queryValue ws S.getWalletBalancesAndUtxo
 createAccount :: ( WalletDbReader ctx m
                  , WalletDbWriter A.CreateAccount m
                  )
-              => AccountId -> CAccountMeta -> m ((), WalletSnapshot)
+              => AccountId -> CAccountMeta -> m ()
 createAccount accId accMeta =
-    askWalletDB >>= updateDisk' (A.CreateAccount accId accMeta)
+    askWalletDB >>= updateDisk (A.CreateAccount accId accMeta)
 
 createWallet :: ( WalletDbReader ctx m
                 , WalletDbWriter A.CreateWallet m

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -89,6 +89,7 @@ module Pos.Wallet.Web.State.State
        , cancelSpecificApplyingPtx
        , flushWalletStorage
        , applyModifierToWallet
+       , rollbackModifierFromWallet
        ) where
 
 import           Data.Acid                    (EventResult, EventState, QueryEvent,
@@ -539,3 +540,28 @@ applyModifierToWallet db walId wAddrs custAddrs utxoMod
           txMetas historyEntries ptxConditions syncTip
       )
       db
+
+rollbackModifierFromWallet
+  :: (WalletDbWriter A.RollbackModifierFromWallet m)
+  => WalletDB
+  -> CId Wal
+  -> [CWAddressMeta] -- ^ Addresses to remove
+  -> [(S.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to remove
+  -> UtxoModifier
+     -- We use this odd representation because Data.Map does not get 'withoutKeys'
+     -- until 5.8.1
+  -> Map TxId a -- ^ Entries to remove from history cache.
+  -> [(TxId, PtxCondition, S.PtxMetaUpdate)] -- ^ Deleted PTX candidates
+  -> HeaderHash -- ^ New sync tip
+  -> m ()
+rollbackModifierFromWallet db walId wAddrs custAddrs utxoMod
+                           historyEntries ptxConditions
+                           syncTip =
+    updateDisk
+      ( A.RollbackModifierFromWallet
+          walId wAddrs custAddrs utxoMod
+          historyEntries' ptxConditions syncTip
+      )
+      db
+  where
+    historyEntries' = Map.map (const ()) historyEntries

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -27,6 +27,7 @@ module Pos.Wallet.Web.State.State
        , getAccountMeta
        , getAccountAddrMaps
        , getAccountWAddresses
+       , getWAddresses
        , getWalletMetas
        , getWalletMeta
        , getWalletMetaIncludeUnready
@@ -209,6 +210,10 @@ getAccountWAddresses
     :: WalletSnapshot -> AddressLookupMode -> AccountId -> Maybe [AddressInfo]
 getAccountWAddresses ws mode wid =
     queryValue ws (S.getAccountWAddresses mode wid)
+
+-- | Get the 'AddressInfo' corresponding to all accounts in this wallet.
+getWAddresses :: WalletSnapshot -> AddressLookupMode -> CId Wal -> [AddressInfo]
+getWAddresses ws mode wid = queryValue ws (S.getWAddresses mode wid)
 
 doesWAddressExist
     :: WalletSnapshot -> AddressLookupMode -> CWAddressMeta -> Bool

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -9,6 +9,7 @@ module Pos.Wallet.Web.State.Storage
        , AccountInfo (..)
        , AddressInfo (..)
        , AddressLookupMode (..)
+       , CAddresses
        , CustomAddressType (..)
        , CurrentAndRemoved (..)
        , WalletBalances

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -5,6 +5,7 @@
 module Pos.Wallet.Web.State.Storage
        (
          WalletStorage (..)
+       , HasWalletStorage (..)
        , WalletInfo (..)
        , AccountInfo (..)
        , AddressInfo (..)

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -87,38 +87,38 @@ module Pos.Wallet.Web.State.Storage
 
 import           Universum
 
-import           Control.Lens                   (at, ix, makeClassy, makeLenses, non', to,
-                                                 toListOf, traversed, (%=), (+=), (.=),
-                                                 (<<.=), (?=), _Empty, _head)
-import           Control.Monad.State.Class      (put)
-import           Data.Default                   (Default, def)
-import qualified Data.HashMap.Strict            as HM
-import qualified Data.Map                       as M
-import           Data.SafeCopy                  (Migrate (..), base, deriveSafeCopySimple,
-                                                 extension)
-import           Data.Time.Clock.POSIX          (POSIXTime)
+import           Control.Lens                    (at, ix, makeClassy, makeLenses, non', to,
+                                                  toListOf, traversed, (%=), (+=), (.=),
+                                                  (<<.=), (?=), _Empty, _head)
+import           Control.Monad.State.Class       (put)
+import           Data.Default                    (Default, def)
+import qualified Data.HashMap.Strict             as HM
+import qualified Data.Map                        as M
+import           Data.SafeCopy                   (Migrate (..), base, deriveSafeCopySimple,
+                                                  extension)
+import           Data.Time.Clock.POSIX           (POSIXTime)
 
-import           Pos.Client.Txp.History         (TxHistoryEntry, txHistoryListToMap)
-import           Pos.Core.Configuration         (HasConfiguration)
-import           Pos.Core.Types                 (SlotId, Timestamp)
-import           Pos.Txp                        (AddrCoinMap, TxAux, TxId, Utxo,
-                                                 UtxoModifier, applyUtxoModToAddrCoinMap,
-                                                 utxoToAddressCoinMap)
-import           Pos.Types                      (HeaderHash)
-import           Pos.Util.BackupPhrase          (BackupPhrase)
-import qualified Pos.Util.Modifier              as MM
-import           Pos.Wallet.Web.ClientTypes     (AccountId, Addr, CAccountMeta, CCoin,
-                                                 CHash, CId, CProfile, CTxId, CTxMeta,
-                                                 CUpdateInfo, CWAddressMeta (..),
-                                                 CWalletAssurance, CWalletMeta,
-                                                 PassPhraseLU, Wal, addrMetaToAccount)
-import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition,
-                                                 PtxSubmitTiming (..), ptxCond,
-                                                 ptxSubmitTiming)
-import           Pos.Wallet.Web.Pending.Updates (cancelApplyingPtx,
-                                                 incPtxSubmitTimingPure,
-                                                 mkPtxSubmitTiming,
-                                                 ptxMarkAcknowledgedPure)
+import           Pos.Client.Txp.History          (TxHistoryEntry, txHistoryListToMap)
+import           Pos.Core.Configuration.Protocol (HasProtocolConstants)
+import           Pos.Core.Types                  (SlotId, Timestamp)
+import           Pos.Txp                         (AddrCoinMap, TxAux, TxId, Utxo,
+                                                  UtxoModifier, applyUtxoModToAddrCoinMap,
+                                                  utxoToAddressCoinMap)
+import           Pos.Types                       (HeaderHash)
+import           Pos.Util.BackupPhrase           (BackupPhrase)
+import qualified Pos.Util.Modifier               as MM
+import           Pos.Wallet.Web.ClientTypes      (AccountId, Addr, CAccountMeta, CCoin,
+                                                  CHash, CId, CProfile, CTxId, CTxMeta,
+                                                  CUpdateInfo, CWAddressMeta (..),
+                                                  CWalletAssurance, CWalletMeta,
+                                                  PassPhraseLU, Wal, addrMetaToAccount)
+import           Pos.Wallet.Web.Pending.Types    (PendingTx (..), PtxCondition,
+                                                  PtxSubmitTiming (..), ptxCond,
+                                                  ptxSubmitTiming)
+import           Pos.Wallet.Web.Pending.Updates  (cancelApplyingPtx,
+                                                  incPtxSubmitTimingPure,
+                                                  mkPtxSubmitTiming,
+                                                  ptxMarkAcknowledgedPure)
 
 type AddressSortingKey = Int
 
@@ -194,7 +194,7 @@ instance Default WalletStorage where
         }
 
 type Query a = forall m. (MonadReader WalletStorage m) => m a
-type Update a = forall m. (HasConfiguration, MonadState WalletStorage m) => m a
+type Update a = forall m. (HasProtocolConstants, MonadState WalletStorage m) => m a
 
 -- | How to lookup addresses of account
 data AddressLookupMode

--- a/node/src/Pos/Wallet/Web/State/Transactions.hs
+++ b/node/src/Pos/Wallet/Web/State/Transactions.hs
@@ -6,14 +6,21 @@
 module Pos.Wallet.Web.State.Transactions
   ( createAccountWithAddress
   , deleteWallet
+  , applyModifierToWallet
   )
   where
 
-import           Universum
+import           Universum                    hiding (for_)
 
+import           Data.Foldable                (for_)
 import qualified Data.HashMap.Strict          as HM
-import           Pos.Wallet.Web.ClientTypes   (AccountId (..), CAccountMeta,
-                                               CId, CWAddressMeta (..), Wal)
+import           Pos.Client.Txp.History       (TxHistoryEntry)
+import           Pos.Txp                      (TxId, UtxoModifier)
+import           Pos.Types                    (HeaderHash)
+import           Pos.Wallet.Web.ClientTypes   (AccountId (..), Addr,
+                                               CAccountMeta, CId, CTxId,
+                                               CTxMeta, CWAddressMeta (..), Wal)
+import           Pos.Wallet.Web.Pending.Types (PtxCondition)
 import           Pos.Wallet.Web.State.Storage (Update)
 import qualified Pos.Wallet.Web.State.Storage as WS
 
@@ -41,3 +48,27 @@ deleteWallet walId = do
   WS.removeWallet walId
   WS.removeTxMetas walId
   WS.removeHistoryCache walId
+
+-- | Apply some set of modifiers to a wallet.
+--   TODO Find out the significance of this set of modifiers and document.
+applyModifierToWallet
+  :: CId Wal
+  -> [CWAddressMeta] -- ^ Wallet addresses to add
+  -> [(WS.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to add
+  -> UtxoModifier
+  -> [(CTxId, CTxMeta)] -- ^ Transaction metadata to add
+  -> Map TxId TxHistoryEntry -- ^ Entries for the history cache
+  -> [(TxId, PtxCondition)] -- ^ PTX Conditions
+  -> HeaderHash -- ^ New sync tip
+  -> Update ()
+applyModifierToWallet walId wAddrs custAddrs utxoMod
+                      txMetas historyEntries ptxConditions
+                      syncTip = do
+  for_ wAddrs WS.addWAddress
+  for_ custAddrs $ \(cat, addrs) ->
+    for_ addrs $ WS.addCustomAddress cat
+  WS.updateWalletBalancesAndUtxo utxoMod
+  for_ txMetas $ uncurry $ WS.addOnlyNewTxMeta walId
+  WS.insertIntoHistoryCache walId historyEntries
+  for_ ptxConditions $ uncurry $ WS.setPtxCondition walId
+  WS.setWalletSyncTip walId syncTip

--- a/node/src/Pos/Wallet/Web/State/Transactions.hs
+++ b/node/src/Pos/Wallet/Web/State/Transactions.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE RankNTypes #-}
+-- | This module contains higher level transctions atop of
+--   'Post.Wallet.Web.State.Storage'. These are defined as
+--   specific (named) functions in order to generate acidic
+--   guarantees for them.
+module Pos.Wallet.Web.State.Transactions
+  ( createAccountWithAddress )
+  where
+
+import           Pos.Wallet.Web.ClientTypes   (AccountId (..), CAccountMeta,
+                                               CWAddressMeta (..))
+import           Pos.Wallet.Web.State.Storage (Update)
+import qualified Pos.Wallet.Web.State.Storage as WS
+
+-- | Create an account with an address.
+createAccountWithAddress
+  :: AccountId
+  -> CAccountMeta
+  -> CWAddressMeta
+  -> Update ()
+createAccountWithAddress accId accMeta addrMeta = do
+  WS.createAccount accId accMeta
+  WS.addWAddress addrMeta

--- a/node/src/Pos/Wallet/Web/State/Transactions.hs
+++ b/node/src/Pos/Wallet/Web/State/Transactions.hs
@@ -7,6 +7,7 @@ module Pos.Wallet.Web.State.Transactions
   ( createAccountWithAddress
   , deleteWallet
   , applyModifierToWallet
+  , rollbackModifierFromWallet
   )
   where
 
@@ -14,9 +15,11 @@ import           Universum                    hiding (for_)
 
 import           Data.Foldable                (for_)
 import qualified Data.HashMap.Strict          as HM
+import qualified Data.Map                     as M
 import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Txp                      (TxId, UtxoModifier)
 import           Pos.Types                    (HeaderHash)
+import           Pos.Util.Servant                 (encodeCType)
 import           Pos.Wallet.Web.ClientTypes   (AccountId (..), Addr,
                                                CAccountMeta, CId, CTxId,
                                                CTxMeta, CWAddressMeta (..), Wal)
@@ -71,4 +74,31 @@ applyModifierToWallet walId wAddrs custAddrs utxoMod
   for_ txMetas $ uncurry $ WS.addOnlyNewTxMeta walId
   WS.insertIntoHistoryCache walId historyEntries
   for_ ptxConditions $ uncurry $ WS.setPtxCondition walId
+  WS.setWalletSyncTip walId syncTip
+
+-- | Rollback some set of modifiers to a wallet.
+--   TODO Find out the significance of this set of modifiers and document.
+rollbackModifierFromWallet
+  :: CId Wal
+  -> [CWAddressMeta] -- ^ Addresses to remove
+  -> [(WS.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to remove
+  -> UtxoModifier
+     -- We use this odd representation because Data.Map does not get 'withoutKeys'
+     -- until 5.8.1
+  -> Map TxId () -- ^ Entries to remove from history cache.
+  -> [(TxId, PtxCondition, WS.PtxMetaUpdate)] -- ^ Deleted PTX candidates
+  -> HeaderHash -- ^ New sync tip
+  -> Update ()
+rollbackModifierFromWallet walId wAddrs custAddrs utxoMod
+                           historyEntries ptxConditions
+                           syncTip = do
+  for_ wAddrs WS.removeWAddress
+  for_ custAddrs $ \(cat, addrs) ->
+    for_ addrs $ WS.removeCustomAddress cat
+  WS.updateWalletBalancesAndUtxo utxoMod
+  WS.removeFromHistoryCache walId historyEntries
+  WS.removeWalletTxMetas walId (encodeCType <$> M.keys historyEntries)
+  for_ ptxConditions $ \(txId, cond, meta) -> do
+    WS.ptxUpdateMeta walId txId meta
+    WS.setPtxCondition walId txId cond
   WS.setWalletSyncTip walId syncTip

--- a/node/src/Pos/Wallet/Web/State/Util.hs
+++ b/node/src/Pos/Wallet/Web/State/Util.hs
@@ -17,13 +17,13 @@ import           System.Directory           (getModificationTime, listDirectory,
 import           System.FilePath            ((</>))
 import           System.Wlog                (WithLogger, logDebug, logError)
 
-import           Pos.Wallet.Web.State.State (MonadWalletWebDB, getWalletWebState)
+import           Pos.Wallet.Web.State.State (WalletDbReader, askWalletState)
 
 type MonadAcidCleanup ctx m =
     ( MonadIO m
     , MonadMask m
     , WithLogger m
-    , MonadWalletWebDB ctx m
+    , WalletDbReader ctx m
     , Mockable Delay m
     )
 
@@ -43,7 +43,7 @@ cleanupAcidStatePeriodically interval = perform
 
     cleanupAction = forever $ do
         logDebug "Starting cleanup"
-        est <- getWalletWebState
+        est <- askWalletState
         let st = extendedStateToAcid est
 
         -- checkpoint/archive

--- a/node/src/Pos/Wallet/Web/State/Util.hs
+++ b/node/src/Pos/Wallet/Web/State/Util.hs
@@ -17,7 +17,7 @@ import           System.Directory           (getModificationTime, listDirectory,
 import           System.FilePath            ((</>))
 import           System.Wlog                (WithLogger, logDebug, logError)
 
-import           Pos.Wallet.Web.State.State (WalletDbReader, askWalletState)
+import           Pos.Wallet.Web.State.State (WalletDbReader, askWalletDB)
 
 type MonadAcidCleanup ctx m =
     ( MonadIO m
@@ -43,7 +43,7 @@ cleanupAcidStatePeriodically interval = perform
 
     cleanupAction = forever $ do
         logDebug "Starting cleanup"
-        est <- askWalletState
+        est <- askWalletDB
         let st = extendedStateToAcid est
 
         -- checkpoint/archive

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -33,53 +33,54 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
 
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.State       (AddressLookupMode(..), AddressInfo (..),
-                                             CurrentAndRemoved (..),
-                                             WebWalletModeDB, getAccountAddrMaps, getAccountIds,
+                                             CurrentAndRemoved (getCurrent, getRemoved),
+                                             WalletSnapshot,
+                                             getAccountAddrMaps, getAccountIds,
                                              getAccountWAddresses, getWalletMeta,
                                              getAccountMeta)
 
-getAccountMetaOrThrow :: (WebWalletModeDB ctx m, MonadThrow m) => AccountId -> m CAccountMeta
-getAccountMetaOrThrow accId = getAccountMeta accId >>= maybeThrow noAccount
+getAccountMetaOrThrow :: MonadThrow m => WalletSnapshot -> AccountId -> m CAccountMeta
+getAccountMetaOrThrow ws accId = maybeThrow noAccount (getAccountMeta ws accId)
   where
     noAccount =
         RequestError $ sformat ("No account with id "%build%" found") accId
 
-getWalletAccountIds :: WebWalletModeDB ctx m => CId Wal -> m [AccountId]
-getWalletAccountIds cWalId = filter ((== cWalId) . aiWId) <$> getAccountIds
+getWalletAccountIds :: WalletSnapshot -> CId Wal -> [AccountId]
+getWalletAccountIds ws cWalId = filter ((== cWalId) . aiWId) (getAccountIds ws)
 
-getAccountAddrsOrThrow
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> AccountId -> m [AddressInfo]
-getAccountAddrsOrThrow mode accId =
-    getAccountWAddresses mode accId >>= maybeThrow noWallet
+getAccountAddrsOrThrow :: MonadThrow m
+                       => WalletSnapshot
+                       -> AddressLookupMode
+                       -> AccountId
+                       -> m [AddressInfo]
+getAccountAddrsOrThrow ws mode accId = maybeThrow noWallet (getAccountWAddresses ws mode accId)
   where
     noWallet =
         RequestError $
         sformat ("No account with id "%build%" found") accId
 
 getWalletAddrMetas
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m [CWAddressMeta]
-getWalletAddrMetas lookupMode cWalId = do
-    accountIds <- getWalletAccountIds cWalId
-    map adiCWAddressMeta <$> concatMapM (getAccountAddrsOrThrow lookupMode) accountIds
+    :: MonadThrow m
+    => WalletSnapshot
+    -> AddressLookupMode
+    -> CId Wal
+    -> m [CWAddressMeta]
+getWalletAddrMetas ws lookupMode cWalId = do
+    let accountIds = getWalletAccountIds ws cWalId
+    map adiCWAddressMeta <$> concatMapM (getAccountAddrsOrThrow ws lookupMode) accountIds
 
-getWalletAddrs
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m [CId Addr]
-getWalletAddrs mode wid = cwamId <<$>> getWalletAddrMetas mode wid
+getWalletAddrs :: MonadThrow m => WalletSnapshot -> AddressLookupMode -> CId Wal -> m [CId Addr]
+getWalletAddrs ws mode wid = fmap cwamId <$> getWalletAddrMetas ws mode wid
 
-getWalletAddrsDetector
-    :: (WebWalletModeDB ctx m, MonadThrow m)
-    => AddressLookupMode -> CId Wal -> m (CId Addr -> Bool)
-getWalletAddrsDetector lookupMode cWalId = do
-    accIds <- getWalletAccountIds cWalId
-    accAddrMaps <- mapM getAccountAddrMaps accIds
+getWalletAddrsDetector :: WalletSnapshot -> AddressLookupMode -> CId Wal -> (CId Addr -> Bool)
+getWalletAddrsDetector ws lookupMode cWalId = do
+    let accIds = getWalletAccountIds ws cWalId
+    let accAddrMaps = map (getAccountAddrMaps ws) accIds
     let lookupExisting addr = any (HM.member addr . getCurrent) accAddrMaps
         lookupDeleted  addr = any (HM.member addr . getRemoved) accAddrMaps
         lookupEver     addr = lookupExisting addr
                            || lookupDeleted  addr
-    return $ case lookupMode of
+    case lookupMode of
         Existing -> lookupExisting
         Deleted  -> lookupDeleted
         Ever     -> lookupEver
@@ -87,12 +88,10 @@ getWalletAddrsDetector lookupMode cWalId = do
 decodeCTypeOrFail :: (MonadThrow m, FromCType c) => c -> m (OriginType c)
 decodeCTypeOrFail = either (throwM . DecodeError) pure . decodeCType
 
-getWalletAssuredDepth
-    :: (WebWalletModeDB ctx m)
-    => CId Wal -> m (Maybe BlockCount)
-getWalletAssuredDepth wid =
-    assuredBlockDepth HighAssurance . cwAssurance <<$>>
-    getWalletMeta wid
+getWalletAssuredDepth :: WalletSnapshot -> CId Wal -> Maybe BlockCount
+getWalletAssuredDepth ws wid =
+    assuredBlockDepth HighAssurance . cwAssurance <$>
+    getWalletMeta ws wid
 
 testOnlyEndpoint :: (HasNodeConfiguration, MonadThrow m) => m a -> m a
 testOnlyEndpoint action

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -36,7 +36,7 @@ import           Pos.Wallet.Web.State       (AddressLookupMode(..), AddressInfo 
                                              CurrentAndRemoved (getCurrent, getRemoved),
                                              WalletSnapshot,
                                              getAccountAddrMaps, getAccountIds,
-                                             getAccountWAddresses, getWalletMeta,
+                                             getAccountWAddresses, getWAddresses, getWalletMeta,
                                              getAccountMeta)
 
 getAccountMetaOrThrow :: MonadThrow m => WalletSnapshot -> AccountId -> m CAccountMeta
@@ -60,17 +60,15 @@ getAccountAddrsOrThrow ws mode accId = maybeThrow noWallet (getAccountWAddresses
         sformat ("No account with id "%build%" found") accId
 
 getWalletAddrMetas
-    :: MonadThrow m
-    => WalletSnapshot
+    :: WalletSnapshot
     -> AddressLookupMode
     -> CId Wal
-    -> m [CWAddressMeta]
-getWalletAddrMetas ws lookupMode cWalId = do
-    let accountIds = getWalletAccountIds ws cWalId
-    map adiCWAddressMeta <$> concatMapM (getAccountAddrsOrThrow ws lookupMode) accountIds
+    -> [CWAddressMeta]
+getWalletAddrMetas ws lookupMode cWalId =
+  map adiCWAddressMeta $ getWAddresses ws lookupMode cWalId
 
-getWalletAddrs :: MonadThrow m => WalletSnapshot -> AddressLookupMode -> CId Wal -> m [CId Addr]
-getWalletAddrs ws mode wid = fmap cwamId <$> getWalletAddrMetas ws mode wid
+getWalletAddrs :: WalletSnapshot -> AddressLookupMode -> CId Wal -> [CId Addr]
+getWalletAddrs ws mode wid = cwamId <$> getWalletAddrMetas ws mode wid
 
 getWalletAddrsDetector :: WalletSnapshot -> AddressLookupMode -> CId Wal -> (CId Addr -> Bool)
 getWalletAddrsDetector ws lookupMode cWalId = do

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -33,7 +33,7 @@ import           Pos.Wallet.SscType   (WalletSscType)
 import           Pos.Wallet.Web       (WalletWebMode, bracketWalletWS, bracketWalletWebDB,
                                        getSKById, runWRealMode, syncWalletsWithGState,
                                        walletServeWebFull, walletServerOuts)
-import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage,
+import           Pos.Wallet.Web.State (getWalletSnapshot, cleanupAcidStatePeriodically, flushWalletStorage,
                                        getWalletAddresses)
 import           Pos.Web              (serveWebGT)
 import           Pos.WorkMode         (WorkMode)
@@ -65,7 +65,8 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
     convPlugins = (, mempty) . map (\act -> ActionSpec $ \__vI __sA -> act)
     syncWallets :: WalletWebMode ()
     syncWallets = do
-        sks <- getWalletAddresses >>= mapM getSKById
+        ws  <- getWalletSnapshot
+        sks <- mapM getSKById (getWalletAddresses ws)
         syncWalletsWithGState @WalletSscType sks
     plugins :: HasConfigurations => ([WorkerSpec WalletWebMode], OutSpecs)
     plugins = mconcat [ convPlugins (pluginsGT wArgs)

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -33,8 +33,8 @@ import           Pos.Wallet.SscType   (WalletSscType)
 import           Pos.Wallet.Web       (WalletWebMode, bracketWalletWS, bracketWalletWebDB,
                                        getSKById, runWRealMode, syncWalletsWithGState,
                                        walletServeWebFull, walletServerOuts)
-import           Pos.Wallet.Web.State (getWalletSnapshot, cleanupAcidStatePeriodically, flushWalletStorage,
-                                       getWalletAddresses)
+import           Pos.Wallet.Web.State (askWalletDB, askWalletSnapshot, cleanupAcidStatePeriodically,
+                                       flushWalletStorage, getWalletAddresses)
 import           Pos.Web              (serveWebGT)
 import           Pos.WorkMode         (WorkMode)
 
@@ -56,7 +56,7 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
     mainAction = runNodeWithInit $ do
         when (walletFlushDb) $ do
             putText "Flushing wallet db..."
-            flushWalletStorage
+            askWalletDB >>= flushWalletStorage
             putText "Resyncing wallets with blockchain..."
             syncWallets
     runNodeWithInit init nr =
@@ -65,7 +65,7 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
     convPlugins = (, mempty) . map (\act -> ActionSpec $ \__vI __sA -> act)
     syncWallets :: WalletWebMode ()
     syncWallets = do
-        ws  <- getWalletSnapshot
+        ws  <- askWalletSnapshot
         sks <- mapM getSKById (getWalletAddresses ws)
         syncWalletsWithGState @WalletSscType sks
     plugins :: HasConfigurations => ([WorkerSpec WalletWebMode], OutSpecs)

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -34,14 +34,13 @@ import           Pos.Util.BackupPhrase (BackupPhrase, safeKeysFromPhrase)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CId, CWAddressMeta (..), Wal,
                                              addrMetaToAccount, addressToCId, encToCId)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), WebWalletModeDB,
+import           Pos.Wallet.Web.State       (AddressLookupMode (Ever), WalletSnapshot,
                                              doesWAddressExist, getAccountMeta)
 
 type AccountMode ctx m =
     ( MonadCatch m
     , WithLogger m
     , MonadKeys ctx m
-    , WebWalletModeDB ctx m
     )
 
 myRootAddresses :: MonadKeys ctx m => m [CId Wal]
@@ -122,7 +121,7 @@ type AddrGenSeed = GenSeed Word32   -- with derivation index
 
 generateUnique
     :: (MonadIO m, MonadThrow m)
-    => Text -> AddrGenSeed -> (Word32 -> m b) -> (Word32 -> b -> m Bool) -> m b
+    => Text -> AddrGenSeed -> (Word32 -> m b) -> (Word32 -> b -> Bool) -> m b
 generateUnique desc RandomSeed generator isDuplicate = loop (100 :: Int)
   where
     loop 0 = throwM . RequestError $
@@ -131,45 +130,46 @@ generateUnique desc RandomSeed generator isDuplicate = loop (100 :: Int)
     loop i = do
         rand  <- liftIO $ randomRIO (firstHardened, maxBound)
         value <- generator rand
-        isDup <- isDuplicate rand value
-        if isDup then
+        if isDuplicate rand value then
             loop (i - 1)
         else
             return value
 generateUnique desc (DeterminedSeed seed) generator notFit = do
     value <- generator (fromIntegral seed)
-    whenM (notFit seed value) $
+    when (notFit seed value) $
         throwM . InternalError $
         sformat (build%": this index is already taken")
         desc
     return value
 
 genUniqueAccountId
-    :: AccountMode ctx m
-    => AddrGenSeed
+    :: (MonadIO m, MonadThrow m)
+    => WalletSnapshot
+    -> AddrGenSeed
     -> CId Wal
     -> m AccountId
-genUniqueAccountId genSeed wsCAddr =
+genUniqueAccountId ws genSeed wsCAddr =
     generateUnique
         "account generation"
         genSeed
         (return . AccountId wsCAddr)
         notFit
   where
-    notFit _idx addr = isJust <$> getAccountMeta addr
+    notFit _idx addr = isJust $ getAccountMeta ws addr
 
 genUniqueAddress
     :: AccountMode ctx m
-    => AddrGenSeed
+    => WalletSnapshot
+    -> AddrGenSeed
     -> PassPhrase
     -> AccountId
     -> m CWAddressMeta
-genUniqueAddress genSeed passphrase wCAddr@AccountId{..} =
+genUniqueAddress ws genSeed passphrase wCAddr@AccountId{..} =
     generateUnique "address generation" genSeed mkAddress notFit
   where
     mkAddress cwamAddressIndex =
         deriveAddress passphrase wCAddr cwamAddressIndex
-    notFit _idx addr = doesWAddressExist Ever addr
+    notFit _idx addr = doesWAddressExist ws Ever addr
 
 deriveAddressSK
     :: AccountMode ctx m

--- a/wallet/src/Pos/Wallet/Web/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Backup.hs
@@ -18,7 +18,7 @@ import           Pos.Wallet.Web.Account     (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountMeta (..), CId,
                                              CWalletMeta (..), Wal)
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (getAccountMeta, getWalletMeta)
+import           Pos.Wallet.Web.State       (WalletSnapshot, getAccountMeta, getWalletMeta)
 import           Pos.Wallet.Web.Util        (getWalletAccountIds)
 
 currentBackupFormatVersion :: V.Version
@@ -35,15 +35,18 @@ data WalletBackup = WalletBackup
 
 data TotalBackup = TotalBackup WalletBackup
 
-getWalletBackup :: AccountMode ctx m => CId Wal -> m WalletBackup
-getWalletBackup wId = do
+getWalletBackup :: AccountMode ctx m
+                => WalletSnapshot
+                -> CId Wal
+                -> m WalletBackup
+getWalletBackup ws wId = do
     sk <- getSKById wId
-    meta <- maybeThrow (InternalError "Wallet have no meta") =<<
-            getWalletMeta wId
-    accountIds <- getWalletAccountIds wId
-    accountMetas <- forM accountIds $
-        maybeThrow (InternalError "Account have no meta") <=<
-        getAccountMeta
+    meta <- maybeThrow (InternalError "Wallet have no meta") $
+            getWalletMeta ws wId
+    let accountIds = getWalletAccountIds ws wId
+    accountMetas <- forM accountIds $ \accid ->
+        maybeThrow (InternalError "Account have no meta") $
+        getAccountMeta ws accid
 
     let accountsMap = HM.fromList $ zip
             (map (fromInteger . fromIntegral . aiIndex) accountIds)

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -27,13 +27,14 @@ import           Pos.Wallet.Web.ClientTypes   (CFilePath (..), CId, CWallet, Wal
 import           Pos.Wallet.Web.Error         (WalletError (..))
 import qualified Pos.Wallet.Web.Methods.Logic as L
 import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
-import           Pos.Wallet.Web.State         (createAccount, getWalletMeta)
+import           Pos.Wallet.Web.State         (createAccount, getWalletMeta, getWalletSnapshot)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
 restoreWalletFromBackup :: MonadWalletWebMode m => WalletBackup -> m CWallet
 restoreWalletFromBackup WalletBackup {..} = do
+    ws <- getWalletSnapshot
     let wId = encToCId wbSecretKey
-    wExists <- isJust <$> getWalletMeta wId
+        wExists = isJust $ getWalletMeta ws wId
 
     if wExists
         then do
@@ -48,7 +49,7 @@ restoreWalletFromBackup WalletBackup {..} = do
             for_ accList $ \(idx, meta) -> do
                 let aIdx = fromInteger $ fromIntegral idx
                     seedGen = DeterminedSeed aIdx
-                accId <- genUniqueAccountId seedGen wId
+                accId <- genUniqueAccountId ws seedGen wId
                 createAccount accId meta
             -- Restoring a wallet from backup may take a long time.
             -- Hence we mark the wallet as "not ready" until `syncWalletOnImport` completes.
@@ -70,5 +71,6 @@ importWalletJSON (CFilePath (toString -> fp)) = do
 
 exportWalletJSON :: MonadWalletWebMode m => CId Wal -> CFilePath -> m ()
 exportWalletJSON wid (CFilePath (toString -> fp)) = do
-    wBackup <- TotalBackup <$> getWalletBackup wid
+    ws <- getWalletSnapshot
+    wBackup <- TotalBackup <$> getWalletBackup ws wid
     liftIO $ BSL.writeFile fp $ A.encode wBackup

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -46,7 +46,11 @@ restoreWalletFromBackup WalletBackup {..} = do
                           & each . _2 %~ \(AccountMetaBackup am) -> am
 
             addSecretKey wbSecretKey
-            -- XXX Transaction
+            -- My current thinking is that we don't want a transaction here. If we're restoring
+            -- from a backup, we can hopefully assume that nothing else is happening. And even if
+            -- is is, it's hard to see that it would interfere with account creation. Further, if
+            -- the bacup is large, there may be a large number of accounts, so forcing atomicity
+            -- may not be what we want.
             db <- askWalletDB
             for_ accList $ \(idx, meta) -> do
                 let aIdx = fromInteger $ fromIntegral idx

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -49,7 +49,7 @@ getFullWalletHistory :: MonadWalletWebMode m
 getFullWalletHistory ws cWalId = do
     logDebug "getFullWalletHistory: start"
 
-    cAddrs <- getWalletAddrs ws Ever cWalId
+    let cAddrs = getWalletAddrs ws Ever cWalId
     addrs <- convertCIdTOAddrs cAddrs
 
     unfilteredLocalHistory <- getLocalHistory addrs

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -76,11 +76,12 @@ getFullWalletHistory ws cWalId = do
     -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
+    -- XXX Transaction
     addHistoryTxs cWalId localHistory
     logDebug "getFullWalletHistory: invoked addHistoryTxs"
-    --TODO: does addHistoryTxs change the db such that we need to re-read for constructCTx?
+    ws' <- getWalletSnapshot
 
-    !cHistory <- forM fullHistory (constructCTx ws cWalId walAddrsDetector diff)
+    !cHistory <- forM fullHistory (constructCTx ws' cWalId walAddrsDetector diff)
     logDebug "getFullWalletHistory: formed cTxs"
     pure (cHistory, fromIntegral $ Map.size cHistory)
 

--- a/wallet/src/Pos/Wallet/Web/Methods/History.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/History.hs
@@ -76,7 +76,6 @@ getFullWalletHistory ws cWalId = do
     -- we will set timestamp tx as current time and remove call of @addHistoryTxs@
     -- We call @addHistoryTxs@ only for mempool transactions because for
     -- transactions from block and resubmitting timestamp is already known.
-    -- XXX Transaction
     addHistoryTxs cWalId localHistory
     logDebug "getFullWalletHistory: invoked addHistoryTxs"
     ws' <- askWalletSnapshot

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -13,7 +13,6 @@ module Pos.Wallet.Web.Methods.Logic
        , newAccountIncludeUnready
        , newAddress
        , newAddress_
-       , markWalletReady
 
        , deleteWallet
        , deleteAccount
@@ -52,18 +51,18 @@ import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccount (..),
                                              encToCId, mkCCoin)
 import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddr)
-import           Pos.Wallet.Web.State       (AddressLookupMode (Existing), AddressInfo (..),
+import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (Existing), AddressInfo (..),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              addWAddress, createAccount, createWallet,
                                              getAccountIds, doesAccountExist,
                                              getWalletAddresses,
                                              getWalletBalancesAndUtxo,
                                              getWalletMetaIncludeUnready, getWalletPassLU,
+                                             getWalletSnapshot,
                                              isCustomAddress, removeAccount,
                                              removeHistoryCache, removeTxMetas,
                                              removeWallet, setAccountMeta, setWalletMeta,
-                                             setWalletPassLU, setWalletReady)
-import           Pos.Wallet.Web.State.Storage (WalBalancesAndUtxo)
+                                             setWalletPassLU)
 import           Pos.Wallet.Web.Tracking     (CAccModifier (..), CachedCAccModifier,
                                               fixCachedAccModifierFor,
                                               fixingCachedAccModifier, sortedInsertions)
@@ -79,52 +78,55 @@ import           Pos.Wallet.Web.Util         (decodeCTypeOrFail, getAccountAddrs
 sumCCoin :: MonadThrow m => [CCoin] -> m CCoin
 sumCCoin ccoins = mkCCoin . unsafeIntegerToCoin . sumCoins <$> mapM decodeCTypeOrFail ccoins
 
-getBalanceWithMod :: WalBalancesAndUtxo -> CachedCAccModifier -> Address -> Coin
-getBalanceWithMod balancesAndUtxo accMod addr =
+getBalanceWithMod :: WalletSnapshot -> CachedCAccModifier -> Address -> Coin
+getBalanceWithMod ws accMod addr =
     fromMaybe (mkCoin 0) .
     HM.lookup addr $
     flip applyUtxoModToAddrCoinMap balancesAndUtxo (camUtxo accMod)
+  where
+    balancesAndUtxo = getWalletBalancesAndUtxo ws
 
 getWAddressBalanceWithMod
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo
+    => WalletSnapshot
     -> CachedCAccModifier
     -> CWAddressMeta
     -> m Coin
-getWAddressBalanceWithMod balancesAndUtxo accMod addr =
-    getBalanceWithMod balancesAndUtxo accMod
+getWAddressBalanceWithMod ws accMod addr =
+    getBalanceWithMod ws accMod
         <$> convertCIdTOAddr (cwamId addr)
 
 -- BE CAREFUL: this function has complexity O(number of used and change addresses)
 getWAddress
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo -> CachedCAccModifier -> CWAddressMeta -> m CAddress
-getWAddress balancesAndUtxo cachedAccModifier cAddr = do
+    => WalletSnapshot
+    -> CachedCAccModifier -> CWAddressMeta -> m CAddress
+getWAddress ws cachedAccModifier cAddr = do
     let aId = cwamId cAddr
-    balance <- getWAddressBalanceWithMod balancesAndUtxo cachedAccModifier cAddr
+    balance <- getWAddressBalanceWithMod ws cachedAccModifier cAddr
 
-    let getFlag customType accessMod = do
-            checkDB <- isCustomAddress customType (cwamId cAddr)
-            let checkMempool = elem aId . map (fst . fst) . toList $
+    let getFlag customType accessMod =
+            let checkDB = isCustomAddress ws customType (cwamId cAddr)
+                checkMempool = elem aId . map (fst . fst) . toList $
                                MM.insertions $ accessMod cachedAccModifier
-            return (checkDB || checkMempool)
-    isUsed   <- getFlag UsedAddr camUsed
-    isChange <- getFlag ChangeAddr camChange
+             in checkDB || checkMempool
+        isUsed   = getFlag UsedAddr camUsed
+        isChange = getFlag ChangeAddr camChange
     return $ CAddress aId (mkCCoin balance) isUsed isChange
 
 getAccountMod
     :: MonadWalletWebMode m
-    => WalBalancesAndUtxo
+    => WalletSnapshot
     -> CachedCAccModifier
     -> AccountId
     -> m CAccount
-getAccountMod balAndUtxo accMod accId = do
-    dbAddrs    <- map adiCWAddressMeta . sortOn adiSortingKey <$> getAccountAddrsOrThrow Existing accId
+getAccountMod ws accMod accId = do
+    dbAddrs    <- map adiCWAddressMeta . sortOn adiSortingKey <$> getAccountAddrsOrThrow ws Existing accId
     let allAddrIds = gatherAddresses (camAddresses accMod) dbAddrs
-    allAddrs <- mapM (getWAddress balAndUtxo accMod) allAddrIds
+    allAddrs <- mapM (getWAddress ws accMod) allAddrIds
     balance <- mkCCoin . unsafeIntegerToCoin . sumCoins <$>
                mapM (decodeCTypeOrFail . cadAmount) allAddrs
-    meta <- getAccountMetaOrThrow accId
+    meta <- getAccountMetaOrThrow ws accId
     pure $ CAccount (encodeCType accId) meta allAddrs balance
   where
     gatherAddresses addrModifier dbAddrs = do
@@ -136,23 +138,25 @@ getAccountMod balAndUtxo accMod accId = do
 
 getAccount :: MonadWalletWebMode m => AccountId -> m CAccount
 getAccount accId = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    fixingCachedAccModifier (getAccountMod balAndUtxo) accId
+    ws <- getWalletSnapshot
+    fixingCachedAccModifier ws (getAccountMod ws) accId
 
 getAccountsIncludeUnready
     :: MonadWalletWebMode m
-    => Bool -> Maybe (CId Wal) -> m [CAccount]
-getAccountsIncludeUnready includeUnready mCAddr = do
-    whenJust mCAddr $ \cAddr -> getWalletMetaIncludeUnready includeUnready cAddr `whenNothingM_` noWallet cAddr
-    accIds <- maybe getAccountIds getWalletAccountIds mCAddr
+    => WalletSnapshot
+    -> Bool -> Maybe (CId Wal) -> m [CAccount]
+getAccountsIncludeUnready ws includeUnready mCAddr = do
+    whenJust mCAddr $ \cAddr ->
+      void $ maybeThrow (noWallet cAddr) $
+        getWalletMetaIncludeUnready ws includeUnready cAddr
+    let accIds = maybe (getAccountIds ws) (getWalletAccountIds ws) mCAddr
     let groupedAccIds = fmap reverse $ HM.fromListWith mappend $
                         accIds <&> \acc -> (aiWId acc, [acc])
-    balAndUtxo <- getWalletBalancesAndUtxo
     concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) ->
-         fixCachedAccModifierFor wid $ \accMod ->
-             mapM (getAccountMod balAndUtxo accMod) walAccIds
+         fixCachedAccModifierFor ws wid $ \accMod ->
+             mapM (getAccountMod ws accMod) walAccIds
   where
-    noWallet cAddr = throwM . RequestError $
+    noWallet cAddr = RequestError $
         -- TODO No WALLET with id ...
         -- dunno whether I can fix and not break compatible w/ daedalus
         sformat ("No account with id "%build%" found") cAddr
@@ -160,26 +164,33 @@ getAccountsIncludeUnready includeUnready mCAddr = do
 getAccounts
     :: MonadWalletWebMode m
     => Maybe (CId Wal) -> m [CAccount]
-getAccounts = getAccountsIncludeUnready False
+getAccounts mCAddr = do
+    ws <- getWalletSnapshot
+    getAccountsIncludeUnready ws False mCAddr
 
-getWalletIncludeUnready :: MonadWalletWebMode m => Bool -> CId Wal -> m CWallet
-getWalletIncludeUnready includeUnready cAddr = do
-    meta       <- getWalletMetaIncludeUnready includeUnready cAddr >>= maybeThrow noWallet
-    accounts   <- getAccountsIncludeUnready includeUnready (Just cAddr)
+getWalletIncludeUnready :: MonadWalletWebMode m
+                        => WalletSnapshot -> Bool -> CId Wal -> m CWallet
+getWalletIncludeUnready ws includeUnready cAddr = do
+    meta       <- maybeThrow noWallet $ getWalletMetaIncludeUnready ws includeUnready cAddr
+    accounts   <- getAccountsIncludeUnready ws includeUnready (Just cAddr)
     let accountsNum = length accounts
     balance    <- sumCCoin (map caAmount accounts)
     hasPass    <- isNothing . checkPassMatches emptyPassphrase <$> getSKById cAddr
-    passLU     <- getWalletPassLU cAddr >>= maybeThrow noWallet
+    passLU     <- maybeThrow noWallet (getWalletPassLU ws cAddr)
     pure $ CWallet cAddr meta accountsNum balance hasPass passLU
   where
     noWallet = RequestError $
         sformat ("No wallet with address "%build%" found") cAddr
 
 getWallet :: MonadWalletWebMode m => CId Wal -> m CWallet
-getWallet = getWalletIncludeUnready False
+getWallet wid = do
+    ws <- getWalletSnapshot
+    getWalletIncludeUnready ws False wid
 
 getWallets :: MonadWalletWebMode m => m [CWallet]
-getWallets = getWalletAddresses >>= mapM getWallet
+getWallets = do
+    ws <- getWalletSnapshot
+    mapM (getWalletIncludeUnready ws False) (getWalletAddresses ws)
 
 ----------------------------------------------------------------------------
 -- Creators
@@ -187,16 +198,17 @@ getWallets = getWalletAddresses >>= mapM getWallet
 
 newAddress_
     :: MonadWalletWebMode m
-    => AddrGenSeed
+    => WalletSnapshot
+    -> AddrGenSeed
     -> PassPhrase
     -> AccountId
     -> m CWAddressMeta
-newAddress_ addGenSeed passphrase accId = do
+newAddress_ ws addGenSeed passphrase accId = do
     -- check whether account exists
-    parentExists <- doesAccountExist accId
+    let parentExists = doesAccountExist ws accId
     unless parentExists $ throwM noAccount
 
-    cAccAddr <- genUniqueAddress addGenSeed passphrase accId
+    cAccAddr <- genUniqueAddress ws addGenSeed passphrase accId
     addWAddress cAccAddr
     return cAccAddr
   where
@@ -210,24 +222,30 @@ newAddress
     -> AccountId
     -> m CAddress
 newAddress addGenSeed passphrase accId = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    cwAddrMeta <- newAddress_ addGenSeed passphrase accId
-    fixCachedAccModifierFor accId $ \accMod -> do
-        getWAddress balAndUtxo accMod cwAddrMeta
+    ws <- getWalletSnapshot
+    cwAddrMeta <- newAddress_ ws addGenSeed passphrase accId
+    fixCachedAccModifierFor ws accId $ \accMod -> do
+        getWAddress ws accMod cwAddrMeta
 
 newAccountIncludeUnready
     :: MonadWalletWebMode m
     => Bool -> AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
 newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} = do
-    balAndUtxo <- getWalletBalancesAndUtxo
-    fixCachedAccModifierFor caInitWId $ \accMod -> do
+    ws <- getWalletSnapshot
+    fixCachedAccModifierFor ws caInitWId $ \accMod -> do
         -- check wallet exists
-        _ <- getWalletIncludeUnready includeUnready caInitWId
+        _ <- getWalletIncludeUnready ws includeUnready caInitWId
 
-        cAddr <- genUniqueAccountId addGenSeed caInitWId
+        cAddr <- genUniqueAccountId ws addGenSeed caInitWId
         createAccount cAddr caInitMeta
+        -- NOTE(adinapoli): 'newAddres' re-reads the DB here.
         () <$ newAddress addGenSeed passphrase cAddr
-        getAccountMod balAndUtxo accMod cAddr
+
+        -- NOTE(adinapoli): Is it correct doing the new read within a
+        -- 'fixCachedAccModifierFor' block?
+        -- Re-read DB after the update.
+        ws' <- getWalletSnapshot
+        getAccountMod ws' accMod cAddr
 
 newAccount
     :: MonadWalletWebMode m
@@ -239,23 +257,14 @@ createWalletSafe
     => CId Wal -> CWalletMeta -> Bool -> m CWallet
 createWalletSafe cid wsMeta isReady = do
     -- Disallow duplicate wallets (including unready wallets)
-    wSetExists <- isJust <$> getWalletMetaIncludeUnready True cid
+    ws <- getWalletSnapshot
+    let wSetExists = isJust $ getWalletMetaIncludeUnready ws True cid
     when wSetExists $
         throwM $ RequestError "Wallet with that mnemonics already exists"
     curTime <- liftIO getPOSIXTime
     createWallet cid wsMeta isReady curTime
     -- Return the newly created wallet irrespective of whether it's ready yet
-    getWalletIncludeUnready True cid
-
-markWalletReady
-  :: MonadWalletWebMode m
-  => CId Wal -> Bool -> m ()
-markWalletReady cid isReady = do
-    _ <- getWalletMetaIncludeUnready True cid >>= maybeThrow noWallet
-    setWalletReady cid isReady
-  where
-    noWallet = RequestError $
-        sformat ("No wallet with that id "%build%" found") cid
+    getWalletIncludeUnready ws True cid
 
 
 ----------------------------------------------------------------------------

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -62,7 +62,6 @@ import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (
                                              getWalletMetaIncludeUnready, getWalletPassLU,
                                              askWalletSnapshot, getWalletSnapshot,
                                              isCustomAddress, removeAccount,
-                                             removeHistoryCache, removeTxMetas,
                                              removeWallet, setAccountMeta, setWalletMeta,
                                              setWalletPassLU)
 import           Pos.Wallet.Web.Tracking     (CAccModifier (..), CachedCAccModifier,
@@ -282,12 +281,7 @@ createWalletSafe cid wsMeta isReady = do
 deleteWallet :: MonadWalletWebMode m => CId Wal -> m ()
 deleteWallet wid = do
     db <- askWalletDB
-    -- XXX Transaction
-    accounts <- getAccounts (Just wid)
-    mapM_ (removeAccount db <=< decodeCTypeOrFail . caId) accounts
     removeWallet db wid
-    removeTxMetas db wid
-    removeHistoryCache db wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
 
 deleteAccount :: MonadWalletWebMode m => AccountId -> m ()

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -246,7 +246,7 @@ newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} 
     -- XXX Transaction
     () <- createAccount db cAddr caInitMeta
     ws' <- askWalletSnapshot
-    () <$ newAddress ws' addGenSeed passphrase cAddr
+    _ <- newAddress ws' addGenSeed passphrase cAddr
     ws'' <- askWalletSnapshot
 
     -- Re-read DB after the update.

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -41,7 +41,7 @@ import qualified Pos.Util.Modifier          as MM
 import           Pos.Util.Servant           (encodeCType)
 import           Pos.Wallet.KeyStorage      (addSecretKey, deleteSecretKey,
                                              getSecretKeysPlain)
-import           Pos.Wallet.Web.Account     (AddrGenSeed, genUniqueAccountId,
+import           Pos.Wallet.Web.Account     (AddrGenSeed, genUniqueAccountId, findKey,
                                              genUniqueAddress, getAddrIdx, getSKById)
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccount (..),
                                              CAccountInit (..), CAccountMeta (..),
@@ -64,8 +64,7 @@ import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (
                                              removeWallet, setAccountMeta, setWalletMeta,
                                              setWalletPassLU)
 import           Pos.Wallet.Web.Tracking     (CAccModifier (..), CachedCAccModifier,
-                                              fixCachedAccModifierFor,
-                                              fixingCachedAccModifier, sortedInsertions)
+                                              txMempoolToModifier, sortedInsertions)
 import           Pos.Wallet.Web.Util         (decodeCTypeOrFail, getAccountAddrsOrThrow,
                                               getWalletAccountIds, getAccountMetaOrThrow)
 
@@ -139,7 +138,8 @@ getAccountMod ws accMod accId = do
 getAccount :: MonadWalletWebMode m => AccountId -> m CAccount
 getAccount accId = do
     ws <- getWalletSnapshot
-    fixingCachedAccModifier ws (getAccountMod ws) accId
+    accMod <- txMempoolToModifier ws =<< findKey accId
+    getAccountMod ws accMod accId
 
 getAccountsIncludeUnready
     :: MonadWalletWebMode m
@@ -152,9 +152,9 @@ getAccountsIncludeUnready ws includeUnready mCAddr = do
     let accIds = maybe (getAccountIds ws) (getWalletAccountIds ws) mCAddr
     let groupedAccIds = fmap reverse $ HM.fromListWith mappend $
                         accIds <&> \acc -> (aiWId acc, [acc])
-    concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) ->
-         fixCachedAccModifierFor ws wid $ \accMod ->
-             mapM (getAccountMod ws accMod) walAccIds
+    concatForM (HM.toList groupedAccIds) $ \(wid, walAccIds) -> do
+      accMod <- txMempoolToModifier ws =<< findKey wid
+      mapM (getAccountMod ws accMod) walAccIds
   where
     noWallet cAddr = RequestError $
         -- TODO No WALLET with id ...
@@ -224,26 +224,29 @@ newAddress
     -> m CAddress
 newAddress ws addGenSeed passphrase accId = do
     cwAddrMeta <- newAddress_ ws addGenSeed passphrase accId
-    fixCachedAccModifierFor ws accId $ \accMod -> do
-        getWAddress ws accMod cwAddrMeta
+    accMod <- txMempoolToModifier ws =<< findKey accId
+    getWAddress ws accMod cwAddrMeta
 
 newAccountIncludeUnready
     :: MonadWalletWebMode m
     => Bool -> AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
 newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} = do
     ws <- getWalletSnapshot
-    fixCachedAccModifierFor ws caInitWId $ \accMod -> do
-        -- check wallet exists
-        _ <- getWalletIncludeUnready ws includeUnready caInitWId
+    -- TODO nclarke We read the mempool at this point to be consistent with the previous
+    -- behaviour, but we may want to consider whether we should read it _after_ the
+    -- account is created, since it's not used until we call 'getAccountMod'
+    accMod <- txMempoolToModifier ws =<< findKey caInitWId
+    -- check wallet exists
+    _ <- getWalletIncludeUnready ws includeUnready caInitWId
 
-        cAddr <- genUniqueAccountId ws addGenSeed caInitWId
-        ((), ws') <- createAccount cAddr caInitMeta
-        () <$ newAddress ws' addGenSeed passphrase cAddr
+    cAddr <- genUniqueAccountId ws addGenSeed caInitWId
+    -- XXX Transaction
+    () <- createAccount cAddr caInitMeta
+    ws' <- getWalletSnapshot
+    () <$ newAddress ws' addGenSeed passphrase cAddr
 
-        -- NOTE(adinapoli): Is it correct doing the new read within a
-        -- 'fixCachedAccModifierFor' block?
-        -- Re-read DB after the update.
-        getAccountMod ws' accMod cAddr
+    -- Re-read DB after the update.
+    getAccountMod ws' accMod cAddr
 
 newAccount
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -244,9 +244,10 @@ newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} 
     () <- createAccount cAddr caInitMeta
     ws' <- getWalletSnapshot
     () <$ newAddress ws' addGenSeed passphrase cAddr
+    ws'' <- getWalletSnapshot
 
     -- Re-read DB after the update.
-    getAccountMod ws' accMod cAddr
+    getAccountMod ws'' accMod cAddr
 
 newAccount
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -54,7 +54,8 @@ import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAdd
 import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (Existing), AddressInfo (..),
                                              CustomAddressType (ChangeAddr, UsedAddr),
                                              askWalletDB,
-                                             addWAddress, createAccount, createWallet,
+                                             addWAddress, createAccountWithAddress,
+                                             createWallet,
                                              getAccountIds, doesAccountExist,
                                              getWalletAddresses,
                                              getWalletBalancesAndUtxo,
@@ -239,18 +240,19 @@ newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} 
     -- behaviour, but we may want to consider whether we should read it _after_ the
     -- account is created, since it's not used until we call 'getAccountMod'
     accMod <- txMempoolToModifier ws =<< findKey caInitWId
+
     -- check wallet exists
     _ <- getWalletIncludeUnready ws includeUnready caInitWId
 
     cAddr <- genUniqueAccountId ws addGenSeed caInitWId
-    -- XXX Transaction
-    () <- createAccount db cAddr caInitMeta
+    cAddrMeta <- genUniqueAddress ws addGenSeed passphrase cAddr
+
+    createAccountWithAddress db cAddr caInitMeta cAddrMeta
+
     ws' <- askWalletSnapshot
-    _ <- newAddress ws' addGenSeed passphrase cAddr
-    ws'' <- askWalletSnapshot
 
     -- Re-read DB after the update.
-    getAccountMod ws'' accMod cAddr
+    getAccountMod ws' accMod cAddr
 
 newAccount
     :: MonadWalletWebMode m

--- a/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Logic.hs
@@ -53,12 +53,13 @@ import           Pos.Wallet.Web.Error       (WalletError (..))
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode, convertCIdTOAddr)
 import           Pos.Wallet.Web.State       (WalletSnapshot, AddressLookupMode (Existing), AddressInfo (..),
                                              CustomAddressType (ChangeAddr, UsedAddr),
+                                             askWalletDB,
                                              addWAddress, createAccount, createWallet,
                                              getAccountIds, doesAccountExist,
                                              getWalletAddresses,
                                              getWalletBalancesAndUtxo,
                                              getWalletMetaIncludeUnready, getWalletPassLU,
-                                             getWalletSnapshot,
+                                             askWalletSnapshot, getWalletSnapshot,
                                              isCustomAddress, removeAccount,
                                              removeHistoryCache, removeTxMetas,
                                              removeWallet, setAccountMeta, setWalletMeta,
@@ -137,7 +138,7 @@ getAccountMod ws accMod accId = do
 
 getAccount :: MonadWalletWebMode m => AccountId -> m CAccount
 getAccount accId = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     accMod <- txMempoolToModifier ws =<< findKey accId
     getAccountMod ws accMod accId
 
@@ -165,7 +166,7 @@ getAccounts
     :: MonadWalletWebMode m
     => Maybe (CId Wal) -> m [CAccount]
 getAccounts mCAddr = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     getAccountsIncludeUnready ws False mCAddr
 
 getWalletIncludeUnready :: MonadWalletWebMode m
@@ -184,12 +185,12 @@ getWalletIncludeUnready ws includeUnready cAddr = do
 
 getWallet :: MonadWalletWebMode m => CId Wal -> m CWallet
 getWallet wid = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     getWalletIncludeUnready ws False wid
 
 getWallets :: MonadWalletWebMode m => m [CWallet]
 getWallets = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     mapM (getWalletIncludeUnready ws False) (getWalletAddresses ws)
 
 ----------------------------------------------------------------------------
@@ -209,7 +210,8 @@ newAddress_ ws addGenSeed passphrase accId = do
     unless parentExists $ throwM noAccount
 
     cAccAddr <- genUniqueAddress ws addGenSeed passphrase accId
-    addWAddress cAccAddr
+    db <- askWalletDB
+    addWAddress db cAccAddr
     return cAccAddr
   where
     noAccount =
@@ -231,7 +233,8 @@ newAccountIncludeUnready
     :: MonadWalletWebMode m
     => Bool -> AddrGenSeed -> PassPhrase -> CAccountInit -> m CAccount
 newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} = do
-    ws <- getWalletSnapshot
+    db <- askWalletDB
+    ws <- getWalletSnapshot db
     -- TODO nclarke We read the mempool at this point to be consistent with the previous
     -- behaviour, but we may want to consider whether we should read it _after_ the
     -- account is created, since it's not used until we call 'getAccountMod'
@@ -241,10 +244,10 @@ newAccountIncludeUnready includeUnready addGenSeed passphrase CAccountInit {..} 
 
     cAddr <- genUniqueAccountId ws addGenSeed caInitWId
     -- XXX Transaction
-    () <- createAccount cAddr caInitMeta
-    ws' <- getWalletSnapshot
+    () <- createAccount db cAddr caInitMeta
+    ws' <- askWalletSnapshot
     () <$ newAddress ws' addGenSeed passphrase cAddr
-    ws'' <- getWalletSnapshot
+    ws'' <- askWalletSnapshot
 
     -- Re-read DB after the update.
     getAccountMod ws'' accMod cAddr
@@ -259,12 +262,13 @@ createWalletSafe
     => CId Wal -> CWalletMeta -> Bool -> m CWallet
 createWalletSafe cid wsMeta isReady = do
     -- Disallow duplicate wallets (including unready wallets)
-    ws <- getWalletSnapshot
+    db <- askWalletDB
+    ws <- getWalletSnapshot db
     let wSetExists = isJust $ getWalletMetaIncludeUnready ws True cid
     when wSetExists $
         throwM $ RequestError "Wallet with that mnemonics already exists"
     curTime <- liftIO getPOSIXTime
-    createWallet cid wsMeta isReady curTime
+    createWallet db cid wsMeta isReady curTime
     -- Return the newly created wallet irrespective of whether it's ready yet
     getWalletIncludeUnready ws True cid
 
@@ -275,15 +279,19 @@ createWalletSafe cid wsMeta isReady = do
 
 deleteWallet :: MonadWalletWebMode m => CId Wal -> m ()
 deleteWallet wid = do
+    db <- askWalletDB
+    -- XXX Transaction
     accounts <- getAccounts (Just wid)
-    mapM_ (deleteAccount <=< decodeCTypeOrFail . caId) accounts
-    removeWallet wid
-    removeTxMetas wid
-    removeHistoryCache wid
+    mapM_ (removeAccount db <=< decodeCTypeOrFail . caId) accounts
+    removeWallet db wid
+    removeTxMetas db wid
+    removeHistoryCache db wid
     deleteSecretKey . fromIntegral =<< getAddrIdx wid
 
 deleteAccount :: MonadWalletWebMode m => AccountId -> m ()
-deleteAccount = removeAccount
+deleteAccount accId = do
+  db <- askWalletDB
+  removeAccount db accId
 
 ----------------------------------------------------------------------------
 -- Modifiers
@@ -291,12 +299,14 @@ deleteAccount = removeAccount
 
 updateWallet :: MonadWalletWebMode m => CId Wal -> CWalletMeta -> m CWallet
 updateWallet wId wMeta = do
-    setWalletMeta wId wMeta
+    db <- askWalletDB
+    setWalletMeta db wId wMeta
     getWallet wId
 
 updateAccount :: MonadWalletWebMode m => AccountId -> CAccountMeta -> m CAccount
 updateAccount accId wMeta = do
-    setAccountMeta accId wMeta
+    db <- askWalletDB
+    setAccountMeta db accId wMeta
     getAccount accId
 
 changeWalletPassphrase
@@ -309,7 +319,8 @@ changeWalletPassphrase wid oldPass newPass = do
         newSK <- maybeThrow badPass =<< changeEncPassphrase oldPass newPass oldSK
         deleteSK oldPass
         addSecretKey newSK
-        setWalletPassLU wid =<< liftIO getPOSIXTime
+        db <- askWalletDB
+        setWalletPassLU db wid =<< liftIO getPOSIXTime
   where
     badPass = RequestError "Invalid old passphrase given"
     deleteSK passphrase = do

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -56,8 +56,8 @@ import           Pos.Wallet.Web.Pending       (PendingTx (..), isPtxInBlocks,
                                                sortPtxsChrono)
 import           Pos.Wallet.Web.State         (WalletSnapshot, cancelApplyingPtxs,
                                                cancelSpecificApplyingPtx, getNextUpdate,
-                                               getPendingTxs, getProfile,
-                                               getWalletSnapshot, removeNextUpdate,
+                                               getPendingTxs, getProfile, askWalletDB,
+                                               askWalletSnapshot, removeNextUpdate,
                                                setProfile, testReset)
 import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoint)
 
@@ -68,13 +68,14 @@ import           Pos.Wallet.Web.Util          (decodeCTypeOrFail, testOnlyEndpoi
 
 getUserProfile :: MonadWalletWebMode m => m CProfile
 getUserProfile = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     return (getProfile ws)
 
 updateUserProfile :: MonadWalletWebMode m => CProfile -> m CProfile
 updateUserProfile profile = do
-    setProfile profile
-    ws <- getWalletSnapshot --TODO: the update tx should get the relevant info
+    db <- askWalletDB
+    setProfile db profile
+    ws <- askWalletSnapshot --TODO: the update tx should get the relevant info
     return (getProfile ws)
 
 ----------------------------------------------------------------------------
@@ -91,11 +92,11 @@ isValidAddress = pure . isRight . cIdToAddress
 -- | Get last update info
 nextUpdate :: MonadWalletWebMode m => m CUpdateInfo
 nextUpdate = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     updateInfo <- maybeThrow noUpdates (getNextUpdate ws)
     if isUpdateActual (cuiSoftwareVersion updateInfo)
         then pure updateInfo
-        else removeNextUpdate >> nextUpdate
+        else askWalletDB >>= removeNextUpdate >> nextUpdate
         --TODO: this should be a single transaction
   where
     isUpdateActual :: SoftwareVersion -> Bool
@@ -106,11 +107,11 @@ nextUpdate = do
 
 -- | Postpone next update after restart
 postponeUpdate :: MonadWalletWebMode m => m ()
-postponeUpdate = removeNextUpdate
+postponeUpdate = askWalletDB >>= removeNextUpdate
 
 -- | Delete next update info and restart immediately
 applyUpdate :: MonadWalletWebMode m => m ()
-applyUpdate = removeNextUpdate >> applyLastUpdate
+applyUpdate = askWalletDB >>= removeNextUpdate >> applyLastUpdate
 
 ----------------------------------------------------------------------------
 -- Sync progress
@@ -128,7 +129,8 @@ syncProgress =
 ----------------------------------------------------------------------------
 
 testResetAll :: MonadWalletWebMode m => m ()
-testResetAll = testOnlyEndpoint $ deleteAllKeys >> testReset
+testResetAll = testOnlyEndpoint $ deleteAllKeys
+               >> (testReset =<< askWalletDB)
   where
     deleteAllKeys = do
         keyNum <- length <$> getSecretKeys
@@ -151,7 +153,7 @@ instance Buildable WalletStateSnapshot where
     build _ = "<wallet-state-snapshot>"
 
 dumpState :: MonadWalletWebMode m => m WalletStateSnapshot
-dumpState = WalletStateSnapshot <$> getWalletSnapshot
+dumpState = WalletStateSnapshot <$> askWalletSnapshot
 
 ----------------------------------------------------------------------------
 -- Print pending transactions info
@@ -186,7 +188,7 @@ instance HasTruncateLogPolicy PendingTxsSummary where
 
 gatherPendingTxsSummary :: MonadWalletWebMode m => m [PendingTxsSummary]
 gatherPendingTxsSummary = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     pure $ map mkInfo .
            getNewestFirst . toNewestFirst . sortPtxsChrono .
            filter unconfirmedPtx $ getPendingTxs ws
@@ -203,9 +205,10 @@ gatherPendingTxsSummary = do
             }
 
 cancelAllApplyingPtxs :: MonadWalletWebMode m => m ()
-cancelAllApplyingPtxs = testOnlyEndpoint cancelApplyingPtxs
+cancelAllApplyingPtxs = testOnlyEndpoint $ cancelApplyingPtxs =<< askWalletDB
 
 cancelOneApplyingPtx :: MonadWalletWebMode m => CTxId -> m ()
 cancelOneApplyingPtx cTxId = do
+    db <- askWalletDB
     txId <- decodeCTypeOrFail cTxId
-    testOnlyEndpoint (cancelSpecificApplyingPtx txId)
+    testOnlyEndpoint (cancelSpecificApplyingPtx db txId)

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -215,7 +215,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     (th, dstAddrs) <-
         rewrapTxError "Cannot send transaction" $ do
             (txAux, inpTxOuts') <-
-                prepareMTx getSigner pendingAddrs policy srcAddrs outputs (relatedAccount, passphrase)
+                prepareMTx getOwnUtxos getSigner pendingAddrs policy srcAddrs outputs (relatedAccount, passphrase)
 
             ts <- Just <$> getCurrentTimestamp
             let tx = taTx txAux

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -60,7 +60,7 @@ import           Pos.Wallet.Web.Methods.Txp       (coinDistrToOutputs,
 import           Pos.Wallet.Web.Mode              (MonadWalletWebMode, WalletWebMode,
                                                    convertCIdTOAddrs)
 import           Pos.Wallet.Web.Pending           (mkPendingTx)
-import           Pos.Wallet.Web.State             (WalletSnapshot, getWalletSnapshot,
+import           Pos.Wallet.Web.State             (WalletSnapshot, askWalletSnapshot,
                                                    AddressLookupMode (Ever, Existing), AddressInfo (..))
 import           Pos.Wallet.Web.Util              (decodeCTypeOrFail,
                                                    getAccountAddrsOrThrow,
@@ -82,7 +82,7 @@ newPayment sa passphrase srcAccount dstAccount coin policy =
     -- 2. To let other things (e. g. block processing) happen if
     -- `newPayment`s are done continuously.
     notFasterThan (6 :: Second) $ do
-      ws <- getWalletSnapshot
+      ws <- askWalletSnapshot
       sendMoney
           sa
           ws
@@ -100,7 +100,7 @@ newPaymentBatch
 newPaymentBatch sa passphrase NewBatchPayment {..} = do
     src <- decodeCTypeOrFail npbFrom
     notFasterThan (6 :: Second) $ do
-      ws <- getWalletSnapshot
+      ws <- askWalletSnapshot
       sendMoney
         sa
         ws
@@ -117,7 +117,7 @@ getTxFee
      -> InputSelectionPolicy
      -> m CCoin
 getTxFee srcAccount dstAccount coin policy = do
-    ws <- getWalletSnapshot
+    ws <- askWalletSnapshot
     let pendingAddrs = getPendingAddresses ws policy
     utxo <- getMoneySourceUtxo ws (AccountMoneySource srcAccount)
     outputs <- coinDistrToOutputs $ one (dstAccount, coin)
@@ -178,7 +178,7 @@ instance
     getNewAddress (accId, passphrase) = do
         -- TODO(adinapoli) This looks like a code smell, can we
         -- remove this typeclass entirely?
-        ws <- getWalletSnapshot
+        ws <- askWalletSnapshot
         cAddrMeta <- L.newAddress_ ws RandomSeed passphrase accId
         decodeCTypeOrFail (cwamId cAddrMeta)
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -15,6 +15,7 @@ import qualified Serokell.Util.Base64           as B64
 import           Pos.Aeson.ClientTypes          ()
 import           Pos.Aeson.WalletBackup         ()
 import           Pos.Client.Txp.Addresses       (MonadAddresses)
+import           Pos.Client.Txp.Balances        (getOwnUtxos)
 import           Pos.Client.Txp.History         (TxHistoryEntry (..))
 import           Pos.Communication              (SendActions (..), prepareRedemptionTx)
 import           Pos.Core                       (getCurrentTimestamp)
@@ -95,7 +96,7 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
                L.newAddress RandomSeed passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
-                prepareRedemptionTx redeemSK dstAddr
+                prepareRedemptionTx getOwnUtxos redeemSK dstAddr
 
         ts <- Just <$> getCurrentTimestamp
         let tx = taTx txAux

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -91,9 +91,8 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     -- new redemption wallet
     _ <- L.getAccount accId
 
-    dstAddr <- decodeCTypeOrFail . cadId =<<
-               L.newAddress RandomSeed passphrase accId
-    ws <- getWalletSnapshot
+    ws  <- getWalletSnapshot
+    dstAddr <- decodeCTypeOrFail . cadId =<< L.newAddress ws RandomSeed passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
                 prepareRedemptionTx (getOwnUtxos ws) redeemSK dstAddr

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -36,7 +36,7 @@ import qualified Pos.Wallet.Web.Methods.Logic   as L
 import           Pos.Wallet.Web.Methods.Txp     (rewrapTxError, submitAndSaveNewPtx)
 import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending         (mkPendingTx)
-import           Pos.Wallet.Web.State           (getWalletSnapshot, AddressLookupMode (Ever))
+import           Pos.Wallet.Web.State           (askWalletSnapshot, AddressLookupMode (Ever))
 import           Pos.Wallet.Web.Util            (decodeCTypeOrFail, getWalletAddrsDetector)
 
 
@@ -91,7 +91,7 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     -- new redemption wallet
     _ <- L.getAccount accId
 
-    ws  <- getWalletSnapshot
+    ws  <- askWalletSnapshot
     dstAddr <- decodeCTypeOrFail . cadId =<< L.newAddress ws RandomSeed passphrase accId
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-
@@ -110,7 +110,7 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     -- add redemption transaction to the history of new wallet
     let cWalId = aiWId accId
     addHistoryTx cWalId th
-    ws' <- getWalletSnapshot
+    ws' <- askWalletSnapshot
     let cWalAddrsDetector = getWalletAddrsDetector ws' Ever cWalId
     diff <- getCurChainDifficulty
     fst <$> constructCTx ws' cWalId cWalAddrsDetector diff th

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -130,7 +130,8 @@ importWalletSecret passphrase WalletUserSecret{..} = do
 
     for_ _wusAddrs $ \(walletIndex, accountIndex) -> do
         let accId = AccountId wid walletIndex
-        L.newAddress (DeterminedSeed accountIndex) passphrase accId
+        ws <- getWalletSnapshot
+        L.newAddress ws (DeterminedSeed accountIndex) passphrase accId
 
     -- `syncWalletOnImport` automatically marks a wallet as "ready".
     void $ syncWalletOnImport key

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -41,7 +41,7 @@ import           Pos.Wallet.Web.Mode          (MonadWalletWebMode)
 import           Pos.Wallet.Web.Secret        (WalletUserSecret (..),
                                                mkGenesisWalletUserSecret, wusAccounts,
                                                wusWalletName)
-import           Pos.Wallet.Web.State         (createAccount, removeHistoryCache,
+import           Pos.Wallet.Web.State         (getWalletSnapshot, createAccount, removeHistoryCache,
                                                setWalletSyncTip)
 import           Pos.Wallet.Web.Tracking      (syncWalletOnImport)
 
@@ -124,7 +124,8 @@ importWalletSecret passphrase WalletUserSecret{..} = do
     for_ _wusAccounts $ \(walletIndex, walletName) -> do
         let accMeta = def{ caName = walletName }
             seedGen = DeterminedSeed walletIndex
-        cAddr <- genUniqueAccountId seedGen wid
+        ws <- getWalletSnapshot
+        cAddr <- genUniqueAccountId ws seedGen wid
         createAccount cAddr accMeta
 
     for_ _wusAddrs $ \(walletIndex, accountIndex) -> do

--- a/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Restore.hs
@@ -71,7 +71,6 @@ newWalletFromBackupPhrase passphrase CWalletInit {..} isReady = do
 
 newWallet :: MonadWalletWebMode m => PassPhrase -> CWalletInit -> m CWallet
 newWallet passphrase cwInit = do
-    -- XXX Transaction
     db <- askWalletDB
     -- A brand new wallet doesn't need any syncing, so we mark isReady=True
     (_, wId) <- newWalletFromBackupPhrase passphrase cwInit True
@@ -123,7 +122,6 @@ importWalletSecret passphrase WalletUserSecret{..} = do
     -- Hence we mark the wallet as "not ready" until `syncWalletOnImport` completes.
     importedWallet <- L.createWalletSafe wid wMeta False
 
-    -- XXX Transaction
     db <- askWalletDB
     for_ _wusAccounts $ \(walletIndex, walletName) -> do
         let accMeta = def{ caName = walletName }

--- a/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Txp.hs
@@ -26,7 +26,7 @@ import           Pos.Wallet.Web.Error       (WalletError (..), rewrapToWalletErr
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending     (PendingTx, allPendingAddresses,
                                              ptxFirstSubmissionHandler, submitAndSavePtx)
-import           Pos.Wallet.Web.State       (getPendingTxs)
+import           Pos.Wallet.Web.State       (WalletSnapshot, getPendingTxs)
 import           Pos.Wallet.Web.Util        (decodeCTypeOrFail)
 
 
@@ -60,13 +60,13 @@ submitAndSaveNewPtx = submitAndSavePtx ptxFirstSubmissionHandler
 
 -- | With regard to tx creation policy which is going to be used,
 -- get addresses which are refered by some yet unconfirmed transaction outputs.
-getPendingAddresses :: MonadWalletWebMode m => InputSelectionPolicy -> m PendingAddresses
-getPendingAddresses = \case
+getPendingAddresses :: WalletSnapshot -> InputSelectionPolicy -> PendingAddresses
+getPendingAddresses ws = \case
     OptimizeForSecurity ->
         -- NOTE (int-index) The pending transactions are ignored when we optimize
         -- for security, so it is faster to not get them. In case they start being
         -- used for other purposes, this shortcut must be removed.
-        return mempty
+        mempty
     OptimizeForHighThroughput ->
-        allPendingAddresses <$> getPendingTxs
+        allPendingAddresses (getPendingTxs ws)
 

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -84,7 +84,7 @@ import           Pos.Wallet.SscType             (WalletSscType)
 import           Pos.Wallet.Web.ClientTypes     (Addr, CHash, CId (..), cIdToAddress)
 import           Pos.Wallet.Web.Error           (WalletError (..))
 import           Pos.Wallet.Web.Sockets.ConnSet (ConnectionsVar)
-import           Pos.Wallet.Web.State.State     (WalletState)
+import           Pos.Wallet.Web.State.State     (WalletDB)
 import           Pos.Wallet.Web.Tracking        (MonadBListener (..), onApplyTracking,
                                                  onRollbackTracking)
 import           Pos.WorkMode                   (RealModeContext (..))
@@ -93,7 +93,7 @@ import           Pos.WorkMode                   (RealModeContext (..))
 
 
 data WalletWebModeContext = WalletWebModeContext
-    { wwmcWalletState     :: !WalletState
+    { wwmcWalletState     :: !WalletDB
     , wwmcConnectionsVar  :: !ConnectionsVar
     , wwmcHashes          :: !AddrCIdHashes
     , wwmcRealModeContext :: !(RealModeContext WalletSscType)
@@ -157,7 +157,7 @@ instance HasSlottingVar WalletWebModeContext where
     slottingTimestamp = wwmcRealModeContext_L . slottingTimestamp
     slottingVar = wwmcRealModeContext_L . slottingVar
 
-instance HasLens WalletState WalletWebModeContext WalletState where
+instance HasLens WalletDB WalletWebModeContext WalletDB where
     lensOf = wwmcWalletState_L
 
 instance HasLens ConnectionsVar WalletWebModeContext ConnectionsVar where

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -45,8 +45,6 @@ import           Pos.DB.Rocks                     (dbDeleteDefault, dbGetDefault
                                                    dbIterSourceDefault, dbPutDefault,
                                                    dbWriteBatchDefault)
 
-import           Pos.Client.Txp.Balances          (MonadBalances (..), getBalanceDefault,
-                                                   getOwnUtxosDefault)
 import           Pos.Client.Txp.History           (MonadTxHistory (..),
                                                    getBlockHistoryDefault,
                                                    getLocalHistoryDefault, saveTxDefault)
@@ -262,10 +260,6 @@ instance (HasConfiguration, HasGtConfiguration, HasInfraConfiguration) => MonadB
     localChainDifficulty = localChainDifficultyWebWallet
     connectedPeers = connectedPeersWebWallet
     blockchainSlotDuration = blockchainSlotDurationWebWallet
-
-instance HasConfiguration => MonadBalances WalletWebMode where
-    getOwnUtxos = getOwnUtxosDefault
-    getBalance = getBalanceDefault
 
 instance (HasConfiguration, HasGtConfiguration, HasInfraConfiguration) => MonadTxHistory WalletSscType WalletWebMode where
     getBlockHistory = getBlockHistoryDefault @WalletSscType

--- a/wallet/src/Pos/Wallet/Web/Pending/Util.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Util.hs
@@ -35,7 +35,7 @@ import           Pos.Wallet.Web.Mode            (MonadWalletWebMode)
 import           Pos.Wallet.Web.Pending.Types   (PendingTx (..), PtxCondition (..),
                                                  PtxPoolInfo)
 import           Pos.Wallet.Web.Pending.Updates (mkPtxSubmitTiming)
-import           Pos.Wallet.Web.State           (getWalletMeta)
+import           Pos.Wallet.Web.State           (WalletSnapshot, getWalletMeta)
 
 ptxPoolInfo :: PtxCondition -> Maybe PtxPoolInfo
 ptxPoolInfo (PtxApplying i)    = Just i
@@ -54,10 +54,11 @@ sortPtxsChrono = OldestFirst . sortWith _ptxCreationSlot . tryTopsort
 
 mkPendingTx
     :: MonadWalletWebMode m
-    => CId Wal -> TxId -> TxAux -> TxHistoryEntry -> m PendingTx
-mkPendingTx wid _ptxTxId _ptxTxAux th = do
+    => WalletSnapshot
+    -> CId Wal -> TxId -> TxAux -> TxHistoryEntry -> m PendingTx
+mkPendingTx ws wid _ptxTxId _ptxTxAux th = do
     _ptxCreationSlot <- getCurrentSlotInaccurate
-    CWalletMeta{..} <- maybeThrow noWallet =<< getWalletMeta wid
+    CWalletMeta{..} <- maybeThrow noWallet (getWalletMeta ws wid)
     return PendingTx
         { _ptxCond = PtxApplying th
         , _ptxWallet = wid

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -8,15 +8,16 @@ module Pos.Wallet.Web.Server.Handlers
 
 import           Universum
 
-import           Pos.Communication        (SendActions (..))
-import           Pos.Update.Configuration (curSoftwareVersion)
-import           Pos.Wallet.WalletMode    (blockchainSlotDuration)
-import           Pos.Wallet.Web.Account   (GenSeed (RandomSeed))
-import           Pos.Wallet.Web.Api       (WalletApi)
-import qualified Pos.Wallet.Web.Methods   as M
-import           Pos.Wallet.Web.Mode      (MonadWalletWebMode)
-import           Servant.API              ((:<|>) ((:<|>)))
-import           Servant.Server           (ServerT)
+import           Pos.Communication          (SendActions (..))
+import           Pos.Update.Configuration   (curSoftwareVersion)
+import           Pos.Wallet.WalletMode      (blockchainSlotDuration)
+import           Pos.Wallet.Web.Account     (GenSeed (RandomSeed))
+import           Pos.Wallet.Web.Api         (WalletApi)
+import qualified Pos.Wallet.Web.Methods     as M
+import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
+import           Pos.Wallet.Web.State.State (getWalletSnapshot)
+import           Servant.API                ((:<|>) ((:<|>)))
+import           Servant.Server             (ServerT)
 
 servantHandlers
     :: MonadWalletWebMode m
@@ -44,7 +45,6 @@ servantHandlers sendActions =
     :<|>
      M.changeWalletPassphrase
     :<|>
-
      M.getAccount
     :<|>
      M.getAccounts
@@ -54,19 +54,17 @@ servantHandlers sendActions =
      M.newAccount RandomSeed
     :<|>
      M.deleteAccount
+    :<|> (\passPhrase accId -> do
+             ws <- getWalletSnapshot
+             M.newAddress ws RandomSeed passPhrase accId
+         )
     :<|>
-
-     M.newAddress RandomSeed
-    :<|>
-
      M.isValidAddress
     :<|>
-
      M.getUserProfile
     :<|>
      M.updateUserProfile
     :<|>
-
      M.newPayment sendActions
     :<|>
      M.newPaymentBatch sendActions

--- a/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Handlers.hs
@@ -15,7 +15,7 @@ import           Pos.Wallet.Web.Account     (GenSeed (RandomSeed))
 import           Pos.Wallet.Web.Api         (WalletApi)
 import qualified Pos.Wallet.Web.Methods     as M
 import           Pos.Wallet.Web.Mode        (MonadWalletWebMode)
-import           Pos.Wallet.Web.State.State (getWalletSnapshot)
+import           Pos.Wallet.Web.State.State (askWalletSnapshot)
 import           Servant.API                ((:<|>) ((:<|>)))
 import           Servant.Server             (ServerT)
 
@@ -55,7 +55,7 @@ servantHandlers sendActions =
     :<|>
      M.deleteAccount
     :<|> (\passPhrase accId -> do
-             ws <- getWalletSnapshot
+             ws <- askWalletSnapshot
              M.newAddress ws RandomSeed passPhrase accId
          )
     :<|>

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -37,13 +37,13 @@ import           Pos.Wallet.Web.Mode            (AddrCIdHashes (..), WalletWebMo
 import           Pos.Wallet.Web.Server.Launcher (walletApplication, walletServeImpl,
                                                  walletServer)
 import           Pos.Wallet.Web.Sockets         (ConnectionsVar)
-import           Pos.Wallet.Web.State           (WalletState)
+import           Pos.Wallet.Web.State           (WalletDB)
 import           Pos.Web                        (TlsParams)
 
 -- | 'WalletWebMode' runner.
 runWRealMode
     :: HasConfigurations
-    => WalletState
+    => WalletDB
     -> ConnectionsVar
     -> NodeResources WalletSscType WalletWebMode
     -> (ActionSpec WalletWebMode a, OutSpecs)

--- a/wallet/src/Pos/Wallet/Web/Sockets/Notifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Sockets/Notifier.hs
@@ -28,7 +28,7 @@ import           Pos.Wallet.Web.ClientTypes        (spLocalCD, spNetworkCD, spPe
 import           Pos.Wallet.Web.Mode               (MonadWalletWebMode)
 import           Pos.Wallet.Web.Sockets.Connection (notifyAll)
 import           Pos.Wallet.Web.Sockets.Types      (NotifyEvent (..))
-import           Pos.Wallet.Web.State              (addUpdate)
+import           Pos.Wallet.Web.State              (askWalletDB, addUpdate)
 
 -- FIXME: this is really inefficient. Temporary solution
 launchNotifier :: MonadWalletWebMode m => (m :~> Handler) -> m ()
@@ -77,9 +77,10 @@ launchNotifier nat =
             spPeers .= peers
 
     updateNotifier = do
+        db <- askWalletDB
         cps <- waitForUpdate
         bvd <- gsAdoptedBVData
-        addUpdate $ toCUpdateInfo bvd cps
+        addUpdate db $ toCUpdateInfo bvd cps
         logDebug "Added update to wallet storage"
         notifyAll UpdateAvailable
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -42,6 +42,7 @@ import           Pos.Util.TimeLimit               (CanLogInParallel, logWarningW
 import           Pos.Wallet.Web.Account           (AccountMode, getSKById)
 import           Pos.Wallet.Web.ClientTypes       (CId, Wal)
 import qualified Pos.Wallet.Web.State             as WS
+import           Pos.Wallet.Web.State             (WalletSnapshot, WebWalletModeDB)
 import           Pos.Wallet.Web.Tracking.Modifier (CAccModifier (..))
 import           Pos.Wallet.Web.Tracking.Sync     (applyModifierToWallet,
                                                    rollbackModifierFromWallet,
@@ -49,13 +50,13 @@ import           Pos.Wallet.Web.Tracking.Sync     (applyModifierToWallet,
 import           Pos.Wallet.Web.Util              (getWalletAddrMetas)
 
 walletGuard ::
-    ( AccountMode ctx m
-    )
-    => HeaderHash
+       (WithLogger m, MonadIO m)
+    => WalletSnapshot
+    -> HeaderHash
     -> CId Wal
     -> m ()
     -> m ()
-walletGuard curTip wAddr action = WS.getWalletSyncTip wAddr >>= \case
+walletGuard ws curTip wAddr action = case WS.getWalletSyncTip ws wAddr of
     Nothing -> logWarningS $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
     Just WS.NotSynced    -> logInfoS $ sformat ("Wallet #"%build%" hasn't been synced yet") wAddr
     Just (WS.SyncedWith wTip)
@@ -70,6 +71,7 @@ onApplyTracking
     :: forall ssc ctx m .
     ( SscHelpersClass ssc
     , AccountMode ctx m
+    , WebWalletModeDB ctx m
     , MonadSlotsData ctx m
     , MonadDBRead m
     , MonadReporting ctx m
@@ -77,12 +79,13 @@ onApplyTracking
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
 onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
+    ws <- WS.getWalletSnapshot
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
     currentTipHH <- GS.getTip
-    mapM_ (catchInSync "apply" $ syncWallet currentTipHH newTipH txsWUndo)
-       =<< WS.getWalletAddresses
+    mapM_ (catchInSync "apply" $ syncWallet ws currentTipHH newTipH txsWUndo)
+          (WS.getWalletAddresses ws)
 
     -- It's silly, but when the wallet is migrated to RocksDB, we can write
     -- something a bit more reasonable.
@@ -90,14 +93,15 @@ onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
   where
 
     syncWallet
-        :: HeaderHash
+        :: WalletSnapshot
+        -> HeaderHash
         -> BlockHeader ssc
         -> [(TxAux, TxUndo, BlockHeader ssc)]
         -> CId Wal
         -> m ()
-    syncWallet curTip newTipH blkTxsWUndo wAddr = walletGuard curTip wAddr $ do
+    syncWallet ws curTip newTipH blkTxsWUndo wAddr = walletGuard ws curTip wAddr $ do
         blkHeaderTs <- blkHeaderTsGetter
-        allAddresses <- getWalletAddrMetas WS.Ever wAddr
+        allAddresses <- getWalletAddrMetas ws WS.Ever wAddr
         encSK <- getSKById wAddr
         let mapModifier =
                 trackingApplyTxs encSK allAddresses gbDiff blkHeaderTs ptxBlkInfo blkTxsWUndo
@@ -111,6 +115,7 @@ onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
 onRollbackTracking
     :: forall ssc ctx m .
     ( AccountMode ctx m
+    , WebWalletModeDB ctx m
     , MonadDBRead m
     , MonadSlots ctx m
     , SscHelpersClass ssc
@@ -119,25 +124,27 @@ onRollbackTracking
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
 onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
+    ws <- WS.getWalletSnapshot
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL
     currentTipHH <- GS.getTip
-    mapM_ (catchInSync "rollback" $ syncWallet currentTipHH newTip txs)
-        =<< WS.getWalletAddresses
+    mapM_ (catchInSync "rollback" $ syncWallet ws currentTipHH newTip txs)
+          (WS.getWalletAddresses ws)
 
     -- It's silly, but when the wallet is migrated to RocksDB, we can write
     -- something a bit more reasonable.
     pure mempty
   where
     syncWallet
-        :: HeaderHash
+        :: WalletSnapshot
+        -> HeaderHash
         -> HeaderHash
         -> [(TxAux, TxUndo, BlockHeader ssc)]
         -> CId Wal
         -> m ()
-    syncWallet curTip newTip txs wid = walletGuard curTip wid $ do
-        allAddresses <- getWalletAddrMetas WS.Ever wid
+    syncWallet ws curTip newTip txs wid = walletGuard ws curTip wid $ do
+        allAddresses <- getWalletAddrMetas ws WS.Ever wid
         encSK <- getSKById wid
         blkHeaderTs <- blkHeaderTsGetter
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -105,7 +105,7 @@ onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
         -> m ()
     syncWallet ws curTip newTipH blkTxsWUndo wAddr = walletGuard ws curTip wAddr $ do
         blkHeaderTs <- blkHeaderTsGetter
-        allAddresses <- getWalletAddrMetas ws WS.Ever wAddr
+        let allAddresses = getWalletAddrMetas ws WS.Ever wAddr
         encSK <- getSKById wAddr
         let mapModifier =
                 trackingApplyTxs encSK allAddresses gbDiff blkHeaderTs ptxBlkInfo blkTxsWUndo
@@ -150,7 +150,7 @@ onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
         -> CId Wal
         -> m ()
     syncWallet ws curTip newTip txs wid = walletGuard ws curTip wid $ do
-        allAddresses <- getWalletAddrMetas ws WS.Ever wid
+        let allAddresses = getWalletAddrMetas ws WS.Ever wid
         encSK <- getSKById wid
         blkHeaderTs <- blkHeaderTsGetter
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -83,7 +83,7 @@ onApplyTracking
     )
     => OldestFirst NE (Blund ssc) -> m SomeBatchOp
 onApplyTracking blunds = setLogger . reportTimeouts "apply" $ do
-    ws <- WS.getWalletSnapshot
+    ws <- WS.askWalletSnapshot
     let oldestFirst = getOldestFirst blunds
         txsWUndo = concatMap gbTxsWUndo oldestFirst
         newTipH = NE.last oldestFirst ^. _1 . blockHeader
@@ -130,7 +130,7 @@ onRollbackTracking
     )
     => NewestFirst NE (Blund ssc) -> m SomeBatchOp
 onRollbackTracking blunds = setLogger . reportTimeouts "rollback" $ do
-    ws <- WS.getWalletSnapshot
+    ws <- WS.askWalletSnapshot
     let newestFirst = getNewestFirst blunds
         txs = concatMap (reverse . gbTxsWUndo) newestFirst
         newTip = (NE.last newestFirst) ^. prevBlockL

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -117,7 +117,7 @@ type WalletTrackingEnv ext ctx m =
      ( BlockLockMode WalletSscType ctx m
      , WebWalletModeDB ctx m
      , MonadTxpMem ext ctx m
-     , WS.MonadWalletWebDB ctx m
+     , WS.WalletDbReader ctx m
      , MonadSlotsData ctx m
      , WithLogger m
      , HasConfiguration

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -163,7 +163,7 @@ syncWalletsWithGState
     => [EncryptedSecretKey] -> m ()
 syncWalletsWithGState encSKs = forM_ encSKs $ \encSK -> handleAll (onErr encSK) $ do
     let wAddr = encToCId encSK
-    ws <- WS.getWalletSnapshot
+    ws <- WS.askWalletSnapshot
     case WS.getWalletSyncTip ws wAddr of
         Nothing                -> logWarningS $ sformat ("There is no syncTip corresponding to wallet #"%build) wAddr
         Just NotSynced         -> syncDo encSK Nothing
@@ -225,6 +225,7 @@ syncWalletWithGStateUnsafe
 syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
     systemStart  <- getSystemStartM
     slottingData <- GS.getSlottingData
+    db <- WS.askWalletDB
 
     let gstateHHash = headerHash gstateH
         loadCond (b, _) _ = b ^. difficultyL <= gstateH ^. difficultyL
@@ -251,8 +252,9 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
             trackingApplyTxs encSK allAddresses mDiff blkHeaderTs ptxBlkInfo $
             zip3 (gbTxs b) (undoTx u) (repeat $ getBlockHeader b)
 
-        computeAccModifier :: WalletSnapshot -> BlockHeader ssc -> m CAccModifier
-        computeAccModifier ws wHeader = do
+        computeAccModifier :: BlockHeader ssc -> m CAccModifier
+        computeAccModifier wHeader = do
+            ws <- WS.getWalletSnapshot db
             let allAddresses = getWalletAddrMetas ws Ever wAddr
             logInfoS $
                 sformat ("Wallet "%build%" header: "%build%", current tip header: "%build)
@@ -283,15 +285,14 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
                 M.toList $ unGenesisUtxo genesisUtxo
             ownGenesisUtxo = M.fromList $ map fst ownGenesisData
             ownGenesisAddrs = map snd ownGenesisData
-        mapM_ WS.addWAddress ownGenesisAddrs
-        WS.updateWalletBalancesAndUtxo (utxoToModifier ownGenesisUtxo)
+        mapM_ (WS.addWAddress db) ownGenesisAddrs
+        WS.updateWalletBalancesAndUtxo db (utxoToModifier ownGenesisUtxo)
 
     startFromH <- maybe firstGenesisHeader pure wTipHeader
-    ws <- WS.getWalletSnapshot
-    mapModifier@CAccModifier{..} <- computeAccModifier ws startFromH
+    mapModifier@CAccModifier{..} <- computeAccModifier startFromH
     applyModifierToWallet wAddr gstateHHash mapModifier
     -- Mark the wallet as ready, so it will be available from api endpoints.
-    WS.setWalletReady wAddr True
+    WS.setWalletReady db wAddr True
     logInfoS $
         sformat ("Wallet "%build%" has been synced with tip "
                 %shortHashF%", "%build)
@@ -431,22 +432,24 @@ applyModifierToWallet
     -> CAccModifier
     -> m ()
 applyModifierToWallet wid newTip CAccModifier{..} = do
+    db <- WS.askWalletDB
     -- TODO maybe do it as one acid-state transaction.
-    mapM_ WS.addWAddress (sortedInsertions camAddresses)
-    mapM_ (WS.addCustomAddress UsedAddr . fst) (MM.insertions camUsed)
-    mapM_ (WS.addCustomAddress ChangeAddr . fst) (MM.insertions camChange)
-    WS.updateWalletBalancesAndUtxo camUtxo
+    -- XXX Transaction
+    mapM_ (WS.addWAddress db) (sortedInsertions camAddresses)
+    mapM_ (WS.addCustomAddress db UsedAddr . fst) (MM.insertions camUsed)
+    mapM_ (WS.addCustomAddress db ChangeAddr . fst) (MM.insertions camChange)
+    WS.updateWalletBalancesAndUtxo db camUtxo
     let cMetas = M.fromList
                $ mapMaybe (\THEntry {..} -> (\mts -> (_thTxId, CTxMeta . timestampToPosix $ mts)) <$> _thTimestamp)
                $ DL.toList camAddedHistory
-    WS.addOnlyNewTxMetas wid cMetas
+    WS.addOnlyNewTxMetas db wid cMetas
     let addedHistory = txHistoryListToMap $ DL.toList camAddedHistory
-    WS.insertIntoHistoryCache wid addedHistory
+    WS.insertIntoHistoryCache db wid addedHistory
     -- resubmitting worker can change ptx in db nonatomically, but
     -- tracker has priority over the resubmiter, thus do not use CAS here
     forM_ camAddedPtxCandidates $ \(txid, ptxBlkInfo) ->
-        WS.setPtxCondition wid txid (PtxInNewestBlocks ptxBlkInfo)
-    WS.setWalletSyncTip wid newTip
+        WS.setPtxCondition db wid txid (PtxInNewestBlocks ptxBlkInfo)
+    WS.setWalletSyncTip db wid newTip
 
 rollbackModifierFromWallet
     :: (WalletDbReader ctx m, MonadSlots ctx m, HasConfiguration)
@@ -455,19 +458,21 @@ rollbackModifierFromWallet
     -> CAccModifier
     -> m ()
 rollbackModifierFromWallet wid newTip CAccModifier{..} = do
+    db <- WS.askWalletDB
     -- TODO maybe do it as one acid-state transaction.
-    mapM_ WS.removeWAddress (indexedDeletions camAddresses)
-    mapM_ (WS.removeCustomAddress UsedAddr) (MM.deletions camUsed)
-    mapM_ (WS.removeCustomAddress ChangeAddr) (MM.deletions camChange)
-    WS.updateWalletBalancesAndUtxo camUtxo
+    -- XXX Transaction
+    mapM_ (WS.removeWAddress db) (indexedDeletions camAddresses)
+    mapM_ (WS.removeCustomAddress db UsedAddr) (MM.deletions camUsed)
+    mapM_ (WS.removeCustomAddress db ChangeAddr) (MM.deletions camChange)
+    WS.updateWalletBalancesAndUtxo db camUtxo
     forM_ camDeletedPtxCandidates $ \(txid, poolInfo) -> do
         curSlot <- getCurrentSlotInaccurate
-        WS.ptxUpdateMeta wid txid (WS.PtxResetSubmitTiming curSlot)
-        WS.setPtxCondition wid txid (PtxApplying poolInfo)
+        WS.ptxUpdateMeta db wid txid (WS.PtxResetSubmitTiming curSlot)
+        WS.setPtxCondition db wid txid (PtxApplying poolInfo)
         let deletedHistory = txHistoryListToMap (DL.toList camDeletedHistory)
-        WS.removeFromHistoryCache wid deletedHistory
-        WS.removeWalletTxMetas wid (map encodeCType $ M.keys deletedHistory)
-    WS.setWalletSyncTip wid newTip
+        WS.removeFromHistoryCache db wid deletedHistory
+        WS.removeWalletTxMetas db wid (map encodeCType $ M.keys deletedHistory)
+    WS.setWalletSyncTip db wid newTip
 
 evalChange
     :: [CWAddressMeta] -- ^ All adresses

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -144,7 +144,7 @@ txMempoolToModifier ws encSK = do
             throwM $ InternalError errMsg
 
     tipH <- DB.getTipHeader @WalletSscType
-    allAddresses <- getWalletAddrMetas ws Ever wId
+    let allAddresses = getWalletAddrMetas ws Ever wId
     case topsortTxs wHash txsWUndo of
         Nothing      -> mempty <$ logWarning "txMempoolToModifier: couldn't topsort mempool txs"
         Just ordered -> pure $
@@ -256,7 +256,7 @@ syncWalletWithGStateUnsafe encSK wTipHeader gstateH = setLogger $ do
 
         computeAccModifier :: WalletSnapshot -> BlockHeader ssc -> m CAccModifier
         computeAccModifier ws wHeader = do
-            allAddresses <- getWalletAddrMetas ws Ever wAddr
+            let allAddresses = getWalletAddrMetas ws Ever wAddr
             logInfoS $
                 sformat ("Wallet "%build%" header: "%build%", current tip header: "%build)
                 wAddr wHeader gstateH

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -462,20 +462,22 @@ rollbackModifierFromWallet
     -> m ()
 rollbackModifierFromWallet wid newTip CAccModifier{..} = do
     db <- WS.askWalletDB
-    -- TODO maybe do it as one acid-state transaction.
-    -- XXX Transaction
-    mapM_ (WS.removeWAddress db) (indexedDeletions camAddresses)
-    mapM_ (WS.removeCustomAddress db UsedAddr) (MM.deletions camUsed)
-    mapM_ (WS.removeCustomAddress db ChangeAddr) (MM.deletions camChange)
-    WS.updateWalletBalancesAndUtxo db camUtxo
-    forM_ camDeletedPtxCandidates $ \(txid, poolInfo) -> do
-        curSlot <- getCurrentSlotInaccurate
-        WS.ptxUpdateMeta db wid txid (WS.PtxResetSubmitTiming curSlot)
-        WS.setPtxCondition db wid txid (PtxApplying poolInfo)
-        let deletedHistory = txHistoryListToMap (DL.toList camDeletedHistory)
-        WS.removeFromHistoryCache db wid deletedHistory
-        WS.removeWalletTxMetas db wid (map encodeCType $ M.keys deletedHistory)
-    WS.setWalletSyncTip db wid newTip
+    curSlot <- getCurrentSlotInaccurate
+
+    WS.rollbackModifierFromWallet
+      db
+      wid
+      (indexedDeletions camAddresses)
+      [ (UsedAddr, MM.deletions camUsed)
+      , (ChangeAddr, MM.deletions camChange)
+      ]
+      camUtxo
+      (txHistoryListToMap (DL.toList camDeletedHistory))
+      ((\(txId, poolInfo) -> ( txId, PtxApplying poolInfo
+                             , WS.PtxResetSubmitTiming curSlot))
+        <$> DL.toList camDeletedPtxCandidates
+      )
+      newTip
 
 evalChange
     :: [CWAddressMeta] -- ^ All adresses

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -435,21 +435,24 @@ applyModifierToWallet wid newTip CAccModifier{..} = do
     db <- WS.askWalletDB
     -- TODO maybe do it as one acid-state transaction.
     -- XXX Transaction
-    mapM_ (WS.addWAddress db) (sortedInsertions camAddresses)
-    mapM_ (WS.addCustomAddress db UsedAddr . fst) (MM.insertions camUsed)
-    mapM_ (WS.addCustomAddress db ChangeAddr . fst) (MM.insertions camChange)
-    WS.updateWalletBalancesAndUtxo db camUtxo
-    let cMetas = M.fromList
-               $ mapMaybe (\THEntry {..} -> (\mts -> (_thTxId, CTxMeta . timestampToPosix $ mts)) <$> _thTimestamp)
+
+    let cMetas = mapMaybe (\THEntry {..} -> (\mts -> (encodeCType _thTxId
+                                                     , CTxMeta . timestampToPosix $ mts)
+                                            ) <$> _thTimestamp)
                $ DL.toList camAddedHistory
-    WS.addOnlyNewTxMetas db wid cMetas
-    let addedHistory = txHistoryListToMap $ DL.toList camAddedHistory
-    WS.insertIntoHistoryCache db wid addedHistory
-    -- resubmitting worker can change ptx in db nonatomically, but
-    -- tracker has priority over the resubmiter, thus do not use CAS here
-    forM_ camAddedPtxCandidates $ \(txid, ptxBlkInfo) ->
-        WS.setPtxCondition db wid txid (PtxInNewestBlocks ptxBlkInfo)
-    WS.setWalletSyncTip db wid newTip
+
+    WS.applyModifierToWallet
+      db
+      wid
+      (sortedInsertions camAddresses)
+      [ (UsedAddr, fst <$> MM.insertions camUsed)
+      , (ChangeAddr, fst <$> MM.insertions camChange)
+      ]
+      camUtxo
+      cMetas
+      (txHistoryListToMap $ DL.toList camAddedHistory)
+      (DL.toList $ second PtxInNewestBlocks <$> camAddedPtxCandidates)
+      newTip
 
 rollbackModifierFromWallet
     :: (WalletDbReader ctx m, MonadSlots ctx m, HasConfiguration)


### PR DESCRIPTION
This work subsumes #2321 and #2357.

Atop those PRs, we:
- Add explicit threading of the DB handle into functions in `State.hs`.
- Rewrites various areas of functionality to use single transactions, where we judge this to be appropriate.

It does not make any changes to the return types of `Update` functions to the Acid state. Doing so would likely result in a number of changes across the codebase as we are forced to discard return types, and the number of places where we need such a return type seems minimal. If we do this, I think we should address in a separate PR.

Commits are currently split for easy review; after review we can rebase and add YT references etc,