### PR TITLE
[CSL-2089] Fix diffusion layer

### DIFF
--- a/block/src/Pos/Block/Logic/Header.hs
+++ b/block/src/Pos/Block/Logic/Header.hs
@@ -7,9 +7,12 @@ module Pos.Block.Logic.Header
        , classifyNewHeader
        , ClassifyHeadersRes (..)
        , classifyHeaders
+
+       , GetHeadersFromManyToError (..)
        , getHeadersFromManyTo
        , getHeadersOlderExp
-       , getHeadersRange
+       , GetHashesRangeError (..)
+       , getHashesRange
        ) where
 
 import           Universum
@@ -244,6 +247,9 @@ classifyHeaders inRecovery headers = do
                           depthDiff blkSecurityParam
             | otherwise -> CHsValid lcaChild
 
+
+data GetHeadersFromManyToError = GHFBadInput Text deriving (Show,Generic)
+
 -- | Given a set of checkpoints @c@ to stop at and a terminating
 -- header hash @h@, we take @h@ block (or tip if latter is @Nothing@)
 -- and fetch the blocks until one of checkpoints is encountered. In
@@ -255,11 +261,11 @@ getHeadersFromManyTo ::
        , WithLogger m
        , HasConfiguration
        )
-    => Maybe Word -- ^ Optional limit on how many to bring in.
+    => Maybe Word          -- ^ Optional limit on how many to bring in.
     -> NonEmpty HeaderHash -- ^ Checkpoints; not guaranteed to be
                            --   in any particular order
     -> Maybe HeaderHash
-    -> m (Either Text (NewestFirst NE BlockHeader))
+    -> m (Either GetHeadersFromManyToError (NewestFirst NE BlockHeader))
 getHeadersFromManyTo mLimit checkpoints startM = runExceptT $ do
     logDebug $
         sformat ("getHeadersFromManyTo: "%listJson%", start: "%build)
@@ -270,12 +276,12 @@ getHeadersFromManyTo mLimit checkpoints startM = runExceptT $ do
 
     -- This filters out invalid/unknown checkpoints also.
     inMainCheckpoints <-
-        noteM "no checkpoints are in the main chain" $ lift $
-        nonEmpty <$> filterM GS.isBlockInMainChain (toList checkpoints)
+        maybe (throwLocal "no checkpoints are in the main chain") pure =<<
+        lift (nonEmpty <$> filterM GS.isBlockInMainChain (toList checkpoints))
     let inMainCheckpointsHashes = map headerHash inMainCheckpoints
     when (tipHash `elem` inMainCheckpointsHashes) $
-        throwError "found checkpoint that is equal to our tip"
-    logDebug $ "got checkpoints in main chain"
+        throwLocal "found checkpoint that is equal to our tip"
+    logDebug $ "getHeadersFromManyTo: got checkpoints in main chain"
 
     if (tip ^. prevBlockL . headerHashG) `elem` inMainCheckpointsHashes
         -- Optimization for the popular case "just get me the newest
@@ -291,15 +297,16 @@ getHeadersFromManyTo mLimit checkpoints startM = runExceptT $ do
                     curH /= startHash && maybe True ((<) h) mLimitInt
             up <- lift $ GS.loadHeadersUpWhile newestCheckpoint loadUpCond
             res <-
-                note "loadHeadersUpWhile returned empty list" $
-                _NewestFirst nonEmpty (toNewestFirst $ over _OldestFirst (drop 1) up)
+                maybe (throwLocal "loadHeadersUpWhile returned empty list") pure $
+                _NewestFirst nonEmpty $
+                toNewestFirst $ over _OldestFirst (drop 1) up
             logDebug $ "getHeadersFromManyTo: loaded non-empty list of headers, returning"
             pure res
   where
-    noteM :: (MonadError e n) => e -> n (Maybe a) -> n a
-    noteM reason action = note reason =<< action
     mLimitInt :: Maybe Int
     mLimitInt = fromIntegral <$> mLimit
