### PR TITLE
First version of the pure wallet

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -219,6 +219,7 @@ test-suite wallet-unit-tests
                       UTxO.PreChain
                       UTxO.Translate
                       UTxO.Verify
+                      Wallet.Spec
   default-language:   Haskell2010
   default-extensions: BangPatterns
                       ConstraintKinds

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -265,6 +265,7 @@ test-suite wallet-unit-tests
                     , lens
                     , log-warper
                     , mtl
+                    , QuickCheck
                     , serokell-util
                     , text
                     , text-format

--- a/wallet-new/test/unit/UTxO/Bootstrap.hs
+++ b/wallet-new/test/unit/UTxO/Bootstrap.hs
@@ -62,6 +62,7 @@ import qualified UTxO.DSL as DSL
 -- >     , Output{ addr: Addr{ actorIx: IxAvvm 9, addrIx:  0}, val:  100000}
 -- >   ]
 -- >   , fee:   0
+-- >   , hash:  0
 -- > }
 bootstrapTransaction :: TransCtxt -> DSL.Transaction h Addr
 bootstrapTransaction ctxt@TransCtxt{..} = DSL.Transaction {
@@ -87,8 +88,5 @@ bootstrapTransaction ctxt@TransCtxt{..} = DSL.Transaction {
     totalAda = sum $ map snd balances -- we're ignoring overflow here
 
 -- | Check if something is the bootstrap transaction
---
--- NOTE: We simply check if creates fresh Ada. This shortcut will only work
--- with the specific way in which we use the DSL.
 isBootstrapTransaction :: DSL.Transaction h a -> Bool
-isBootstrapTransaction DSL.Transaction{..} = trFresh > 0
+isBootstrapTransaction = Set.null . DSL.trIns

--- a/wallet-new/test/unit/UTxO/PreChain.hs
+++ b/wallet-new/test/unit/UTxO/PreChain.hs
@@ -27,7 +27,7 @@ import UTxO.Translate
   Chain with some information still missing
 -------------------------------------------------------------------------------}
 
-newtype PreChain h = PreChain (h (Transaction h Addr) -> [[Fee]] -> Blocks h Addr)
+newtype PreChain h = PreChain (Transaction h Addr -> [[Fee]] -> Blocks h Addr)
 
 data FromPreChain h = FromPreChain {
       fpcBoot   :: Transaction h Addr
@@ -39,7 +39,7 @@ fromPreChain :: Hash h Addr
              => PreChain h -> Translate IntException (FromPreChain h)
 fromPreChain (PreChain f) = do
     fpcBoot <- asks bootstrapTransaction
-    txs <- calcFees fpcBoot (f (hash fpcBoot))
+    txs <- calcFees fpcBoot (f fpcBoot)
     let fpcChain  = Chain txs -- doesn't include the boot transactions
         fpcLedger = chainToLedger fpcBoot fpcChain
     return FromPreChain{..}

--- a/wallet-new/test/unit/Wallet/Spec.hs
+++ b/wallet-new/test/unit/Wallet/Spec.hs
@@ -1,0 +1,180 @@
+-- | Pure specification of the wallet
+module Wallet.Spec (
+    -- * Types
+    Ours
+  , Pending
+  , Wallet(..)
+  , walletEmpty
+    -- * Main wallet operations
+  , totalBalance
+  , availableBalance
+  , applyBlock
+  , newPending
+    -- * Properties
+    -- ** Invariants
+  , InductiveWallet(..)
+  , invariant
+  , pendingInUtxo
+  , utxoIsOurs
+  , changeNotAvailable
+  , changeNotInUtxo
+  , changeAvailable
+  , balanceChangeAvailable
+  ) where
+
+import Universum
+import qualified Data.Foldable   as Fold
+import qualified Data.Map.Strict as Map
+import qualified Data.Set        as Set
+
+import UTxO.DSL
+import UTxO.Crypto
+
+{-------------------------------------------------------------------------------
+  Wallet types
+-------------------------------------------------------------------------------}
+
+-- | Check if an address is ours
+type Ours a = a -> Maybe SomeKeyPair
+
+-- | Pending transactions
+type Pending h a = Set (Transaction h a)
+
+-- | Wallet state
+data Wallet h a = Wallet {
+      walletUtxo    :: Utxo h a
+    , walletPending :: Pending h a
+    }
+
+walletEmpty :: Wallet h a
+walletEmpty = Wallet {
+      walletUtxo    = utxoEmpty
+    , walletPending = Set.empty
+    }
+
+{-------------------------------------------------------------------------------
+  Main wallet operations
+
+  TODO: Undo operations currently ignored
+-------------------------------------------------------------------------------}
+
+totalBalance :: Hash h a => Ours a -> Wallet h a -> Value
+totalBalance ours = balance . total ours
+
+availableBalance :: Hash h a => Wallet h a -> Value
+availableBalance = balance . available
+
+applyBlock :: Hash h a => Ours a -> Block h a -> Wallet h a -> Wallet h a
+applyBlock ours b Wallet{..} = Wallet{
+      walletUtxo    = updateUtxo ours b walletUtxo
+    , walletPending = updatePending   b walletPending
+    }
+
+newPending :: (Hash h a, Ord a)
+           => Transaction h a -> Wallet h a -> Maybe (Wallet h a)
+newPending tx w@Wallet{..} = do
+    guard $ trIns tx `Set.isSubsetOf` utxoDomain (available w)
+    return Wallet {
+        walletUtxo    = walletUtxo
+      , walletPending = Set.insert tx walletPending
+      }
+
+{-------------------------------------------------------------------------------
+  Auxiliary operations
+-------------------------------------------------------------------------------}
+
+txIns :: (Hash h a, Foldable f) => f (Transaction h a) -> Set (Input h a)
+txIns = Set.unions . map trIns . Fold.toList
+
+txOuts :: (Hash h a, Foldable f) => f (Transaction h a) -> Utxo h a
+txOuts = utxoUnions . map trUtxo . Fold.toList
+
+available :: Hash h a => Wallet h a -> Utxo h a
+available Wallet{..} = walletUtxo `utxoRemove` txIns walletPending
+
+change :: Hash h a => Ours a -> Wallet h a -> Utxo h a
+change ours Wallet{..} = filterUtxo ours (txOuts walletPending)
+
+total :: Hash h a => Ours a -> Wallet h a -> Utxo h a
+total ours w = available w `utxoUnion` change ours w
+
+balance :: Utxo h a -> Value
+balance = sum . map outVal . Map.elems . utxoToMap
+
+updateUtxo :: forall h a. Hash h a
+           => Ours a -> Block h a -> Utxo h a -> Utxo h a
+updateUtxo ours b = remSpent . addNew
+  where
+    addNew, remSpent :: Utxo h a -> Utxo h a
+    addNew   = (`utxoUnion`  filterUtxo ours (txOuts b))
+    remSpent = (`utxoRemove`                  txIns  b)
+
+updatePending :: forall h a. Hash h a => Block h a -> Pending h a -> Pending h a
+updatePending b = Set.filter $ \t -> disjoint (trIns t) (txIns b)
+
+filterUtxo :: Ours a -> Utxo h a -> Utxo h a
+filterUtxo ours = utxoFilterByAddr (isJust . ours)
+
+{-------------------------------------------------------------------------------
+  Invariants
+-------------------------------------------------------------------------------}
+
+-- | Inductive definition of a wallet
+--
+-- TODO: We should generate random 'InductiveWallet's and then verify the
+-- invariants.
+data InductiveWallet h a =
+    WalletEmpty
+  | ApplyBlock (Block       h a) (InductiveWallet h a)
+  | NewPending (Transaction h a) (InductiveWallet h a)
+
+type Invariant h a = InductiveWallet h a -> Bool
+
+-- | Check if a property is invariant for all wallet constructions
+invariant :: forall h a. (Hash h a, Ord a)
+          => Ours a -> (Wallet h a -> Bool) -> Invariant h a
+invariant ours p = isJust . go
+  where
+    go :: InductiveWallet h a -> Maybe (Wallet h a)
+    go WalletEmpty      = verify walletEmpty
+    go (ApplyBlock b w) = go w >>= verify . applyBlock ours b
+    go (NewPending t w) = go w >>= \w' ->
+                          -- If pending not ours, just ignore
+                          maybe (Just w') verify (newPending t w')
+
+    verify :: Wallet h a -> Maybe (Wallet h a)
+    verify w = guard (p w) >> return w
+
+pendingInUtxo :: (Hash h a, Ord a) => Ours a -> Invariant h a
+pendingInUtxo ours = invariant ours $ \Wallet{..} ->
+    txIns walletPending `Set.isSubsetOf` utxoDomain walletUtxo
+
+utxoIsOurs :: (Hash h a, Ord a) => Ours a -> Invariant h a
+utxoIsOurs ours = invariant ours $ \Wallet{..} ->
+    all (isJust . ours . outAddr) (utxoRange walletUtxo)
+
+changeNotAvailable :: (Hash h a, Ord a) => Ours a -> Invariant h a
+changeNotAvailable ours = invariant ours $ \w ->
+    utxoDomain (change ours w) `disjoint` utxoDomain (available w)
+
+changeNotInUtxo :: (Hash h a, Ord a) => Ours a -> Invariant h a
+changeNotInUtxo ours = invariant ours $ \w ->
+    utxoDomain (change ours w) `disjoint` utxoDomain (walletUtxo w)
+
+changeAvailable :: (Hash h a, Ord a) => Ours a -> Invariant h a
+changeAvailable ours = invariant ours $ \w ->
+    change ours w `utxoUnion` available w == total ours w
+
+balanceChangeAvailable :: (Hash h a, Ord a) => Ours a -> Invariant h a
+balanceChangeAvailable ours = invariant ours $ \w ->
+    balance (change ours w) + balance (available w) == balance (total ours w)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+-- | Check that two sets are disjoint
+--
+-- This is available out of the box from containters >= 0.5.11
+disjoint :: Ord a => Set a -> Set a -> Bool
+disjoint a b = Set.null (a `Set.intersection` b)

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -7,6 +7,8 @@ module Main (main) where
 import Universum
 import Formatting (sformat, bprint, build, (%), shown)
 import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
 import Prelude (Show(..))
 import qualified Data.Text.Buildable
 import qualified Data.Set as Set
@@ -49,139 +51,172 @@ _showContext = do
 tests :: Spec
 tests = describe "Wallet unit tests" $ do
     testSanityChecks
+    quickcheckSanityChecks
 
 testSanityChecks :: Spec
 testSanityChecks = describe "Test sanity checks" $ do
     it "can construct and verify empty block" $
-      intAndVerify emptyBlock `shouldSatisfy` expectValid
+      intAndVerifyPure emptyBlock `shouldSatisfy` expectValid
 
     it "can construct and verify block with one transaction" $
-      intAndVerify oneTrans `shouldSatisfy` expectValid
+      intAndVerifyPure oneTrans `shouldSatisfy` expectValid
 
     it "can construct and verify example 1 from the UTxO paper" $
-      intAndVerify example1 `shouldSatisfy` expectValid
+      intAndVerifyPure example1 `shouldSatisfy` expectValid
 
     it "can reject overspending" $
-      intAndVerify overspend `shouldSatisfy` expectInvalid
+      intAndVerifyPure overspend `shouldSatisfy` expectInvalid
 
     it "can reject double spending" $
-      intAndVerify doublespend `shouldSatisfy` expectInvalid
-  where
-    ExampleChains{..} = exampleChains :: ExampleChains GivenHash
+      intAndVerifyPure doublespend `shouldSatisfy` expectInvalid
+
+quickcheckSanityChecks :: Spec
+quickcheckSanityChecks = describe "QuickCheck sanity checks" $ do
+    prop "can construct and verify block with one arbitrary transaction" $
+      expectValid <$> intAndVerifyGen genOneTrans
 
 {-------------------------------------------------------------------------------
-  Example chains that we use in the tests
+  Example QuickCheck generated chains
 -------------------------------------------------------------------------------}
 
-data ExampleChains h = ExampleChains {
-      emptyBlock  :: PreChain h
-    , oneTrans    :: PreChain h
-    , overspend   :: PreChain h
-    , doublespend :: PreChain h
-    , example1    :: PreChain h
-    }
+genOneTrans :: Hash h Addr => PreChain h Gen
+genOneTrans = PreChain $ \boot ((fee : _) : _) -> do
+    -- TODO: 'initR0' should be derived from 'boot'
+    value <- choose (0, initR0 - fee)
+    let t1 = Transaction {
+                 trFresh = 0
+               , trFee   = fee
+               , trHash  = 1
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r1 value
+                           , Output r0 (initR0 - value - fee)
+                           ]
+               }
+    return $ OldestFirst [OldestFirst [t1]]
 
-exampleChains :: Hash h Addr => ExampleChains h
-exampleChains = ExampleChains {..}
-  where
-    emptyBlock = PreChain $ \_boot _fees ->
-      OldestFirst [OldestFirst []]
+{-------------------------------------------------------------------------------
+  Example hand-constructed chains
+-------------------------------------------------------------------------------}
 
-    oneTrans = PreChain $ \boot ((fee : _) : _) ->
-      let t1 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee
-                 , trHash  = 1
-                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
-                 , trOuts  = [ Output r1 1000
-                             , Output r0 (initR0 - 1000 - fee)
-                             ]
-                 }
-      in OldestFirst [OldestFirst [t1]]
+emptyBlock :: Hash h Addr => PreChain h Identity
+emptyBlock = PreChain $ \_boot _fees ->
+  return $ OldestFirst [OldestFirst []]
 
