### PR TITLE
CSL-2212 Eliminate `forkIO` usages in wallet 

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7596,7 +7596,7 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.mit;
          }) {};
       "cardano-sl-wallet" = callPackage
-        ({ mkDerivation, acid-state, aeson, base, base58-bytestring
+        ({ mkDerivation, acid-state, aeson, async, base, base58-bytestring
          , bytestring, cardano-sl, cardano-sl-block, cardano-sl-client
          , cardano-sl-core, cardano-sl-crypto, cardano-sl-db
          , cardano-sl-delegation, cardano-sl-generator, cardano-sl-infra
@@ -7620,7 +7620,7 @@ inherit (pkgs) mesa;};
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
-             acid-state aeson base base58-bytestring bytestring cardano-sl
+             acid-state aeson async base base58-bytestring bytestring cardano-sl
              cardano-sl-block cardano-sl-client cardano-sl-core
              cardano-sl-crypto cardano-sl-db cardano-sl-infra
              cardano-sl-networking cardano-sl-ssc cardano-sl-txp

--- a/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
+++ b/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.Server.Plugins (
     , conversation
     , walletBackend
     , resubmitterPlugin
+    , notifierPlugin
     ) where
 
 import           Universum
@@ -95,6 +96,10 @@ walletBackend WalletBackendParams {..} =
 -- | A @Plugin@ to resubmit pending transactions.
 resubmitterPlugin :: (HasConfigurations, HasCompileInfo) => Plugin WalletWebMode
 resubmitterPlugin = ([ActionSpec $ \_ _ -> startPendingTxsResubmitter], mempty)
+
+-- | A @Plugin@ to notify frontend via websockets.
+notifierPlugin :: (HasConfigurations, HasCompileInfo) => Plugin WalletWebMode
+notifierPlugin = ([ActionSpec $ \_ _ -> V0.notifierPlugin], mempty)
 
 -- | "Attaches" the middleware to this 'Application', if any.
 -- When running in debug mode, chances are we want to at least allow CORS to test the API

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -79,6 +79,7 @@ actionWithWallet sscParams nodeParams wArgs@WalletBackendParams {..} =
     plugins = mconcat [ Plugins.conversation wArgs
                       , Plugins.walletBackend wArgs
                       , Plugins.acidCleanupWorker wArgs
+                      , Plugins.resubmitterPlugin
                       ]
 
 -- | Runs an edge node plus its wallet backend API.

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -80,6 +80,7 @@ actionWithWallet sscParams nodeParams wArgs@WalletBackendParams {..} =
                       , Plugins.walletBackend wArgs
                       , Plugins.acidCleanupWorker wArgs
                       , Plugins.resubmitterPlugin
+                      , Plugins.notifierPlugin
                       ]
 
 -- | Runs an edge node plus its wallet backend API.

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -104,6 +104,7 @@ library
   build-depends:        QuickCheck
                       , acid-state
                       , aeson >= 0.11.2.1
+                      , async
                       , base
                       , base58-bytestring
                       , bytestring

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -33,8 +33,8 @@ import           Pos.Util (logException)
 import           Pos.Util.CompileInfo (HasCompileInfo, retrieveCompileTimeInfo, withCompileInfo)
 import           Pos.Util.UserSecret (usVss)
 import           Pos.Wallet.Web (WalletWebMode, bracketWalletWS, bracketWalletWebDB, getSKById,
-                                 runWRealMode, startPendingTxsResubmitter, syncWalletsWithGState,
-                                 walletServeWebFull, walletServerOuts)
+                                 notifierPlugin, runWRealMode, startPendingTxsResubmitter,
+                                 syncWalletsWithGState, walletServeWebFull, walletServerOuts)
 import           Pos.Wallet.Web.State (cleanupAcidStatePeriodically, flushWalletStorage,
                                        getWalletAddresses)
 import           Pos.Web (serveWeb)
@@ -84,11 +84,13 @@ actionWithWallet sscParams nodeParams wArgs@WalletArgs {..} =
         sks <- getWalletAddresses >>= mapM getSKById
         syncWalletsWithGState sks
     resubmitterPlugins = ([ActionSpec $ \_ _ -> startPendingTxsResubmitter], mempty)
+    notifierPlugins = ([ActionSpec $ \_ _ -> notifierPlugin], mempty)
     allPlugins :: HasConfigurations => ([WorkerSpec WalletWebMode], OutSpecs)
     allPlugins = mconcat [ convPlugins (plugins wArgs)
                          , walletProd wArgs
                          , acidCleanupWorker wArgs
                          , resubmitterPlugins
+                         , notifierPlugins
                          ]
 
 acidCleanupWorker :: HasConfigurations => WalletArgs -> ([WorkerSpec WalletWebMode], OutSpecs)

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -156,8 +156,6 @@ processPtxsOnSlot curSlot = do
 startPendingTxsResubmitter
     :: MonadPendings ctx m
     => m ()
-startPendingTxsResubmitter =
-    void . fork . setLogger $
-    onNewSlot False processPtxsOnSlot
+startPendingTxsResubmitter = setLogger $ onNewSlot False processPtxsOnSlot
   where
     setLogger = modifyLoggerName (<> "tx" <> "resubmitter")

--- a/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
@@ -31,7 +31,6 @@ import           Pos.Wallet.Web.Account (findKey, myRootAddresses)
 import           Pos.Wallet.Web.Api (WalletSwaggerApi, swaggerWalletApi)
 import           Pos.Wallet.Web.Mode (MonadFullWalletWebMode, MonadWalletWebMode,
                                       MonadWalletWebSockets)
-import           Pos.Wallet.Web.Pending (startPendingTxsResubmitter)
 import           Pos.Wallet.Web.Server.Handlers (servantHandlersWithSwagger)
 import           Pos.Wallet.Web.Sockets (ConnectionsVar, closeWSConnections, getWalletWebSockets,
                                          initWSConnections, launchNotifier, upgradeApplicationWS)
@@ -65,7 +64,6 @@ walletServer
     -> m (Server WalletSwaggerApi)
 walletServer nat = do
     syncWalletsWithGState =<< mapM findKey =<< myRootAddresses
-    startPendingTxsResubmitter
     launchNotifier nat
     return $ servantHandlersWithSwagger nat
 

--- a/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
@@ -33,7 +33,7 @@ import           Pos.Wallet.Web.Mode (MonadFullWalletWebMode, MonadWalletWebMode
                                       MonadWalletWebSockets)
 import           Pos.Wallet.Web.Server.Handlers (servantHandlersWithSwagger)
 import           Pos.Wallet.Web.Sockets (ConnectionsVar, closeWSConnections, getWalletWebSockets,
-                                         initWSConnections, launchNotifier, upgradeApplicationWS)
+                                         initWSConnections, upgradeApplicationWS)
 import           Pos.Wallet.Web.State (closeState, openState)
 import           Pos.Wallet.Web.State.Storage (WalletStorage)
 import           Pos.Wallet.Web.Tracking (syncWalletsWithGState)
