### PR TITLE
[CSL-1918] Update launcher documentation

### DIFF
--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -18,8 +18,8 @@ and the client scenario. The server scenario is used when the launcher is used
 for the node alone (without wallet), and the client scenario is used when the
 launcher coordinates the node together with the wallet.
 
-The choice of scenario is determined by whether the optional CLI parameter
-`--wallet` was specified.
+The choice of scenario is determined by whether `walletPath` was specified
+in the config or not.
 
 ### Server scenario
 
@@ -53,7 +53,7 @@ In the client scenario, the launcher operates as follows:
     4. Goto to step 1 of client scenario
 6. If the wallet exited first, check its exit code:
     1. If it indicated that it needs an update (code 20)
-        * Wait for the node to die (timeout specified in CLI)
+        * Wait for the node to die (timeout specified in `nodeTimeoutSec` in config file)
         * Kill the node in case of timeout, and then goto the step 1 of client scenario
     2. If the wallet exited with a different code, assume it has crashed and kill the node (without timeout)
 
@@ -63,52 +63,20 @@ Here we describe flow of updater execution.
 
 1. Check that updater script exists
     * If it doesn't exist, update script execution finishes
-    * Note, that updater script is passed via CLI parameter `--updater`
+    * Note, that updater script is passed via config parameter `updaterPath`
 2. Launch updater:
-    * Pass the downloaded update archive (provided via CLI parameter `--update-archive`) to updater script as last
-argument
+    * Pass the downloaded update archive (provided via config parameter `updateArchive`) to updater script as last argument
 3. Wait for updater to finish, check the exit code:
     * Update script failed (non-zero exit code):
         * The update archive is not touched
         * Update script execution finishes
     * Update script succeeded (zero exit code):
         1. Mark the update as installed in the database
-           * Later, if the node tries to download another update, it will check this database entry and skip already installed update.
-        2. Delete the update archive, as this indicates to the launcher, node that there's no update pending or in progress.
+           * Later, if the node tries to download another update, it will check
+           this database entry and skip already installed update.
+        2. Delete the update archive, as this indicates to the launcher and the
+        node that there's no update pending or in progress.
 
-## CLI Parameters
+## Config parameters
 
