### PR TITLE
Migration to rocksdb-haskell-ng

### DIFF
--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -106,7 +106,7 @@ library
                       , mtl
                       , random
                       , reflection
-                      , rocksdb-haskell
+                      , rocksdb-haskell-ng
                       , safe-exceptions
                       , serokell-util
                       , stm

--- a/db/Pos/DB/Rocks/Functions.hs
+++ b/db/Pos/DB/Rocks/Functions.hs
@@ -19,10 +19,6 @@ module Pos.DB.Rocks.Functions
        , rocksDelete
        , rocksPutBi
 
-       -- * Snapshot
-       , Snapshot (..)
-       , usingSnapshot
-
        -- * Iteration
        , rocksIterSource
 
@@ -39,7 +35,6 @@ import           Universum
 import           Control.Lens (ASetter')
 import           Control.Monad.Trans.Resource (MonadResource)
 import           Data.Conduit (ConduitM, Source, bracketP, yield)
-import           Data.Default (def)
 import qualified Database.RocksDB as Rocks
 import           Ether.Internal (lensOf)
 import           System.Directory (createDirectoryIfMissing, doesDirectoryExist,
@@ -59,11 +54,12 @@ import qualified Pos.Util.Concurrent.RWLock as RWL
 ----------------------------------------------------------------------------
 
 openRocksDB :: MonadIO m => FilePath -> m DB
-openRocksDB fp = DB def def def
-                   <$> Rocks.open fp def
-                        { Rocks.createIfMissing = True
-                        , Rocks.compression     = Rocks.NoCompression
-                        }
+openRocksDB fp = DB Rocks.defaultReadOptions Rocks.defaultWriteOptions options
+                   <$> Rocks.open options
+  where options = (Rocks.defaultOptions fp)
+          { Rocks.optionsCreateIfMissing = True
+          , Rocks.optionsCompression     = Rocks.NoCompression
+          }
 
 closeRocksDB :: MonadIO m => DB -> m ()
 closeRocksDB = Rocks.close . rocksDB
@@ -150,6 +146,11 @@ rocksPutBi k v = rocksPutBytes k (dbSerializeValue v)
 -- Snapshot
 ----------------------------------------------------------------------------
 
+-- The following is not used in the project yet. So the
+-- rocksdb-haskell-ng binding doesn't include it yet, and we simply
+-- comment it out here, to be added back at a later stage when needed.
+
+{-
 newtype Snapshot = Snapshot Rocks.Snapshot
 
 usingSnapshot
@@ -160,6 +161,7 @@ usingSnapshot DB {..} action =
         (Rocks.createSnapshot rocksDB)
         (Rocks.releaseSnapshot rocksDB)
         (action . Snapshot)
+-}
 
 ----------------------------------------------------------------------------
 -- Iteration

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -47,7 +47,7 @@ library
                      , mmorph
                      , mtl
                      , resourcet
-                     , rocksdb-haskell >= 1.0.0
+                     , rocksdb-haskell-ng
                      , serokell-util
                      , text-format
                      , transformers

--- a/delegation/cardano-sl-delegation.cabal
+++ b/delegation/cardano-sl-delegation.cabal
@@ -62,8 +62,8 @@ library
                      , mtl
                      , reflection
                      , resourcet
-                     , rocksdb-haskell
                      , safe-exceptions
+                     , rocksdb-haskell-ng
                      , serokell-util
                      , text-format
                      , time

--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -66,7 +66,7 @@ library
                       , log-warper
                       , memory
                       , resourcet
-                      , rocksdb-haskell
+                      , rocksdb-haskell-ng
                       , safe-exceptions
                       , serokell-util
                       , servant-generic

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -201,7 +201,7 @@ library
                       , random
                       , reflection
                       , resourcet
-                      , rocksdb-haskell >= 1.0.0
+                      , rocksdb-haskell-ng
                       , safe-exceptions
                       , safecopy
                       , serokell-util >= 0.1.3.4

--- a/lib/src/Pos/GState/GState.hs
+++ b/lib/src/Pos/GState/GState.hs
@@ -2,18 +2,13 @@
 
 module Pos.GState.GState
        ( prepareGStateDB
-       , usingGStateSnapshot
        ) where
 
 import           Universum
 
-import qualified Database.RocksDB as Rocks
-
 import           Pos.Core (GenesisData (..), HasConfiguration, HeaderHash, genesisData)
 import           Pos.DB.Class (MonadDB)
 import           Pos.DB.GState.Common (initGStateCommon, isInitialized, setInitialized)
-import           Pos.DB.Rocks (DB (..), MonadRealDB, NodeDBs (..), Snapshot (..), gStateDB,
-                               getNodeDBs, usingReadOptions, usingSnapshot)
 import           Pos.Delegation.DB (initGStateDlg)
 import           Pos.GState.BlockExtra (initGStateBlockExtra)
 import           Pos.Ssc.Configuration (HasSscConfiguration)
@@ -42,9 +37,14 @@ prepareGStateDB initialTip = unlessM isInitialized $ do
 
     setInitialized
 
+-- The following is not used in the project yet. To be added back at a
+-- later stage when needed.
+
+{-
 usingGStateSnapshot :: (MonadRealDB ctx m, MonadMask m) => m a -> m a
 usingGStateSnapshot action = do
     db <- _gStateDB <$> getNodeDBs
     let readOpts = rocksReadOpts db
     usingSnapshot db (\(Snapshot sn) ->
         usingReadOptions readOpts {Rocks.useSnapshot = Just sn} gStateDB action)
+-}

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -44,7 +44,7 @@ library
                      , lens
                      , log-warper
                      , reflection
-                     , rocksdb-haskell
+                     , rocksdb-haskell-ng
                      , text-format
                      , universum
                      , unordered-containers

--- a/ssc/cardano-sl-ssc.cabal
+++ b/ssc/cardano-sl-ssc.cabal
@@ -95,7 +95,7 @@ library
                      , mtl
                      , parsec
                      , reflection
-                     , rocksdb-haskell >= 1.0.0
+                     , rocksdb-haskell-ng
                      , serokell-util
                      , stm
                      , tagged

--- a/stack.yaml
+++ b/stack.yaml
@@ -112,6 +112,11 @@ packages:
     commit: 2d261bb971bada1893753b503452d9e6e217bc4a
   extra-dep: true
 
+- location:
+    git: https://github.com/chrisdone/rocksdb-haskell-ng.git
+    commit: 83dfc412f69f6c9e946876fcead990f50b6911b3
+  extra-dep: true
+
 nix:
   shell-file: shell.nix
 
@@ -137,7 +142,6 @@ extra-deps:
 - servant-quickcheck-0.0.4
 - ether-0.5.1.0
 - pipes-interleave-1.1.1
-- rocksdb-haskell-1.0.0
 - generic-arbitrary-0.1.0
 - happy-1.19.5                    # https://github.com/commercialhaskell/stack/issues/3151
 - entropy-0.3.7                   # https://github.com/commercialhaskell/stack/issues/3151

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -97,7 +97,7 @@ library
                      , neat-interpolation
                      , plutus-prototype
                      , resourcet
-                     , rocksdb-haskell >= 1.0.0
+                     , rocksdb-haskell-ng
                      , safe-exceptions
                      , serokell-util
                      , stm

--- a/update/cardano-sl-update.cabal
+++ b/update/cardano-sl-update.cabal
@@ -111,7 +111,7 @@ library
                      , mtl
                      , reflection
                      , resourcet
-                     , rocksdb-haskell >= 1.0.0
+                     , rocksdb-haskell-ng
                      , safe-exceptions
                      , serokell-util
                      , stm


### PR DESCRIPTION
Summary:

* Comments out a few RocksDB-related things that aren't currently used.
* Switches all cabal-depends to rocksdb-haskell-ng.
* Adds rocksdb-haskell-ng as an extra-dep to the stack.yaml.

The rocksdb-haskell-ng project is a ground-up rewrite (with some code re-used where possible) of the rocksdb-haskell project, with things that are not used by cardano-sl not included.

The rewrite is motivated by making the binding as safe as possible: it should not ever segfault, and should be safe from memory leaks, double closes, async exceptions, and safe concurrent use, all for both connection handles and for iterators. The worst case scenario is that it should throw a meaningful exception when you have made a mistake.

To backup these aims, included is a fairly comprehensive test suite which attempts to test edge-cases and programmer error. Included are tests made by Niklas and some fixes for Unicode file access on Linux and Windows. It also includes a benchmark suite to track any performance improvements.

It also has Linux and Windows CI.

[![Linux build Status](https://travis-ci.org/chrisdone/rocksdb-haskell-ng.svg)](https://travis-ci.org/chrisdone/rocksdb-haskell-ng) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/chrisdone/rocksdb-haskell-ng?branch=master&svg=true)](https://ci.appveyor.com/project/chrisdone/rocksdb-haskell-ng)
