### PR TITLE
[CSL-2165] Add `since=<timestamp>` parameter to tx history endpoint

### DIFF
--- a/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Instances.hs
@@ -49,8 +49,8 @@ import           Pos.Wallet.Web.ClientTypes.Types     (AccountId (..), ApiVersio
                                                        CWallet, CWalletAssurance,
                                                        CWalletInit (..), CWalletMeta (..),
                                                        CWalletRedeem (..),
-                                                       ClientInfo (..), ScrollLimit (..),
-                                                       ScrollOffset (..),
+                                                       ClientInfo (..), SinceTime (..),
+                                                       ScrollLimit (..), ScrollOffset (..),
                                                        SyncProgress (..))
 import           Pos.Wallet.Web.Pending.Types         (PtxCondition)
 
@@ -238,6 +238,9 @@ instance Buildable CInitialized where
 instance Buildable (SecureLog CInitialized) where
     build = buildUnsecure
 
+instance Buildable (SecureLog SinceTime) where
+    build = buildUnsecure
+
 instance Buildable (SecureLog ScrollOffset) where
     build = buildUnsecure
 
@@ -343,6 +346,9 @@ instance FromHttpApiData CTxId where
 
 instance FromHttpApiData CPassPhrase where
     parseUrlPiece = pure . CPassPhrase
+
+instance FromHttpApiData SinceTime where
+    parseUrlPiece = fmap SinceTime . parseUrlPiece
 
 instance FromHttpApiData ScrollOffset where
     parseUrlPiece = fmap ScrollOffset . parseUrlPiece

--- a/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -37,6 +37,7 @@ module Pos.Wallet.Web.ClientTypes.Types
       , CElectronCrashReport (..)
       , Wal (..)
       , Addr (..)
+      , SinceTime (..)
       , ScrollOffset (..)
       , ScrollLimit (..)
       , CFilePath (..)
@@ -366,6 +367,10 @@ data CElectronCrashReport = CElectronCrashReport
 ----------------------------------------------------------------------------
 -- Misc
 ----------------------------------------------------------------------------