-    -- Try to transfer from R0 to R1, but leaving R0's balance the same
-    overspend = PreChain $ \boot ((fee : _) : _) ->
-      let t1 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee
-                 , trHash  = 1
-                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
-                 , trOuts  = [ Output r1 1000
-                             , Output r0 initR0
-                             ]
-                 }
-      in OldestFirst [OldestFirst [t1]]
+oneTrans :: Hash h Addr => PreChain h Identity
+oneTrans = PreChain $ \boot ((fee : _) : _) -> do
+    let t1 = Transaction {
+                 trFresh = 0
+               , trFee   = fee
+               , trHash  = 1
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r1 1000
+                           , Output r0 (initR0 - 1000 - fee)
+                           ]
+               }
+    return $ OldestFirst [OldestFirst [t1]]
 
-    -- Try to transfer to R1 and R2 using the same output
-    -- TODO: in principle this example /ought/ to work without any kind of
-    -- outputs at all; but in practice this breaks stuff because now we have
-    -- two identical transactions which would therefore get identical IDs?
-    doublespend = PreChain $ \boot ((fee1 : fee2 : _) : _) ->
-      let t1 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee1
-                 , trHash  = 1
-                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
-                 , trOuts  = [ Output r1 1000
-                             , Output r0 (initR0 - 1000 - fee1)
-                             ]
-                 }
-          t2 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee2
-                 , trHash  = 2
-                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
-                 , trOuts  = [ Output r2 1000
-                             , Output r0 (initR0 - 1000 - fee2)
-                             ]
-                 }
-      in OldestFirst [OldestFirst [t1, t2]]
+-- Try to transfer from R0 to R1, but leaving R0's balance the same
+overspend :: Hash h Addr => PreChain h Identity
+overspend = PreChain $ \boot ((fee : _) : _) -> do
+    let t1 = Transaction {
+                 trFresh = 0
+               , trFee   = fee
+               , trHash  = 1
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r1 1000
+                           , Output r0 initR0
+                           ]
+               }
+    return $ OldestFirst [OldestFirst [t1]]
 
