### PR TITLE
[CSL-2266] Remove BlockHeaderStub

### DIFF
--- a/block/src/Pos/Arbitrary/Block/Message.hs
+++ b/block/src/Pos/Arbitrary/Block/Message.hs
@@ -6,10 +6,10 @@ module Pos.Arbitrary.Block.Message
 import           Test.QuickCheck (Arbitrary (..))
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
+import           Pos.Arbitrary.Block ()
 import           Pos.Arbitrary.Ssc (SscPayloadDependsOnSlot (..))
 import           Pos.Arbitrary.Txp ()
 import           Pos.Arbitrary.Update ()
-import           Pos.Arbitrary.Block ()
 import           Pos.Binary.Class (Bi, Raw)
 import qualified Pos.Block.Network.Types as T
 import           Pos.Core (HasConfiguration)
@@ -19,11 +19,11 @@ import           Pos.Core.Ssc (SscPayload, SscProof)
 -- Block network types
 ------------------------------------------------------------------------------------------
 
-instance Arbitrary T.MsgGetHeaders where
+instance HasConfiguration => Arbitrary T.MsgGetHeaders where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary T.MsgGetBlocks where
+instance HasConfiguration => Arbitrary T.MsgGetBlocks where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/block/src/Pos/Block/Logic/Creation.hs
+++ b/block/src/Pos/Block/Logic/Creation.hs
@@ -31,7 +31,7 @@ import           Pos.Block.Slog (HasSlogGState (..), ShouldCallBListener (..))
 import           Pos.Core (Blockchain (..), EpochIndex, EpochOrSlot (..), HasConfiguration,
                            HeaderHash, SlotId (..), chainQualityThreshold, epochIndexL, epochSlots,
                            flattenSlotId, getEpochOrSlot, headerHash)
-import           Pos.Core.Block (BlockHeader, GenesisBlock, MainBlock, MainBlockchain)
+import           Pos.Core.Block (BlockHeader (..), GenesisBlock, MainBlock, MainBlockchain)
 import qualified Pos.Core.Block as BC
 import           Pos.Core.Context (HasPrimaryKey, getOurSecretKey)
 import           Pos.Core.Ssc (SscPayload)
@@ -173,11 +173,11 @@ needCreateGenesisBlock ::
     -> m Bool
 needCreateGenesisBlock epoch tipHeader = do
     case tipHeader of
-        Left _ -> pure False
+        BlockHeaderGenesis _ -> pure False
         -- This is true iff tip is from 'epoch' - 1 and last
         -- 'blkSecurityParam' blocks fully fit into last
         -- 'slotSecurityParam' slots from 'epoch' - 1.
-        Right mb ->
+        BlockHeaderMain mb ->
             if mb ^. epochIndexL /= epoch - 1
                 then pure False
                 else calcChainQualityM (flattenSlotId $ SlotId epoch minBound) <&> \case

--- a/block/src/Pos/Block/Logic/Header.hs
+++ b/block/src/Pos/Block/Logic/Header.hs
@@ -31,7 +31,7 @@ import           Pos.Core (BlockCount, EpochOrSlot (..), HasConfiguration, Heade
                            blkSecurityParam, bvdMaxHeaderSize, difficultyL, epochIndexL,
                            epochOrSlotG, getChainDifficulty, getEpochOrSlot, headerHash,
                            headerHashG, headerSlotL, prevBlockL)
-import           Pos.Core.Block (BlockHeader)
+import           Pos.Core.Block (BlockHeader (..))
 import           Pos.Crypto (hash)
 import           Pos.DB (MonadDBRead)
 import qualified Pos.DB.Block.Load as DB
@@ -80,8 +80,8 @@ classifyNewHeader
     )
     => BlockHeader -> m ClassifyHeaderRes
 -- Genesis headers seem useless, we can create them by ourselves.
-classifyNewHeader (Left _) = pure $ CHUseless "genesis header is useless"
-classifyNewHeader (Right header) = fmap (either identity identity) <$> runExceptT $ do
+classifyNewHeader (BlockHeaderGenesis _) = pure $ CHUseless "genesis header is useless"
+classifyNewHeader (BlockHeaderMain header) = fmap (either identity identity) <$> runExceptT $ do
     curSlot <- getCurrentSlot
     tipHeader <- DB.getTipHeader
     let tipEoS = getEpochOrSlot tipHeader