+
+    throwLocal = throwError . GHFBadInput
 
 -- | Given a starting point hash (we take tip if it's not in storage)
 -- it returns not more than 'blkSecurityParam' blocks distributed
@@ -354,29 +361,40 @@ getHeadersOlderExp upto = do
                 | otherwise = selGo es ii $ succ skipped
         in selGo elems ixs 0
 
+
+data GetHashesRangeError = GHRBadInput Text deriving (Show,Generic)
+
+-- Throws 'GetHashesRangeException'.
+throwGHR :: Monad m => Text -> ExceptT GetHashesRangeError m a
+throwGHR = throwError . GHRBadInput
+
 -- | Given optional @depthLimit@, @from@ and @to@ headers where @from@
 -- is older (not strict) than @to@, and valid chain in between can be
 -- found, headers in range @[from..to]@ will be found. If the number
 -- of headers in the chain (which should be returned) is more than
 -- @depthLimit@, error will be thrown.
-getHeadersRange ::
+getHashesRange ::
        forall m. (HasConfiguration, MonadDBRead m)
     => Maybe Word
     -> HeaderHash
     -> HeaderHash
-    -> m (Either Text (OldestFirst NE HeaderHash))
-getHeadersRange depthLimitM older newer | older == newer = runExceptT $ do
+    -> m (Either GetHashesRangeError (OldestFirst NE HeaderHash))
+getHashesRange depthLimitM older newer | older == newer = runExceptT $ do
     unlessM (isJust <$> lift (DB.getHeader newer)) $
-        throwError "getHeadersRange: can't find newer-older header"
+        throwGHR "can't find newer-older header"
     whenJust depthLimitM $ \depthLimit ->
         when (depthLimit < 1) $
-        throwError $
-        sformat ("getHeadersRange: depthLimit is "%int%
+        throwGHR $
+        sformat ("depthLimit is "%int%
                  ", we can't return the single requested header "%build)
                 depthLimit
                 newer
     pure $ OldestFirst $ one newer
-getHeadersRange depthLimitM older newer = runExceptT $ do
+getHashesRange depthLimitM older newer = runExceptT $ do
+    let fromMaybeM :: Text
+                   -> ExceptT GetHashesRangeError m (Maybe x)
+                   -> ExceptT GetHashesRangeError m x
+        fromMaybeM r m = maybe (throwGHR r) pure =<< m
     -- oldest and newest blocks do exist
     newerHd <- fromMaybeM "can't retrieve newer header" $ DB.getHeader newer
     olderHd <- fromMaybeM "can't retrieve older header" $ DB.getHeader older
@@ -386,13 +404,13 @@ getHeadersRange depthLimitM older newer = runExceptT $ do
     -- Proving newerD >= olderD
     let newerOlderF = "newer: "%build%", older: "%build
     when (newerD == olderD) $
-        throwError $
-        sformat ("getHeadersRange: newer and older headers have "%
+        throwGHR $
+        sformat ("newer and older headers have "%
                  "the same difficulty, but are not equal. "%newerOlderF)
                 newerHd olderHd
     when (newerD < olderD) $
-        throwError $
-        sformat ("getHeadersRange: newer header is less dificult than older one. "%
+        throwGHR $
+        sformat ("newer header is less dificult than older one. "%
                  newerOlderF)
                 newerHd olderHd
 
@@ -406,8 +424,8 @@ getHeadersRange depthLimitM older newer = runExceptT $ do
 
     whenJust depthLimitM $ \depthLimit ->
         when (depthDiff + 1 > depthLimit) $
-        throwError $
-        sformat ("getHeadersRange: requested "%int%" headers, but depthLimit is "%
+        throwGHR $
+        sformat ("requested "%int%" headers, but depthLimit is "%
                  int%". Headers: "%newerOlderF)
                 depthDiff
                 depthLimit
@@ -423,15 +441,15 @@ getHeadersRange depthLimitM older newer = runExceptT $ do
     -- branch (after first checks are performed here) and olderHd is
     -- no longer in the main chain.
     -- CSL-1950 We should use snapshots here.
-    when (null $ allExceptNewest ^. _OldestFirst) $ throwError $
-        "getHeadersRange: loaded 0 headers though checks passed. " <>
+    when (null $ allExceptNewest ^. _OldestFirst) $ throwGHR $
+        "loaded 0 headers though checks passed. " <>
         "May be (very rare) concurrency problem, just retry"
 
     -- It's safe to use 'unsafeLast' here after the last check.
     let lastElem = allExceptNewest ^. _OldestFirst . to unsafeLast
     when (newerHd ^. prevBlockL . headerHashG /= lastElem) $
-        throwError $
-        sformat ("getHeadersRange: newest block parent is not "%
+        throwGHR $
+        sformat ("getHashesRange: newest block parent is not "%
                  "equal to the newest one iterated. It may indicate recent fork or "%
                  "inconsistent request. Newest: "%build%
                  ", last list hash: "%build%", already retrieved (w/o last): "%listJson)
@@ -441,9 +459,7 @@ getHeadersRange depthLimitM older newer = runExceptT $ do
 
     -- We append last element and convert to nonempty.
     let conv =
-           fromMaybe (error "getHeadersRange: can't happen") .
+           fromMaybe (error "getHashesRange: can't happen") .
            nonEmpty .
            (++ [newer])
     pure $ allExceptNewest & _OldestFirst %~ conv
-  where
-    fromMaybeM r m = ExceptT $ maybeToRight ("getHeadersRange: " <> r) <$> m

--- a/block/src/Pos/Block/Logic/Util.hs
+++ b/block/src/Pos/Block/Logic/Util.hs
@@ -36,11 +36,13 @@ import           Pos.Slotting (MonadSlots (..), getCurrentSlotFlat, slotFromTime
 import           Pos.Util (_neHead)
 import           Pos.Util.Chrono (NE, OldestFirst (..))
 
---- Usually in this method oldest header is LCA, so it can be optimized
--- by traversing from older to newer.
 -- | Find LCA of headers list and main chain, including oldest
--- header's parent hash. Iterates from newest to oldest until meets
--- first header that's in main chain. O(n).
+-- header's parent hash. Acts as it would iterate from newest to
+-- oldest until it meets the first header in the main chain (which is
+-- O(n)).
+--
+-- Though, usually in this method oldest header is LCA, so it can be
+-- optimized by traversing from older to newer.
 lcaWithMainChain
     :: (HasConfiguration, MonadBlockDBRead m)
     => OldestFirst NE BlockHeader -> m (Maybe HeaderHash)
@@ -56,8 +58,6 @@ lcaWithMainChain headers =
             (_, False)   -> pure prevValue
             ([], True)   -> pure $ Just h
             (x:xs, True) -> lcaProceed (Just h) (x :| xs)
-
-
 
 -- | Calculate chain quality using slot of the block which has depth =
 -- 'blocksCount' and another slot after that one for which we

--- a/block/src/Pos/Block/Network/Logic.hs
+++ b/block/src/Pos/Block/Network/Logic.hs
@@ -11,12 +11,6 @@ module Pos.Block.Network.Logic
        , requestTipOuts
        , requestTip
 
-       , handleUnsolicitedHeaders
-       , mkHeadersRequest
-       , MkHeadersRequestResult(..)
-       , requestHeaders
-
-       , mkBlocksRequest
        , handleBlocks
 
        , handleUnsolicitedHeader
@@ -26,47 +20,39 @@ import           Universum
 
 import           Control.Concurrent.STM (isFullTBQueue, readTVar, writeTBQueue, writeTVar)
 import           Control.Exception.Safe (Exception (..))
-import           Control.Lens (to)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text.Buildable as B
-import           Formatting (bprint, build, builder, int, sformat, shown, stext, (%))
-import           Serokell.Data.Memory.Units (unitBuilder)
+import           Formatting (bprint, build, sformat, shown, stext, (%))
 import           Serokell.Util.Text (listJson)
 import qualified System.Metrics.Gauge as Metrics
 import           System.Wlog (logDebug, logInfo, logWarning)
 
-import           Pos.Binary.Class (biSize)
 import           Pos.Binary.Txp ()
 import           Pos.Block.BlockWorkMode (BlockInstancesConstraint, BlockWorkMode)
 import           Pos.Block.Error (ApplyBlocksException)
-import           Pos.Block.Logic (ClassifyHeaderRes (..), ClassifyHeadersRes (..), classifyHeaders,
-                                  classifyNewHeader, getHeadersOlderExp, lcaWithMainChain,
+import           Pos.Block.Logic (ClassifyHeaderRes (..), classifyNewHeader, lcaWithMainChain,
                                   verifyAndApplyBlocks)
 import qualified Pos.Block.Logic as L
-import           Pos.Block.Network.Types (MsgGetBlocks (..), MsgGetHeaders (..), MsgHeaders (..))
+import           Pos.Block.Network.Types (MsgGetHeaders (..), MsgHeaders (..))
 import           Pos.Block.RetrievalQueue (BlockRetrievalQueue, BlockRetrievalQueueTag,
                                            BlockRetrievalTask (..))
 import           Pos.Block.Types (Blund, LastKnownHeaderTag)
 import           Pos.Communication.Limits.Types (recvLimited)
 import           Pos.Communication.Protocol (ConversationActions (..), NodeId, OutSpecs, convH,
                                              toOutSpecs)
-import           Pos.Core (EpochOrSlot (..), HasConfiguration, HasHeaderHash (..), HeaderHash,
-                           SlotId (..), criticalForkThreshold, crucialSlot, epochIndexL,
-                           epochOrSlotG, gbHeader, headerHashG, isMoreDifficult, prevBlockL)
+import           Pos.Core (HasHeaderHash (..), HeaderHash, criticalForkThreshold, gbHeader,
+                           headerHashG, isMoreDifficult, prevBlockL)
 import           Pos.Core.Block (Block, BlockHeader, blockHeader)
 import           Pos.Crypto (shortHashF)
 import qualified Pos.DB.Block.Load as DB
-import qualified Pos.DB.BlockIndex as DB
 import           Pos.Diffusion.Types (Diffusion)
 import qualified Pos.Diffusion.Types as Diffusion (Diffusion (announceBlockHeader, requestTip))
 import           Pos.Exception (cardanoExceptionFromException, cardanoExceptionToException)
-import           Pos.Lrc (lrcSingleShot)
-import           Pos.Lrc.Error (LrcError (UnknownBlocksForLrc))
 import           Pos.Recovery.Info (recoveryInProgress)
 import           Pos.Reporting.MemState (HasMisbehaviorMetrics (..), MisbehaviorMetrics (..))
 import           Pos.Reporting.Methods (reportMisbehaviour)
-import           Pos.StateLock (Priority (..), modifyStateLock, withStateLockNoMetrics)
-import           Pos.Util (buildListBounds, multilineBounds, _neHead, _neLast)
+import           Pos.StateLock (Priority (..), modifyStateLock)
+import           Pos.Util (buildListBounds, multilineBounds, _neLast)
 import           Pos.Util.AssertMode (inAssertMode)
 import           Pos.Util.Chrono (NE, NewestFirst (..), OldestFirst (..), _NewestFirst,
                                   _OldestFirst)
@@ -148,40 +134,6 @@ requestTip nodeId conv = do
 -- Headers processing
 ----------------------------------------------------------------------------
 
--- | Result of creating a request message for more headers.
-data MkHeadersRequestResult
-    = MhrrBlockAdopted
-      -- ^ The block pointed by the header is already adopted, no need to
-      -- make the request.
-    | MhrrWithCheckpoints MsgGetHeaders
-      -- ^ A good request with checkpoints can be made.
-
--- | Make 'GetHeaders' message using our main chain. This function
--- chooses appropriate 'from' hashes and puts them into 'GetHeaders'
--- message.
-mkHeadersRequest
-    :: forall ctx m.
-       BlockWorkMode ctx m
-    => HeaderHash -> m MkHeadersRequestResult
-mkHeadersRequest upto = do
-    uHdr <- DB.getHeader upto
-    if isJust uHdr then return MhrrBlockAdopted else do
-        bHeaders <- toList <$> getHeadersOlderExp Nothing
-        pure $ MhrrWithCheckpoints $ MsgGetHeaders (toList bHeaders) (Just upto)
-
--- Second case of 'handleBlockheaders'
-handleUnsolicitedHeaders
-    :: BlockWorkMode ctx m
-    => NonEmpty BlockHeader
-    -> NodeId
-    -> m ()
-handleUnsolicitedHeaders (header :| []) nodeId =
-    handleUnsolicitedHeader header nodeId
--- TODO: ban node for sending more than one unsolicited header.
-handleUnsolicitedHeaders (h:|hs) _ = do
-    logWarning "Someone sent us nonzero amount of headers we didn't expect"
-    logWarning $ sformat ("Here they are: "%listJson) (h:hs)
-
 handleUnsolicitedHeader
     :: BlockWorkMode ctx m
     => BlockHeader
@@ -215,179 +167,6 @@ handleUnsolicitedHeader header nodeId = do
         " potentially represents good alternative chain, will process"
     uselessFormat =
         "Header " %shortHashF % " is useless for the following reason: " %stext
-
--- | Result of 'matchHeadersRequest'
-data MatchReqHeadersRes
-    = MRGood
-      -- ^ Headers were indeed requested and precisely match our
-      -- request
-    | MRUnexpected Text
-      -- ^ Headers don't represent valid response to our
-      -- request. Reason is attached.
-    deriving (Show)
-
--- TODO This function is used ONLY in recovery mode, so passing the
--- flag is redundant, it's always True.
-matchRequestedHeaders
-    :: HasConfiguration
-    => NewestFirst NE BlockHeader -> MsgGetHeaders -> Bool -> MatchReqHeadersRes
-matchRequestedHeaders headers mgh@MsgGetHeaders {..} inRecovery =
-    let newTip = headers ^. _NewestFirst . _neHead
-        startHeader = headers ^. _NewestFirst . _neLast
-        startMatches =
-            or [ (startHeader ^. headerHashG) `elem` mghFrom
-               , (startHeader ^. prevBlockL) `elem` mghFrom
-               ]
-        mghToMatches
-            | inRecovery = True
-            | isNothing mghTo = True
-            | otherwise = Just (headerHash newTip) == mghTo
-    in if | not startMatches ->
-            MRUnexpected $ sformat ("start (from) header "%build%
-                                    " doesn't match request "%build)
-                                   startHeader mgh
-          | not mghToMatches ->
-            MRUnexpected $ sformat ("finish (to) header "%build%
-                                    " doesn't match request "%build%
-                                    ", recovery: "%shown%", newTip:"%build)
-                                   mghTo mgh inRecovery newTip
-          | otherwise -> MRGood
-
-requestHeaders
-    :: forall ctx m.
-       BlockWorkMode ctx m
-    => (NewestFirst NE BlockHeader -> m ())
-    -> MsgGetHeaders
-    -> NodeId
-    -> ConversationActions MsgGetHeaders MsgHeaders m
-    -> m ()
-requestHeaders cont mgh nodeId conv = do
-    logDebug $ sformat ("requestHeaders: sending "%build) mgh
-    send conv mgh
-    mHeaders <- recvLimited conv
-    inRecovery <- recoveryInProgress
-    -- TODO: it's very suspicious to see False here as requestHeaders
-    -- is only called when we're in recovery mode.
-    logDebug $ sformat ("requestHeaders: inRecovery = "%shown) inRecovery
-    case mHeaders of
-        Nothing -> do
-            logWarning "requestHeaders: received Nothing as a response on MsgGetHeaders"
-            throwM $ DialogUnexpected $
-                sformat ("requestHeaders: received Nothing from "%build) nodeId
-        Just (MsgNoHeaders t) -> do
-            logWarning $ "requestHeaders: received MsgNoHeaders: " <> t
-            throwM $ DialogUnexpected $
-                sformat ("requestHeaders: received MsgNoHeaders from "%
-                         build%", msg: "%stext)
-                        nodeId
-                        t
-        Just (MsgHeaders headers) -> do
-            logDebug $ sformat
-                ("requestHeaders: received "%int%" headers of total size "%builder%
-                 " from nodeId "%build%": "%listJson)
-                (headers ^. _NewestFirst . to NE.length)
-                (unitBuilder $ biSize headers)
-                nodeId
-                (map headerHash headers)
-            case matchRequestedHeaders headers mgh inRecovery of
-                MRGood           ->
-                    handleRequestedHeaders cont inRecovery headers
-                MRUnexpected msg ->
-                    handleUnexpected headers msg
-  where
-    handleUnexpected hs msg = do
-        -- TODO: ban node for sending unsolicited header in conversation
-        logWarning $ sformat
-            ("requestHeaders: headers received were not requested or are invalid"%
-             ", peer id: "%build%", reason:"%stext)
-            nodeId msg
-        logWarning $ sformat
-            ("requestHeaders: unexpected or invalid headers: "%listJson) hs
-        throwM $ DialogUnexpected $
-            sformat ("requestHeaders: received unexpected headers from "%build) nodeId
-
-handleRequestedHeaders
-    :: forall ctx m.
-       BlockWorkMode ctx m
-    => (NewestFirst NE BlockHeader -> m ())
-    -> Bool -- recovery in progress?
-    -> NewestFirst NE BlockHeader
-    -> m ()
-handleRequestedHeaders cont inRecovery headers = do
-    -- Try to calculate LRC for the oldest header epoch. If we're in
-    -- recovery and oldest header is from the next epoch, no lrc will
-    -- be automatically calculated as all workers are locked in
-    -- recovery mode. So we should try to do it manually.
-    tryCalculateLrc
-
-    classificationRes <- classifyHeaders inRecovery headers
-    case classificationRes of
-        CHsValid lcaChild -> do
-            let lcaHash = lcaChild ^. prevBlockL
-            let headers' = NE.takeWhile ((/= lcaHash) . headerHash)
-                                        (getNewestFirst headers)
-            logDebug $ sformat validFormat (headerHash lcaChild)newestHash
-            case nonEmpty headers' of
-                Nothing ->
-                    throwM $ BlockNetLogicInternal $
-                        "handleRequestedHeaders: couldn't find LCA child " <>
-                        "within headers returned, most probably classifyHeaders is broken"
-                Just headersPostfix ->
-                    cont (NewestFirst headersPostfix)
-        CHsUseless reason -> do
-            let msg = sformat uselessFormat oldestHash newestHash reason
-            logDebug msg
-            throwM $ DialogUnexpected msg
-        CHsInvalid reason -> do
-             -- TODO: ban node for sending invalid block.
-            let msg = sformat invalidFormat oldestHash newestHash reason
-            logDebug msg
-            throwM $ DialogUnexpected msg
-  where
-    newestHeader = headers ^. _NewestFirst . _neHead
-    oldestHeader = headers ^. _NewestFirst . _neLast
-    newestHash = headerHash newestHeader
-    oldestHash = headerHash oldestHeader
-    oldestEpoch = oldestHeader ^. epochIndexL
-
-    tryCalculateLrc = do
-        tip <- DB.getTipHeader
-        let tipEpochOrSlot = tip ^. epochOrSlotG
-        let tipEpoch = tip ^. epochIndexL
-        let differentEpochs = oldestEpoch == tipEpoch + 1
-        -- CSL-1660 We should also check that there's k blocks after
-        -- crucial slot.
-        let tipAfterCrucial = case unEpochOrSlot tipEpochOrSlot of
-                -- we assume differentEpochs is true, so this is
-                -- before zero's slot of epoch e, while new header has
-                -- epoch e+1.
-                Left _   -> False
-                Right si -> siSlot si > siSlot (crucialSlot $ siEpoch si)
-        let shouldExecute = differentEpochs && tipAfterCrucial
-
-        if shouldExecute then do
-            logDebug "handleRequesteHeaders: LRC started"
-            let handler UnknownBlocksForLrc =
-                    logWarning $
-                    "handleRequestedHeaders: tried lrcSingleShot, " <>
-                    "got UnknownBlocksForLrc"
-                handler e                   = throwM e
-            withStateLockNoMetrics HighPriority $ const $
-                lrcSingleShot oldestEpoch `catch` handler
-            logDebug "handleRequesteHeaders: LRC ended"
-        else logDebug $ sformat ("handleRequestHeaders: not calculating LRC: "%
-                                 "oldest header epoch "%build%", tip epoch "%build)
-                                oldestEpoch tipEpoch
-
-    validFormat =
-        "Received valid headers, can request blocks from "%shortHashF%
-        " to "%shortHashF
-    genericFormat what =
-        "handleRequestedHeaders: chain of headers from "%shortHashF%
-        " to "%shortHashF%
-        " is "%what%" for the following reason: "%stext
-    uselessFormat = genericFormat "useless"
-    invalidFormat = genericFormat "invalid"
 
 ----------------------------------------------------------------------------
 -- Putting things into request queue
@@ -442,18 +221,9 @@ updateLastKnownHeader lastKnownH header = do
 -- Handling blocks
 ----------------------------------------------------------------------------
 
--- | Make message which requests chain of blocks which is based on our
--- tip. LcaChild is the first block after LCA we don't
--- know. WantedBlock is the newest one we want to get.
-mkBlocksRequest :: HeaderHash -> HeaderHash -> MsgGetBlocks
-mkBlocksRequest lcaChild wantedBlock =
-    MsgGetBlocks
-    { mgbFrom = lcaChild
-    , mgbTo = wantedBlock
-    }
-
+-- | Carefully apply blocks that came from the network.
 handleBlocks
-    :: BlockWorkMode ctx m
+    :: forall ctx m. BlockWorkMode ctx m
     => NodeId
     -> OldestFirst NE Block
     -> Diffusion m
@@ -463,7 +233,7 @@ handleBlocks nodeId blocks diffusion = do
     inAssertMode $ logInfo $
         sformat ("Processing sequence of blocks: " % buildListBounds % "...") $
             getOldestFirst $ map headerHash blocks
-    maybe onNoLca (handleBlocksWithLca nodeId diffusion blocks) =<<
+    maybe onNoLca handleBlocksWithLca =<<
         lcaWithMainChain (map (view blockHeader) blocks)
     inAssertMode $ logDebug $ "Finished processing sequence of blocks"
   where
@@ -471,22 +241,14 @@ handleBlocks nodeId blocks diffusion = do
         "Sequence of blocks can't be processed, because there is no LCA. " <>
         "Probably rollback happened in parallel"
 
-handleBlocksWithLca
-    :: BlockWorkMode ctx m
-    => NodeId
-    -> Diffusion m
-    -> OldestFirst NE Block
-    -> HeaderHash
-    -> m ()
-handleBlocksWithLca nodeId diffusion blocks lcaHash = do
-    logDebug $ sformat lcaFmt lcaHash
-    -- Head blund in result is the youngest one.
-    toRollback <- DB.loadBlundsFromTipWhile $ \blk -> headerHash blk /= lcaHash
-    maybe (applyWithoutRollback diffusion blocks)
-          (applyWithRollback nodeId diffusion blocks lcaHash)
-          (_NewestFirst nonEmpty toRollback)
-  where
-    lcaFmt = "Handling block w/ LCA, which is "%shortHashF
+    handleBlocksWithLca :: HeaderHash -> m ()
+    handleBlocksWithLca lcaHash = do
+        logDebug $ sformat ("Handling block w/ LCA, which is "%shortHashF) lcaHash
+        -- Head blund in result is the youngest one.
+        toRollback <- DB.loadBlundsFromTipWhile $ \blk -> headerHash blk /= lcaHash
+        maybe (applyWithoutRollback diffusion blocks)
+              (applyWithRollback nodeId diffusion blocks lcaHash)
+              (_NewestFirst nonEmpty toRollback)
 
 applyWithoutRollback
     :: forall ctx m.

--- a/block/src/Pos/GState/BlockExtra.hs
+++ b/block/src/Pos/GState/BlockExtra.hs
@@ -15,12 +15,10 @@ module Pos.GState.BlockExtra
        , loadHeadersUpWhile
        , loadBlocksUpWhile
        , initGStateBlockExtra
-       , blocksSourceFrom
        ) where
 
 import           Universum
 
-import           Data.Conduit (ConduitT, yield)
 import qualified Data.Text.Buildable
 import qualified Database.RocksDB as Rocks
 import           Formatting (bprint, build, (%))
@@ -176,26 +174,6 @@ loadBlocksUpWhile
     -> (Block -> Int -> Bool)
     -> m (OldestFirst [] Block)
 loadBlocksUpWhile = loadUpWhile getBlock
-
--- | Produce blocks from a database (MonadBlockDBRead) beginning at a hash.
--- Forward links are resolved after each block is yielded, and the source
--- ends when that forward link does not determine another block.
--- Semantics depend upon the MonadBlockDBRead instance, of course. If the
--- underlying database is changed while streaming, what happens?
-blocksSourceFrom
-    :: ( MonadBlockDBRead m )
-    => HeaderHash -> ConduitT () Block m ()
-blocksSourceFrom fromH = do
-    mBlk <- lift $ getBlock fromH
-    case mBlk of
-        Nothing  -> pure ()
-        Just blk -> yield blk >> continue blk
-  where
-    continue blk = do
-        mNextH <- lift $ resolveForwardLink blk
-        case mNextH of
-            Nothing    -> pure ()
-            Just nextH -> blocksSourceFrom nextH
 
 ----------------------------------------------------------------------------
 -- Initialization

--- a/explorer/src/Pos/Explorer/Socket/Methods.hs
+++ b/explorer/src/Pos/Explorer/Socket/Methods.hs
@@ -55,6 +55,7 @@ module Pos.Explorer.Socket.Methods
 
 import           Universum
 
+import           Control.Exception.Safe (tryAny)
 import           Control.Lens (at, ix, lens, non, (.=), _Just)
 import           Control.Monad.State (MonadState)
 import           Data.Aeson (ToJSON)
@@ -358,10 +359,10 @@ getBlundsFromTo
     :: forall ctx m . ExplorerMode ctx m
     => HeaderHash -> HeaderHash -> m (Maybe [Blund])
 getBlundsFromTo recentBlock oldBlock =
-    DB.getHeadersRange Nothing oldBlock recentBlock >>= \case
+    DB.getHashesRange Nothing oldBlock recentBlock >>= \case
         Left _ -> pure Nothing
-        Right (getOldestFirst -> headers) ->
-            Just . catMaybes <$> forM (NE.tail headers) getBlund
+        Right (getOldestFirst -> hashes) ->
+            Just . catMaybes <$> forM (NE.tail hashes) getBlund
 
 addrsTouchedByTx
     :: (MonadDBRead m, WithLogger m)

--- a/lib/src/Pos/Diffusion/Full/Block.hs
+++ b/lib/src/Pos/Diffusion/Full/Block.hs
@@ -21,15 +21,11 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import qualified Data.Text.Buildable as B
 import           Data.Time.Units (toMicroseconds)
--- TODO hopefully we can get rid of this import. It's needed for the
--- security workers stuff and peeking into some reader context which contains
--- it (part of WorkMode).
 import           Formatting (bprint, build, int, sformat, shown, stext, (%))
 import qualified Network.Broadcast.OutboundQueue as OQ
 import           Serokell.Util.Text (listJson)
 import           System.Wlog (logDebug, logWarning)
 
--- MsgGetHeaders Bi instance etc.
 import           Pos.Binary.Communication ()
 import           Pos.Block.Configuration (recoveryHeadersMessage)
 import           Pos.Block.Network (MsgBlock (..), MsgGetBlocks (..), MsgGetHeaders (..),
@@ -483,7 +479,8 @@ handleBlockHeaders
     -> OQ.OutboundQ pack NodeId Bucket
     -> Timer
     -> (ListenerSpec m, OutSpecs)
-handleBlockHeaders logic oq keepaliveTimer = listenerConv @MsgGetHeaders oq $ \__ourVerInfo nodeId conv -> do
+handleBlockHeaders logic oq keepaliveTimer =
+  listenerConv @MsgGetHeaders oq $ \__ourVerInfo nodeId conv -> do
     -- The type of the messages we send is set to 'MsgGetHeaders' for
     -- protocol compatibility reasons only. We could use 'Void' here because
     -- we don't really send any messages.
@@ -493,7 +490,8 @@ handleBlockHeaders logic oq keepaliveTimer = listenerConv @MsgGetHeaders oq $ \_
         (MsgHeaders headers) -> do
             -- Reset the keepalive timer.
             -- slotDuration <- fromIntegral . toMicroseconds <$> getCurrentEpochSlotDuration
-            slotDuration <- fromIntegral . toMicroseconds . bvdSlotDuration <$> getAdoptedBVData logic
+            slotDuration <-
+                fromIntegral . toMicroseconds . bvdSlotDuration <$> getAdoptedBVData logic
             setTimerDuration keepaliveTimer $ 3 * slotDuration
             startTimer keepaliveTimer
             handleUnsolicitedHeaders logic (getNewestFirst headers) nodeId

--- a/lib/src/Pos/Logic/Full.hs
+++ b/lib/src/Pos/Logic/Full.hs
@@ -130,6 +130,9 @@ logicLayerFull jsonLogTx k = do
             -> m (Either Block.GetHeadersFromManyToError (NewestFirst NE BlockHeader))
         getBlockHeaders = Block.getHeadersFromManyTo
 
+        getLcaMainChain :: OldestFirst NE BlockHeader -> m (Maybe HeaderHash)
+        getLcaMainChain = Block.lcaWithMainChain
+
         postBlockHeader :: BlockHeader -> NodeId -> m ()
         postBlockHeader = Block.handleUnsolicitedHeader
 

--- a/lib/src/Pos/Logic/Pure.hs
+++ b/lib/src/Pos/Logic/Pure.hs
@@ -43,10 +43,9 @@ pureLogic
 pureLogic = Logic
     { ourStakeholderId   = stakeholderId
     , getBlock           = \_ -> pure (Just block)
-    , getChainFrom       = \_ -> pure ()
     , getBlockHeader     = \_ -> pure (Just blockHeader)
+    , getHashesRange     = \_ _ _ -> pure (Right (OldestFirst (pure mainBlockHeaderHash)))
     , getBlockHeaders    = \_ _ _ -> pure (Right (NewestFirst (pure blockHeader)))
-    , getBlockHeaders'   = \_ _ _ -> pure (Right (OldestFirst (pure mainBlockHeaderHash)))
     , getTip             = pure block
     , getTipHeader       = pure blockHeader
     , getAdoptedBVData   = pure blockVersionData

--- a/lib/src/Pos/Logic/Pure.hs
+++ b/lib/src/Pos/Logic/Pure.hs
@@ -46,6 +46,7 @@ pureLogic = Logic
     , getBlockHeader     = \_ -> pure (Just blockHeader)
     , getHashesRange     = \_ _ _ -> pure (Right (OldestFirst (pure mainBlockHeaderHash)))
     , getBlockHeaders    = \_ _ _ -> pure (Right (NewestFirst (pure blockHeader)))
+    , getLcaMainChain    = \_ -> pure Nothing
     , getTip             = pure block
     , getTipHeader       = pure blockHeader
     , getAdoptedBVData   = pure blockVersionData

--- a/lib/src/Pos/Logic/Types.hs
+++ b/lib/src/Pos/Logic/Types.hs
@@ -5,16 +5,15 @@ module Pos.Logic.Types
     ( LogicLayer (..)
     , Logic (..)
     , KeyVal (..)
-    , GetBlockHeadersError (..)
     , dummyLogicLayer
     ) where
 
 import           Universum
 
-import           Data.Conduit (ConduitT)
 import           Data.Default (def)
 import           Data.Tagged (Tagged)
 
+import           Pos.Block.Logic (GetHashesRangeError, GetHeadersFromManyToError)
 import           Pos.Communication (NodeId, TxMsgContents)
 import           Pos.Core (HeaderHash, ProxySKHeavy, StakeholderId)
 import           Pos.Core.Block (Block, BlockHeader)
@@ -27,53 +26,37 @@ import           Pos.Util.Chrono (NE, NewestFirst, OldestFirst)
 -- | The interface to a logic layer, i.e. some component which encapsulates
 -- blockchain / crypto logic.
 data Logic m = Logic
-    { -- The stakeholder id of our node.
+    { -- | The stakeholder id of our node.
       ourStakeholderId   :: StakeholderId
-      -- Get a block, perhaps from a database.
+      -- | Get a block, perhaps from a database.
     , getBlock           :: HeaderHash -> m (Maybe Block)
-      -- Stream blocks from first hash to second hash.
-      -- Conduit is chosen mainly due to precedent: it's already used in
-      -- cardano-sl.
-    , getChainFrom       :: HeaderHash
-                         -> ConduitT () Block m ()
-      -- Get a block header.
-      -- TBD: necessary? Is it any different/faster than getting the block
-      -- and taking the header?
+      -- | Get a block header.
     , getBlockHeader     :: HeaderHash -> m (Maybe BlockHeader)
-      -- Inspired by 'getHeadersFromManyTo'.
-      -- Included here because that function is quite complicated; it's not
-      -- clear whether it can be expressed simply in terms of getBlockHeader.:q
+      -- TODO CSL-2089 use conduits in this and the following methods
+      -- | Retrieve block header hashes from specified interval.
+    , getHashesRange     :: Maybe Word -- ^ Optional limit on how many to bring in.
+                         -> HeaderHash
+                         -> HeaderHash
+                         -> m (Either GetHashesRangeError (OldestFirst NE HeaderHash))
+      -- | Interface for 'getHeadersFromManyTo'. Retrieves blocks from
+      -- the checkpoints to some particular point (or tip, if
+      -- 'Nothing').
     , getBlockHeaders    :: Maybe Word -- ^ Optional limit on how many to bring in.
                          -> NonEmpty HeaderHash
                          -> Maybe HeaderHash
-                         -> m (Either GetBlockHeadersError (NewestFirst NE BlockHeader))
-      -- Inspired by 'getHeadersFromToIncl', which is apparently distinct from
-      -- 'getHeadersFromManyTo' (getBlockHeaders without the tick above).
-      -- FIXME we must unify these.
-      -- May want to think about giving a streaming-IO interface (pipes, conduit
-      -- or similar).
-    , getBlockHeaders'   :: Maybe Word -- ^ Optional limit on how many to bring in.
-                         -> HeaderHash
-                         -> HeaderHash
-                         -> m (Either GetBlockHeadersError (OldestFirst NE HeaderHash))
-      -- Get the current tip of chain.
-      -- It's not in Maybe, as getBlock is, because really there should always
-      -- be a tip, whereas trying to get a block that isn't in the database is
-      -- normal.
+                         -> m (Either GetHeadersFromManyToError (NewestFirst NE BlockHeader))
+      -- | Get the current tip of chain.
     , getTip             :: m Block
-      -- Apparently 'getTipHeader' can be cheaper than
-      -- 'headerHash <$> getTip' in some particular cases, so we have
-      -- both.
+      -- | Cheaper version of 'headerHash <$> getTip'.
     , getTipHeader       :: m BlockHeader
-
       -- | Get state of last adopted BlockVersion. Related to update system.
     , getAdoptedBVData   :: m BlockVersionData
 
-      -- Give a block header to the logic layer.
+      -- | Give a block header to the logic layer.
       -- NodeId is needed for first iteration, but will be removed later.
     , postBlockHeader    :: BlockHeader -> NodeId -> m ()
 
-      -- Tx, update, ssc...
+      -- | Tx, update, ssc...
       -- Common pattern is:
       --   - What to do with it when we receive it (key and data).
       --   - How to get it when it's requested (key).
@@ -93,10 +76,8 @@ data Logic m = Logic
     , postSscShares      :: KeyVal (Tagged MCShares StakeholderId) MCShares m
     , postSscVssCert     :: KeyVal (Tagged MCVssCertificate StakeholderId) MCVssCertificate m
 
-      -- Give a heavy delegation certificate. Returns False if something
+      -- | Give a heavy delegation certificate. Returns False if something
       -- went wrong.
-      --
-      -- NB light delegation is apparently disabled in master.
     , postPskHeavy       :: ProxySKHeavy -> m Bool
 
       -- Recovery mode related stuff.
@@ -143,12 +124,6 @@ data KeyVal key val m = KeyVal
     , handleData :: val -> m Bool
     }
 
--- | Failure description for getting a block header from the logic layer.
-data GetBlockHeadersError = GetBlockHeadersError Text
-
-deriving instance Show GetBlockHeadersError
-instance Exception GetBlockHeadersError
-
 -- | A diffusion layer: its interface, and a way to run it.
 data LogicLayer m = LogicLayer
     { runLogicLayer :: forall x . m x -> m x
@@ -170,10 +145,9 @@ dummyLogicLayer = LogicLayer
     dummyLogic = Logic
         { ourStakeholderId   = error "dummy: no stakeholder id"
         , getBlock           = \_ -> pure (error "dummy: can't get block")
-        , getChainFrom       = \_ -> error "dummy: can't get chain"
         , getBlockHeader     = \_ -> pure (error "dummy: can't get header")
-        , getBlockHeaders    = \_ _ _ -> pure (error "dummy: can't get headers")
-        , getBlockHeaders'   = \_ _ _ -> pure (error "dummy: can't get headers")
+        , getBlockHeaders    = \_ _ _ -> pure (error "dummy: can't get block headers")
+        , getHashesRange    = \_ _ _ -> pure (error "dummy: can't get hashes range")
         , getTip             = pure (error "dummy: can't get tip")
         , getTipHeader       = pure (error "dummy: can't get tip header")
         , getAdoptedBVData   = pure (error "dummy: can't get block version data")

--- a/lib/src/Pos/Logic/Types.hs
+++ b/lib/src/Pos/Logic/Types.hs
@@ -45,6 +45,8 @@ data Logic m = Logic
                          -> NonEmpty HeaderHash
                          -> Maybe HeaderHash
                          -> m (Either GetHeadersFromManyToError (NewestFirst NE BlockHeader))
+      -- | Compute LCA with the main chain.
+    , getLcaMainChain    :: OldestFirst NE BlockHeader -> m (Maybe HeaderHash)
       -- | Get the current tip of chain.
     , getTip             :: m Block
       -- | Cheaper version of 'headerHash <$> getTip'.
@@ -147,7 +149,8 @@ dummyLogicLayer = LogicLayer
         , getBlock           = \_ -> pure (error "dummy: can't get block")
         , getBlockHeader     = \_ -> pure (error "dummy: can't get header")
         , getBlockHeaders    = \_ _ _ -> pure (error "dummy: can't get block headers")
-        , getHashesRange    = \_ _ _ -> pure (error "dummy: can't get hashes range")
+        , getLcaMainChain    = \_ -> pure Nothing
+        , getHashesRange     = \_ _ _ -> pure (error "dummy: can't get hashes range")
         , getTip             = pure (error "dummy: can't get tip")
         , getTipHeader       = pure (error "dummy: can't get tip header")
         , getAdoptedBVData   = pure (error "dummy: can't get block version data")


### PR DESCRIPTION
This PR attempts to cleanup some things that became redundant after diffusion layer was merged, also it tries to fix several important bugs that were not noticed at the review stage.

At the time of writing, I've pushed two commits. One removes copy-pasted logic that was moved to the diffusion layer, but wasn't cleaned up from `Block.Networking`. Second fixes exception handling that violate the exceptions guideline (`docs/exceptions.md`). It also renames some things and removes `getChainFrom` (which must be implemented in a completely different way and wasn't used anywhere). 

As for bugs, there are two of them:
1. `getHashesRange` is used without `depthLimit` in diffusion layer. This means everybody can query the whole blockchain at once, which is an easy way to attack the node. This changed wasn't discuss explicitly, so it's a bug unless it's decided to think otherwise.
2. More serious one: block/headers communication is broken in case of rollbacks. It was decided to move all the checks out of the diffusion layer, but one important bit was missed: `classifyHeaders` was returning LCA header which then was helping to form `MsgGetBlocks`. Now, we request the very same headers server returned to us after `MsgGetHeaders` call, which is a mistake, because checkpoints are distributed exponentially over last `k` blocks (so some blocks are not included). Example: client has `A B C D E F G H` (oldest first), server has `A B C D E' F' G' H'`, client sends checkpoints set `{H G E A}` and thus server wil return `B..H'`, then the corresponding blocks will be fetched. But in fact we only need `E'..H'`. This comparison logic was previously made in `classifyHeaders`. I must also admit that there is an extra check (taking LCA in `handleBlocks`) that prevents client to fail when he tries to apply unexpectedly big list of blocks (with already known prefix). But facts are still left: protocol is used incorrectly, leading to non-optimal data transfer in case of forks.

@avieth Please tell your thoughts on this and let's decide what to do. 

IMHO:
* (1) behavior should be restored, it's easy to do so
* (2) should be left as it is, because I think the protocol format will be changed to a more compact one (one request-response instead of two) anyway. Remember though, that neither cheap to increase the size of checkpoints set on the client side as it leads to slower request processing on the server side (every checkpoint must be checked).