### PR TITLE
Upgrade cache-s3 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     STACK_ROOT: "c:\\s"
     STACK_WORK: ".w"
     WORK_DIR: "c:\\w"
-    CACHE_S3_VERSION: v0.1.1
+    CACHE_S3_VERSION: v0.1.3
     AWS_REGION: us-west-1
     S3_BUCKET: appveyor-ci-cache
     AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
Apply new `cache-s3` version that properly handles unicode file names