+
+newtype SinceTime = SinceTime Word
+    deriving (Eq, Ord, Show, Enum, Num, Real, Integral, Generic, Typeable,
+              Buildable)
 
 newtype ScrollOffset = ScrollOffset Word
     deriving (Eq, Ord, Show, Enum, Num, Real, Integral, Generic, Typeable,

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -97,7 +97,7 @@ import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccoun
                                              CId, CInitialized, CPaperVendWalletRedeem,
                                              CPassPhrase, CProfile, CTx, CTxId, CTxMeta,
                                              CUpdateInfo, CWallet, CWalletInit,
-                                             CWalletMeta, CWalletRedeem, ScrollLimit,
+                                             CWalletMeta, CWalletRedeem, ScrollLimit, SinceTime,
                                              ScrollOffset, NewBatchPayment,
                                              SyncProgress, Wal)
 import           Pos.Wallet.Web.Error       (WalletError (DecodeError),
@@ -331,6 +331,7 @@ type GetHistory =
     :> QueryParam "walletId" (CId Wal)
     :> CQueryParam "accountId" CAccountId
     :> QueryParam "address" (CId Addr)
+    :> QueryParam "since" SinceTime
     :> QueryParam "skip" ScrollOffset
     :> QueryParam "limit" ScrollLimit
     :> WRes Get ([CTx], Word)

--- a/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Payment.hs
@@ -263,7 +263,7 @@ sendMoney SendActions{..} passphrase moneySource dstDistr policy = do
     let srcWalletAddrsDetector = getWalletAddrsDetector ws' Ever srcWallet
 
     logDebug "sendMoney: constructing response"
-    fst <$> constructCTx ws' srcWallet srcWalletAddrsDetector diff th
+    constructCTx ws' srcWallet srcWalletAddrsDetector diff th
   where
      -- TODO eliminate copy-paste
      listF separator formatter =

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -123,4 +123,4 @@ redeemAdaInternal SendActions {..} passphrase cAccId seedBs = do
     ws' <- askWalletSnapshot
     let cWalAddrsDetector = getWalletAddrsDetector ws' Ever cWalId
     diff <- getCurChainDifficulty
-    fst <$> constructCTx ws' cWalId cWalAddrsDetector diff th
+    constructCTx ws' cWalId cWalAddrsDetector diff th

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -23,8 +23,8 @@ import           Pos.Block.Slog                   (HasSlogContext (..),
 import           Pos.Block.Types                  (Undo)
 import           Pos.Configuration                (HasNodeConfiguration)
 import           Pos.Context                      (HasNodeContext (..))
-import           Pos.Core                         (HasConfiguration,
-                                                   HasPrimaryKey (..), IsHeader)
+import           Pos.Core                         (HasConfiguration, HasPrimaryKey (..),
+                                                   IsHeader)
 import           Pos.DB                           (MonadGState (..))
 import           Pos.DB.Block                     (dbGetBlockDefault,
                                                    dbGetBlockSscDefault,
@@ -46,8 +46,8 @@ import           Pos.Client.Txp.History           (MonadTxHistory (..),
 import           Pos.Infra.Configuration          (HasInfraConfiguration)
 import           Pos.KnownPeers                   (MonadFormatPeers (..),
                                                    MonadKnownPeers (..))
-import           Pos.Reporting                    (HasReportingContext (..))
 import           Pos.Network.Types                (HasNodeType (..))
+import           Pos.Reporting                    (HasReportingContext (..))
 import           Pos.Shutdown                     (HasShutdownContext (..))
 import           Pos.Slotting.Class               (MonadSlots (..))
 import           Pos.Slotting.Impl.Sum            (currentTimeSlottingSum,
@@ -57,30 +57,30 @@ import           Pos.Slotting.Impl.Sum            (currentTimeSlottingSum,
 import           Pos.Slotting.MemState            (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Ssc.Class.Types              (HasSscContext (..), SscBlock)
 import           Pos.Ssc.GodTossing.Configuration (HasGtConfiguration)
-import           Pos.Update.Configuration       (HasUpdateConfiguration)
-import           Pos.Util                       (Some (..))
-import           Pos.Util.JsonLog               (HasJsonLogConfig (..), jsonLogDefault)
-import           Pos.Util.LoggerName            (HasLoggerName' (..),
-                                                 getLoggerNameDefault,
-                                                 modifyLoggerNameDefault)
-import qualified Pos.Util.OutboundQueue         as OQ.Reader
-import           Pos.Util.TimeWarp              (CanJsonLog (..))
-import           Pos.Util.UserSecret            (HasUserSecret (..))
-import           Pos.Util.Util                  (postfixLFields)
-import           Pos.Wallet.Redirect            (MonadBlockchainInfo (..),
-                                                 MonadUpdates (..),
-                                                 applyLastUpdateWebWallet,
-                                                 blockchainSlotDurationWebWallet,
-                                                 connectedPeersWebWallet,
-                                                 localChainDifficultyWebWallet,
-                                                 networkChainDifficultyWebWallet,
-                                                 waitForUpdateWebWallet)
-import           Pos.Wallet.SscType             (WalletSscType)
-import           Pos.Wallet.Web.Sockets.ConnSet (ConnectionsVar)
-import           Pos.Wallet.Web.State.State     (WalletDB)
-import           Pos.Wallet.Web.Tracking        (MonadBListener (..), onApplyTracking,
-                                                 onRollbackTracking)
-import           Pos.WorkMode                   (RealModeContext (..))
+import           Pos.Update.Configuration         (HasUpdateConfiguration)
+import           Pos.Util                         (Some (..))
+import           Pos.Util.JsonLog                 (HasJsonLogConfig (..), jsonLogDefault)
+import           Pos.Util.LoggerName              (HasLoggerName' (..),
+                                                   getLoggerNameDefault,
+                                                   modifyLoggerNameDefault)
+import qualified Pos.Util.OutboundQueue           as OQ.Reader
+import           Pos.Util.TimeWarp                (CanJsonLog (..))
+import           Pos.Util.UserSecret              (HasUserSecret (..))
+import           Pos.Util.Util                    (postfixLFields)
+import           Pos.Wallet.Redirect              (MonadBlockchainInfo (..),
+                                                   MonadUpdates (..),
+                                                   applyLastUpdateWebWallet,
+                                                   blockchainSlotDurationWebWallet,
+                                                   connectedPeersWebWallet,
+                                                   localChainDifficultyWebWallet,
+                                                   networkChainDifficultyWebWallet,
+                                                   waitForUpdateWebWallet)
+import           Pos.Wallet.SscType               (WalletSscType)
+import           Pos.Wallet.Web.Sockets.ConnSet   (ConnectionsVar)
+import           Pos.Wallet.Web.State.State       (WalletDB)
+import           Pos.Wallet.Web.Tracking          (MonadBListener (..), onApplyTracking,
+                                                   onRollbackTracking)
+import           Pos.WorkMode                     (RealModeContext (..))
 
 
 

--- a/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
+++ b/wallet/src/Pos/Wallet/Web/Swagger/Instances/Schema.hs
@@ -83,6 +83,7 @@ instance ToSchema      InputSelectionPolicy
 instance ToSchema      BlockVersion
 instance ToSchema      BackupPhrase
 instance ToParamSchema CT.CPassPhrase
+instance ToParamSchema CT.SinceTime
 instance ToParamSchema CT.ScrollOffset
 instance ToParamSchema CT.ScrollLimit
 instance ToSchema      CT.CFilePath


### PR DESCRIPTION
Add 'since' parameter to /api/txs/histories enpoint, which accepts time in seconds
