### PR TITLE
[CSL-2231] Upgrade to conduit-1.3 and resourcet-1.2

### DIFF
--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -58,6 +58,7 @@ library
                      , cardano-sl-txp
                      , cardano-sl-update
                      , cardano-sl-util
+                     , conduit
                      , constraints
                      , containers
                      , data-default
@@ -76,6 +77,7 @@ library
                      , quickcheck-instances
                      , random
                      , reflection
+                     , resourcet
                      , safe-exceptions
                      , scientific
                      , serokell-util >= 0.1.3.4

--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -23,8 +23,9 @@ module Mode
 import           Universum
 
 import           Control.Lens (lens, makeLensesWith)
-import           Control.Monad.Morph (hoist)
 import           Control.Monad.Reader (withReaderT)
+import           Control.Monad.Trans.Resource (transResourceT)
+import           Data.Conduit (transPipe)
 import           Data.Default (def)
 import           Mockable (Production)
 import           System.Wlog (HasLoggerName (..))
@@ -182,7 +183,8 @@ instance {-# OVERLAPPING #-} CanJsonLog AuxxMode where
 
 instance HasConfiguration => MonadDBRead AuxxMode where
     dbGet = realModeToAuxx ... dbGet
-    dbIterSource tag p = hoist (hoist realModeToAuxx) (dbIterSource tag p)
+    dbIterSource tag p =
+        transPipe (transResourceT realModeToAuxx) (dbIterSource tag p)
     dbGetSerBlock = realModeToAuxx ... dbGetSerBlock
     dbGetSerUndo = realModeToAuxx ... dbGetSerUndo
 

--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -118,6 +118,7 @@ library
                       , time-units
                       , transformers
                       , universum
+                      , unliftio
                       , unordered-containers
 
 

--- a/block/src/Pos/Block/Logic/Creation.hs
+++ b/block/src/Pos/Block/Logic/Creation.hs
@@ -250,7 +250,7 @@ createMainBlockInternal sId pske = do
         -- 100 bytes is substracted to account for different unexpected
         -- overhead.  You can see that in bitcoin blocks are 1-2kB less
         -- than limit. So i guess it's fine in general.
-        sizeLimit <- (\x -> bool 0 (x - 100) (x > 100)) <$> UDB.getMaxBlockSize
+        sizeLimit <- (\x -> bool 0 (x - 100) (x > 100)) <$> lift UDB.getMaxBlockSize
         block <- createMainBlockPure sizeLimit prevHeader pske sId sk rawPay
         logInfoS $
             "Created main block of size: " <> sformat memory (biSize block)
@@ -263,7 +263,7 @@ canCreateBlock ::
     -> m (Either Text ())
 canCreateBlock sId tipHeader =
     runExceptT $ do
-        unlessM usCanCreateBlock $
+        unlessM (lift usCanCreateBlock) $
             throwError "this software is obsolete and can't create block"
         unless (EpochOrSlot (Right sId) > tipEOS) $
             throwError "slot id is not greater than one from the tip block"

--- a/block/src/Pos/Block/Slog/Logic.hs
+++ b/block/src/Pos/Block/Slog/Logic.hs
@@ -30,6 +30,7 @@ import           Formatting (build, sformat, (%))
 import           Serokell.Util (Color (Red), colorize)
 import           Serokell.Util.Verify (formatAllErrors, verResToMonadError)
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Core ()
 import           Pos.Block.BListener (MonadBListener (..))
@@ -102,6 +103,7 @@ mustDataBeKnown adoptedBV =
 type MonadSlogBase ctx m =
     ( MonadSlots ctx m
     , MonadIO m
+    , MonadUnliftIO m
     , MonadDBRead m
     , WithLogger m
     , HasConfiguration
@@ -117,19 +119,16 @@ type MonadSlogVerify ctx m =
 
 -- | Verify everything from block that is not checked by other components.
 -- All blocks must be from the same epoch.
-slogVerifyBlocks
-    :: forall ctx m.
-    ( MonadSlogVerify ctx m
-    , MonadError Text m
-    )
+slogVerifyBlocks ::
+       forall ctx m. (MonadSlogVerify ctx m)
     => OldestFirst NE Block
-    -> m (OldestFirst NE SlogUndo)
-slogVerifyBlocks blocks = do
+    -> m (Either Text (OldestFirst NE SlogUndo))
+slogVerifyBlocks blocks = runExceptT $ do
     curSlot <- getCurrentSlot
-    (adoptedBV, adoptedBVD) <- GS.getAdoptedBVFull
+    (adoptedBV, adoptedBVD) <- lift GS.getAdoptedBVFull
     let dataMustBeKnown = mustDataBeKnown adoptedBV
     let headEpoch = blocks ^. _Wrapped . _neHead . epochIndexL
-    leaders <-
+    leaders <- lift $
         lrcActionOnEpochReason
             headEpoch
             (sformat
@@ -149,7 +148,7 @@ slogVerifyBlocks blocks = do
     -- Here we need to compute 'SlogUndo'. When we add apply a block,
     -- we can remove one of the last slots stored in
     -- 'BlockExtra'. This removed slot must be put into 'SlogUndo'.
-    lastSlots <- GS.getLastSlots
+    lastSlots <- lift GS.getLastSlots
     let toFlatSlot = fmap (flattenSlotId . view mainBlockSlot) . rightToMaybe
     -- these slots will be added if we apply all blocks
     let newSlots = mapMaybe toFlatSlot (toList blocks)

--- a/block/src/Pos/GState/SanityCheck.hs
+++ b/block/src/Pos/GState/SanityCheck.hs
@@ -7,6 +7,7 @@ module Pos.GState.SanityCheck
 import           Universum
 
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.DB.Class (MonadDBRead)
 import           Pos.DB.GState.Stakes (getRealTotalStake)
@@ -17,6 +18,7 @@ sanityCheckDB ::
        ( MonadMask m
        , WithLogger m
        , MonadDBRead m
+       , MonadUnliftIO m
        , MonadReader ctx m
        )
     => m ()
@@ -26,6 +28,7 @@ sanityCheckDB = inAssertMode sanityCheckGStateDB
 sanityCheckGStateDB ::
        forall ctx m.
        ( MonadDBRead m
+       , MonadUnliftIO m
        , MonadMask m
        , WithLogger m
        , MonadReader ctx m

--- a/client/src/Pos/Client/Txp/History.hs
+++ b/client/src/Pos/Client/Txp/History.hs
@@ -34,7 +34,6 @@ import           Universum
 
 import           Control.Lens (makeLenses)
 import           Control.Monad.Trans (MonadTrans)
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as M (fromList, insert, lookup)
@@ -221,7 +220,6 @@ type TxHistoryEnv ctx m =
     , HasLens' ctx StateLock
     , HasLens' ctx StateLockMetrics
     , HasReportingContext ctx
-    , MonadBaseControl IO m
     , Mockable CurrentTime m
     , MonadFormatPeers m
     , HasNodeType ctx

--- a/db/Pos/DB/Class.hs
+++ b/db/Pos/DB/Class.hs
@@ -50,11 +50,10 @@ module Pos.DB.Class
 
 import           Universum
 
-import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans (MonadTrans (..))
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import           Control.Monad.Trans.Resource (ResourceT)
-import           Data.Conduit (Source)
+import           Control.Monad.Trans.Resource (ResourceT, transResourceT)
+import           Data.Conduit (Source, transPipe)
 import qualified Database.RocksDB as Rocks
 import           Serokell.Data.Memory.Units (Byte)
 
@@ -122,10 +121,9 @@ instance {-# OVERLAPPABLE #-}
   where
     dbGet tag = lift . dbGet tag
     dbIterSource tag (p :: Proxy i) =
-        hoist (hoist lift) (dbIterSource tag p)
+        transPipe (transResourceT lift) (dbIterSource tag p)
     dbGetSerBlock = lift . dbGetSerBlock
     dbGetSerUndo = lift . dbGetSerUndo
-
 
 type MonadBlockDBRead m = (MonadDBRead m, BlockchainHelpers MainBlockchain)
 

--- a/db/Pos/DB/Pure.hs
+++ b/db/Pos/DB/Pure.hs
@@ -38,10 +38,9 @@ module Pos.DB.Pure
 import           Universum
 
 import           Control.Lens (at, makeLenses)
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Trans.Resource (MonadResource)
 import qualified Data.ByteString as BS
-import           Data.Conduit (Source)
+import           Data.Conduit (ConduitT)
 import qualified Data.Conduit.List as CL
 import           Data.Default (Default (..))
 import qualified Data.Map as M
@@ -95,7 +94,6 @@ type MonadPureDB ctx m =
     ( MonadReader ctx m
     , HasLens DBPureVar ctx DBPureVar
     , MonadMask m
-    , MonadBaseControl IO m
     , MonadIO m
     , HasConfiguration
     )
@@ -124,7 +122,7 @@ dbIterSourcePureDefault ::
        , Bi (IterValue i))
     => DBTag
     -> Proxy i
-    -> Source m (IterType i)
+    -> ConduitT () (IterType i) m ()
 dbIterSourcePureDefault (tagToLens -> l) (_ :: Proxy i) = do
     let filterPrefix = M.filterWithKey $ \k _ -> iterKeyPrefix @i `BS.isPrefixOf` k
     (dbPureVar :: DBPureVar) <- lift $ view (lensOf @DBPureVar)

--- a/db/Pos/DB/Rocks/Types.hs
+++ b/db/Pos/DB/Rocks/Types.hs
@@ -34,7 +34,6 @@ module Pos.DB.Rocks.Types
 import           Universum
 
 import           Control.Lens (makeLenses)
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Database.RocksDB as Rocks
 
 import           Pos.Core.Configuration (HasConfiguration)
@@ -52,7 +51,6 @@ type MonadRealDB ctx m =
     ( MonadReader ctx m
     , HasLens NodeDBs ctx NodeDBs
     , MonadIO m
-    , MonadBaseControl IO m
     , MonadCatch m
     , HasConfiguration
     )

--- a/db/Pos/DB/Sum.hs
+++ b/db/Pos/DB/Sum.hs
@@ -16,10 +16,9 @@ module Pos.DB.Sum
 
 import           Universum
 
-import           Control.Monad.Morph (hoist)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Trans.Resource (MonadResource)
-import           Data.Conduit (Source)
+import           Data.Conduit (Source, transPipe)
 
 import qualified Database.RocksDB as Rocks
 import           Pos.Binary.Class (Bi)
@@ -64,8 +63,8 @@ dbIterSourceSumDefault
        )
     => DBTag -> Proxy i -> Source m (IterType i)
 dbIterSourceSumDefault tag proxy = view (lensOf @DBSum) >>= \case
-    RealDB dbs -> hoist (flip runReaderT dbs) (DB.dbIterSourceDefault tag proxy)
-    PureDB pdb -> hoist (flip runReaderT pdb) (DB.dbIterSourcePureDefault tag proxy)
+    RealDB dbs -> transPipe (flip runReaderT dbs) (DB.dbIterSourceDefault tag proxy)
+    PureDB pdb -> transPipe (flip runReaderT pdb) (DB.dbIterSourcePureDefault tag proxy)
 
 dbPutSumDefault
     :: MonadDBSum ctx m

--- a/db/Pos/DB/Sum.hs
+++ b/db/Pos/DB/Sum.hs
@@ -16,9 +16,8 @@ module Pos.DB.Sum
 
 import           Universum
 
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Control.Monad.Trans.Resource (MonadResource)
-import           Data.Conduit (Source, transPipe)
+import           Data.Conduit (ConduitT, transPipe)
 
 import qualified Database.RocksDB as Rocks
 import           Pos.Binary.Class (Bi)
@@ -36,7 +35,6 @@ type MonadDBSum ctx m =
     ( MonadReader ctx m
     , HasLens DBSum ctx DBSum
     , MonadMask m
-    , MonadBaseControl IO m
     , MonadIO m
     , HasConfiguration
     )
@@ -61,7 +59,7 @@ dbIterSourceSumDefault
        , Bi (IterKey i)
        , Bi (IterValue i)
        )
-    => DBTag -> Proxy i -> Source m (IterType i)
+    => DBTag -> Proxy i -> ConduitT () (IterType i) m ()
 dbIterSourceSumDefault tag proxy = view (lensOf @DBSum) >>= \case
     RealDB dbs -> transPipe (flip runReaderT dbs) (DB.dbIterSourceDefault tag proxy)
     PureDB pdb -> transPipe (flip runReaderT pdb) (DB.dbIterSourcePureDefault tag proxy)

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -52,6 +52,7 @@ library
                      , text-format
                      , transformers
                      , universum
+                     , unliftio
 
   default-language:    Haskell2010
 

--- a/delegation/cardano-sl-delegation.cabal
+++ b/delegation/cardano-sl-delegation.cabal
@@ -69,6 +69,7 @@ library
                      , time
                      , transformers
                      , universum
+                     , unliftio
                      , unordered-containers
 
   default-extensions:  DeriveDataTypeable

--- a/delegation/src/Pos/Delegation/Cede/Logic.hs
+++ b/delegation/src/Pos/Delegation/Cede/Logic.hs
@@ -116,8 +116,8 @@ dlgReachesIssuance i d psk = reach i
 dlgVerifyHeader ::
        (MonadCedeRead m)
     => MainBlockHeader
-    -> ExceptT Text m ()
-dlgVerifyHeader h = do
+    -> m (Either Text ())
+dlgVerifyHeader h = runExceptT $ do
     -- Issuer didn't delegate the right to issue to elseone.
     let issuer = h ^. mainHeaderLeaderKey
     let sig = h ^. gbhConsensus . mcdSignature

--- a/delegation/src/Pos/Delegation/Listeners.hs
+++ b/delegation/src/Pos/Delegation/Listeners.hs
@@ -13,6 +13,7 @@ import           Universum
 import           Formatting (build, sformat, shown, (%))
 import           Mockable (CurrentTime, Delay, Mockable)
 import           System.Wlog (WithLogger, logDebug, logWarning)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Delegation ()
 import           Pos.Communication.Limits.Types (MessageLimited)
@@ -36,6 +37,7 @@ type DlgMessageConstraint m
 -- | This is a subset of 'WorkMode'.
 type DlgListenerConstraint ctx m
      = ( MonadIO m
+       , MonadUnliftIO m
        , MonadDelegation ctx m
        , MonadMask m
        , Mockable Delay m
@@ -46,7 +48,8 @@ type DlgListenerConstraint ctx m
        , HasLrcContext ctx
        , WithLogger m
        , DlgMessageConstraint m
-       , HasDlgConfiguration)
+       , HasDlgConfiguration
+       )
 
 handlePsk :: DlgListenerConstraint ctx m => ProxySKHeavy -> m Bool
 handlePsk pSk = do

--- a/delegation/src/Pos/Delegation/Logic/Common.hs
+++ b/delegation/src/Pos/Delegation/Logic/Common.hs
@@ -21,6 +21,7 @@ import           Control.Exception.Safe (Exception (..))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Buildable as B
 import           Formatting (bprint, build, sformat, stext, (%))
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Core (ProxySKHeavy, StakeholderId, addressHash)
 import           Pos.Crypto (ProxySecretKey (..), PublicKey)
@@ -81,7 +82,7 @@ runDelegationStateAction action = do
 -- and resolves the passed issuer to a public key. Doesn't check that
 -- user himself didn't delegate. Uses database only.
 getDlgTransPsk
-    :: MonadDBRead m
+    :: (MonadDBRead m, MonadUnliftIO m)
     => StakeholderId -> m (Maybe (PublicKey, ProxySKHeavy))
 getDlgTransPsk issuer = getDlgTransitive issuer >>= \case
     Nothing -> pure Nothing

--- a/delegation/src/Pos/Delegation/Logic/Mempool.hs
+++ b/delegation/src/Pos/Delegation/Logic/Mempool.hs
@@ -23,6 +23,7 @@ import           Control.Lens (at, uses, (%=), (+=), (-=), (.=))
 import qualified Data.Cache.LRU as LRU
 import qualified Data.HashMap.Strict as HM
 import           Mockable (CurrentTime, Mockable, currentTime)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Class (biSize)
 import           Pos.Core (HasConfiguration, ProxySKHeavy, addressHash, bvdMaxBlockSize,
@@ -116,6 +117,7 @@ data PskHeavyVerdict
 
 type ProcessHeavyConstraint ctx m =
        ( MonadIO m
+       , MonadUnliftIO m
        , MonadMask m
        , MonadDBRead m
        , MonadGState m

--- a/delegation/src/Pos/Delegation/Logic/VAR.hs
+++ b/delegation/src/Pos/Delegation/Logic/VAR.hs
@@ -24,6 +24,7 @@ import           Formatting (bprint, build, sformat, (%))
 import           Mockable (CurrentTime, Mockable)
 import           Serokell.Util (listJson, mapJson)
 import           System.Wlog (WithLogger, logDebug)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Core (ComponentBlock (..), EpochIndex (..), HasConfiguration, StakeholderId,
                            addressHash, epochIndexL, gbHeader, headerHash, prevBlockL, siEpoch)
@@ -72,7 +73,7 @@ type ReverseTrans = HashMap StakeholderId (HashSet StakeholderId, HashSet Stakeh
 -- executed under shared Gstate DB lock.
 calculateTransCorrections
     :: forall m.
-       (MonadDBRead m, WithLogger m)
+       (MonadUnliftIO m, MonadDBRead m, WithLogger m)
     => HashSet DlgEdgeAction -> m SomeBatchOp
 calculateTransCorrections eActions = do
     -- Get the changeset and convert it to transitive ops.
@@ -243,7 +244,7 @@ calculateTransCorrections eActions = do
                 Just Nothing  -> pure v
 
             loop :: StakeholderId ->
-                    MapCede (StateT (HashMap StakeholderId (Maybe StakeholderId)) m) StakeholderId
+                    StateT (HashMap StakeholderId (Maybe StakeholderId)) (MapCede m) StakeholderId
             loop v = retCached v $ resolve v >>= \case
                 -- There's no delegate = we are the delegate/end of the chain.
                 Nothing -> (at v ?= Nothing) $> v
@@ -260,7 +261,7 @@ calculateTransCorrections eActions = do
                                       HS.toList eActions)
                     mempty
 
-        in void $ evalMapCede eActionsHM $ loop iSId
+        in void $ StateT $ \s -> evalMapCede eActionsHM $ runStateT (loop iSId) s
 
     -- Given changeset, returns map d → (ad,dl), where ad is set of
     -- new issuers that delegate to d, while dl is set of issuers that
@@ -315,6 +316,7 @@ dlgVerifyBlocks ::
        forall ctx m.
        ( MonadDBRead m
        , MonadIO m
+       , MonadUnliftIO m
        , MonadReader ctx m
        , HasLrcContext ctx
        , HasConfiguration
@@ -323,7 +325,7 @@ dlgVerifyBlocks ::
     => OldestFirst NE Block
     -> ExceptT Text m (OldestFirst NE DlgUndo)
 dlgVerifyBlocks blocks = do
-    richmen <- getDlgRichmen "dlgVerifyBlocks" headEpoch
+    richmen <- lift $ getDlgRichmen "dlgVerifyBlocks" headEpoch
     hoist (evalMapCede mempty) $ mapM (verifyBlock richmen) blocks
   where
     headEpoch = blocks ^. _Wrapped . _neHead . epochIndexL
@@ -348,7 +350,7 @@ dlgVerifyBlocks blocks = do
 
         ------------- [Header] -------------
 
-        dlgVerifyHeader $ blk ^. gbHeader
+        ExceptT $ dlgVerifyHeader $ blk ^. gbHeader
 
         ------------- [Payload] -------------
 
@@ -400,6 +402,7 @@ dlgApplyBlocks ::
        ( MonadDelegation ctx m
        , MonadIO m
        , MonadDBRead m
+       , MonadUnliftIO m
        , WithLogger m
        , MonadMask m
        , HasConfiguration
@@ -458,6 +461,7 @@ dlgRollbackBlocks
     :: forall ctx m.
        ( MonadDelegation ctx m
        , MonadDBRead m
+       , MonadUnliftIO m
        , WithLogger m
        )
     => NewestFirst NE DlgBlund
@@ -487,6 +491,7 @@ dlgNormalizeOnRollback ::
        forall ctx m.
        ( MonadDelegation ctx m
        , MonadDBRead m
+       , MonadUnliftIO m
        , DB.MonadGState m
        , MonadIO m
        , MonadMask m

--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -77,6 +77,7 @@ library
                       , time-units
                       , transformers
                       , universum
+                      , unliftio
                       , unordered-containers
                       , vector
 

--- a/explorer/src/Pos/Explorer/BListener.hs
+++ b/explorer/src/Pos/Explorer/BListener.hs
@@ -28,6 +28,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import qualified Ether
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Block.BListener (MonadBListener (..))
 import           Pos.Block.Types (Blund)
@@ -64,11 +65,13 @@ type MonadBListenerT m =
     ( WithLogger m
     , MonadCatch m
     , MonadDBRead m
+    , MonadUnliftIO m
     , HasConfiguration
     )
 
 -- Explorer implementation for usual node. Combines the operations.
 instance ( MonadDBRead m
+         , MonadUnliftIO m
          , MonadCatch m
          , WithLogger m
          , HasConfiguration

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -67,6 +67,7 @@ library
                      , time-units
                      , transformers-base
                      , universum
+                     , unliftio
                      , unordered-containers
                      , vector
 

--- a/generator/src/Pos/Generator/Block/Mode.hs
+++ b/generator/src/Pos/Generator/Block/Mode.hs
@@ -23,11 +23,11 @@ import           Universum
 import           Control.Lens.TH (makeLensesWith)
 import qualified Control.Monad.Catch as UnsafeExc
 import           Control.Monad.Random.Strict (RandT)
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Crypto.Random as Rand
 import           Data.Default (Default)
 import           Mockable (MonadMockable, Promise)
 import           System.Wlog (WithLogger, logWarning)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Block.BListener (MonadBListener (..))
 import           Pos.Block.Slog (HasSlogGState (..))
@@ -75,7 +75,7 @@ type MonadBlockGenBase m
      = ( WithLogger m
        , MonadMask m
        , MonadIO m
-       , MonadBaseControl IO m
+       , MonadUnliftIO m
        , MonadFormatPeers m
        , MonadMockable m
        , Eq (Promise m (Maybe ())) -- are you cereal boyz??1?

--- a/generator/src/Test/Pos/Block/Logic/Emulation.hs
+++ b/generator/src/Test/Pos/Block/Logic/Emulation.hs
@@ -26,12 +26,13 @@ import           Mockable (Async, Channel, ChannelT, Concurrently, CurrentTime (
                            ThreadId)
 import qualified Mockable.Metrics as Metrics
 import           System.Wlog (CanLog (..))
+import           UnliftIO (MonadUnliftIO)
 
 newtype ClockVar = ClockVar (IORef Microsecond)
 
 newtype Emulation a = Emulation { unEmulation :: ReaderT ClockVar IO a }
   deriving
-    (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask)
+    (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask, MonadUnliftIO)
 
 instance Rand.MonadRandom Emulation where
     getRandomBytes = Emulation . lift . Rand.getRandomBytes

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -206,6 +206,7 @@ library
                       , transformers
                       , transformers-base
                       , universum >= 0.1.11
+                      , unliftio
                       , unordered-containers
                       , vector
                       , wai

--- a/lib/src/Pos/Diffusion/Full/Types.hs
+++ b/lib/src/Pos/Diffusion/Full/Types.hs
@@ -11,14 +11,13 @@ module Pos.Diffusion.Full.Types
 
 import           Universum
 
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Crypto.Random as Rand
 import           Mockable (Mockable, MonadMockable)
 import qualified Mockable.Metrics as Mockable
-import           System.Wlog (WithLogger)
 import qualified System.Metrics.Counter as Metrics
 import qualified System.Metrics.Distribution as Metrics
 import qualified System.Metrics.Gauge as Metrics
+import           System.Wlog (WithLogger)
 
 import           Pos.Block.Configuration (HasBlockConfiguration)
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData)
@@ -42,7 +41,6 @@ type DiffusionWorkMode m
       -- Needed for message size limits, but shouldn't be [CSL-2242].
       , HasInfraConfiguration
       , HasNodeConfiguration
-      , MonadBaseControl IO m
       , Rand.MonadRandom m
       , MonadMask m
       -- TODO should not need HasAdoptedBlockVersionData

--- a/lib/src/Pos/Logic/Full.hs
+++ b/lib/src/Pos/Logic/Full.hs
@@ -9,8 +9,7 @@ module Pos.Logic.Full
 import           Universum
 
 import           Control.Lens (at, to)
-import           Control.Monad.Trans.Except (runExceptT)
-import           Data.Conduit (Source)
+import           Data.Conduit (ConduitT)
 import qualified Data.HashMap.Strict as HM
 import           Data.Tagged (Tagged (..), tagWith)
 import           Formatting (build, sformat, (%))
@@ -105,7 +104,7 @@ logicLayerFull jsonLogTx k = do
         getBlock :: HeaderHash -> m (Maybe Block)
         getBlock = DB.getBlock
 
-        getChainFrom :: HeaderHash -> Source m Block
+        getChainFrom :: HeaderHash -> ConduitT () Block m ()
         getChainFrom = DB.blocksSourceFrom
 
         getTip :: m Block
@@ -127,9 +126,9 @@ logicLayerFull jsonLogTx k = do
             :: NonEmpty HeaderHash
             -> Maybe HeaderHash
             -> m (Either GetBlockHeadersError (NewestFirst NE BlockHeader))
-        getBlockHeaders checkpoints start = do
-            result <- runExceptT (DB.getHeadersFromManyTo checkpoints start)
-            either (pure . Left . GetBlockHeadersError) (pure . Right) result
+        getBlockHeaders checkpoints start =
+            first GetBlockHeadersError <$>
+            DB.getHeadersFromManyTo checkpoints start
 
         getBlockHeaders'
             :: HeaderHash
@@ -201,7 +200,7 @@ logicLayerFull jsonLogTx k = do
             => SscTag
             -> (contents -> StakeholderId)
             -> (StakeholderId -> TossModifier -> Maybe contents)
-            -> (contents -> ExceptT err m ())
+            -> (contents -> m (Either err ()))
             -> KeyVal (Tagged contents StakeholderId) contents m
         postSscCommon sscTag contentsToKey toContents processData = KeyVal
             { toKey = pure . tagWith contentsProxy . contentsToKey
@@ -223,7 +222,7 @@ logicLayerFull jsonLogTx k = do
                 | shouldIgnore = False <$ logDebug (sformat ignoreFmt id dat)
                 | otherwise = sscProcessMessage processData dat
             sscProcessMessage sscProcessMessageDo dat =
-                runExceptT (sscProcessMessageDo dat) >>= \case
+                sscProcessMessageDo dat >>= \case
                     Left err -> False <$ logDebug (sformat ("Data is rejected, reason: "%build) err)
                     Right () -> return True
 

--- a/lib/src/Pos/Logic/Types.hs
+++ b/lib/src/Pos/Logic/Types.hs
@@ -11,7 +11,7 @@ module Pos.Logic.Types
 
 import           Universum
 
-import           Data.Conduit (Source)
+import           Data.Conduit (ConduitT)
 import           Data.Default (def)
 import           Data.Tagged (Tagged)
 
@@ -35,7 +35,7 @@ data Logic m = Logic
       -- Conduit is chosen mainly due to precedent: it's already used in
       -- cardano-sl.
     , getChainFrom       :: HeaderHash
-                         -> Source m Block
+                         -> ConduitT () Block m ()
       -- Get a block header.
       -- TBD: necessary? Is it any different/faster than getting the block
       -- and taking the header?

--- a/lib/src/Pos/Recovery/Instance.hs
+++ b/lib/src/Pos/Recovery/Instance.hs
@@ -33,7 +33,7 @@ instance ( Monad m
                 False -> pass
                 True -> throwError SSDoingRecovery
             curSlot <- note SSUnknownSlot =<< getCurrentSlot
-            tipHeader <- DB.getTipHeader
+            tipHeader <- lift DB.getTipHeader
             let tipSlot = epochOrSlotToSlot (tipHeader ^. epochOrSlotG)
             unless (tipSlot <= curSlot) $
                 throwError

--- a/lib/src/Pos/Web/Server.hs
+++ b/lib/src/Pos/Web/Server.hs
@@ -18,13 +18,14 @@ import           Control.Monad.Except (MonadError (throwError))
 import qualified Control.Monad.Reader as Mtl
 import           Data.Aeson.TH (defaultOptions, deriveToJSON)
 import           Data.Default (Default)
-import           Mockable (Production (runProduction), Mockable, Async, withAsync)
+import           Mockable (Async, Mockable, Production (runProduction), withAsync)
 import           Network.Wai (Application)
 import           Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 import           Network.Wai.Handler.WarpTLS (TLSSettings, runTLS, tlsSettingsChain)
 import           Servant.API ((:<|>) ((:<|>)), FromHttpApiData)
 import           Servant.Server (Handler, HasServer, ServantErr (errBody), Server, ServerT, err404,
                                  err503, hoistServer, serve)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Aeson.Txp ()
 import           Pos.Context (HasNodeContext (..), HasSscContext (..), NodeContext, getOurPublicKey)
@@ -175,7 +176,7 @@ getLocalTxsNum = fromIntegral . length <$> getLocalTxs
 
 -- | Get info on all confirmed proposals
 confirmedProposals
-    :: (HasUpdateConfiguration, MonadDBRead m)
+    :: (HasUpdateConfiguration, MonadDBRead m, MonadUnliftIO m)
     => m [CConfirmedProposalState]
 confirmedProposals = do
     proposals <- GS.getConfirmedProposals Nothing

--- a/lib/src/Pos/WorkMode/Class.hs
+++ b/lib/src/Pos/WorkMode/Class.hs
@@ -16,6 +16,7 @@ import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Crypto.Random as Rand
 import           Mockable (MonadMockable)
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Block.BListener (MonadBListener)
 import           Pos.Block.Configuration (HasBlockConfiguration)
@@ -97,6 +98,7 @@ type MinWorkMode m
       , CanJsonLog m
       , MonadMockable m
       , MonadIO m
+      , MonadUnliftIO m
       , HasConfiguration
       , HasInfraConfiguration
       , HasUpdateConfiguration

--- a/lrc/Pos/Lrc/Fts.hs
+++ b/lrc/Pos/Lrc/Fts.hs
@@ -5,10 +5,11 @@ module Pos.Lrc.Fts
        ( followTheSatoshiM
        ) where
 
-import           Control.Lens (makeLenses, makePrisms, uses)
-import           Data.Conduit (Sink, await)
-import           Data.List.NonEmpty (fromList)
 import           Universum
+
+import           Control.Lens (makeLenses, makePrisms, uses)
+import           Data.Conduit (ConduitT, await)
+import           Data.List.NonEmpty (fromList)
 
 import           Pos.Core.Common (Coin, SharedSeed (..), SlotLeaders, StakeholderId, coinToInteger,
                                   mkCoin, unsafeGetCoin)
@@ -197,7 +198,7 @@ followTheSatoshiM
     :: forall m . (Monad m, HasConfiguration)
     => SharedSeed
     -> Coin
-    -> Sink (StakeholderId, Coin) m SlotLeaders
+    -> ConduitT (StakeholderId, Coin) Void m SlotLeaders
 followTheSatoshiM _ totalCoins
     | totalCoins == mkCoin 0 = error "followTheSatoshiM: nobody has any stake"
 followTheSatoshiM (SharedSeed seed) totalCoins = do
@@ -214,7 +215,7 @@ followTheSatoshiM (SharedSeed seed) totalCoins = do
     findLeaders = (traverse . _2) findLeader
 
     findLeader :: CoinIndex ->
-                  StateT FtsState (Sink (StakeholderId, Coin) m) StakeholderId
+                  StateT FtsState (ConduitT (StakeholderId, Coin) Void m) StakeholderId
     findLeader coinIndex = do
         inRange <- uses fsCurrentCoinRangeUpperBound (coinIndex <=)
         if inRange

--- a/lrc/Pos/Lrc/Mode.hs
+++ b/lrc/Pos/Lrc/Mode.hs
@@ -10,6 +10,7 @@ import           Universum
 
 import           Mockable (Async, Concurrently, Delay, Mockables)
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Core (HasConfiguration)
 import           Pos.DB.Class (MonadDB, MonadGState)
@@ -22,6 +23,7 @@ type LrcMode ctx m
        , MonadGState m
        , MonadDB m
        , MonadIO m
+       , MonadUnliftIO m
        , Mockables m [Async, Concurrently, Delay]
        , MonadReader ctx m
        , HasLrcContext ctx

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -47,6 +47,7 @@ library
                      , rocksdb-haskell-ng
                      , text-format
                      , universum
+                     , unliftio
                      , unordered-containers
 
   default-extensions:  DeriveDataTypeable

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -87,6 +87,7 @@ Library
                       , resourcet
                       , transformers-lift
                       , universum
+                      , unliftio-core
                       , safe-exceptions
                       , serokell-util
                       , stm

--- a/networking/src/Mockable/Production.hs
+++ b/networking/src/Mockable/Production.hs
@@ -17,6 +17,7 @@ import qualified Control.Exception.Safe as Exception
 import           Control.Monad (forever)
 import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.IO.Class (MonadIO)
+import           Control.Monad.IO.Unlift (MonadUnliftIO (..))
 import qualified Crypto.Random as Rand
 import           Data.Time.Units (Hour)
 import qualified GHC.IO as GHC
@@ -42,6 +43,7 @@ newtype Production t = Production
     } deriving (Functor, Applicative, Monad)
 
 deriving instance MonadIO Production
+deriving instance MonadUnliftIO Production
 deriving instance MonadFix Production
 deriving instance MonadThrow Production
 deriving instance MonadCatch Production

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -26573,21 +26573,28 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.asl20;
          }) {};
       "mono-traversable" = callPackage
-        ({ mkDerivation, base, bytestring, containers, hashable, split
-         , stdenv, text, transformers, unordered-containers, vector
-         , vector-algorithms
+        ({ mkDerivation, base, bytestring, containers, fetchgit, hashable
+         , hpack, split, stdenv, text, transformers, unordered-containers
+         , vector, vector-algorithms
          }:
          mkDerivation {
            pname = "mono-traversable";
-           version = "1.0.2.1";
-           sha256 = "4ed2f4a2c389105b330b631eeff03e36908765ca120888922aeda819f9cdb16a";
+           version = "1.0.7.0";
+           src = fetchgit {
+             url = "https://github.com/snoyberg/mono-traversable.git";
+             sha256 = "0hfli0lhw0ppikz1m6wvbkq8zmrqny33m4dm15nzpm0q6c4v6n61";
+             rev = "a4c980c36f2fe8b8f78ac5b235c60ab91493bf01";
+           };
+           postUnpack = "sourceRoot+=/mono-traversable; echo source root reset to $sourceRoot";
            libraryHaskellDepends = [
              base bytestring containers hashable split text transformers
              unordered-containers vector vector-algorithms
            ];
+           libraryToolDepends = [ hpack ];
            doHaddock = false;
            doCheck = false;
-           homepage = "https://github.com/snoyberg/mono-traversable";
+           preConfigure = "hpack";
+           homepage = "https://github.com/snoyberg/mono-traversable#readme";
            description = "Type classes for mapping, folding, and traversing monomorphic containers";
            license = stdenv.lib.licenses.mit;
          }) {};
@@ -41025,15 +41032,22 @@ inherit (pkgs) which;};
       "wai-extra" = callPackage
         ({ mkDerivation, aeson, ansi-terminal, base, base64-bytestring
          , blaze-builder, bytestring, case-insensitive, containers, cookie
-         , data-default-class, deepseq, directory, fast-logger, http-types
-         , iproute, lifted-base, network, old-locale, resourcet, stdenv
-         , streaming-commons, stringsearch, text, time, transformers, unix
-         , unix-compat, vault, void, wai, wai-logger, word8, zlib
+         , data-default-class, deepseq, directory, fast-logger, fetchgit
+         , http-types, iproute, lifted-base, network, old-locale, resourcet
+         , stdenv, streaming-commons, stringsearch, text, time, transformers
+         , unix, unix-compat, vault, void, wai, wai-logger, word8, zlib
          }:
          mkDerivation {
            pname = "wai-extra";
-           version = "3.0.20.0";
-           sha256 = "ad63ca529e812f5edec84e197a58433095a1376a127f8e9416235028bf021971";
+           version = "3.0.22.0";
+           src = fetchgit {
+             url = "https://github.com/yesodweb/wai.git";
+             sha256 = "152p2jj2awhyc2m1vygsmm3cfg6bjl39y9w7sj548pl89dbnz7n7";
+             rev = "d43e4b1d4ed874803632e07ef09b0009e0479135";
+           };
+           postUnpack = "sourceRoot+=/wai-extra; echo source root reset to $sourceRoot";
+           isLibrary = true;
+           isExecutable = true;
            libraryHaskellDepends = [
              aeson ansi-terminal base base64-bytestring blaze-builder bytestring
              case-insensitive containers cookie data-default-class deepseq
@@ -43048,14 +43062,18 @@ inherit (pkgs) which;};
          }) {};
       "yaml" = callPackage
         ({ mkDerivation, aeson, attoparsec, base, bytestring, conduit
-         , containers, directory, filepath, resourcet, scientific
+         , containers, directory, fetchgit, filepath, resourcet, scientific
          , semigroups, stdenv, template-haskell, text, transformers
          , unordered-containers, vector
          }:
          mkDerivation {
            pname = "yaml";
-           version = "0.8.23.3";
-           sha256 = "cc855c7ed50cbc4c706400f98854087ce7b8eadbd98646001a15c13c11ed7543";
+           version = "0.8.28";
+           src = fetchgit {
+             url = "https://github.com/snoyberg/yaml.git";
+             sha256 = "0fcy0bqzxyw46ykdmx191ffw8v2wnzqsk9cppnwq8akpgarw0xf0";
+             rev = "7ce90970adb3b278dffb2d5e4ac724bfe59db768";
+           };
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6925,8 +6925,8 @@ inherit (pkgs) mesa;};
          , safe-exceptions, safecopy, serokell-util, servant, servant-server
          , servant-swagger, stdenv, stm, systemd, tagged, template-haskell
          , text, text-format, time, time-units, transformers
-         , transformers-base, universum, unix, unordered-containers, vector
-         , wai, warp, warp-tls, yaml
+         , transformers-base, universum, unix, unliftio
+         , unordered-containers, vector, wai, warp, warp-tls, yaml
          }:
          mkDerivation {
            pname = "cardano-sl";
@@ -6948,8 +6948,8 @@ inherit (pkgs) mesa;};
              reflection resourcet rocksdb-haskell-ng safe-exceptions safecopy
              serokell-util servant servant-server servant-swagger stm systemd
              tagged template-haskell text text-format time time-units
-             transformers transformers-base universum unix unordered-containers
-             vector wai warp warp-tls yaml
+             transformers transformers-base universum unix unliftio
+             unordered-containers vector wai warp warp-tls yaml
            ];
            testHaskellDepends = [
              base bytestring canonical-json cardano-sl-binary cardano-sl-block
@@ -6972,14 +6972,15 @@ inherit (pkgs) mesa;};
          , cardano-sl-core, cardano-sl-crypto, cardano-sl-db
          , cardano-sl-generator, cardano-sl-infra, cardano-sl-networking
          , cardano-sl-ssc, cardano-sl-txp, cardano-sl-update
-         , cardano-sl-util, constraints, containers, cpphs, data-default
-         , Earley, formatting, generic-arbitrary, haskeline, hspec, lens
-         , loc, log-warper, megaparsec, mmorph, MonadRandom, mtl
-         , neat-interpolation, network-transport-tcp, optparse-applicative
-         , parser-combinators, QuickCheck, quickcheck-instances, random
-         , reflection, safe-exceptions, scientific, serokell-util, split
-         , stdenv, stm, temporary, text, text-format, time-units
-         , transformers, universum, unix, unordered-containers
+         , cardano-sl-util, conduit, constraints, containers, cpphs
+         , data-default, Earley, formatting, generic-arbitrary, haskeline
+         , hspec, lens, loc, log-warper, megaparsec, mmorph, MonadRandom
+         , mtl, neat-interpolation, network-transport-tcp
+         , optparse-applicative, parser-combinators, QuickCheck
+         , quickcheck-instances, random, reflection, resourcet
+         , safe-exceptions, scientific, serokell-util, split, stdenv, stm
+         , temporary, text, text-format, time-units, transformers, universum
+         , unix, unordered-containers
          }:
          mkDerivation {
            pname = "cardano-sl-auxx";
@@ -6992,13 +6993,14 @@ inherit (pkgs) mesa;};
              cardano-sl-block cardano-sl-client cardano-sl-core
              cardano-sl-crypto cardano-sl-db cardano-sl-generator
              cardano-sl-infra cardano-sl-networking cardano-sl-ssc
-             cardano-sl-txp cardano-sl-update cardano-sl-util constraints
-             containers data-default Earley formatting generic-arbitrary
-             haskeline lens loc log-warper megaparsec mmorph MonadRandom mtl
-             neat-interpolation optparse-applicative parser-combinators
-             QuickCheck quickcheck-instances random reflection safe-exceptions
-             scientific serokell-util split stm text text-format time-units
-             transformers universum unix unordered-containers
+             cardano-sl-txp cardano-sl-update cardano-sl-util conduit
+             constraints containers data-default Earley formatting
+             generic-arbitrary haskeline lens loc log-warper megaparsec mmorph
+             MonadRandom mtl neat-interpolation optparse-applicative
+             parser-combinators QuickCheck quickcheck-instances random
+             reflection resourcet safe-exceptions scientific serokell-util split
+             stm text text-format time-units transformers universum unix
+             unordered-containers
            ];
            libraryToolDepends = [ cpphs ];
            executableHaskellDepends = [
@@ -7052,7 +7054,7 @@ inherit (pkgs) mesa;};
          , exceptions, filepath, formatting, generic-arbitrary, lens
          , log-warper, mtl, QuickCheck, random, reflection
          , rocksdb-haskell-ng, safe-exceptions, serokell-util, stdenv, stm
-         , text, text-format, time-units, transformers, universum
+         , text, text-format, time-units, transformers, universum, unliftio
          , unordered-containers
          }:
          mkDerivation {
@@ -7068,7 +7070,7 @@ inherit (pkgs) mesa;};
              ether exceptions filepath formatting generic-arbitrary lens
              log-warper mtl QuickCheck random reflection rocksdb-haskell-ng
              safe-exceptions serokell-util stm text text-format time-units
-             transformers universum unordered-containers
+             transformers universum unliftio unordered-containers
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7178,7 +7180,7 @@ inherit (pkgs) mesa;};
          , concurrent-extra, conduit, containers, cpphs, data-default
          , directory, ether, filepath, formatting, lens, memory, mmorph
          , monad-control, mtl, resourcet, rocksdb-haskell-ng, serokell-util
-         , stdenv, text-format, transformers, universum
+         , stdenv, text-format, transformers, universum, unliftio
          }:
          mkDerivation {
            pname = "cardano-sl-db";
@@ -7189,7 +7191,7 @@ inherit (pkgs) mesa;};
              cardano-sl-util concurrent-extra conduit containers data-default
              directory ether filepath formatting lens memory mmorph
              monad-control mtl resourcet rocksdb-haskell-ng serokell-util
-             text-format transformers universum
+             text-format transformers universum unliftio
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7203,7 +7205,8 @@ inherit (pkgs) mesa;};
          , cpphs, ether, formatting, generic-arbitrary, lens, log-warper
          , lrucache, mmorph, mtl, QuickCheck, reflection, resourcet
          , rocksdb-haskell-ng, safe-exceptions, serokell-util, stdenv
-         , text-format, time, transformers, universum, unordered-containers
+         , text-format, time, transformers, universum, unliftio
+         , unordered-containers
          }:
          mkDerivation {
            pname = "cardano-sl-delegation";
@@ -7215,7 +7218,7 @@ inherit (pkgs) mesa;};
              cardano-sl-util conduit ether formatting generic-arbitrary lens
              log-warper lrucache mmorph mtl QuickCheck reflection resourcet
              rocksdb-haskell-ng safe-exceptions serokell-util text-format time
