### PR TITLE
[DEVOPS-640] ci: show more logs in windows appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ test_script:
 #   - stack hpc report cardano-sl cardano-sl-txp cardano-sl-core cardano-sl-db cardano-sl-update cardano-sl-infra cardano-sl-lrc cardano-sl-ssc
 # Retry transient failures due to https://github.com/haskell/cabal/issues/4005
   # We intentionally don't build auxx here, because this build is for installer.
-  - scripts\ci\appveyor-retry call stack install cardano-sl cardano-sl-tools cardano-sl-wallet cardano-sl-wallet-new
+  - scripts\ci\appveyor-retry call stack --dump-logs install cardano-sl cardano-sl-tools cardano-sl-wallet cardano-sl-wallet-new
       -j 2
       --no-terminal
       --local-bin-path %WORK_DIR%


### PR DESCRIPTION
This will print the contents of log files after the build finishes. Helps with diagnosing build failures.