-* `--node`: the path to the node executable
-
-* `--wallet`: the path to the wallet executable (determines the scenario)
-
-* `--db-path`: the path to node database (used for tracking of installed updates)
-
-* `--node-log-config`: the path to the node logging config (attached to crash
-reports)
-
-* `--node-log-path`: the path to a log file for the node; passed to the node as
-is, but also has defaulting logic (a temporary file is created when no path is
-specified)
-
-* `--updater`: the path to the updater script (used when an update is available)
-
-* `--update-archive`: the path at which an update archive will be saved by the
-node when a new update is broadcasted is registered in the blockchain
-
-* `--node-timeout`: the time (in seconds) to wait for a graceful shutdown of the
-  node in case the wallet exited with code 20
-
-* `--report-server`: a URL of the server where crash reports will be sent
-
-* `--launcher-logs-prefix`: a directory for launcher logs (optional)
-
-Besides these launcher-specific parameters, the launcher also expects:
-
-* parameters prefixed with `-n` -- those are passed to the node verbatim
-* parameters prefixed with `-w` -- those are passed to the wallet verbatim
-* paremeters prefixed with `-u` -- those are passed to the update script
-  verbatim
-* `--configuration-file`, `--configuration-key`, `--system-start`, and
-  `--configuration-seed`: these are used to initialize the global constant
-  configuration
+See [`tools/src/launcher/launcher-config.yaml`](https://github.com/input-output-hk/cardano-sl/blob/develop/tools/src/launcher/launcher-config.yaml).

--- a/docs/network/example-topologies/mainnet-staging.yaml
+++ b/docs/network/example-topologies/mainnet-staging.yaml
@@ -1,0 +1,6 @@
+# Topology for connecting to the mainnet-staging cluster.
+
+wallet:
+    relays: [[{ host: relays.awstest.iohkdev.io }]]
+    valency: 1
+    fallbacks: 7

--- a/scripts/launch/connect-to-cluster/mainnet-staging.sh
+++ b/scripts/launch/connect-to-cluster/mainnet-staging.sh
@@ -14,11 +14,7 @@ fi
 
 echo "Launch a single node and connect it to '${CLUSTER}' cluster..."
 
-readonly TMP_TOPOLOGY_YAML=/tmp/topology.yaml
-printf "wallet:
-    relays: [[{ host: relays.awstest.iohkdev.io }]]
-    valency: 1
-    fallbacks: 7" > "${TMP_TOPOLOGY_YAML}"
+readonly TOPOLOGY_YAML=docs/network/example-topologies/mainnet-staging.yaml
 
 stack exec -- cardano-node                                  \
     --tlscert ./scripts/tls-files/server.crt                \
@@ -26,7 +22,7 @@ stack exec -- cardano-node                                  \
     --tlsca ./scripts/tls-files/ca.crt                      \
     --web                                                   \
     --no-ntp                                                \
-    --topology "${TMP_TOPOLOGY_YAML}"                       \
+    --topology "${TOPOLOGY_YAML}"                       \
     --log-config scripts/log-templates/log-config-qa.yaml   \
     --logs-prefix "logs/${CLUSTER}"                         \
     --db-path db-${CLUSTER}                                 \

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -409,7 +409,7 @@ serverScenario ndbp logConf node updater report = do
 clientScenario
     :: NodeDbPath
     -> Maybe FilePath    -- ^ Logger config
-    -> NodeData          -- ^ Node, args, wallet log path
+    -> NodeData          -- ^ Node, args, node log path
     -> NodeData          -- ^ Wallet, args, wallet log path
     -> UpdaterData       -- ^ Updater, args, updater runner, archive path
     -> Int               -- ^ Node timeout, in seconds

--- a/tools/src/launcher/launcher-config.yaml
+++ b/tools/src/launcher/launcher-config.yaml
@@ -1,7 +1,10 @@
-# Path to the node executable
-nodePath: .stack-work/install/x86_64-linux-nopie/lts-9.1/8.0.2/bin/cardano-node
+# Path to the node executable.
+nodePath: binaries/cardano-node
 
-# Arguments to be passed to the node
+# For development with Stack you can use something like:
+# nodePath: .stack-work/install/x86_64-linux-nopie/lts-9.1/8.0.2/bin/cardano-node
+
+# Arguments to be passed to the node.
 nodeArgs:
   - "--tlscert"
   - "./scripts/tls-files/server.crt"
@@ -12,7 +15,7 @@ nodeArgs:
   - "--web"
   - "--no-ntp"
   - "--topology"
-  - "/tmp/topology.yaml"
+  - "docs/network/example-topologies/mainnet-staging.yaml"
   - "--logs-prefix"
   - "logs/test"
   - "--wallet-db-path"
@@ -24,28 +27,33 @@ nodeArgs:
   - "--configuration-key"
   - "mainnet_dryrun_full"
 
-# Path to directory with all DBs used by the node
+# Path to directory with all DBs used by the node. The launcher
+# needs it to record information about installed updates.
 nodeDbPath: db-mainnet-staging
 
-# Path to log config that will be used by the node
+# Path to log config that will be used by the node. The launcher
+# attaches it to crash reports.
 nodeLogConfig: scripts/log-templates/log-config-qa.yaml
 
-# File where node stdout/err will be redirected (def: temp file)
+# File where node stdout/err will be redirected (def: no redirection).
 # nodeLogPath: node.log
 
-# Path to the wallet frontend executable (e. g. Daedalus)
+# Path to the wallet frontend executable (e. g. Daedalus).
+# If it is provided, the launcher runs in client scenario;
+# otherwise, in server scenario.
 # walletPath: binaries/daedalus
 
 # Arguments to be passed to the wallet frontend executable.
 # walletArgs: []
 
-# Bool that determines if wallet should log to stdout
+# Bool that determines if wallet should log to stdout.
 # walletLogging: true
 
-# File where wallet stdout/err will be redirected
+# File where wallet stdout/err will be redirected.
 # walletLogPath: /tmp/wallet-log
 
-# Path to the updater executable.
+# Path to the updater executable. Should be specified only when
+# there is an update available.
 updaterPath: binaries/cardano-updater
 
 # Arguments to be passed to the updater.
@@ -59,7 +67,8 @@ updateArchive: updateDownloaded.tar
 # Path to write the Windows batch file executing updater.
 # updateWindowsRunner:
 
-# How much to wait for the node to exit before killing it
+# The time (in seconds) to wait for graceful shutdown of the
+# node in case the wallet exits with code 20.
 nodeTimeoutSec: 5
 
 # Where to send logs in case of failure.
@@ -68,6 +77,7 @@ nodeTimeoutSec: 5
 # Where to put launcher logs (def: console only).
 # launcherLogsPrefix:
 
+# Global constant configuration.
 configuration:
   filePath: lib/configuration.yaml
   key: default


### PR DESCRIPTION
There is one thing I am not sure about. Both the old documentation for CLI parameters and the newer `docs/launcher.md` state that not specifying `nodeLogPath` cause launcher to create a temporary file where node output is redirected. After reviewing the code I couldn't find anything resembling that. Instead, apparently the output simply gets passed through to `stdout`/`stderr`. See [here](https://github.com/input-output-hk/cardano-sl/blob/2d23da907fa49436dcdd5911ae712f8aee99bc86/tools/src/launcher/Main.hs#L555) for more details.