-             transformers universum unordered-containers
+             transformers universum unliftio unordered-containers
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7236,7 +7239,7 @@ inherit (pkgs) mesa;};
          , rocksdb-haskell-ng, safe-exceptions, serokell-util, servant
          , servant-generic, servant-multipart, servant-server
          , servant-swagger, socket-io, stdenv, stm, swagger2, text
-         , text-format, time, time-units, transformers, universum
+         , text-format, time, time-units, transformers, universum, unliftio
          , unordered-containers, vector, wai, wai-cors, wai-extra, warp
          }:
          mkDerivation {
@@ -7255,8 +7258,8 @@ inherit (pkgs) mesa;};
              generic-arbitrary http-types lens log-warper memory mtl QuickCheck
              resourcet rocksdb-haskell-ng safe-exceptions serokell-util servant
              servant-generic servant-server socket-io stm text text-format time
-             time-units transformers universum unordered-containers vector wai
-             wai-cors wai-extra warp
+             time-units transformers universum unliftio unordered-containers
+             vector wai wai-cors wai-extra warp
            ];
            libraryToolDepends = [ cpphs ];
            executableHaskellDepends = [
@@ -7289,7 +7292,8 @@ inherit (pkgs) mesa;};
          , ether, exceptions, formatting, hspec, lens, log-warper
          , monad-control, MonadRandom, QuickCheck, random, safe-exceptions
          , serokell-util, stdenv, text, text-format, time-units
