### PR TITLE
[CSL-2150] Speed up 'getWallet'

### DIFF
--- a/core/Pos/Util/Modifier.hs
+++ b/core/Pos/Util/Modifier.hs
@@ -7,6 +7,7 @@ module Pos.Util.Modifier
        , lookupM
        , lookup
        , filter
+       , filterWithKey
        , keysM
        , keys
        , valuesM
@@ -88,6 +89,9 @@ lookup getter k = runIdentity . lookupM (Identity . getter) k
 
 filter :: (Eq k, Hashable k) => (Maybe v -> Bool) -> MapModifier k v -> MapModifier k v
 filter fil = MapModifier . HM.filter fil . getMapModifier
+
+filterWithKey :: (Eq k, Hashable k) => (k -> Maybe v -> Bool) -> MapModifier k v -> MapModifier k v
+filterWithKey fil = MapModifier . HM.filterWithKey fil . getMapModifier
 
 -- | Get keys of something map-like in Functor context taking
 -- 'MapModifier' into account.

--- a/node/src/Pos/Wallet/Web/State/State.hs
+++ b/node/src/Pos/Wallet/Web/State/State.hs
@@ -7,6 +7,7 @@ module Pos.Wallet.Web.State.State
        , WalletTip (..)
        , PtxMetaUpdate (..)
        , AddressInfo (..)
+       , S.WalBalancesAndUtxo
        , askWalletDB
        , openState
        , openMemState


### PR DESCRIPTION
This PR slightly changes the way which we compute balances, instead of getting wallet's accounts and then summing, the following approach was implemented:
1. take wallet's accounts
2. union their addresses
3. sum coins on these addresses using balance map, which is already presented in `WalletStorage`