### PR TITLE
[CSL-2184] Fixes in NTP logic after switching to `async`s

### DIFF
--- a/infra/Pos/Infra/Configuration.hs
+++ b/infra/Pos/Infra/Configuration.hs
@@ -67,6 +67,8 @@ infraConfiguration = given
 
 ntpServers :: [String]
 ntpServers =
-    [ "time.windows.com"
-    , "clock.isc.org"
-    , "ntp5.stratum2.ru" ]
+    [ "0.pool.ntp.org"
+    , "2.pool.ntp.org"
+    , "3.pool.ntp.org"
+    ]
+    -- need only 3 servers :shrug:

--- a/infra/Pos/Slotting/Impl/Ntp.hs
+++ b/infra/Pos/Slotting/Impl/Ntp.hs
@@ -241,8 +241,7 @@ ntpSettings var = NtpClientSettings
     , ntpHandler         = ntpHandlerDo var
     -- logger name modifier
     , ntpLogName         = "ntp"
-    -- delay between making requests and response collection;
-    -- it also means that handler will be invoked with this lag
+    -- delay between making requests and response collection
     , ntpResponseTimeout = C.ntpResponseTimeout
     -- how often to send responses to server
     , ntpPollDelay       = C.ntpPollDelay

--- a/networking/src/NTP/Client.hs
+++ b/networking/src/NTP/Client.hs
@@ -17,7 +17,7 @@ module NTP.Client
 
 import           Universum
 
-import           Control.Concurrent.STM (modifyTVar')
+import           Control.Concurrent.STM (check, modifyTVar')
 import           Control.Concurrent.STM.TVar (TVar, readTVar)
 import           Control.Exception.Safe (Exception, MonadMask, catchAny, handleAny)
 import           Control.Lens ((%=), (.=), _Just)
@@ -39,7 +39,8 @@ import           System.Wlog (LoggerName, WithLogger, logDebug, logError, logInf
                               modifyLoggerName)
 
 import           Mockable.Class (Mockable)
-import           Mockable.Concurrent (Async, Concurrently, concurrently, forConcurrently, race)
+import           Mockable.Concurrent (Async, Concurrently, concurrently, forConcurrently, race,
+                                      withAsync)
 import           NTP.Packet (NtpPacket (..), evalClockOffset, mkCliNtpPacket, ntpPacketSize)
 import           NTP.Util (createAndBindSock, resolveNtpHost, selectIPv4, selectIPv6,
                            udpLocalAddresses, withSocketsDoLifted)
@@ -52,8 +53,7 @@ data NtpClientSettings m = NtpClientSettings
     , ntpLogName         :: LoggerName
       -- ^ logger name modifier
     , ntpResponseTimeout :: Microsecond
-      -- ^ delay between making requests and response collection;
-      -- it also means that handler will be invoked with this lag
+      -- ^ delay between making requests and response collection
     , ntpPollDelay       :: Microsecond
       -- ^ how often to send responses to server
     , ntpMeanSelection   :: [(Microsecond, Microsecond)] -> (Microsecond, Microsecond)
@@ -124,6 +124,14 @@ handleCollectedResponses cli = do
   where
     handleE = logError . sformat ("ntpMeanSelection: "%shown)
 
+allResponsesGathered :: NtpClient m -> STM Bool
+allResponsesGathered cli = do
+    responsesState <- readTVar $ ncState cli
+    let servers = ntpServers $ ncSettings cli
+    return $ case responsesState of
+        Nothing        -> False
+        Just responses -> length responses >= length servers
+
 doSend :: NtpMonad m => SockAddr -> NtpClient m -> m ()
 doSend addr cli = do
     sock   <- liftIO $ readTVarIO $ ncSockets cli
@@ -146,14 +154,20 @@ startSend :: NtpMonad m => [SockAddr] -> NtpClient m -> m ()
 startSend addrs cli = do
     let timeout = ntpResponseTimeout (ncSettings cli)
     let poll    = ntpPollDelay (ncSettings cli)
-    logDebug "Sending requests"
-    liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Just []
-    () <$ threadDelay timeout `race` forConcurrently addrs (flip doSend cli)
 
-    logDebug "Collecting responses"
-    handleCollectedResponses cli
-    liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Nothing
-    liftIO $ threadDelay (poll - timeout)
+    _ <- concurrently (threadDelay poll) $ do
+        logDebug "Sending requests"
+        liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Just []
+        let sendRequests = forConcurrently addrs (flip doSend cli)
+        let waitTimeout =
+                void $ race
+                    (threadDelay timeout)
+                    (atomically $ check =<< allResponsesGathered cli)
+        withAsync sendRequests $ \_ -> waitTimeout
+
+        logDebug "Collecting responses"
+        handleCollectedResponses cli
+        liftIO . atomically . modifyTVarS (ncState cli) $ identity .= Nothing
 
     startSend addrs cli
 

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -50,7 +50,7 @@ import           Pos.Client.KeyStorage (MonadKeys (..), deleteAllSecretKeys)
 import           Pos.Configuration (HasNodeConfiguration)
 import           Pos.Core (Address, SlotId, SoftwareVersion (..))
 import           Pos.Crypto (hashHexF)
-import           Pos.NtpCheck (NtpCheckMonad, NtpStatus (..), mkNtpStatusVar)
+import           Pos.NtpCheck (NtpCheckMonad, NtpStatus (..), getNtpStatusOnce)
 import           Pos.Shutdown (HasShutdownContext, triggerShutdown)
 import           Pos.Slotting (MonadSlots, getCurrentSlotBlocking)
 import           Pos.Txp (TxId, TxIn, TxOut)
@@ -150,7 +150,7 @@ syncProgress =
 
 localTimeDifference :: (NtpCheckMonad m, MonadMockable m) => m Word
 localTimeDifference =
-    diff <$> (mkNtpStatusVar >>= readMVar)
+    diff <$> getNtpStatusOnce
   where
     diff :: NtpStatus -> Word
     diff = \case


### PR DESCRIPTION
See commits' descriptions.
Tested with `api/time/difference` and `/api/v1/node-info` endpoints, now they don't hang.