-         , transformers-base, universum, unordered-containers, vector
+         , transformers-base, universum, unliftio, unordered-containers
+         , vector
          }:
          mkDerivation {
            pname = "cardano-sl-generator";
@@ -7304,7 +7308,7 @@ inherit (pkgs) mesa;};
              data-default ether exceptions formatting lens log-warper
              monad-control MonadRandom QuickCheck random safe-exceptions
              serokell-util text text-format time-units transformers-base
-             universum unordered-containers vector
+             universum unliftio unordered-containers vector
            ];
            libraryToolDepends = [ cpphs ];
            testHaskellDepends = [
@@ -7360,7 +7364,7 @@ inherit (pkgs) mesa;};
          , cardano-sl-networking, cardano-sl-util, conduit, cpphs, ether
          , formatting, generic-arbitrary, lens, log-warper, QuickCheck
          , reflection, rocksdb-haskell-ng, stdenv, text-format, universum
-         , unordered-containers
+         , unliftio, unordered-containers
          }:
          mkDerivation {
            pname = "cardano-sl-lrc";
@@ -7370,7 +7374,8 @@ inherit (pkgs) mesa;};
              base bytestring cardano-sl-binary cardano-sl-core cardano-sl-crypto
              cardano-sl-db cardano-sl-networking cardano-sl-util conduit ether
              formatting generic-arbitrary lens log-warper QuickCheck reflection