-    -- Translation of example 1 of the paper, adjusted to allow for fees
-    --
-    -- Transaction t1 in the example creates new coins, and transaction t2
-    -- tranfers this to an ordinary address. In other words, t1 and t2
-    -- corresponds to the bootstrap transactions.
-    --
-    -- Transaction t3 then transfers part of R0's balance to R1, returning the
-    -- rest to back to R0; and t4 transfers the remainder of R0's balance to
-    -- R2.
-    --
-    -- Transaction 5 in example 1 is a transaction /from/ the treasury /to/ an
-    -- ordinary address. This currently has no equivalent in Cardano, so we omit
-    -- it.
-    example1 = PreChain $ \boot ((fee3 : fee4 : _) : _) ->
-      let t3 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee3
-                 , trHash  = 3
-                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
-                 , trOuts  = [ Output r1 1000
-                             , Output r0 (initR0 - 1000 - fee3)
-                             ]
-                 }
-          t4 = Transaction {
-                   trFresh = 0
-                 , trFee   = fee4
-                 , trHash  = 4
-                 , trIns   = Set.fromList [ Input (hash t3) 1 ]
-                 , trOuts  = [ Output r2 (initR0 - 1000 - fee3 - fee4) ]
-                 }
-      in OldestFirst [OldestFirst [t3, t4]]
+-- Try to transfer to R1 and R2 using the same output
+-- TODO: in principle this example /ought/ to work without any kind of
+-- outputs at all; but in practice this breaks stuff because now we have
+-- two identical transactions which would therefore get identical IDs?
+doublespend :: Hash h Addr => PreChain h Identity
+doublespend = PreChain $ \boot ((fee1 : fee2 : _) : _) -> do
+    let t1 = Transaction {
+                 trFresh = 0
+               , trFee   = fee1
+               , trHash  = 1
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r1 1000
+                           , Output r0 (initR0 - 1000 - fee1)
+                           ]
+               }
+        t2 = Transaction {
+                 trFresh = 0
+               , trFee   = fee2
+               , trHash  = 2
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r2 1000
+                           , Output r0 (initR0 - 1000 - fee2)
+                           ]
+               }
+    return $ OldestFirst [OldestFirst [t1, t2]]
 