@@ -124,7 +124,7 @@ classifyNewHeader (Right header) = fmap (either identity identity) <$> runExcept
                     , vhpMaxSize = Just maxBlockHeaderSize
                     , vhpVerifyNoUnknown = False
                     }
-            case verifyHeader vhp (Right header) of
+            case verifyHeader vhp (BlockHeaderMain header) of
                 VerFailure errors -> throwError $ mkCHRinvalid errors
                 _                 -> pass
 

--- a/core/Pos/Binary/Core/Block.hs
+++ b/core/Pos/Binary/Core/Block.hs
@@ -7,7 +7,7 @@ module Pos.Binary.Core.Block
 import           Universum
 
 import           Pos.Binary.Class (Bi (..), Cons (..), Field (..), deriveSimpleBi, encodeListLen,
-                                   enforceSize)
+                                   encodeListLen, enforceSize)
 import           Pos.Binary.Core.Txp ()
 import qualified Pos.Core.Block.Blockchain as Core
 import qualified Pos.Core.Block.Genesis.Chain as BC

--- a/core/Pos/Binary/Core/Common.hs
+++ b/core/Pos/Binary/Core/Common.hs
@@ -35,12 +35,6 @@ deriveSimpleBi ''T.ChainDifficulty [
         Field [| T.getChainDifficulty :: T.BlockCount |]
     ]]
 
--- | This instance required only for Arbitrary instance of HeaderHash
--- due to @instance Bi a => Hash a@.
-instance Bi T.BlockHeaderStub where
-    encode = error "somebody tried to binary encode BlockHeaderStub"
-    decode = error "somebody tried to binary decode BlockHeaderStub"
-
 ----------------------------------------------------------------------------
 -- Coin
 ----------------------------------------------------------------------------

