### PR TITLE
[CSL-2258] health status determined by topology, auxx topology policies

### DIFF
--- a/auxx/Main.hs
+++ b/auxx/Main.hs
@@ -40,7 +40,7 @@ import           Pos.WorkMode (EmptyMempoolExt, RealMode)
 import           Pos.Worker.Types (WorkerSpec)
 
 import           AuxxOptions (AuxxAction (..), AuxxOptions (..), AuxxStartMode (..), getAuxxOptions)
-import           Mode (AuxxContext (..), AuxxMode, CmdCtx (..))
+import           Mode (AuxxContext (..), AuxxMode)
 import           Plugin (auxxPlugin, rawExec)
 import           Repl (WithCommandAction (..), withAuxxRepl)
 
@@ -118,7 +118,6 @@ action opts@AuxxOptions {..} command = do
                   let auxxContext =
                           AuxxContext
                           { acRealModeContext = realModeContext
-                          , acCmdCtx = cmdCtx
                           , acTempDbUsed = tempDbUsed }
                   lift $ runReaderT auxxAction auxxContext
           let vssSK = unsafeFromJust $ npUserSecret nodeParams ^. usVss
@@ -137,7 +136,6 @@ action opts@AuxxOptions {..} command = do
     conf = CLI.configurationOptions (CLI.commonArgs cArgs)
     nArgs =
         CLI.NodeArgs {behaviorConfigPath = Nothing}
-    cmdCtx = CmdCtx {ccPeers = aoPeers}
 
 main :: IO ()
 main = withCompileInfo $(retrieveCompileTimeInfo) $ do

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -50,8 +50,7 @@ import           Lang.Name (Name)
 import           Lang.Value (AddKeyParams (..), AddrDistrPart (..), GenBlocksParams (..),
                              ProposeUpdateParams (..), ProposeUpdateSystem (..),
                              RollbackParams (..), Value (..))
-import           Mode (CmdCtx (..), MonadAuxxMode, deriveHDAddressAuxx, getCmdCtx,
-                       makePubKeyAddressAuxx)
+import           Mode (MonadAuxxMode, deriveHDAddressAuxx, makePubKeyAddressAuxx)
 import           Repl (PrintAction)
 
 createCommandProcs ::
@@ -410,7 +409,6 @@ createCommandProcs hasAuxxMode printAction mDiffusion = rights . fix $ \commands
     , cpArgumentConsumer = getArgMany tyInt "i"
     , cpExec = \is -> do
         when (null is) $ logWarning "Not adding keys from pool (list is empty)"
-        CmdCtx {..} <- getCmdCtx
         let secrets = fromMaybe (error "Secret keys are unknown") genesisSecretKeys
         forM_ is $ \i -> do
             key <- evaluateNF $ secrets !! i