-    initR0 = 11137499999752500
+-- Translation of example 1 of the paper, adjusted to allow for fees
+--
+-- Transaction t1 in the example creates new coins, and transaction t2
+-- tranfers this to an ordinary address. In other words, t1 and t2
+-- corresponds to the bootstrap transactions.
+--
+-- Transaction t3 then transfers part of R0's balance to R1, returning the
+-- rest to back to R0; and t4 transfers the remainder of R0's balance to
+-- R2.
+--
+-- Transaction 5 in example 1 is a transaction /from/ the treasury /to/ an
+-- ordinary address. This currently has no equivalent in Cardano, so we omit
+-- it.
+example1 :: Hash h Addr => PreChain h Identity
+example1 = PreChain $ \boot ((fee3 : fee4 : _) : _) -> do
+    let t3 = Transaction {
+                 trFresh = 0
+               , trFee   = fee3
+               , trHash  = 3
+               , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
+               , trOuts  = [ Output r1 1000
+                           , Output r0 (initR0 - 1000 - fee3)
+                           ]
+               }
+        t4 = Transaction {
+                 trFresh = 0
+               , trFee   = fee4
+               , trHash  = 4
+               , trIns   = Set.fromList [ Input (hash t3) 1 ]
+               , trOuts  = [ Output r2 (initR0 - 1000 - fee3 - fee4) ]
+               }
+    return $ OldestFirst [OldestFirst [t3, t4]]
 
