### PR TITLE
[CSL-2252] NTP improvements

### DIFF
--- a/infra/Pos/Infra/Configuration.hs
+++ b/infra/Pos/Infra/Configuration.hs
@@ -67,6 +67,8 @@ infraConfiguration = given
 
 ntpServers :: [String]
 ntpServers =
-    [ "time.windows.com"
-    , "clock.isc.org"
-    , "ntp5.stratum2.ru" ]
+    [ "0.pool.ntp.org"
+    , "2.pool.ntp.org"
+    , "3.pool.ntp.org"
+    ]
+    -- need only 3 servers :shrug:

--- a/infra/Pos/NtpCheck.hs
+++ b/infra/Pos/NtpCheck.hs
@@ -12,7 +12,6 @@ module Pos.NtpCheck
 import           Universum
 
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import qualified Data.List.NonEmpty as NE
 import           Data.Time.Units (Microsecond)
 import           Mockable (Async, Concurrently, CurrentTime, Delay, Mockable, Mockables,
                            currentTime, withAsync)
@@ -46,7 +45,7 @@ ntpSettings onStatus = NtpClientSettings
     , ntpLogName         = "ntp-check"
     , ntpResponseTimeout = sec 5
     , ntpPollDelay       = timeDifferenceWarnInterval
-    , ntpMeanSelection   = median . NE.fromList
+    , ntpMeanSelection   = median
     }
 
 data NtpStatus = NtpSyncOk | NtpDesync Microsecond

--- a/infra/Pos/Slotting/Impl/Ntp.hs
+++ b/infra/Pos/Slotting/Impl/Ntp.hs
@@ -241,8 +241,7 @@ ntpSettings var = NtpClientSettings
     , ntpHandler         = ntpHandlerDo var
     -- logger name modifier
     , ntpLogName         = "ntp"
-    -- delay between making requests and response collection;
-    -- it also means that handler will be invoked with this lag
+    -- delay between making requests and response collection
     , ntpResponseTimeout = C.ntpResponseTimeout
     -- how often to send responses to server
     , ntpPollDelay       = C.ntpPollDelay

--- a/infra/Pos/Slotting/Impl/Ntp.hs
+++ b/infra/Pos/Slotting/Impl/Ntp.hs
@@ -30,7 +30,6 @@ import           Universum
 
 import qualified Control.Concurrent.STM as STM
 import           Control.Lens (makeLenses)
-import qualified Data.List.NonEmpty as NE
 import           Data.Time.Units (Microsecond)
 import           Formatting (int, sformat, shown, stext, (%))
 import           Mockable (CurrentTime, Delay, Mockable, Mockables, currentTime, delay)
@@ -246,5 +245,5 @@ ntpSettings var = NtpClientSettings
     -- how often to send responses to server
     , ntpPollDelay       = C.ntpPollDelay
     -- way to sumarize results received from different servers.
-    , ntpMeanSelection   = median . NE.fromList
+    , ntpMeanSelection   = median
     }

--- a/networking/src/NTP/Client.hs
+++ b/networking/src/NTP/Client.hs
@@ -166,6 +166,8 @@ startSend addrs cli = do
         logDebug "Sending requests"
         atomically . modifyTVarS (ncState cli) $ identity .= Just []
         let sendRequests = forConcurrently addrs (flip doSend cli)
+        -- here we do only "send" part, so need to wait for some time
+        -- or till receiving all responses
         let waitTimeout =
                 void $ race
                     (threadDelay timeout)

--- a/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Misc.hs
@@ -50,7 +50,7 @@ import           Pos.Client.KeyStorage (MonadKeys (..), deleteAllSecretKeys)
 import           Pos.Configuration (HasNodeConfiguration)
 import           Pos.Core (Address, SlotId, SoftwareVersion (..))
 import           Pos.Crypto (hashHexF)
-import           Pos.NtpCheck (NtpCheckMonad, NtpStatus (..), mkNtpStatusVar)
+import           Pos.NtpCheck (NtpCheckMonad, NtpStatus (..), getNtpStatusOnce)
 import           Pos.Shutdown (HasShutdownContext, triggerShutdown)
 import           Pos.Slotting (MonadSlots, getCurrentSlotBlocking)
 import           Pos.Txp (TxId, TxIn, TxOut)
@@ -150,7 +150,7 @@ syncProgress =
 
 localTimeDifference :: (NtpCheckMonad m, MonadMockable m) => m Word
 localTimeDifference =
-    diff <$> (mkNtpStatusVar >>= readMVar)
+    diff <$> getNtpStatusOnce
   where
     diff :: NtpStatus -> Word
     diff = \case


### PR DESCRIPTION
Some cosmetics. This PR is based on #2445, see only last 3 commits (better one commit per time).

`api/time/difference` endpoint now works instantly.