--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -4,16 +4,12 @@
 
 module Mode
        (
-         -- * Extra types
-         CmdCtx (..)
-
        -- * Mode, context, etc.
-       , AuxxContext (..)
+         AuxxContext (..)
        , AuxxMode
        , MonadAuxxMode
 
        -- * Helpers
-       , getCmdCtx
        , isTempDbUsed
        , realModeToAuxx
        , makePubKeyAddressAuxx
@@ -38,7 +34,6 @@ import           Pos.Client.Txp.Balances (MonadBalances (..), getBalanceFromUtxo
                                           getOwnUtxosGenesis)
 import           Pos.Client.Txp.History (MonadTxHistory (..), getBlockHistoryDefault,
                                          getLocalHistoryDefault, saveTxDefault)
-import           Pos.Communication (NodeId)
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData (..))
 import           Pos.Context (HasNodeContext (..))
 import           Pos.Core (Address, HasConfiguration, HasPrimaryKey (..), IsBootstrapEraAddr (..),
@@ -70,11 +65,6 @@ import           Pos.Util.TimeWarp (CanJsonLog (..))
 import           Pos.Util.UserSecret (HasUserSecret (..))
 import           Pos.WorkMode (EmptyMempoolExt, RealMode, RealModeContext (..))
 
--- | Command execution context.
-data CmdCtx = CmdCtx
-    { ccPeers :: ![NodeId]
-    }
-
 type AuxxMode = ReaderT AuxxContext Production
 
 class (m ~ AuxxMode, HasConfigurations, HasCompileInfo) => MonadAuxxMode m
@@ -82,7 +72,6 @@ instance (HasConfigurations, HasCompileInfo) => MonadAuxxMode AuxxMode
 
 data AuxxContext = AuxxContext
     { acRealModeContext :: !(RealModeContext EmptyMempoolExt)
-    , acCmdCtx          :: !CmdCtx
     , acTempDbUsed      :: !Bool
     }
 
@@ -91,10 +80,6 @@ makeLensesWith postfixLFields ''AuxxContext
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
-
--- | Get 'CmdCtx' in 'AuxxMode'.
-getCmdCtx :: MonadAuxxMode m => m CmdCtx
-getCmdCtx = view acCmdCtx_L
 
 isTempDbUsed :: AuxxMode Bool
 isTempDbUsed = view acTempDbUsed_L

--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -3,11 +3,14 @@ module Pos.Network.Policy
        , defaultEnqueuePolicyRelay
        , defaultEnqueuePolicyEdgeBehindNat
        , defaultEnqueuePolicyEdgeP2P
+       , defaultEnqueuePolicyAuxx
        , defaultDequeuePolicyCore
        , defaultDequeuePolicyRelay
        , defaultDequeuePolicyEdgeBehindNat
+       , defaultDequeuePolicyAuxx
        , defaultDequeuePolicyEdgeP2P
        , defaultFailurePolicy
+       , defaultFailurePolicyAuxx
        ) where
 
 
@@ -107,6 +110,36 @@ defaultEnqueuePolicyEdgeBehindNat = go
         -- not relevant
       ]
 
+-- | Default enqueue policy for the Auxx CLI tool.
+defaultEnqueuePolicyAuxx :: EnqueuePolicy nid
+defaultEnqueuePolicyAuxx = go
+  where
+    -- Enqueue policy for edge nodes
+    go :: EnqueuePolicy nid
+    go (MsgTransaction OriginSender) = [
+        EnqueueAll NodeRelay (MaxAhead 2) PLow
+      ]
+    go (MsgTransaction (OriginForward _)) = [
+        -- don't forward transactions that weren't created at this node
+      ]
+    go (MsgAnnounceBlockHeader _) = [
+        -- not forwarded
+      ]
+    go (MsgRequestBlockHeaders Nothing) = [
+        EnqueueAll NodeRelay (MaxAhead 1) PHigh
+      ]
+    go (MsgRequestBlockHeaders (Just _)) = [
+        EnqueueOne [NodeRelay] (MaxAhead 2) PHigh
+      ]
+    go (MsgRequestBlocks _) = [
+        -- Edge nodes can only talk to relay nodes
+        EnqueueOne [NodeRelay] (MaxAhead 2) PHigh
+      ]
+    go (MsgMPC _) = [
+        EnqueueAll NodeCore (MaxAhead 2) PMedium
+      , EnqueueAll NodeRelay (MaxAhead 2) PMedium
+      ]
+
 -- | Default enqueue policy for edge nodes using P2P
 defaultEnqueuePolicyEdgeP2P :: EnqueuePolicy nid
 defaultEnqueuePolicyEdgeP2P = go
@@ -157,6 +190,15 @@ defaultDequeuePolicyEdgeBehindNat = go
     go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
     go NodeEdge  = error "defaultDequeuePolicy: edge to edge not applicable"
 