--- a/core/Pos/Core/Block/Genesis/Instances.hs
+++ b/core/Pos/Core/Block/Genesis/Instances.hs
@@ -19,7 +19,7 @@ import           Pos.Core.Block.Blockchain (GenericBlock (..), GenericBlockHeade
 import           Pos.Core.Block.Genesis.Chain (Body (..), ConsensusData (..))
 import           Pos.Core.Block.Genesis.Lens (gcdDifficulty, gcdEpoch)
 import           Pos.Core.Block.Genesis.Types (GenesisBlock, GenesisBlockHeader, GenesisBlockchain)
-import           Pos.Core.Block.Union.Types (BlockHeader, blockHeaderHash)
+import           Pos.Core.Block.Union.Types (BlockHeader (..), blockHeaderHash)
 import           Pos.Core.Class (HasDifficulty (..), HasEpochIndex (..), HasEpochOrSlot (..),
                                  HasHeaderHash (..), IsGenesisHeader, IsHeader)
 import           Pos.Core.Common (HeaderHash)
@@ -45,7 +45,7 @@ instance Bi BlockHeader => Buildable GenesisBlockHeader where
             _gcdDifficulty
       where
         gbhHeaderHash :: HeaderHash
-        gbhHeaderHash = blockHeaderHash $ Left gbh
+        gbhHeaderHash = blockHeaderHash $ BlockHeaderGenesis gbh
         GenesisConsensusData {..} = _gbhConsensus
 
 instance Bi BlockHeader => Buildable GenesisBlock where
@@ -86,11 +86,11 @@ instance HasEpochOrSlot GenesisBlock where
 
 instance Bi BlockHeader =>
          HasHeaderHash GenesisBlockHeader where
-    headerHash = blockHeaderHash . Left
+    headerHash = blockHeaderHash . BlockHeaderGenesis
 
 instance Bi BlockHeader =>
          HasHeaderHash GenesisBlock where
-    headerHash = blockHeaderHash . Left . _gbHeader
+    headerHash = blockHeaderHash . BlockHeaderGenesis . _gbHeader
 
 instance HasDifficulty (ConsensusData GenesisBlockchain) where
     difficultyL = gcdDifficulty

--- a/core/Pos/Core/Block/Main/Instances.hs
+++ b/core/Pos/Core/Block/Main/Instances.hs
@@ -24,7 +24,7 @@ import           Pos.Core.Block.Main.Lens (mainBlockBlockVersion, mainBlockDiffi
                                            mehBlockVersion, mehSoftwareVersion)
 import           Pos.Core.Block.Main.Types (MainBlock, MainBlockHeader, MainBlockchain,
                                             MainExtraHeaderData (..))
-import           Pos.Core.Block.Union.Types (BlockHeader, blockHeaderHash)
+import           Pos.Core.Block.Union.Types (BlockHeader (..), blockHeaderHash)
 import           Pos.Core.Class (HasBlockVersion (..), HasDifficulty (..), HasEpochIndex (..),
                                  HasEpochOrSlot (..), HasHeaderHash (..), HasSoftwareVersion (..),
                                  IsHeader, IsMainHeader (..))
@@ -55,7 +55,7 @@ instance Bi BlockHeader => Buildable MainBlockHeader where
             _gbhExtra
       where
         gbhHeaderHash :: HeaderHash
-        gbhHeaderHash = blockHeaderHash $ Right gbh
+        gbhHeaderHash = blockHeaderHash $ BlockHeaderMain gbh
         MainConsensusData {..} = _gbhConsensus
 
 instance (HasConfiguration, Bi BlockHeader) => Buildable MainBlock where
@@ -99,11 +99,11 @@ instance HasEpochOrSlot MainBlock where
 
 instance Bi BlockHeader =>
          HasHeaderHash MainBlockHeader where
-    headerHash = blockHeaderHash . Right
+    headerHash = blockHeaderHash . BlockHeaderMain
 
 instance Bi BlockHeader =>
          HasHeaderHash MainBlock where
-    headerHash = blockHeaderHash . Right . _gbHeader
+    headerHash = blockHeaderHash . BlockHeaderMain . _gbHeader
 
 instance HasDifficulty (ConsensusData MainBlockchain) where
     difficultyL = mcdDifficulty

--- a/core/Pos/Core/Common/Types.hs
+++ b/core/Pos/Core/Common/Types.hs
@@ -221,7 +221,7 @@ newtype ChainDifficulty = ChainDifficulty
 ----------------------------------------------------------------------------
 
 -- We use a data family instead of a data type solely to avoid a module
--- cycle.
+-- cycle. Grep for @data instance BlockHeader@ to find the definition.
 --
 -- | Forward-declaration of block headers. See the corresponding type instance
 -- for the actual definition.
@@ -231,8 +231,7 @@ data family BlockHeader
 -- HeaderHash
 ----------------------------------------------------------------------------
 
--- | 'Hash' of block header. This should be @Hash BlockHeader@
--- but 'BlockHeader' is not defined in core.
+-- | 'Hash' of block header.
 type HeaderHash = Hash BlockHeader
 
 -- | Specialized formatter for 'HeaderHash'.

--- a/core/Pos/Core/Common/Types.hs
+++ b/core/Pos/Core/Common/Types.hs
@@ -13,6 +13,9 @@ module Pos.Core.Common.Types
        , mkMultiKeyDistr
        , Address (..)
 
+       -- * Forward-declared BlockHeader
+       , BlockHeader
+
        -- * Stakeholders
        , StakeholderId
        , StakesMap
@@ -22,7 +25,6 @@ module Pos.Core.Common.Types
        , ChainDifficulty (..)
 
        -- * HeaderHash related types and functions
-       , BlockHeaderStub
        , HeaderHash
        , headerHashF
 
@@ -215,13 +217,23 @@ newtype ChainDifficulty = ChainDifficulty
     } deriving (Show, Eq, Ord, Num, Enum, Real, Integral, Generic, Buildable, Typeable, NFData)
 
 ----------------------------------------------------------------------------
