### PR TITLE
Show epochs as “#1”, not “epoch #1”

### DIFF
--- a/block/src/Pos/Block/Logic/VAR.hs
+++ b/block/src/Pos/Block/Logic/VAR.hs
@@ -161,7 +161,7 @@ verifyAndApplyBlocks rollback blocks = runExceptT $ do
         let prefixHead = prefix ^. _Wrapped . _neHead
         when (isLeft prefixHead) $ do
             let epochIndex = prefixHead ^. epochIndexL
-            logDebug $ "Rolling: Calculating LRC if needed for "
+            logDebug $ "Rolling: Calculating LRC if needed for epoch "
                        <> pretty epochIndex
             lift $ lrcSingleShot epochIndex
         logDebug "Rolling: verifying"

--- a/block/src/Pos/Lrc/Worker.hs
+++ b/block/src/Pos/Lrc/Worker.hs
@@ -225,7 +225,7 @@ leadersComputationDo epochId seed =
   where
     logLeaders :: SlotLeaders -> m ()
     logLeaders leaders = logInfo $
-        sformat ("Slot leaders for "%build%" are: "%slotLeadersF)
+        sformat ("Slot leaders for epoch "%build%" are: "%slotLeadersF)
         epochId (toList leaders)
 
 richmenComputationDo

--- a/core/Pos/Core/Slotting/Types.hs
+++ b/core/Pos/Core/Slotting/Types.hs
@@ -33,7 +33,7 @@ newtype EpochIndex = EpochIndex
     } deriving (Show, Eq, Ord, Num, Enum, Ix, Integral, Real, Generic, Hashable, Bounded, Typeable, NFData)
 
 instance Buildable EpochIndex where
-    build = bprint ("epoch #"%int)
+    build = bprint ("#"%int)
 
 -- | Index of slot inside a concrete epoch.
 newtype LocalSlotIndex = UnsafeLocalSlotIndex


### PR DESCRIPTION
In lots of cases we have code that goes like this:

```
    build (NoRichmen epoch) =
        bprint ("no richmen for epoch"%build) epoch

    ("slogVerifyBlocks: there are no leaders for epoch " %build)

    logInfo ("Downloading blockchain dump for epoch "+|epoch|+"")

    ("Calculated seed for epoch "%build%" successfully")

    bprint ("stake distribution for epoch "%build%" is unknown") epoch
```

In all those cases the resulting message says “epoch epoch #N”. Mda.