+-- | Dequeueing policy for the Auxx CLI tool.
+defaultDequeuePolicyAuxx :: DequeuePolicy
+defaultDequeuePolicyAuxx = go
+  where
+    go :: DequeuePolicy
+    go NodeCore  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+    go NodeRelay = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+    go NodeEdge  = Dequeue (MaxMsgPerSec 1) (MaxInFlight 2)
+
 -- | Dequeueing policy for P2P edge nodes
 defaultDequeuePolicyEdgeP2P :: DequeuePolicy
 defaultDequeuePolicyEdgeP2P = go
@@ -172,3 +214,7 @@ defaultDequeuePolicyEdgeP2P = go
 defaultFailurePolicy :: NodeType -- ^ Our node type
                      -> FailurePolicy nid
 defaultFailurePolicy _ourType _theirType _msgType _err = ReconsiderAfter 200
+
+-- | Failure policy for the Auxx CLI tool.
+defaultFailurePolicyAuxx :: FailurePolicy nid
+defaultFailurePolicyAuxx _ _ _ = ReconsiderAfter 0

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -433,7 +433,7 @@ initQueue NetworkConfig{..} mStore = do
                  ncEnqueuePolicy
                  ncDequeuePolicy
                  ncFailurePolicy
-                 (maybe (OQ.BucketSizeMax 0) identity . topologyMaxBucketSize ncTopology)
+                 (fromMaybe (OQ.BucketSizeMax 0) . topologyMaxBucketSize ncTopology)
                  (topologyUnknownNodeType ncTopology)
 
     case mStore of

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -19,6 +19,7 @@ module Pos.Network.Types
        , topologyDequeuePolicy
        , topologyFailurePolicy
        , topologyMaxBucketSize
+       , topologyHealthStatus
        , topologyRoute53HealthCheckEnabled
        -- * Queue initialization
        , Bucket(..)
@@ -48,6 +49,7 @@ module Pos.Network.Types
 import           Universum hiding (show)
 
 import           Data.IP (IPv4)
+import qualified Data.Set as Set (null)
 import           GHC.Show (Show (..))
 import           Network.Broadcast.OutboundQueue (OutboundQ)
 import qualified Network.Broadcast.OutboundQueue as OQ
@@ -62,6 +64,7 @@ import           System.Wlog.CanLog (WithLogger)
 import           Pos.Network.DnsDomains (DnsDomains (..), NodeAddr)
 import qualified Pos.Network.DnsDomains as DnsDomains
 import qualified Pos.Network.Policy as Policy
