### PR TITLE
CSL-1606 Find better approach for long running actions passed no 'onNewSlot' 

### DIFF
--- a/block/src/Pos/Block/Worker.hs
+++ b/block/src/Pos/Block/Worker.hs
@@ -13,7 +13,7 @@ import           Control.Lens (ix)
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Units (Microsecond)
 import           Formatting (Format, bprint, build, fixed, int, now, sformat, shown, (%))
-import           Mockable (delay, fork)
+import           Mockable (delay)
 import           Serokell.Util (enumerate, listJson, pairF, sec)
 import qualified System.Metrics.Label as Label
 import           System.Random (randomRIO)
@@ -52,7 +52,8 @@ import           Pos.Recovery.Info (getSyncStatus, getSyncStatusK, needTriggerRe
                                     recoveryCommGuard)
 import           Pos.Reporting (MetricMonitor (..), MetricMonitorState, noReportMonitor,
                                 recordValue, reportOrLogE)
-import           Pos.Slotting (currentTimeSlotting, getSlotStartEmpatically)
+import           Pos.Slotting (ActionTerminationPolicy (..), OnNewSlotParams (..),
+                               currentTimeSlotting, defaultOnNewSlotParams, getSlotStartEmpatically)
 import           Pos.Update.DB (getAdoptedBVData)
 import           Pos.Util (mconcatPair)
 import           Pos.Util.Chrono (OldestFirst (..))
@@ -81,7 +82,7 @@ blkWorkers keepAliveTimer =
 
 informerWorker :: BlockWorkMode ctx m => (WorkerSpec m, OutSpecs)
 informerWorker =
-    onNewSlotWorker True announceBlockOuts $ \slotId _ ->
+    onNewSlotWorker defaultOnNewSlotParams announceBlockOuts $ \slotId _ ->
         recoveryCommGuard "onNewSlot worker, informerWorker" $ do
             tipHeader <- DB.getTipHeader
             -- Printe tip header
@@ -102,16 +103,17 @@ informerWorker =
 -- Block creation worker
 ----------------------------------------------------------------------------
 
--- TODO [CSL-1606] Using 'fork' here is quite bad, it's a temporary solution.
 blkCreatorWorker :: BlockWorkMode ctx m => (WorkerSpec m, OutSpecs)
 blkCreatorWorker =
-    onNewSlotWorker True announceBlockOuts $ \slotId sendActions ->
+    onNewSlotWorker onsp announceBlockOuts $ \slotId sendActions ->
         recoveryCommGuard "onNewSlot worker, blkCreatorWorker" $
-            void $ fork $
-            blockCreator slotId sendActions `catchAny` onBlockCreatorException
+        blockCreator slotId sendActions `catchAny` onBlockCreatorException
   where
     onBlockCreatorException = reportOrLogE "blockCreator failed: "
-
+    onsp :: OnNewSlotParams
+    onsp =
+        defaultOnNewSlotParams
+        {onspTerminationPolicy = NewSlotTerminationPolicy "block creator"}
 
 blockCreator
     :: BlockWorkMode ctx m

--- a/infra/Pos/NtpCheck.hs
+++ b/infra/Pos/NtpCheck.hs
@@ -11,14 +11,11 @@ module Pos.NtpCheck
 
 import           Universum
 
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Units (Microsecond)
-import           Mockable (Async, Concurrently, CurrentTime, Delay, Mockable, Mockables,
-                           currentTime, withAsync)
-import           NTP.Client (NtpClientSettings (..), ntpSingleShot, spawnNtpClient)
+import           Mockable (CurrentTime, Delay, Mockable, Mockables, currentTime, withAsync)
+import           NTP.Client (NtpClientSettings (..), NtpMonad, ntpSingleShot, spawnNtpClient)
 import           Serokell.Util (sec)
-import           System.Wlog (WithLogger)
 
 import           Pos.Core.Slotting (Timestamp (..), diffTimestamp)
 import           Pos.Infra.Configuration (HasInfraConfiguration, infraConfiguration)
@@ -26,13 +23,8 @@ import qualified Pos.Infra.Configuration as Infra
 import           Pos.Util.Util (median)
 
 type NtpCheckMonad m =