@@ -64,7 +64,6 @@ walletServer
     -> m (Server WalletSwaggerApi)
 walletServer nat = do
     syncWalletsWithGState =<< mapM findKey =<< myRootAddresses
-    launchNotifier nat
     return $ servantHandlersWithSwagger nat
 
 bracketWalletWebDB

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -11,6 +11,7 @@ module Pos.Wallet.Web.Server.Runner
        , runWRealMode
        , walletWebModeContext
        , convertHandler
+       , notifierPlugin
        ) where
 
 import           Universum
@@ -37,7 +38,7 @@ import           Pos.Wallet.Web.Methods (AddrCIdHashes (..), addInitialRichAccou
 import           Pos.Wallet.Web.Mode (WalletWebMode, WalletWebModeContext (..),
                                       WalletWebModeContextTag)
 import           Pos.Wallet.Web.Server.Launcher (walletApplication, walletServeImpl, walletServer)
-import           Pos.Wallet.Web.Sockets (ConnectionsVar)
+import           Pos.Wallet.Web.Sockets (ConnectionsVar, launchNotifier)
 import           Pos.Wallet.Web.State (WalletState)
 import           Pos.Web (TlsParams)
 
@@ -99,3 +100,8 @@ convertHandler wwmc handler =
 
     excHandlers = [E.Handler catchServant]
     catchServant = throwError
+
+notifierPlugin :: (HasConfigurations, HasCompileInfo) => WalletWebMode ()
+notifierPlugin = do
+    wwmc <- walletWebModeContext
+    launchNotifier (convertHandler wwmc)


### PR DESCRIPTION
All usages of `forkIO` and similar functions in wallet were replaced by functions from `async`.
It's better to review each commit separately, I provided brief explanations in commit messages.