+-- BlockHeader (forward-declaration)
+----------------------------------------------------------------------------
+
+-- We use a data family instead of a data type solely to avoid a module
+-- cycle.
+--
+-- | Forward-declaration of block headers. See the corresponding type instance
+-- for the actual definition.
+data family BlockHeader
+
+----------------------------------------------------------------------------
 -- HeaderHash
 ----------------------------------------------------------------------------
 
 -- | 'Hash' of block header. This should be @Hash BlockHeader@
 -- but 'BlockHeader' is not defined in core.
-type HeaderHash = Hash BlockHeaderStub
-data BlockHeaderStub
+type HeaderHash = Hash BlockHeader
 
 -- | Specialized formatter for 'HeaderHash'.
 headerHashF :: Format r (HeaderHash -> r)

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -192,8 +192,10 @@ library
                        DefaultSignatures
                        NoImplicitPrelude
                        OverloadedStrings
+                       RankNTypes
                        RecordWildCards
                        TypeApplications
+                       TypeFamilies
                        TupleSections
                        ViewPatterns
                        LambdaCase

--- a/explorer/src/Pos/Arbitrary/Explorer.hs
+++ b/explorer/src/Pos/Arbitrary/Explorer.hs
@@ -5,9 +5,10 @@ module Pos.Arbitrary.Explorer () where
 import           Test.QuickCheck (Arbitrary (..))
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
+import           Pos.Core.Common (HeaderHash)
 import           Pos.Explorer.Core.Types (TxExtra (..))
 import           Pos.Txp ()
 
-instance Arbitrary TxExtra where
+instance Arbitrary HeaderHash => Arbitrary TxExtra where
     arbitrary = genericArbitrary
     shrink = genericShrink

--- a/lib/src/Pos/Diffusion/Full/Block.hs
+++ b/lib/src/Pos/Diffusion/Full/Block.hs
@@ -37,11 +37,11 @@ import           Pos.Communication.Limits (HasAdoptedBlockVersionData, recvLimit
 import           Pos.Communication.Listener (listenerConv)
 import           Pos.Communication.Message ()
 import           Pos.Communication.Protocol (Conversation (..), ConversationActions (..),
-                                             EnqueueMsg, MsgType (..), NodeId, Origin (..),
-                                             waitForConversations, OutSpecs, ListenerSpec,
-                                             MkListeners (..), constantListeners)
-import           Pos.Core (HeaderHash, headerHash, prevBlockL, bvdSlotDuration)
-import           Pos.Core.Block (Block, BlockHeader, MainBlockHeader, blockHeader)
+                                             EnqueueMsg, ListenerSpec, MkListeners (..),
+                                             MsgType (..), NodeId, Origin (..), OutSpecs,
+                                             constantListeners, waitForConversations)
+import           Pos.Core (HeaderHash, bvdSlotDuration, headerHash, prevBlockL)
+import           Pos.Core.Block (Block, BlockHeader (..), MainBlockHeader, blockHeader)
 import           Pos.Crypto (shortHashF)
 import           Pos.DB (DBError (DBMalformed))
 import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