-             rocksdb-haskell-ng text-format universum unordered-containers
+             rocksdb-haskell-ng text-format universum unliftio
+             unordered-containers
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7386,7 +7391,7 @@ inherit (pkgs) mesa;};
          , network-transport-tcp, optparse-simple, QuickCheck, random
          , resourcet, safe-exceptions, serokell-util, statistics, stdenv
          , stm, text, text-format, time, time-units, transformers
-         , transformers-base, transformers-lift, universum
+         , transformers-base, transformers-lift, universum, unliftio-core
          }:
          mkDerivation {
            pname = "cardano-sl-networking";
@@ -7401,6 +7406,7 @@ inherit (pkgs) mesa;};
              network-transport-tcp QuickCheck random resourcet safe-exceptions
              serokell-util statistics stm text text-format time time-units
              transformers transformers-base transformers-lift universum
+             unliftio-core
            ];
            executableHaskellDepends = [
              attoparsec base binary bytestring conduit conduit-extra containers
@@ -7520,7 +7526,7 @@ inherit (pkgs) mesa;};
          , mmorph, mtl, neat-interpolation, plutus-prototype, QuickCheck
          , resourcet, rocksdb-haskell-ng, safe-exceptions, serokell-util
          , stdenv, stm, tagged, template-haskell, text, text-format