+import           Pos.Reporting.Health.Types (HealthStatus (..))
 import           Pos.System.Metrics.Constants (cardanoNamespace)
 import           Pos.Util.TimeWarp (addressToNodeId)
 import           Pos.Util.Util (HasLens', lensOf)
@@ -305,15 +308,78 @@ topologyFailurePolicy :: Topology kademia -> OQ.FailurePolicy NodeId
 topologyFailurePolicy = Policy.defaultFailurePolicy . topologyNodeType
 
 -- | Maximum bucket size
-topologyMaxBucketSize :: Topology kademia -> Bucket -> OQ.MaxBucketSize
+topologyMaxBucketSize :: Topology kademia -> Bucket -> Maybe OQ.MaxBucketSize
 topologyMaxBucketSize topology bucket =
     case bucket of
       BucketSubscriptionListener ->
         case topologySubscribers topology of
-          Just (_subscriberType, maxBucketSize) -> maxBucketSize
-          Nothing                               -> OQ.BucketSizeMax 0 -- subscription not allowed
-      _otherBucket ->
-        OQ.BucketSizeUnlimited
+          Just (_subscriberType, maxBucketSize) -> Just maxBucketSize
+          Nothing                               -> Nothing -- subscription not allowed
+      _otherBucket -> Just OQ.BucketSizeUnlimited
+
+topologyHealthStatus :: MonadIO m => Topology kademlia -> OutboundQ msg nid Bucket -> m HealthStatus
+topologyHealthStatus topology = case topology of
+    TopologyCore{} -> const (pure topologyHealthStatusCore)
+    TopologyRelay{..} -> topologyHealthStatusRelay topologyMaxSubscrs
+    TopologyBehindNAT{} -> topologyHealthStatusNAT
+    TopologyP2P{} -> topologyHealthStatusP2P
+    TopologyTraditional{} -> topologyHealthStatusTraditional
+    TopologyAuxx{} -> topologyHealthStatusAuxx
+
+-- | Core nodes are always healthy.
+topologyHealthStatusCore :: HealthStatus
+topologyHealthStatusCore = HSHealthy ""
+
+-- | Health of a relay is determined by its spare capacity.
+topologyHealthStatusRelay
+    :: MonadIO m
+    => OQ.MaxBucketSize
+    -> OQ.OutboundQ msg nid Bucket
+    -> m HealthStatus
+topologyHealthStatusRelay mbs oq = do
+    let maxCapacityText :: Text
+        maxCapacityText = case mbs of
+            OQ.BucketSizeUnlimited -> fromString "unlimited"
+            OQ.BucketSizeMax x -> fromString (show x)
+    spareCapacity <- OQ.bucketSpareCapacity oq BucketSubscriptionListener
+    pure $ case spareCapacity of
+        OQ.SpareCapacity sc | sc == 0 -> HSUnhealthy (fromString "0/" <> maxCapacityText)
+        OQ.SpareCapacity sc           -> HSHealthy $ fromString (show sc) <> "/" <> maxCapacityText
+        OQ.UnlimitedCapacity          -> HSHealthy maxCapacityText
+
+-- | Health of a behind-NAT node is good iff it is connected to some other node.
+topologyHealthStatusNAT
+    :: MonadIO m
+    => OQ.OutboundQ msg nid bucket
+    -> m HealthStatus
+topologyHealthStatusNAT oq = do
+    peers <- OQ.getAllPeers oq
+    if (Set.null (peersSet peers))
+    then pure $ HSUnhealthy "not connected"
+    else pure $ HSHealthy "connected"
+
+-- | Health status of a P2P node is the same as for behind NAT. Its capacity to
+-- support new subscribers is ignored.
+topologyHealthStatusP2P
+    :: MonadIO m
+    => OQ.OutboundQ msg nid bucket
+    -> m HealthStatus
+topologyHealthStatusP2P = topologyHealthStatusNAT
+
+-- | Health status of a traditional node is the same as for behind NAT. Its
+-- capacity to support new subscribers is ignored.
+topologyHealthStatusTraditional
+    :: MonadIO m
+    => OQ.OutboundQ msg nid bucket
+    -> m HealthStatus
+topologyHealthStatusTraditional = topologyHealthStatusTraditional
+
+-- | Auxx health status is the same as for behind-NAT.
+topologyHealthStatusAuxx
+    :: MonadIO m
+    => OQ.OutboundQ msg nid bucket
+    -> m HealthStatus
+topologyHealthStatusAuxx = topologyHealthStatusNAT
 
 -- | Whether or not we want to enable the health-check endpoint to be used by Route53
 -- in determining if a relay is healthy (i.e. it can accept more subscriptions or not)
@@ -367,7 +433,7 @@ initQueue NetworkConfig{..} mStore = do
                  ncEnqueuePolicy
                  ncDequeuePolicy
                  ncFailurePolicy
-                 (topologyMaxBucketSize   ncTopology)
+                 (maybe (OQ.BucketSizeMax 0) identity . topologyMaxBucketSize ncTopology)
                  (topologyUnknownNodeType ncTopology)
 
     case mStore of

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -290,7 +290,7 @@ topologyEnqueuePolicy = go
     go TopologyBehindNAT{..} = Policy.defaultEnqueuePolicyEdgeBehindNat
     go TopologyP2P{}         = Policy.defaultEnqueuePolicyEdgeP2P
     go TopologyTraditional{} = Policy.defaultEnqueuePolicyCore
-    go TopologyAuxx{}        = Policy.defaultEnqueuePolicyEdgeBehindNat
+    go TopologyAuxx{}        = Policy.defaultEnqueuePolicyAuxx
 
 -- | Dequeue policy for the given topology
 topologyDequeuePolicy :: Topology kademia -> OQ.DequeuePolicy
@@ -301,11 +301,14 @@ topologyDequeuePolicy = go
     go TopologyBehindNAT{..} = Policy.defaultDequeuePolicyEdgeBehindNat
     go TopologyP2P{}         = Policy.defaultDequeuePolicyEdgeP2P
     go TopologyTraditional{} = Policy.defaultDequeuePolicyCore
-    go TopologyAuxx{}        = Policy.defaultDequeuePolicyEdgeBehindNat
+    go TopologyAuxx{}        = Policy.defaultDequeuePolicyAuxx
 
 -- | Failure policy for the given topology
 topologyFailurePolicy :: Topology kademia -> OQ.FailurePolicy NodeId
-topologyFailurePolicy = Policy.defaultFailurePolicy . topologyNodeType
+topologyFailurePolicy = go
+  where
+    go TopologyAuxx{} = Policy.defaultFailurePolicyAuxx
+    go topo           = Policy.defaultFailurePolicy . topologyNodeType $ topo
 
 -- | Maximum bucket size
 topologyMaxBucketSize :: Topology kademia -> Bucket -> Maybe OQ.MaxBucketSize

--- a/lib/src/Pos/Diffusion/Full.hs
+++ b/lib/src/Pos/Diffusion/Full.hs
@@ -133,11 +133,16 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
 
             workerOuts :: HandlerSpecs
             OutSpecs workerOuts = mconcat
-                [ sscWorkerOutSpecs
-                , securityWorkerOutSpecs
-                , usWorkerOutSpecs
+                [ -- First: the relay system out specs.
+                  Diffusion.Txp.txOutSpecs logic
+                , Diffusion.Update.updateOutSpecs logic
+                , Diffusion.Delegation.delegationOutSpecs logic
+                , Diffusion.Ssc.sscOutSpecs logic
+                  -- Relay system for blocks is ad-hoc.
                 , blockWorkerOutSpecs
-                , delegationWorkerOutSpecs
+                  -- SSC has non-relay out specs, defined below.
+                , sscWorkerOutSpecs
+                , securityWorkerOutSpecs
                 , slottingWorkerOutSpecs
                 , subscriptionWorkerOutSpecs
                 , dhtWorkerOutSpecs
@@ -159,9 +164,6 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
                         (Proxy :: Proxy MsgHeaders)
                 ]
 
-            -- Definition of usWorkers plainly shows the out specs = mempty.
-            usWorkerOutSpecs = mempty
-
             -- announceBlockHeaderOuts from blkCreatorWorker
             -- announceBlockHeaderOuts from blkMetricCheckerWorker
             -- along with the retrieval worker outs which also include
@@ -177,9 +179,6 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
             announceBlockHeaderOuts = toOutSpecs [ convH (Proxy :: Proxy MsgHeaders)
                                                          (Proxy :: Proxy MsgGetHeaders)
                                                  ]
-
-            -- It's a local worker, no out specs.
-            delegationWorkerOutSpecs = mempty
 
             -- Plainly mempty from the definition of allWorkers.
             slottingWorkerOutSpecs = mempty

--- a/lib/src/Pos/Diffusion/Full/Delegation.hs
+++ b/lib/src/Pos/Diffusion/Full/Delegation.hs
@@ -4,6 +4,7 @@
 
 module Pos.Diffusion.Full.Delegation
        ( delegationListeners
+       , delegationOutSpecs
        , sendPskHeavy
        ) where
 
@@ -14,9 +15,11 @@ import qualified Network.Broadcast.OutboundQueue as OQ
 import           Pos.Binary ()
 import           Pos.Communication.Limits ()
 import           Pos.Communication.Message ()
-import           Pos.Communication.Protocol (MsgType (..), NodeId, EnqueueMsg, MkListeners)
+import           Pos.Communication.Protocol (MsgType (..), NodeId, EnqueueMsg,
+                                             MkListeners, OutSpecs)
 import           Pos.Communication.Relay (DataParams (..), Relay (..),
-                                          relayListeners, dataFlow)
+                                          relayListeners, dataFlow,
+                                          relayPropagateOut)
 import           Pos.Core       (ProxySKHeavy)
 import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
 import           Pos.Logic.Types (Logic (..))
@@ -37,6 +40,17 @@ delegationRelays
     => Logic m
     -> [Relay m]
 delegationRelays logic = [ pskHeavyRelay logic ]
+
+-- | 'OutSpecs' for the tx relays, to keep up with the 'InSpecs'/'OutSpecs'
+-- motif required for communication.
+-- The 'Logic m' isn't *really* needed, it's just an artefact of the design.
+delegationOutSpecs
+    :: forall m .
+       ( DiffusionWorkMode m
+       )
+    => Logic m
+    -> OutSpecs
+delegationOutSpecs logic = relayPropagateOut (delegationRelays logic)
 
 pskHeavyRelay
     :: ( DiffusionWorkMode m )

--- a/lib/src/Pos/Diffusion/Full/Ssc.hs
+++ b/lib/src/Pos/Diffusion/Full/Ssc.hs
@@ -2,6 +2,7 @@
 
 module Pos.Diffusion.Full.Ssc
     ( sscListeners
+    , sscOutSpecs
       -- TODO move the conversation starters here too (they're defined inline
       -- in Pos.Diffusion.Full).
     ) where
@@ -23,9 +24,9 @@ import           Pos.Communication.Limits (HasAdoptedBlockVersionData)
 import           Pos.Communication.Limits.Types (MessageLimited)
 import           Pos.Communication.Relay (DataMsg, InvOrData, InvReqDataParams (..),
                                           MempoolParams (NoMempool), Relay (..), ReqMsg, ReqOrRes,
-                                          relayListeners)
+                                          relayListeners, relayPropagateOut)
 import           Pos.Communication.Types.Protocol (MsgType (..), NodeId, EnqueueMsg,
-                                                   MkListeners)
+                                                   MkListeners, OutSpecs)
 import           Pos.Core (StakeholderId)
 import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
 import           Pos.Network.Types (Bucket)