-    ( MonadIO m
-    , MonadMask m
-    , MonadBaseControl IO m
-    , Mockable Async m
-    , Mockable Concurrently m
+    ( NtpMonad m
     , Mockable CurrentTime m
-    , WithLogger m
     , HasInfraConfiguration
     )
 

--- a/networking/src/Mockable/Concurrent.hs
+++ b/networking/src/Mockable/Concurrent.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -42,7 +43,11 @@ module Mockable.Concurrent (
   , mapConcurrently
   , forConcurrently
 
+  -- * Utility functions
+  , timeout
   ) where
+
+import           Universum
 
 import           Control.Exception (AsyncException (..))
 import           Control.Exception.Safe (Exception)
@@ -221,3 +226,9 @@ forConcurrently
     -> (s -> m t)
     -> m (f t)
 forConcurrently = flip mapConcurrently
+
+-- | This function is analogous to `System.Timeout.timeout`, it's
+-- based on `Race` and `Delay`.
+{-# INLINE timeout #-}
+timeout :: (Mockable Delay m, Mockable Async m, TimeUnit t) => t -> m a -> m (Maybe a)
+timeout t ma = rightToMaybe <$> race (delay t) ma

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -783,7 +783,7 @@ let
            homepage = "http://github.com/ryantm/hdbc-mysql";
            description = "MySQL driver for HDBC";
            license = "LGPL";
-         }) {inherit (pkgs) mysqlclient; inherit (pkgs) openssl; 
+         }) {inherit (pkgs) mysqlclient; inherit (pkgs) openssl;
 inherit (pkgs) zlib;};
       "HDBC-session" = callPackage
         ({ mkDerivation, base, HDBC, stdenv }:
@@ -2022,8 +2022,8 @@ inherit (pkgs) zlib;};
            description = "A binding to part of the Win32 library";
            license = stdenv.lib.licenses.bsd3;
            platforms = stdenv.lib.platforms.none;
-         }) {inherit (pkgs) advapi32; inherit (pkgs) gdi32; 
-inherit (pkgs) shell32; inherit (pkgs) shfolder; 
+         }) {inherit (pkgs) advapi32; inherit (pkgs) gdi32;
+inherit (pkgs) shell32; inherit (pkgs) shfolder;
 inherit (pkgs) user32; inherit (pkgs) winmm;};
       "Win32-extras" = callPackage
         ({ mkDerivation, base, imm32, msimg32, stdenv, Win32 }:
@@ -2093,7 +2093,7 @@ inherit (pkgs) user32; inherit (pkgs) winmm;};
            homepage = "https://github.com/xmonad/X11";
            description = "A binding to the X11 graphics library";
            license = stdenv.lib.licenses.bsd3;
-         }) {inherit (pkgs.xorg) libXext; inherit (pkgs.xorg) libXinerama; 
+         }) {inherit (pkgs.xorg) libXext; inherit (pkgs.xorg) libXinerama;
 inherit (pkgs.xorg) libXrender;};
       "X11-xft" = callPackage
         ({ mkDerivation, base, libXft, stdenv, utf8-string, X11 }:
@@ -5486,7 +5486,7 @@ inherit (pkgs.xorg) libXrender;};
            doCheck = false;
            description = "Low-level bindings to GLFW OpenGL library";
            license = stdenv.lib.licenses.bsd3;
-         }) {inherit (pkgs.xorg) libXext; inherit (pkgs.xorg) libXfixes; 
+         }) {inherit (pkgs.xorg) libXext; inherit (pkgs.xorg) libXfixes;
 inherit (pkgs) mesa;};
       "bindings-libzip" = callPackage
         ({ mkDerivation, base, bindings-DSL, libzip, stdenv }:
@@ -14157,7 +14157,7 @@ inherit (pkgs) mesa;};
            homepage = "https://github.com/chrisdone/freenect";
            description = "Interface to the Kinect device";
            license = stdenv.lib.licenses.bsd3;