-         , transformers, universum, unordered-containers, vector
+         , transformers, universum, unliftio, unordered-containers, vector
          }:
          mkDerivation {
            pname = "cardano-sl-txp";
@@ -7534,7 +7540,7 @@ inherit (pkgs) mesa;};
              generic-arbitrary hashable lens log-warper memory mmorph mtl
              neat-interpolation plutus-prototype QuickCheck resourcet
              rocksdb-haskell-ng safe-exceptions serokell-util stm tagged
-             template-haskell text text-format transformers universum
+             template-haskell text text-format transformers universum unliftio
              unordered-containers vector
            ];
            libraryToolDepends = [ cpphs ];
@@ -7552,7 +7558,7 @@ inherit (pkgs) mesa;};
          , log-warper, memory, mtl, QuickCheck, reflection, resourcet
          , rocksdb-haskell-ng, safe-exceptions, serokell-util, stdenv, stm
          , tagged, template-haskell, text, text-format, time-units
-         , transformers, universum, unordered-containers
+         , transformers, universum, unliftio, unordered-containers
          }:
          mkDerivation {
            pname = "cardano-sl-update";
@@ -7567,7 +7573,7 @@ inherit (pkgs) mesa;};
              lens log-warper memory mtl QuickCheck reflection resourcet
              rocksdb-haskell-ng safe-exceptions serokell-util stm tagged
              template-haskell text text-format time-units transformers universum
-             unordered-containers
+             unliftio unordered-containers
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7584,7 +7590,7 @@ inherit (pkgs) mesa;};
          , safe-exceptions, semigroups, serokell-util, stdenv, stm, tagged
          , template-haskell, text, text-format, th-lift-instances, time
          , time-units, transformers, transformers-base, transformers-lift
-         , universum, unordered-containers, vector
+         , universum, unliftio-core, unordered-containers, vector
          }:
          mkDerivation {
            pname = "cardano-sl-util";
@@ -7598,8 +7604,8 @@ inherit (pkgs) mesa;};
              quickcheck-instances random reflection resourcet safe-exceptions
              semigroups serokell-util stm tagged template-haskell text
              text-format th-lift-instances time time-units transformers
-             transformers-base transformers-lift universum unordered-containers
-             vector
+             transformers-base transformers-lift universum unliftio-core
+             unordered-containers vector
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7621,7 +7627,7 @@ inherit (pkgs) mesa;};
          , servant, servant-generic, servant-multipart, servant-server
          , servant-swagger, servant-swagger-ui, stdenv, stm, swagger2, text
          , text-format, time, time-units, transformers, universum, unix
-         , unordered-containers, wai, wai-websockets, websockets
+         , unliftio, unordered-containers, wai, wai-websockets, websockets
          }:
          mkDerivation {
            pname = "cardano-sl-wallet";
@@ -7640,7 +7646,7 @@ inherit (pkgs) mesa;};
              quickcheck-instances random reflection safe-exceptions safecopy
              semver serokell-util servant servant-generic servant-multipart
              servant-server servant-swagger servant-swagger-ui stm swagger2 text
-             text-format time time-units transformers universum unix
+             text-format time time-units transformers universum unix unliftio
              unordered-containers wai wai-websockets websockets
            ];
            libraryToolDepends = [ cpphs ];