-    r0 = Addr (IxRich 0) 0
-    r1 = Addr (IxRich 1) 0
-    r2 = Addr (IxRich 2) 0
+{-------------------------------------------------------------------------------
+  Some initial values
+
+  TODO: These come from the genesis block. We shouldn't hardcode them
+  in the tests but rather derive them from the bootstrap transaction.
+-------------------------------------------------------------------------------}
+
+initR0 :: Value
+initR0 = 11137499999752500
+
+r0, r1, r2 :: Addr
+r0 = Addr (IxRich 0) 0
+r1 = Addr (IxRich 1) 0
+r2 = Addr (IxRich 2) 0
 
 {-------------------------------------------------------------------------------
   Verify chain
 -------------------------------------------------------------------------------}
 
+intAndVerifyPure :: PreChain GivenHash Identity -> ValidationResult
+intAndVerifyPure = runIdentity . intAndVerify
+
+intAndVerifyGen :: PreChain GivenHash Gen -> Gen ValidationResult
+intAndVerifyGen = intAndVerify
+
 -- | Interpret and verify a chain, given the bootstrap transactions
-intAndVerify :: Hash h Addr => PreChain h -> ValidationResult
-intAndVerify pc = runTranslate $ do
+intAndVerify :: (Hash h Addr, Monad m)
+             => PreChain h m -> m ValidationResult
+intAndVerify pc = runTranslateT $ do
     FromPreChain{..} <- fromPreChain pc
     let dslIsValid = ledgerIsValid fpcLedger
         dslUtxo    = ledgerUtxo    fpcLedger