@@ -49,13 +49,13 @@ import           Pos.Exception (cardanoExceptionFromException, cardanoExceptionT
 import           Pos.Logic.Types (GetBlockHeadersError (..), Logic (..))
 import           Pos.Network.Types (Bucket)
 -- Dubious having this security stuff in here.
-import           Pos.Security.Params (AttackType (..), NodeAttackedError (..),
-                                      AttackTarget (..), SecurityParams (..))
+import           Pos.Security.Params (AttackTarget (..), AttackType (..), NodeAttackedError (..),
+                                      SecurityParams (..))
 import           Pos.Util (_neHead, _neLast)
-import           Pos.Util.Chrono (NewestFirst (..), _NewestFirst, OldestFirst (..),
-                                  NE, nonEmptyNewestFirst)
-import           Pos.Util.TimeWarp (nodeIdToAddress, NetworkAddress)
+import           Pos.Util.Chrono (NE, NewestFirst (..), OldestFirst (..), nonEmptyNewestFirst,
+                                  _NewestFirst)
 import           Pos.Util.Timer (Timer, setTimerDuration, startTimer)
+import           Pos.Util.TimeWarp (NetworkAddress, nodeIdToAddress)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -320,7 +320,7 @@ announceBlockHeader logic enqueue header =  do
                 ("Announcing block"%shortHashF%" to "%build)
                 (headerHash header)
                 nodeId
-        send cA $ MsgHeaders (one (Right header))
+        send cA $ MsgHeaders (one (BlockHeaderMain header))
         -- After we announce, the peer is given an opportunity to request more
         -- headers within the same conversation.
         handleHeadersCommunication logic cA
@@ -338,7 +338,7 @@ handleHeadersCommunication
 handleHeadersCommunication logic conv = do
     whenJustM (recvLimited conv) $ \mgh@(MsgGetHeaders {..}) -> do
         logDebug $ sformat ("Got request on handleGetHeaders: "%build) mgh
-        -- FIXME 
+        -- FIXME
         -- Diffusion layer is entirely capable of serving blocks even if the
         -- logic layer is in recovery mode.
         ifM (recoveryInProgress logic) onRecovery $ do

--- a/lib/src/Pos/Logic/Pure.hs
+++ b/lib/src/Pos/Logic/Pure.hs
@@ -12,28 +12,28 @@ import           Data.Coerce (coerce)
 import           Data.Default (def)
 import           Data.Reflection (give)
 
-import           Pos.Core (StakeholderId, SoftwareVersion (..), BlockVersion (..),
-                           HeaderHash, Block, BlockHeader, GenericBlock (..),
-                           GenericBlockHeader (..), ExtraHeaderData, ExtraBodyData,
-                           BlockVersionData (..), mkApplicationName,
-                           unsafeCoinPortionFromDouble, TxFeePolicy (..), SoftforkRule (..))
+import           Pos.Core (Block, BlockHeader (..), BlockVersion (..), BlockVersionData (..),
+                           ExtraBodyData, ExtraHeaderData, GenericBlock (..),
+                           GenericBlockHeader (..), HeaderHash, SoftforkRule (..),
+                           SoftwareVersion (..), StakeholderId, TxFeePolicy (..), mkApplicationName,
+                           unsafeCoinPortionFromDouble)
 import           Pos.Core.Block.Main
-import           Pos.Core.Common (ChainDifficulty (..), BlockCount (..))
+import           Pos.Core.Common (BlockCount (..), ChainDifficulty (..))
 import           Pos.Core.Delegation (DlgPayload (..))
+import           Pos.Core.Slotting (EpochIndex (..), LocalSlotIndex (..), SlotId (..))
 import           Pos.Core.Ssc (SscPayload (..), SscProof (..), VssCertificatesMap (..))
-import           Pos.Core.Slotting (SlotId (..), EpochIndex (..), LocalSlotIndex (..))
 import           Pos.Core.Txp (TxProof (..))
 import           Pos.Core.Update (UpdatePayload (..), UpdateProof)
-import           Pos.Txp.Base (emptyTxPayload)
 import           Pos.Crypto.Configuration (ProtocolMagic (..))
 import           Pos.Crypto.Hashing (Hash, unsafeMkAbstractHash)
 import           Pos.Crypto.Signing (PublicKey (..), SecretKey (..), Signature (..),
                                      deterministicKeyGen, signRaw)
-import           Pos.Data.Attributes (UnparsedFields (..), Attributes (..))
+import           Pos.Data.Attributes (Attributes (..), UnparsedFields (..))
 import           Pos.Merkle (MerkleRoot (..))
-import           Pos.Util.Chrono (OldestFirst (..), NewestFirst (..))
+import           Pos.Txp.Base (emptyTxPayload)
+import           Pos.Util.Chrono (NewestFirst (..), OldestFirst (..))
 
-import           Pos.Logic.Types (Logic (..), KeyVal (..))
+import           Pos.Logic.Types (KeyVal (..), Logic (..))
 
 -- | Serves up a single (invalid but well-formed) block and block header for
 -- any request.
@@ -84,7 +84,7 @@ blockVersionData = BlockVersionData
     -- There's no way to say "no limit".
     --
     -- To fix this, perhaps we should augment the logic layer interface with
-    -- 
+    --
     --   limits :: m Limits
     --
     -- where Limits gives all of these 4 limits. Then we can use them to do
@@ -168,7 +168,7 @@ extraBodyData = MainExtraBodyData
     }
 
 blockHeader :: BlockHeader