@@ -9071,17 +9077,17 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "conduit" = callPackage
-        ({ mkDerivation, base, exceptions, lifted-base, mmorph
-         , monad-control, mtl, primitive, resourcet, stdenv, transformers
-         , transformers-base
+        ({ mkDerivation, base, bytestring, directory, exceptions, filepath
+         , mono-traversable, mtl, primitive, resourcet, stdenv, text
+         , transformers, unix, unliftio-core, vector
          }:
          mkDerivation {
            pname = "conduit";
-           version = "1.2.11";
-           sha256 = "0b66423f04d991262b800174064d0c6046fba0009eddcca616f9afaf84dca8f7";
+           version = "1.3.0";
+           sha256 = "d7cff0a7ee0de8661457cf7d209aa9b6ff9f24453be4abf0625c51b47cbb4094";
            libraryHaskellDepends = [
-             base exceptions lifted-base mmorph monad-control mtl primitive
-             resourcet transformers transformers-base
+             base bytestring directory exceptions filepath mono-traversable mtl
+             primitive resourcet text transformers unix unliftio-core vector
            ];
            doHaddock = false;
            doCheck = false;
@@ -9130,19 +9136,19 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "conduit-extra" = callPackage
-        ({ mkDerivation, async, attoparsec, base, blaze-builder, bytestring
-         , conduit, directory, exceptions, filepath, monad-control, network
-         , primitive, process, resourcet, stdenv, stm, streaming-commons
-         , text, transformers, transformers-base
+        ({ mkDerivation, async, attoparsec, base, bytestring, conduit
+         , directory, filepath, network, primitive, process, resourcet
+         , stdenv, stm, streaming-commons, text, transformers, typed-process
+         , unliftio-core
          }:
          mkDerivation {
            pname = "conduit-extra";
-           version = "1.1.16";
-           sha256 = "bd72c1bacd5f59a74a73a0aa115b8314f0a1dc1b24d939e52a983113c960f8d5";
+           version = "1.3.0";
+           sha256 = "2c41c925fc53d9ba2e640c7cdca72c492b28c0d45f1a82e94baef8dfa65922ae";
            libraryHaskellDepends = [
-             async attoparsec base blaze-builder bytestring conduit directory
-             exceptions filepath monad-control network primitive process
-             resourcet stm streaming-commons text transformers transformers-base
+             async attoparsec base bytestring conduit directory filepath network
+             primitive process resourcet stm streaming-commons text transformers
+             typed-process unliftio-core
            ];
            doHaddock = false;
            doCheck = false;
@@ -21145,17 +21151,16 @@ inherit (pkgs) which;};
          }) {};
       "http-conduit" = callPackage
         ({ mkDerivation, aeson, base, bytestring, conduit, conduit-extra
-         , exceptions, http-client, http-client-tls, http-types, lifted-base
-         , monad-control, mtl, resourcet, stdenv, transformers
+         , http-client, http-client-tls, http-types, mtl, resourcet, stdenv
+         , transformers, unliftio-core
          }:
          mkDerivation {
            pname = "http-conduit";
-           version = "2.2.3.2";
-           sha256 = "e359c3ef370731e895a5c213e805c6806394f13598647f36dce7be41d4c41eb8";
+           version = "2.3.0";
+           sha256 = "a43b401a2bf072037d79cf450de958ff71b158343c4eb8f679d3bc23142a217d";
            libraryHaskellDepends = [
-             aeson base bytestring conduit conduit-extra exceptions http-client
-             http-client-tls http-types lifted-base monad-control mtl resourcet
-             transformers
+             aeson base bytestring conduit conduit-extra http-client
+             http-client-tls http-types mtl resourcet transformers unliftio-core
            ];
            doHaddock = false;
            doCheck = false;
@@ -24919,24 +24924,55 @@ inherit (pkgs) which;};
            description = "DSL for SVG using lucid for HTML";
            license = stdenv.lib.licenses.bsd3;
          }) {};
+      "lzma" = callPackage
+        ({ mkDerivation, base, bytestring, lzma, stdenv }:
+         mkDerivation {
+           pname = "lzma";
+           version = "0.0.0.3";
+           sha256 = "af8321c3511bde3e2745093fa3bd74c642e386db7d2e7c43b3a54814f1338144";
+           revision = "1";
+           editedCabalFile = "0y89blvpswvji1ya7h67gcx322iqi93di3jmwx47l6mic3ki4r2d";
+           libraryHaskellDepends = [ base bytestring ];
+           librarySystemDepends = [ lzma ];
+           doHaddock = false;
+           doCheck = false;
+           homepage = "https://github.com/hvr/lzma";
+           description = "LZMA/XZ compression and decompression";
+           license = stdenv.lib.licenses.bsd3;
+         }) {inherit (pkgs) lzma;};
+      "lzma-clib" = callPackage
+        ({ mkDerivation, stdenv }:
+         mkDerivation {
+           pname = "lzma-clib";
+           version = "5.2.2";
+           sha256 = "0aed9cb8ef3a2b0e71c429b00161ee3fb342cce2603ccb934f507fb236a09fd5";
+           doHaddock = false;
+           doCheck = false;
+           description = "liblzma C library and headers for use by LZMA bindings";
+           license = stdenv.lib.licenses.publicDomain;
+           platforms = stdenv.lib.platforms.none;
+         }) {};
       "lzma-conduit" = callPackage
-        ({ mkDerivation, base, bindings-DSL, bytestring, conduit, lzma
+        ({ mkDerivation, base, bytestring, conduit, fetchgit, lzma
          , resourcet, stdenv, transformers
          }:
          mkDerivation {
            pname = "lzma-conduit";
-           version = "1.1.3.3";
-           sha256 = "17cc0669639891a86fdae101b785f614fbd8560c170b4f8a88929134f2936da5";
+           version = "1.2.1";
+           src = fetchgit {
+             url = "https://github.com/serokell/lzma-conduit.git";
+             sha256 = "1nxvnfz6ci9apqqd00iy604492q1laqkcyzz48b9jg57hxmakm9s";
+             rev = "0f6a8754bcd97c701465d71f4a0ad83f2c11aaf4";
+           };
            libraryHaskellDepends = [
-             base bindings-DSL bytestring conduit resourcet transformers
+             base bytestring conduit lzma resourcet transformers
            ];
-           librarySystemDepends = [ lzma ];
            doHaddock = false;
            doCheck = false;
            homepage = "http://github.com/alphaHeavy/lzma-conduit";
            description = "Conduit interface for lzma/xz compression";
            license = stdenv.lib.licenses.bsd3;
-         }) {inherit (pkgs) lzma;};
+         }) {};
       "machines" = callPackage
         ({ mkDerivation, adjunctions, base, Cabal, cabal-doctest, comonad
          , containers, distributive, mtl, pointed, profunctors
@@ -26573,27 +26609,20 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.asl20;
          }) {};
       "mono-traversable" = callPackage
-        ({ mkDerivation, base, bytestring, containers, fetchgit, hashable
-         , hpack, split, stdenv, text, transformers, unordered-containers
-         , vector, vector-algorithms
+        ({ mkDerivation, base, bytestring, containers, hashable, split
+         , stdenv, text, transformers, unordered-containers, vector
+         , vector-algorithms
          }:
          mkDerivation {
            pname = "mono-traversable";
-           version = "1.0.7.0";
-           src = fetchgit {
-             url = "https://github.com/snoyberg/mono-traversable.git";
-             sha256 = "0hfli0lhw0ppikz1m6wvbkq8zmrqny33m4dm15nzpm0q6c4v6n61";
-             rev = "a4c980c36f2fe8b8f78ac5b235c60ab91493bf01";
-           };
-           postUnpack = "sourceRoot+=/mono-traversable; echo source root reset to $sourceRoot";
+           version = "1.0.8.1";
+           sha256 = "991290797bd77ce2f2e23dd5dea32fb159c6cb9310615f64a0703ea4c6373935";
            libraryHaskellDepends = [
              base bytestring containers hashable split text transformers
              unordered-containers vector vector-algorithms
            ];
-           libraryToolDepends = [ hpack ];
            doHaddock = false;
            doCheck = false;
-           preConfigure = "hpack";
            homepage = "https://github.com/snoyberg/mono-traversable#readme";
            description = "Type classes for mapping, folding, and traversing monomorphic containers";
            license = stdenv.lib.licenses.mit;
@@ -32656,17 +32685,15 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "resourcet" = callPackage
-        ({ mkDerivation, base, containers, exceptions, lifted-base, mmorph
-         , monad-control, mtl, stdenv, transformers, transformers-base
-         , transformers-compat
+        ({ mkDerivation, base, containers, exceptions, mtl, primitive
+         , stdenv, transformers, unliftio-core
          }:
          mkDerivation {
            pname = "resourcet";
-           version = "1.1.9";
-           sha256 = "5a1999d26b896603cab8121b77f36723dc50960291872b691ff4a9533e162ef5";
+           version = "1.2.0";
+           sha256 = "095dc971a170f5cd2880e303ffb04a0feabeba29a1d776238b9691ece666fa26";
            libraryHaskellDepends = [
-             base containers exceptions lifted-base mmorph monad-control mtl
-             transformers transformers-base transformers-compat
+             base containers exceptions mtl primitive transformers unliftio-core
            ];
            doHaddock = false;
            doCheck = false;
@@ -34105,14 +34132,18 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "servant-multipart" = callPackage
-        ({ mkDerivation, base, bytestring, directory, http-client
+        ({ mkDerivation, base, bytestring, directory, fetchgit, http-client
          , http-media, lens, network, resourcet, servant, servant-docs
          , servant-server, stdenv, text, transformers, wai, wai-extra, warp
          }:
          mkDerivation {
            pname = "servant-multipart";
            version = "0.11";
-           sha256 = "f26e5be0c26e47dec06936e15c5fc6330549b0136a6584f26cac26f034fe75d4";
+           src = fetchgit {
+             url = "https://github.com/serokell/servant-multipart.git";
+             sha256 = "042lw09j79qlax8ymwzphc29q8sx1vzlbyf42hmwy2pg5fgmw0qv";
+             rev = "e7de56b5f7c39f8dc473f1bbaf534bb7affc3cf4";
+           };
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
@@ -34189,18 +34220,21 @@ inherit (pkgs) which;};
       "servant-server" = callPackage
         ({ mkDerivation, aeson, attoparsec, base, base-compat
          , base64-bytestring, bytestring, Cabal, cabal-doctest, containers
-         , exceptions, filepath, http-api-data, http-types, monad-control
-         , mtl, network, network-uri, resourcet, safe, servant, split
-         , stdenv, string-conversions, system-filepath, tagged, text
-         , transformers, transformers-base, transformers-compat, wai
-         , wai-app-static, warp, word8
+         , exceptions, fetchgit, filepath, http-api-data, http-types
+         , monad-control, mtl, network, network-uri, resourcet, safe
+         , servant, split, stdenv, string-conversions, system-filepath
+         , tagged, text, transformers, transformers-base
+         , transformers-compat, wai, wai-app-static, warp, word8
          }:
          mkDerivation {
            pname = "servant-server";
            version = "0.12";
-           sha256 = "65f23367fc1cdc3ee63e37464b5e0c9680b87c6ac4c251fbece417921a993cc6";
-           revision = "1";
-           editedCabalFile = "1b0vqzbaaz3bqzdh640rss5xsyl0s5q42xccfdmzmpn559w3p81r";
+           src = fetchgit {
+             url = "https://github.com/serokell/servant.git";
+             sha256 = "1irn9kvyyv2xxfm5rg92f3sw4x5c0drg44g74ccpsw83dh1wl169";
+             rev = "5db013cc36894afdff9e748dbc1c05947c54df3d";
+           };
+           postUnpack = "sourceRoot+=/servant-server; echo source root reset to $sourceRoot";
            isLibrary = true;
            isExecutable = true;
            setupHaskellDepends = [ base Cabal cabal-doctest ];
@@ -34812,10 +34846,8 @@ inherit (pkgs) which;};
         ({ mkDerivation, base, bytestring, network, stdenv, unix }:
          mkDerivation {
            pname = "simple-sendfile";
-           version = "0.2.25";
-           sha256 = "0ae68821cd828b29772654b5613d514a421b1b1440d82a4b610339e67a92294d";
-           revision = "1";
-           editedCabalFile = "1axghvn2iz0gzlc0ics4q8abl15ggwvcwcmly5cxhmc32hqv8y5c";
+           version = "0.2.27";
+           sha256 = "f68572592099a2db3f7212ac7d133447ae5bbb2605285d3de1a29a52d9c79caf";
            libraryHaskellDepends = [ base bytestring network unix ];
            doHaddock = false;
            doCheck = false;
@@ -39564,20 +39596,19 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "typed-process" = callPackage
-        ({ mkDerivation, async, base, bytestring, conduit, conduit-extra
-         , exceptions, process, stdenv, stm, transformers
+        ({ mkDerivation, async, base, bytestring, process, stdenv, stm
+         , transformers
          }:
          mkDerivation {
            pname = "typed-process";
-           version = "0.1.0.0";
-           sha256 = "de866bc6ccb3ae3ccce20701add8bd913f7d7b4e252a9133eac35d035d0a10f8";
+           version = "0.2.1.0";
+           sha256 = "d214d88575dc0fe919d23eacd91a212ed7bf5b1dbb4360038e99926ff9bcdcd0";
            libraryHaskellDepends = [
-             async base bytestring conduit conduit-extra exceptions process stm
-             transformers
+             async base bytestring process stm transformers
            ];
            doHaddock = false;
            doCheck = false;
-           homepage = "https://github.com/fpco/typed-process#readme";
+           homepage = "https://haskell-lang.org/library/typed-process";
            description = "Run external processes, with strong typing of streams";
            license = stdenv.lib.licenses.mit;
          }) {};
@@ -40147,21 +40178,20 @@ inherit (pkgs) which;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "unliftio" = callPackage
-        ({ mkDerivation, async, base, deepseq, directory, filepath
-         , monad-logger, resourcet, stdenv, transformers, unix
-         , unliftio-core
+        ({ mkDerivation, async, base, deepseq, directory, filepath, stdenv
+         , stm, transformers, unix, unliftio-core
          }:
          mkDerivation {
            pname = "unliftio";
-           version = "0.1.0.0";
-           sha256 = "1105fbf108f3578b9caeb229653f3ff2589e12b72f4fcd69cd1985adbee27a14";
+           version = "0.2.4.0";
+           sha256 = "3ff5fe8b0627dcfeac17ca769a819f08d7fe1a26da3a1cff32eb17ac7865f66e";
            libraryHaskellDepends = [
-             async base deepseq directory filepath monad-logger resourcet
-             transformers unix unliftio-core
+             async base deepseq directory filepath stm transformers unix
+             unliftio-core
            ];
            doHaddock = false;
            doCheck = false;
-           homepage = "https://github.com/fpco/monad-unlift/tree/master/unliftio#readme";
+           homepage = "https://github.com/fpco/unliftio/tree/master/unliftio#readme";
            description = "The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)";
            license = stdenv.lib.licenses.mit;
          }) {};
@@ -40169,12 +40199,12 @@ inherit (pkgs) which;};
         ({ mkDerivation, base, stdenv, transformers }:
          mkDerivation {
            pname = "unliftio-core";
-           version = "0.1.0.0";
-           sha256 = "92b9f2bdc921df134231f770fcab750cbeed08a89c9ed08b13db5d1e9236bb73";
+           version = "0.1.1.0";
+           sha256 = "7550b017d87af53ae3e0d3b8524e24a77faf739073f35e40663454a9e9752385";
            libraryHaskellDepends = [ base transformers ];
            doHaddock = false;
            doCheck = false;
-           homepage = "https://github.com/fpco/monad-unlift/tree/master/unliftio-core#readme";
+           homepage = "https://github.com/fpco/unliftio/tree/master/unliftio-core#readme";
            description = "The MonadUnliftIO typeclass for unlifting monads to IO";
            license = stdenv.lib.licenses.mit;
          }) {};
@@ -41032,20 +41062,15 @@ inherit (pkgs) which;};
       "wai-extra" = callPackage
         ({ mkDerivation, aeson, ansi-terminal, base, base64-bytestring
          , blaze-builder, bytestring, case-insensitive, containers, cookie
-         , data-default-class, deepseq, directory, fast-logger, fetchgit
-         , http-types, iproute, lifted-base, network, old-locale, resourcet
-         , stdenv, streaming-commons, stringsearch, text, time, transformers
-         , unix, unix-compat, vault, void, wai, wai-logger, word8, zlib
+         , data-default-class, deepseq, directory, fast-logger, http-types
+         , iproute, lifted-base, network, old-locale, resourcet, stdenv
+         , streaming-commons, stringsearch, text, time, transformers, unix
+         , unix-compat, vault, void, wai, wai-logger, word8, zlib
          }:
          mkDerivation {
            pname = "wai-extra";
            version = "3.0.22.0";
-           src = fetchgit {
-             url = "https://github.com/yesodweb/wai.git";
-             sha256 = "152p2jj2awhyc2m1vygsmm3cfg6bjl39y9w7sj548pl89dbnz7n7";
-             rev = "d43e4b1d4ed874803632e07ef09b0009e0479135";
-           };
-           postUnpack = "sourceRoot+=/wai-extra; echo source root reset to $sourceRoot";
+           sha256 = "62943d71071cbc557686ccb00b4c64383c24b8839b838841686fc2290bd59367";
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
@@ -43062,18 +43087,16 @@ inherit (pkgs) which;};
          }) {};
       "yaml" = callPackage
         ({ mkDerivation, aeson, attoparsec, base, bytestring, conduit
-         , containers, directory, fetchgit, filepath, resourcet, scientific
+         , containers, directory, filepath, resourcet, scientific
          , semigroups, stdenv, template-haskell, text, transformers
          , unordered-containers, vector
          }:
          mkDerivation {
            pname = "yaml";
            version = "0.8.28";
-           src = fetchgit {
-             url = "https://github.com/snoyberg/yaml.git";
-             sha256 = "0fcy0bqzxyw46ykdmx191ffw8v2wnzqsk9cppnwq8akpgarw0xf0";
-             rev = "7ce90970adb3b278dffb2d5e4ac724bfe59db768";
-           };
+           sha256 = "f702b6a489ad94cda3c0cb15db34a30356d7b2cdc86a4d0f5340f2ece69f8f6b";
+           revision = "1";
+           editedCabalFile = "0f8vb5v0xfpsc02zqh9pzgv4fir93sgijk342lz5k872gscfjn62";
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [

--- a/ssc/Pos/Ssc/Worker.hs
+++ b/ssc/Pos/Ssc/Worker.hs
@@ -258,9 +258,9 @@ onNewSlotShares params SlotId {..} sendShares = do
 
 sscProcessOurMessage
     :: (Buildable err, SscMode ctx m)
-    => ExceptT err m () -> m ()
+    => m (Either err ()) -> m ()
 sscProcessOurMessage action =
-    runExceptT action >>= logResult
+    action >>= logResult
   where
     logResult (Right _) = logDebugS "We have accepted our message"
     logResult (Left er) =

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,29 @@ packages:
   - cborg
   extra-dep: true
 - location:
+    git: https://github.com/snoyberg/conduit.git
+    commit: 7f75bfca8d479e1737861a75437a288af662a3cf
+    subdirs:
+    - resourcet
+    - conduit
+    - conduit-extra
+- location:
+    git: https://github.com/yesodweb/wai.git
+    commit: d43e4b1d4ed874803632e07ef09b0009e0479135
+    subdirs:
+    - wai-extra
+  extra-dep: true
+- location:
+    git: https://github.com/snoyberg/mono-traversable.git
+    commit: a4c980c36f2fe8b8f78ac5b235c60ab91493bf01
+    subdirs:
+    - mono-traversable
+  extra-dep: true
+- location:
+    git: https://github.com/snoyberg/yaml.git
+    commit: 7ce90970adb3b278dffb2d5e4ac724bfe59db768
+  extra-dep: true
+- location:
     git: https://github.com/serokell/time-units.git
     commit: 6c3747c1ac794f952de996dd7ba8a2f6d63bf132
   extra-dep: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,29 +42,6 @@ packages:
   - cborg
   extra-dep: true
 - location:
-    git: https://github.com/snoyberg/conduit.git
-    commit: 7f75bfca8d479e1737861a75437a288af662a3cf
-    subdirs:
-    - resourcet
-    - conduit
-    - conduit-extra
-- location:
-    git: https://github.com/yesodweb/wai.git
-    commit: d43e4b1d4ed874803632e07ef09b0009e0479135
-    subdirs:
-    - wai-extra
-  extra-dep: true
-- location:
-    git: https://github.com/snoyberg/mono-traversable.git
-    commit: a4c980c36f2fe8b8f78ac5b235c60ab91493bf01
-    subdirs:
-    - mono-traversable
-  extra-dep: true
-- location:
-    git: https://github.com/snoyberg/yaml.git
-    commit: 7ce90970adb3b278dffb2d5e4ac724bfe59db768
-  extra-dep: true
-- location:
     git: https://github.com/serokell/time-units.git
     commit: 6c3747c1ac794f952de996dd7ba8a2f6d63bf132
   extra-dep: true
@@ -140,6 +117,24 @@ packages:
     commit: 49f501a082d745f3b880677220a29cafaa181452
   extra-dep: true
 
+# Required due to conduit bump
+# See https://github.com/alphaHeavy/lzma-conduit/pull/18
+- location:
+    git: https://github.com/serokell/lzma-conduit.git
+    commit: 0f6a8754bcd97c701465d71f4a0ad83f2c11aaf4
+  extra-dep: true
+# I don't think making a PR to servant is a good idea at this point
+- location:
+    git: https://github.com/serokell/servant.git
+    commit: 5db013cc36894afdff9e748dbc1c05947c54df3d
+  extra-dep: true
+  subdirs:
+    - servant-server
+- location:
+    git: https://github.com/serokell/servant-multipart.git
+    commit: e7de56b5f7c39f8dc473f1bbaf534bb7affc3cf4
+  extra-dep: true
+
 nix:
   shell-file: shell.nix
 
@@ -155,10 +150,8 @@ extra-deps:
 # - purescript-bridge-0.8.0.1
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8
 - servant-0.12
-- servant-server-0.12
 - servant-client-0.12
 - servant-client-core-0.12
-- servant-multipart-0.11
 - servant-docs-0.11.1             # needed for servant-0.12
 - servant-swagger-1.1.4           # needed for servant-0.12
 - servant-swagger-ui-0.2.4.3.4.0  # needed for servant-0.12
@@ -182,6 +175,20 @@ extra-deps:
 - lens-sop-0.2.0.2
 - json-sop-0.2.0.3
 - servant-generic-0.1.0.1
+# See CSL-2231
+- conduit-1.3.0
+- conduit-extra-1.3.0
+- mono-traversable-1.0.8.1
+- resourcet-1.2.0
+- yaml-0.8.28
+- lzma-0.0.0.3
+- lzma-clib-5.2.2
+- wai-extra-3.0.22.0
+- typed-process-0.2.1.0
+- unliftio-0.2.4.0
+- unliftio-core-0.1.1.0
+- http-conduit-2.3.0
+- simple-sendfile-0.2.27
 
 # This is for CI to pass --fast to all dependencies
 apply-ghc-options: everything

--- a/txp/Pos/Txp/Logic/Local.hs
+++ b/txp/Pos/Txp/Logic/Local.hs
@@ -131,7 +131,7 @@ txProcessTransactionAbstract buildPTxContext txAction itw@(txId, txAux) = report
     -- Also note that we don't need to use a snapshot here and can be
     -- sure that GState won't change, because changing it requires
     -- 'StateLock' which we own inside this function.
-    tipDB <- GS.getTip
+    tipDB <- lift GS.getTip
     epoch <- siEpoch <$> (note ToilSlotUnknown =<< getCurrentSlot)
     pctx <- lift $ buildPTxContext txAux
     pRes <-

--- a/txp/Pos/Txp/Settings/Global.hs
+++ b/txp/Pos/Txp/Settings/Global.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE TypeOperators       #-}
 
 -- | Global settings of Txp.
 
@@ -14,7 +15,6 @@ module Pos.Txp.Settings.Global
 
 import           Universum
 
-import           Control.Monad.Except (MonadError)
 import           System.Wlog (WithLogger)
 
 import           Pos.Core (ComponentBlock, HasConfiguration)
@@ -33,7 +33,6 @@ type TxpCommonMode m =
 
 type TxpGlobalVerifyMode m =
     ( TxpCommonMode m
-    , MonadError ToilVerFailure m
     )
 
 type TxpGlobalApplyMode ctx m =
@@ -53,7 +52,8 @@ data TxpGlobalSettings = TxpGlobalSettings
       -- all data from transactions is known (script versions,
       -- attributes, addresses, witnesses).
       tgsVerifyBlocks :: forall m. TxpGlobalVerifyMode m =>
-                         Bool -> OldestFirst NE TxpBlock -> m (OldestFirst NE TxpUndo)
+                         Bool -> OldestFirst NE TxpBlock ->
+                         m $ Either ToilVerFailure $ OldestFirst NE TxpUndo
     , -- | Apply chain of /definitely/ valid blocks to Txp's GState.
       tgsApplyBlocks :: forall ctx m . TxpGlobalApplyMode ctx m =>
                         OldestFirst NE TxpBlund -> m SomeBatchOp

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -105,6 +105,7 @@ library
                      , text-format
                      , transformers
                      , universum
+                     , unliftio
                      , unordered-containers
                      , vector
 

--- a/update/Pos/Update/Logic/Local.hs
+++ b/update/Pos/Update/Logic/Local.hs
@@ -30,6 +30,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import           Formatting (sformat, (%))
 import           System.Wlog (WithLogger, logWarning)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Class (biSize)
 import           Pos.Core (BlockVersionData (bvdMaxBlockSize), HasConfiguration, HeaderHash,
@@ -57,6 +58,7 @@ import           Pos.Util.Util (HasLens (..), HasLens')
 type USLocalLogicMode ctx m =
     ( MonadIO m
     , MonadDBRead m
+    , MonadUnliftIO m
     , WithLogger m
     , MonadReader ctx m
     , HasLens UpdateContext ctx UpdateContext
@@ -127,7 +129,7 @@ processSkeleton payload =
     withUSLock $
     runExceptT $
     modifyMemState $ \ms@MemState {..} -> do
-        dbTip <- DB.getTip
+        dbTip <- lift DB.getTip
         -- We must check tip here, because we can't be sure that tip
         -- in DB is the same as the tip in memory. Normally it will be
         -- the case, but if normalization fails, it won't be true.
@@ -138,24 +140,28 @@ processSkeleton payload =
         unless (dbTip == msTip) $ do
             let err = PollTipMismatch {ptmTipMemory = msTip, ptmTipDB = dbTip}
             throwError err
-        maxBlockSize <- bvdMaxBlockSize <$> DB.getAdoptedBVData
+        maxBlockSize <- bvdMaxBlockSize <$> lift DB.getAdoptedBVData
         msIntermediate <-
             -- TODO: This is a rather arbitrary limit, we should revisit it (see CSL-1664)
-            if | maxBlockSize * 2 <= mpSize msPool -> refreshMemPool ms
+            if | maxBlockSize * 2 <= mpSize msPool -> lift (refreshMemPool ms)
                | otherwise -> pure ms
         processSkeletonDo msIntermediate
   where
     processSkeletonDo ms@MemState {..} = do
-        modifier <-
-            runDBPoll . evalPollT msModifier . execPollT def $
+        modifierOrFailure <-
+            lift . runDBPoll . runExceptT . evalPollT msModifier . execPollT def $
             verifyAndApplyUSPayload True (Left msSlot) payload
-        let newModifier = modifyPollModifier msModifier modifier
-        let newPool = addToMemPool payload msPool
-        pure $ ms {msModifier = newModifier, msPool = newPool}
+        case modifierOrFailure of
+            Left failure -> throwError failure
+            Right modifier -> do
+                let newModifier = modifyPollModifier msModifier modifier
+                let newPool = addToMemPool payload msPool
+                pure $ ms {msModifier = newModifier, msPool = newPool}
 
 -- Remove most useless data from mem pool to make it smaller.
 refreshMemPool
     :: ( MonadDBRead m
+       , MonadUnliftIO m
        , MonadIO m
        , MonadReader ctx m
        , HasLens UpdateContext ctx UpdateContext

--- a/update/Pos/Update/Mode.hs
+++ b/update/Pos/Update/Mode.hs
@@ -9,6 +9,7 @@ import           Universum
 
 import           Mockable (MonadMockable)
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Update ()
 import           Pos.Core.Configuration (HasConfiguration)
@@ -28,6 +29,7 @@ type UpdateMode ctx m
     = ( WithLogger m
       , MonadMockable m
       , MonadIO m
+      , MonadUnliftIO m
       , MonadMask m
       , MonadGState m
       , MonadDB m

--- a/update/Pos/Update/Poll/DBPoll.hs
+++ b/update/Pos/Update/Poll/DBPoll.hs
@@ -14,6 +14,7 @@ import           Data.Coerce (coerce)
 import qualified Data.HashMap.Strict as HM
 import qualified Ether
 import           System.Wlog (WithLogger)
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Core (Coin, HasConfiguration)
 import           Pos.DB.Class (MonadDBRead)
@@ -38,6 +39,7 @@ runDBPoll = coerce
 
 instance ( MonadIO m
          , MonadDBRead m
+         , MonadUnliftIO m
          , WithLogger m
          , MonadReader ctx m
          , HasLrcContext ctx

--- a/update/cardano-sl-update.cabal
+++ b/update/cardano-sl-update.cabal
@@ -123,6 +123,7 @@ library
                      , time-units
                      , transformers
                      , universum
+                     , unliftio
                      , unordered-containers
 
   default-language:    Haskell2010

--- a/util/Pos/Util/Orphans.hs
+++ b/util/Pos/Util/Orphans.hs
@@ -154,9 +154,6 @@ instance (Typeable s, Buildable a) => Buildable (Tagged s a) where
 -- MonadResource/ResourceT
 ----------------------------------------------------------------------------
 
-instance LiftLocal ResourceT where
-    liftLocal _ l f = hoist (l f)
-
 instance {-# OVERLAPPABLE #-}
     (MonadResource m, MonadTrans t, Applicative (t m),
      MonadBase IO (t m), MonadIO (t m), MonadThrow (t m)) =>

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -88,6 +88,7 @@ library
                      , transformers-base
                      , transformers-lift
                      , universum
+                     , unliftio-core
                      , unordered-containers
                      , vector
 

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -156,6 +156,7 @@ library
                       , time-units
                       , transformers
                       , universum >= 0.1.11
+                      , unliftio
                       , unordered-containers
                       , wai
                       , wai-websockets

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -29,6 +29,7 @@ import           Data.List (partition)
 import qualified Data.Map.Strict as M
 import           Mockable (Production)
 import           System.Wlog (HasLoggerName (..))
+import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Block.Slog (HasSlogContext (..), HasSlogGState (..))
 import           Pos.Client.KeyStorage (MonadKeys (..), MonadKeysRead (..), getSecretDefault,
@@ -183,6 +184,7 @@ instance HasLens WalletWebModeContextTag WalletWebModeContext WalletWebModeConte
 
 type MonadWalletWebMode ctx m =
     ( MinWorkMode m
+    , MonadUnliftIO m
     , MonadBaseControl IO m
     , MonadMask m
     , MonadSlots ctx m
@@ -271,10 +273,12 @@ instance (HasConfiguration, HasSscConfiguration, HasInfraConfiguration) =>
 
 type BalancesEnv ext ctx m =
     ( MonadDBRead m
+    , MonadUnliftIO m
     , MonadGState m
     , MonadWalletDBRead ctx m
     , MonadMask m
-    , MonadTxpMem ext ctx m)
+    , MonadTxpMem ext ctx m
+    )
 
 getOwnUtxosDefault :: BalancesEnv ext ctx m => [Address] -> m Utxo
 getOwnUtxosDefault addrs = do


### PR DESCRIPTION
This PR upgrades `conduit` and `resourcet` to more modern versions and resolves dependency hell and other breakages associated with that.

`MonadBaseControl IO` usages were removed in many places. `MonadUnliftIO` appeared instead. That's due to changes in `resourcet`.

`Source`, `Sink` and friends are deprecated in `conduit-1.3.0`, `ConduitT` is used instead.

`hoist` calls for `ResourceT`/`ConduitT` were replaced by concrete
calls to `transResourceT`/`transPipe` as these types are no longer
instances of `MFunctor`.

Demo works locally.