@@ -200,7 +235,7 @@ intAndVerify pc = runTranslate $ do
           (False, Right _) -> return $ Disagreement UnexpectedValid
           (True,  Left e)  -> return $ Disagreement (UnexpectedInvalid e)
           (True,  Right (_undo, utxo)) -> do
-            (utxo', _) <- runIntM ctxt dslUtxo
+            (utxo', _) <- runIntT ctxt dslUtxo
             if utxo == utxo'
               then return $ ExpectedValid
               else return $ Disagreement (UnexpectedUtxo dslUtxo utxo utxo')

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -92,7 +92,7 @@ exampleChains = ExampleChains {..}
                    trFresh = 0
                  , trFee   = fee
                  , trHash  = 1
-                 , trIns   = Set.fromList [ Input boot 0 ] -- rich 0
+                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
                  , trOuts  = [ Output r1 1000
                              , Output r0 (initR0 - 1000 - fee)
                              ]
@@ -105,7 +105,7 @@ exampleChains = ExampleChains {..}
                    trFresh = 0
                  , trFee   = fee
                  , trHash  = 1
-                 , trIns   = Set.fromList [ Input boot 0 ] -- rich 0
+                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
                  , trOuts  = [ Output r1 1000
                              , Output r0 initR0
                              ]
@@ -121,7 +121,7 @@ exampleChains = ExampleChains {..}
                    trFresh = 0
                  , trFee   = fee1
                  , trHash  = 1
-                 , trIns   = Set.fromList [ Input boot 0 ] -- rich 0
+                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
                  , trOuts  = [ Output r1 1000
                              , Output r0 (initR0 - 1000 - fee1)
                              ]
@@ -130,7 +130,7 @@ exampleChains = ExampleChains {..}
                    trFresh = 0
                  , trFee   = fee2
                  , trHash  = 2
-                 , trIns   = Set.fromList [ Input boot 0 ] -- rich 0
+                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
                  , trOuts  = [ Output r2 1000
                              , Output r0 (initR0 - 1000 - fee2)
                              ]
@@ -155,7 +155,7 @@ exampleChains = ExampleChains {..}
                    trFresh = 0
                  , trFee   = fee3
                  , trHash  = 3
-                 , trIns   = Set.fromList [ Input boot 0 ] -- rich 0
+                 , trIns   = Set.fromList [ Input (hash boot) 0 ] -- rich 0
                  , trOuts  = [ Output r1 1000
                              , Output r0 (initR0 - 1000 - fee3)
                              ]


### PR DESCRIPTION
This introduces module `Wallet.Spec`, which is a fairly direct translation of
Duncan's pure wallet specification. The idea is that we should be able to use
this to unit test the "real" wallet later.

This also makes a few minor additional changes:

* The 'isBootstrapTransaction' now just checks if the set of inputs is empty
  (that's what it should have done in the first place..)
* Few additional operations on the UTxO in the DSL, including a definition
  of equality.
* A 'PreChain' now gets the actual boot transaction rather than its hash,
  so that we inspect it to generate arbitrary valid ledgers. (We may have
  to add a monad parameter to 'PreChain' though.)