-blockHeader = Right mainBlockHeader
+blockHeader = BlockHeaderMain mainBlockHeader
 
 mainBlockHeader :: MainBlockHeader
 mainBlockHeader = UnsafeGenericBlockHeader

--- a/tools/src/blockchain-analyser/Rendering.hs
+++ b/tools/src/blockchain-analyser/Rendering.hs
@@ -14,7 +14,7 @@ import           Pos.Binary.Class (biSize)
 import           Pos.Block.Types (Undo)
 import           Pos.Core (EpochIndex, EpochOrSlot (..), HasConfiguration, LocalSlotIndex (..),
                            SlotId (..), Tx, getEpochIndex, getEpochOrSlot)
-import           Pos.Core.Block (Block, BlockHeader, blockHeaderHash, getBlockHeader, mbTxs,
+import           Pos.Core.Block (Block, BlockHeader (..), blockHeaderHash, getBlockHeader, mbTxs,
                                  _gbBody, _gbhConsensus, _mcdLeaderKey)
 import           Pos.Crypto (PublicKey)
 import           Pos.Merkle (MerkleTree (..))
@@ -157,15 +157,16 @@ getSlot :: BlockHeader -> Maybe SlotId
 getSlot = either (const Nothing) Just . unEpochOrSlot . getEpochOrSlot
 
 getLeader :: BlockHeader -> Maybe PublicKey
-getLeader (Left _)   = Nothing
-getLeader (Right bh) = Just . _mcdLeaderKey . _gbhConsensus $ bh
+getLeader (BlockHeaderGenesis _) = Nothing
+getLeader (BlockHeaderMain bh)   = Just . _mcdLeaderKey . _gbhConsensus $ bh
 
 getTxs :: Block -> MerkleTree Tx
 getTxs (Left _)          = MerkleEmpty
 getTxs (Right mainBlock) = (_gbBody mainBlock) ^. mbTxs
 
 getHeaderSize :: HasConfiguration => BlockHeader -> Integer
-getHeaderSize = either (toBytes . biSize) (toBytes . biSize)
+getHeaderSize (BlockHeaderGenesis h) = toBytes (biSize h)
+getHeaderSize (BlockHeaderMain h)    = toBytes (biSize h)
 
 getBlockSize :: HasConfiguration => Block -> Integer
 getBlockSize = either (toBytes . biSize) (toBytes . biSize)

--- a/update/Pos/Arbitrary/Update/Poll.hs
+++ b/update/Pos/Arbitrary/Update/Poll.hs
@@ -15,6 +15,7 @@ import           Pos.Arbitrary.Slotting ()
 import           Pos.Arbitrary.Update.Core ()
 import           Pos.Binary.Core ()
 import           Pos.Binary.Update ()
+import           Pos.Core.Common (HeaderHash)
 import           Pos.Core.Configuration (HasConfiguration)
 import           Pos.Update.Poll.Modifier (PollModifier (..))
 import           Pos.Update.Poll.PollState (PollState (..), psActivePropsIdx)
@@ -23,45 +24,45 @@ import           Pos.Update.Poll.Types (BlockVersionState (..), ConfirmedProposa
                                         ProposalState (..), USUndo, UndecidedProposalState (..),
                                         UpsExtra (..))
 
-instance Arbitrary UpsExtra where
+instance Arbitrary HeaderHash => Arbitrary UpsExtra where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary UndecidedProposalState where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary UndecidedProposalState where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary DpsExtra where
+instance Arbitrary HeaderHash => Arbitrary DpsExtra where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary DecidedProposalState where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary DecidedProposalState where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary ConfirmedProposalState where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary ConfirmedProposalState where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary ProposalState  where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary ProposalState  where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary BlockVersionState where
+instance Arbitrary HeaderHash => Arbitrary BlockVersionState where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary PollModifier where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary PollModifier where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary PollState where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary PollState where
     arbitrary = do
         ps <- genericArbitrary
         return (ps & psActivePropsIdx %~ HM.filter (not . null))
     shrink = genericShrink
 
-instance HasConfiguration => Arbitrary USUndo where
+instance (Arbitrary HeaderHash, HasConfiguration) => Arbitrary USUndo where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -31,22 +31,22 @@ module UTxO.Context (
   , blockSignInfoForSlot
   ) where
 
-import Universum
-import Formatting (sformat, bprint, build, (%))
-import Serokell.Util (listJson, mapJson, pairF)
-import Serokell.Util.Base16 (base16F)
 import qualified Data.HashMap.Strict as HM
-import qualified Data.List.NonEmpty  as NE
-import qualified Data.Map.Strict     as Map
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
 import qualified Data.Text.Buildable
+import           Formatting (bprint, build, sformat, (%))
+import           Serokell.Util (listJson, mapJson, pairF)
+import           Serokell.Util.Base16 (base16F)
+import           Universum
 
-import Pos.Block.Genesis
-import Pos.Core
-import Pos.Crypto
-import Pos.Lrc.Genesis
-import Pos.Txp
+import           Pos.Block.Genesis
+import           Pos.Core
+import           Pos.Crypto
+import           Pos.Lrc.Genesis
+import           Pos.Txp
 
-import UTxO.Crypto
+import           UTxO.Crypto
 
 {-------------------------------------------------------------------------------
   Summary of the information we get about the genesis block from Cardano core
@@ -69,7 +69,7 @@ data CardanoContext = CardanoContext {
       -- | Hash of block0
       --
       -- NOTE: Derived from 'ccBlock0', /not/ the same as 'genesisHash'.
-    , ccHash0 :: HeaderHash
+    , ccHash0    :: HeaderHash
     }
 
 initCardanoContext :: HasConfiguration => CardanoContext
@@ -84,7 +84,7 @@ initCardanoContext = CardanoContext{..}
                  generatedSecrets
 
     ccBalances = utxoToAddressCoinPairs ccUtxo
-    ccHash0    = (blockHeaderHash . Left . _gbHeader) ccBlock0
+    ccHash0    = (blockHeaderHash . BlockHeaderGenesis . _gbHeader) ccBlock0
 
 {-------------------------------------------------------------------------------
   More explicit representation of the various actors in the genesis block
@@ -414,9 +414,9 @@ initAddrMap Actors{..} = AddrMap{
 -------------------------------------------------------------------------------}
 
 data TransCtxt = TransCtxt {
-      tcCardano  :: CardanoContext
-    , tcActors   :: Actors
-    , tcAddrMap  :: AddrMap
+      tcCardano :: CardanoContext
+    , tcActors  :: Actors
+    , tcAddrMap :: AddrMap
     }
 
 initContext :: CardanoContext -> TransCtxt

--- a/wallet-new/test/unit/UTxO/Interpreter.hs
+++ b/wallet-new/test/unit/UTxO/Interpreter.hs
@@ -313,8 +313,8 @@ instance DSL.Hash h Addr => Interpret h (DSL.Chain h Addr) where
         -- if none specified, use genesis block
         prev <-
           case mPrev of
-            Just prev -> (Right . view gbHeader) <$> return prev
-            Nothing   -> (Left  . view gbHeader) <$> asks (ccBlock0 . tcCardano)
+            Just prev -> (BlockHeaderMain . view gbHeader) <$> return prev
+            Nothing   -> (BlockHeaderGenesis . view gbHeader) <$> asks (ccBlock0 . tcCardano)
 
         -- figure out who needs to sign the block
         BlockSignInfo{..} <- asks $ blockSignInfoForSlot slotId


### PR DESCRIPTION
* remove `BlockHeaderStub` — it was an awkward hack to resolve module cycles, I used a more principled technique
* rewrite `BlockHeader` as an ADT — previously it was an `Either`, and I had plans to refactor it for a long time, but now I simply had to, as `BlockHeader` is now a data family (a type family wouldn't work because we need to declare instances for `Hash BlockHeader`)