@@ -60,6 +61,18 @@ sscRelays logic =
     , sharesRelay (postSscShares logic)
     , vssCertRelay (postSscVssCert logic)
     ]
+
+-- | 'OutSpecs' for the tx relays, to keep up with the 'InSpecs'/'OutSpecs'
+-- motif required for communication.
+-- The 'Logic m' isn't *really* needed, it's just an artefact of the design.
+sscOutSpecs
+    :: forall m .
+       ( DiffusionWorkMode m
+       , HasAdoptedBlockVersionData m
+       )
+    => Logic m
+    -> OutSpecs
+sscOutSpecs logic = relayPropagateOut (sscRelays logic)
 
 commitmentRelay
     :: ( SscMessageConstraints m

--- a/lib/src/Pos/Diffusion/Full/Txp.hs
+++ b/lib/src/Pos/Diffusion/Full/Txp.hs
@@ -4,6 +4,7 @@
 module Pos.Diffusion.Full.Txp
        ( sendTx
        , txListeners
+       , txOutSpecs
        ) where
 
 import           Universum
@@ -16,10 +17,11 @@ import           Pos.Binary.Txp ()
 import           Pos.Communication.Message ()
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData)
 import           Pos.Communication.Protocol (EnqueueMsg, MsgType (..), Origin (..), NodeId,
-                                             MkListeners)
+                                             MkListeners, OutSpecs)
 import           Pos.Communication.Relay (invReqDataFlowTK, resOk, MinRelayWorkMode,
                                           InvReqDataParams (..), invReqMsgType, Relay (..),
-                                          relayListeners, MempoolParams (..))
+                                          relayListeners, MempoolParams (..),
+                                          relayPropagateOut)
 import           Pos.Core.Txp (TxAux (..), TxId)
 import           Pos.Crypto (hash)
 import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
