### PR TITLE
[CSL-2200] Get rid of some forks in cardano-sl-networking

### DIFF
--- a/networking/bench/LogReader/Main.hs
+++ b/networking/bench/LogReader/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 import           Control.Applicative (empty, (<|>))
+import           Control.Exception.Safe (Exception, handle)
 import           Control.Lens (at, (%=), (^.), _2, _Just)
 import           Control.Monad (forM_)
 import           Control.Monad.State (StateT (..), evalStateT, execStateT, get, modify)
@@ -27,8 +28,8 @@ import           Bench.Network.Commons (LogMessage (..), MeasureEvent (..), Meas
                                         Payload (..), Timestamp, logMessageParser,
                                         measureInfoParser)
 import           LogReaderOptions (Args (..), argsParser)
-import           System.Wlog (LoggerNameBox, Severity (Info), initTerminalLogging, logError,
-                              logWarning, usingLoggerName)
+import           System.Wlog (LoggerNameBox, logError, logWarning, productionB, setupLogging,
+                              usingLoggerName)
 import           System.Wlog.Formatter (centiUtcTimeF)
 
 
@@ -123,7 +124,7 @@ getOptions = (\(a, ()) -> a) <$> simpleOptions
 
 main :: IO ()
 main = usingLoggerName mempty $ do
-    initTerminalLogging centiUtcTimeF True True (Just Info)
+    setupLogging (Just centiUtcTimeF) productionB
     Args{..} <- liftIO getOptions
     measures <- flip execStateT M.empty $
         forM_ inputFiles analyze

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -218,6 +218,7 @@ executable bench-log-reader
                      , mtl
                      , optparse-simple
                      , resourcet
+                     , safe-exceptions
                      , text
                      , text-format
   hs-source-dirs:      bench/LogReader


### PR DESCRIPTION
It turned out that remaining forks are only in tests and benches (there are
a few in OutboundQueue demo which in turn is used only in tests).
So I didn't put much effort into it and left some forks.
I eliminated those which were easy to eliminate.
I've also fixed compilation of some benchmarks.