### PR TITLE
[CSL-1855] Move exitWith to runServer, refactor lancher exit code handling

### DIFF
--- a/lib/src/Pos/Launcher/Runner.hs
+++ b/lib/src/Pos/Launcher/Runner.hs
@@ -16,30 +16,33 @@ module Pos.Launcher.Runner
 
 import           Universum
 
-import qualified Control.Monad.Reader as Mtl
 import           Control.Monad.Fix (MonadFix)
+import qualified Control.Monad.Reader as Mtl
 import           Data.Default (Default)
 import           JsonLog (jsonLog)
+import           Mockable (race)
 import           Mockable.Production (Production (..))
+import           System.Exit (ExitCode (..))
 
 import           Pos.Binary ()
 import           Pos.Communication (ActionSpec (..), OutSpecs (..))
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData)
 import           Pos.Configuration (networkConnectionTimeout)
 import           Pos.Context.Context (NodeContext (..))
+import           Pos.Diffusion.Full (diffusionLayerFull)
+import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
+import           Pos.Diffusion.Transport.TCP (bracketTransportTCP)
+import           Pos.Diffusion.Types (Diffusion (..), DiffusionLayer (..))
 import           Pos.Launcher.Configuration (HasConfigurations)
 import           Pos.Launcher.Param (BaseParams (..), LoggingParams (..), NodeParams (..))
 import           Pos.Launcher.Resource (NodeResources (..))
-import           Pos.Diffusion.Transport.TCP (bracketTransportTCP)
-import           Pos.Diffusion.Types (DiffusionLayer (..), Diffusion (..))
-import           Pos.Diffusion.Full (diffusionLayerFull)
-import           Pos.Diffusion.Full.Types (DiffusionWorkMode)
-import           Pos.Logic.Full (logicLayerFull, LogicWorkMode)
+import           Pos.Logic.Full (LogicWorkMode, logicLayerFull)
 import           Pos.Logic.Types (LogicLayer (..))
 import           Pos.Network.Types (NetworkConfig (..), topologyRoute53HealthCheckEnabled)
 import           Pos.Recovery.Instance ()
+import           Pos.Reporting.Ekg (EkgNodeMetrics (..), registerEkgMetrics, withEkgServer)
 import           Pos.Reporting.Statsd (withStatsd)
-import           Pos.Reporting.Ekg (withEkgServer, registerEkgMetrics, EkgNodeMetrics (..))
+import           Pos.Shutdown (HasShutdownContext, waitForShutdown)
 import           Pos.Txp (MonadTxpLocal)
 import           Pos.Update.Configuration (lastKnownBlockVersion)
 import           Pos.Util.CompileInfo (HasCompileInfo)
@@ -111,11 +114,12 @@ elimRealMode NodeResources {..} action = do
 -- | "Batteries-included" server.
 -- Bring up a full diffusion layer over a TCP transport and use it to run some
 -- action. Also brings up ekg monitoring, route53 health check, statds,
--- according to parameters. 
+-- according to parameters.
 runServer
     :: forall ctx m t .
        ( DiffusionWorkMode m
        , LogicWorkMode ctx m
+       , HasShutdownContext ctx
        , MonadFix m
        )
     => NodeParams
@@ -124,7 +128,7 @@ runServer
     -> ActionSpec m t
     -> m t
 runServer NodeParams {..} ekgNodeMetrics _ (ActionSpec act) =
-    logicLayerFull jsonLog $ \logicLayer ->
+    exitOnShutdown . logicLayerFull jsonLog $ \logicLayer ->
         bracketTransportTCP networkConnectionTimeout tcpAddr $ \transport ->
             diffusionLayerFull npNetworkConfig lastKnownBlockVersion transport (Just ekgNodeMetrics) $ \withLogic -> do
                 diffusionLayer <- withLogic (logic logicLayer)
@@ -136,17 +140,20 @@ runServer NodeParams {..} ekgNodeMetrics _ (ActionSpec act) =
                     maybeWithStatsd $
                     act (diffusion diffusionLayer)
   where
+    exitOnShutdown action = do
+        _ <- race waitForShutdown action
+        exitWith (ExitFailure 20) -- special exit code to indicate an update
     tcpAddr = ncTcpAddr npNetworkConfig
     ekgStore = enmStore ekgNodeMetrics
     (hcHost, hcPort) = case npRoute53Params of
-        Nothing -> ("127.0.0.1", 3030)
+        Nothing         -> ("127.0.0.1", 3030)
         Just (hst, prt) -> (decodeUtf8 hst, fromIntegral prt)
     maybeWithRoute53 mStatus = case topologyRoute53HealthCheckEnabled (ncTopology npNetworkConfig) of
-        True -> withRoute53HealthCheckApplication mStatus hcHost hcPort
+        True  -> withRoute53HealthCheckApplication mStatus hcHost hcPort
         False -> identity
     maybeWithEkg = case (npEnableMetrics, npEkgParams) of
         (True, Just ekgParams) -> withEkgServer ekgParams ekgStore
-        _ -> identity
+        _                      -> identity
     maybeWithStatsd = case (npEnableMetrics, npStatsdParams) of
         (True, Just sdParams) -> withStatsd sdParams ekgStore
-        _ -> identity
+        _                     -> identity

--- a/scripts/launch/ui-simulator.sh
+++ b/scripts/launch/ui-simulator.sh
@@ -9,6 +9,8 @@ if [[ "$1" == "" ]]; then
   case $v in
     bla)
       echo "Update started"
+      curl -X POST -kv https://127.0.0.1:8090/api/update/apply
+      sleep 1s
       exit 20
       ;;
     *)


### PR DESCRIPTION
The node now exits with exit code 20 after a shutdown as it is supposed to.

Launcher exit code handling was refactored a little bit, we do not restart the node if it didn't exit code 20 or was forcefully killed.