@@ -61,6 +63,18 @@ txListeners
     -> EnqueueMsg m
     -> MkListeners m
 txListeners logic oq enqueue = relayListeners oq enqueue (txRelays logic)
+
+-- | 'OutSpecs' for the tx relays, to keep up with the 'InSpecs'/'OutSpecs'
+-- motif required for communication.
+-- The 'Logic m' isn't *really* needed, it's just an artefact of the design.
+txOutSpecs
+    :: forall m .
+       ( DiffusionWorkMode m
+       , HasAdoptedBlockVersionData m
+       )
+    => Logic m
+    -> OutSpecs
+txOutSpecs logic = relayPropagateOut (txRelays logic)
 
 txInvReqDataParams
     :: DiffusionWorkMode m

--- a/lib/src/Pos/Diffusion/Full/Update.hs
+++ b/lib/src/Pos/Diffusion/Full/Update.hs
@@ -6,6 +6,7 @@ module Pos.Diffusion.Full.Update
        , sendUpdateProposal
 
        , updateListeners
+       , updateOutSpecs
        ) where
 
 import           Universum
@@ -20,10 +21,11 @@ import           Pos.Core.Update (UpId, UpdateVote, UpdateProposal, mkVoteId)
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData)
 import           Pos.Communication.Message ()
 import           Pos.Communication.Protocol (EnqueueMsg, MsgType (..), Origin (..),
-                                             NodeId, MkListeners)
+                                             NodeId, MkListeners, OutSpecs)
 import           Pos.Communication.Relay (invReqDataFlowTK, MinRelayWorkMode,
                                           Relay (..), relayListeners,
-                                          InvReqDataParams (..), MempoolParams (..))
+                                          InvReqDataParams (..), MempoolParams (..),
+                                          relayPropagateOut)
 import           Pos.Crypto (hashHexF)
 import           Pos.Crypto.Configuration (HasCryptoConfiguration)
 import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