-         }) {inherit (pkgs) freenect; inherit (pkgs) freenect_sync; 
+         }) {inherit (pkgs) freenect; inherit (pkgs) freenect_sync;
 inherit (pkgs) libfreenect;};
       "freer" = callPackage
         ({ mkDerivation, base, stdenv }:
@@ -14375,8 +14375,8 @@ inherit (pkgs) libfreenect;};
            doCheck = false;
            description = "A Haskell binding to a subset of the GD graphics library";
            license = stdenv.lib.licenses.bsd3;
-         }) {inherit (pkgs) expat; inherit (pkgs) fontconfig; 
-inherit (pkgs) freetype; inherit (pkgs) gd; 
+         }) {inherit (pkgs) expat; inherit (pkgs) fontconfig;
+inherit (pkgs) freetype; inherit (pkgs) gd;
 inherit (pkgs) libjpeg; inherit (pkgs) libpng; inherit (pkgs) zlib;};
       "general-games" = callPackage
         ({ mkDerivation, base, monad-loops, MonadRandom, random
@@ -15245,9 +15245,9 @@ inherit (pkgs) libjpeg; inherit (pkgs) libpng; inherit (pkgs) zlib;};
            description = "manage files with git, without checking their contents into git";
            license = stdenv.lib.licenses.gpl3;
            platforms = [ "i686-linux" "x86_64-linux" ];
-         }) {inherit (pkgs) bup; inherit (pkgs) curl; inherit (pkgs) git; 
-inherit (pkgs) gnupg; inherit (pkgs) lsof; inherit (pkgs) openssh; 
-inherit (pkgs) perl; inherit (pkgs) rsync; inherit (pkgs) wget; 
+         }) {inherit (pkgs) bup; inherit (pkgs) curl; inherit (pkgs) git;
+inherit (pkgs) gnupg; inherit (pkgs) lsof; inherit (pkgs) openssh;
+inherit (pkgs) perl; inherit (pkgs) rsync; inherit (pkgs) wget;
 inherit (pkgs) which;};
       "github" = callPackage
         ({ mkDerivation, aeson, aeson-compat, base, base-compat

--- a/ssc/Pos/Ssc/Worker.hs
+++ b/ssc/Pos/Ssc/Worker.hs
@@ -44,7 +44,8 @@ import           Pos.Lrc.Types (RichmenStakes)
 import           Pos.Recovery.Info (recoveryCommGuard)
 import           Pos.Reporting (reportMisbehaviour)
 import           Pos.Reporting.MemState (HasMisbehaviorMetrics (..), MisbehaviorMetrics (..))
-import           Pos.Slotting (getCurrentSlot, getSlotStartEmpatically, onNewSlot)
+import           Pos.Slotting (defaultOnNewSlotParams, getCurrentSlot, getSlotStartEmpatically,
+                               onNewSlot)
 import           Pos.Ssc.Base (genCommitmentAndOpening, isCommitmentIdx, isOpeningIdx, isSharesIdx,
                                mkSignedCommitment)
 import           Pos.Ssc.Behavior (SscBehavior (..), SscOpeningParams (..), SscSharesParams (..))
@@ -90,7 +91,7 @@ shouldParticipate epoch = do
 onNewSlotSsc
     :: (SscMessageConstraints m, SscMode ctx m)
     => (WorkerSpec m, OutSpecs)
-onNewSlotSsc = onNewSlotWorker True outs $ \slotId sendActions ->
+onNewSlotSsc = onNewSlotWorker defaultOnNewSlotParams outs $ \slotId sendActions ->
     recoveryCommGuard "onNewSlot worker in SSC" $ do
         sscGarbageCollectLocalData slotId
         whenM (shouldParticipate $ siEpoch slotId) $ do
@@ -402,7 +403,7 @@ checkForIgnoredCommitmentsWorker
     => (WorkerSpec m, OutSpecs)
 checkForIgnoredCommitmentsWorker = localWorker $ do
     counter <- newTVarIO 0
-    onNewSlot True (checkForIgnoredCommitmentsWorkerImpl counter)
+    onNewSlot defaultOnNewSlotParams (checkForIgnoredCommitmentsWorkerImpl counter)
 
 -- This worker checks whether our commitments appear in blocks. This check
 -- is done only if we actually should participate in SSC. It's triggered if

--- a/update/Pos/Update/Worker.hs
+++ b/update/Pos/Update/Worker.hs
@@ -17,6 +17,8 @@ import           Pos.Core (SoftwareVersion (..))
 import           Pos.Core.Update (UpdateProposal (..))
 import           Pos.Recovery.Info (recoveryCommGuard)
 import           Pos.Shutdown (triggerShutdown)
+import           Pos.Slotting.Util (ActionTerminationPolicy (..), OnNewSlotParams (..),
+                                    defaultOnNewSlotParams)
 import           Pos.Update.Configuration (curSoftwareVersion)
 import           Pos.Update.Context (UpdateContext (..))
 import           Pos.Update.DB (getConfirmedProposals)
@@ -32,18 +34,17 @@ usWorkers = (map fst [processNewSlotWorker, checkForUpdateWorker], mempty)
   where
     -- These are two separate workers. We want them to run in parallel
     -- and not affect each other.
-    --
-    -- TODO [CSL-1606] If for some reason this action doesn't finish
-    -- before the next slot starts, we should probably cancel this
-    -- action. It can be achieved using timeout or by explicitly
-    -- cancelling it when never slot begins.
+    processNewSlotParams = defaultOnNewSlotParams
+        { onspTerminationPolicy =
+              NewSlotTerminationPolicy "Update.processNewSlot"
+        }
     processNewSlotWorker =
-        localOnNewSlotWorker True $ \s ->
+        localOnNewSlotWorker processNewSlotParams $ \s ->
             recoveryCommGuard "processNewSlot in US" $ do
                 logDebug "Updating slot for US..."
                 processNewSlot s
     checkForUpdateWorker =
-        localOnNewSlotWorker True $ \_ ->
+        localOnNewSlotWorker defaultOnNewSlotParams $ \_ ->
             recoveryCommGuard "checkForUpdate" (checkForUpdate @ctx @m)
 
 checkForUpdate ::

--- a/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
+++ b/wallet/src/Pos/Wallet/Web/Pending/Worker.hs
@@ -28,7 +28,8 @@ import           Pos.DB.Class (MonadDBRead)
 import           Pos.Recovery.Info (MonadRecoveryInfo)
 import           Pos.Reporting (MonadReporting)
 import           Pos.Shutdown (HasShutdownContext)
-import           Pos.Slotting (MonadSlots, getNextEpochSlotDuration, onNewSlot)
+import           Pos.Slotting (MonadSlots, OnNewSlotParams (..), defaultOnNewSlotParams,
+                               getNextEpochSlotDuration, onNewSlot)
 import           Pos.Util.Chrono (getOldestFirst)
 import           Pos.Util.LogSafe (logDebugS, logInfoS)
 import           Pos.Wallet.Web.Networking (MonadWalletSendActions)
@@ -156,6 +157,8 @@ processPtxsOnSlot curSlot = do
 startPendingTxsResubmitter
     :: MonadPendings ctx m
     => m ()
-startPendingTxsResubmitter = setLogger $ onNewSlot False processPtxsOnSlot
+startPendingTxsResubmitter = setLogger $ onNewSlot onsp processPtxsOnSlot
   where
     setLogger = modifyLoggerName (<> "tx" <> "resubmitter")
+    onsp :: OnNewSlotParams
+    onsp = defaultOnNewSlotParams { onspStartImmediately = False }


### PR DESCRIPTION
`onNewSlot` worker now takes `ActionTerminationPolicy` as an argument.
    Parameters are wrapped in `OnNewSlotParams` type.
    `ActionTerminationPolicy` allows to cancel running action when new slot starts.
    This feature is used in two workers: block creator and `Update.processNewSlot`.
    The detailed analysis was performed here:
    https://github.com/input-output-hk/cardano-sl/pull/1163#issuecomment-318136810
    In particular it allowed us to avoid `fork` in block creator.
    Ideally we also want to separate actual block creation and network stuff which
    happens afterwards, but I think it's minor, so it hasn't been done.