@@ -100,6 +102,18 @@ usRelays
     => Logic m
     -> [Relay m]
 usRelays logic = [proposalRelay logic, voteRelay logic]
+
+-- | 'OutSpecs' for the update system, to keep up with the 'InSpecs'/'OutSpecs'
+-- motif required for communication.
+-- The 'Logic m' isn't *really* needed, it's just an artefact of the design.
+updateOutSpecs
+    :: forall m .
+       ( DiffusionWorkMode m
+       , HasAdoptedBlockVersionData m
+       )
+    => Logic m
+    -> OutSpecs
+updateOutSpecs logic = relayPropagateOut (usRelays logic)
 
 ----------------------------------------------------------------------------
 -- UpdateProposal relays

--- a/networking/src/Network/Broadcast/OutboundQueue.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue.hs
@@ -72,6 +72,7 @@ module Network.Broadcast.OutboundQueue (
   , simplePeers
   , peersFromList
   , updatePeersBucket
+  , getAllPeers
     -- * Debugging
   , registerQueueMetrics
   , dumpState


### PR DESCRIPTION
The health status was appropriate for relays: if they're at max subscriber capacity, then they're unhealth, and the amazon health status check will reflect that. For other types of nodes, this doesn't fit. An edge node should not be considered unhealthy just because it has 0 subscribers out of 0. 

The auxx topology policies are updated so that MPC messages are actually sent out.