### PR TITLE
Remove the use of encoded Address in the wallet DB

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,13 @@ before_test:
 # CSL-1509: After moving the 'cardano-sl' project itself into a separate folder ('node/'), the 'cardano-text.exe' executable fails on AppVeyor CI.
 # After some investigation, it was discovered that this was because 'rocksdb.dll' has to be located in this folder as well, or else the test executable doesn't work.
 - copy rocksdb.dll node
+- copy rocksdb.dll lib
+- copy rocksdb.dll wallet
+- copy rocksdb.dll wallet-new
+
+# Install liblzma/xz
+- ps: Start-FileDownload https://tukaani.org/xz/xz-5.2.3-windows.zip -Filename xz-5.2.3-windows.zip
+- 7z -oC:\xz_extracted x xz-5.2.3-windows.zip
 
 test_script:
   - cd "%WORK_DIR%"

--- a/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/node/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -11,14 +11,12 @@ module Pos.Wallet.Web.ClientTypes.Functions
       , txIdToCTxId
       , toCUpdateInfo
       , addrMetaToAccount
-      , isTxLocalAddress
       ) where
 
 import           Universum
 
 import           Control.Monad.Error.Class        (throwError)
 import qualified Data.List.NonEmpty               as NE
-import qualified Data.Set                         as S
 import           Data.Text                        (Text)
 import           Formatting                       (sformat)
 import qualified Formatting                       as F
@@ -79,46 +77,6 @@ ptxCondToCPtxCond = maybe CPtxNotTracked $ \case
     PtxPersisted{}      -> CPtxInBlocks
     PtxWontApply{}      -> CPtxWontApply
 
--- [CSM-309] This may work until transaction have multiple source accounts
--- | Get all addresses of source account of given transaction.
-getTxSourceAccountAddresses
-    :: [CWAddressMeta]      -- ^ All addresses in wallet
-    -> NonEmpty (CId Addr)  -- ^ Input addresses of transaction
-    -> Maybe [CId Addr]     -- ^ `Just` addrs if the wallet is source of
-                            --   transaction, `Nothing` otherwise
-getTxSourceAccountAddresses walAddrMetas (someInputAddr :| _) = do
-    someSrcAddrMeta <- find ((== someInputAddr) . cwamId) walAddrMetas
-    let srcAccount = addrMetaToAccount someSrcAddrMeta
-    return $
-        map cwamId $
-        filter ((srcAccount ==) . addrMetaToAccount) walAddrMetas
-
--- | Produces a function which for a given address says whether this address
--- belongs to the same account as the addresses which are the sources
--- of a given transaction. This assumes that the source addresses belong
--- to the same account.
--- Note that if you apply this function to the outputs of a transaction,
--- you will effectively get /change/ addresses.
-isTxLocalAddress
-    :: [CWAddressMeta]      -- ^ All addresses in wallet
-    -> NonEmpty (CId Addr)  -- ^ Input addresses of transaction
-    -> (CId Addr -> Bool)
-isTxLocalAddress wAddrMetas inputs = do
-    let mLocalAddrs = getTxSourceAccountAddresses wAddrMetas inputs
-    case mLocalAddrs of
-       Just changeAddrs -> do
-           -- if given wallet is source of tx, /local addresses/
-           -- can be fetched according to definition
-           let changeAddrsSet = S.fromList changeAddrs
-           flip S.member changeAddrsSet
-       Nothing -> do
-           -- if given wallet is *not* source of tx, then it's incoming
-           -- transaction, and only addresses of given wallet are *not*
-           -- local addresses
-           -- [CSM-309] This may work until transaction have multiple
-           -- destination addresses
-           let nonLocalAddrsSet = S.fromList $ cwamId <$> wAddrMetas
-           not . flip S.member nonLocalAddrsSet
 
 mergeTxOuts :: [TxOut] -> [TxOut]
 mergeTxOuts = map stick . NE.groupWith txOutAddress
@@ -130,10 +88,10 @@ mkCTx
     -> TxHistoryEntry     -- ^ Tx history entry
     -> CTxMeta            -- ^ Transaction metadata
     -> CPtxCondition      -- ^ State of resubmission
-    -> (CId Addr -> Bool) -- ^ Whether addresses belongs to the wallet
+    -> (Address -> Bool) -- ^ Whether addresses belongs to the wallet
     -> Either Text CTx
 mkCTx diff THEntry {..} meta pc addrBelongsToWallet = do
-    let isOurTxAddress = addrBelongsToWallet . addressToCId . txOutAddress
+    let isOurTxAddress = addrBelongsToWallet . txOutAddress
 
         ownInputs = filter isOurTxAddress inputs
         ownOutputs = filter isOurTxAddress outputs

--- a/node/src/Pos/Wallet/Web/State.hs
+++ b/node/src/Pos/Wallet/Web/State.hs
@@ -1,7 +1,11 @@
 module Pos.Wallet.Web.State
        ( module Pos.Wallet.Web.State.State
        , module Pos.Wallet.Web.State.Util
+       , Storage.WAddressMeta(..)
+       , Storage.HasWAddressMeta(..)
+       , Storage.wamAccount
        ) where
 
 import           Pos.Wallet.Web.State.State
 import           Pos.Wallet.Web.State.Util
+import qualified Pos.Wallet.Web.State.Storage as Storage

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -109,11 +109,7 @@ import           Pos.Txp                         (AddrCoinMap, TxAux, TxId, Utxo
 import           Pos.Types                       (HeaderHash)
 import           Pos.Util.BackupPhrase           (BackupPhrase)
 import qualified Pos.Util.Modifier               as MM
-import           Pos.Wallet.Web.ClientTypes      (AccountId(..), Addr, CAccountMeta, CCoin,
-                                                  CHash, CId, CProfile, CTxId, CTxMeta,
-                                                  CUpdateInfo, CWAddressMeta (..),
-                                                  CWalletAssurance, CWalletMeta,
-                                                  PassPhraseLU, Wal, addrMetaToAccount)
+import qualified Pos.Wallet.Web.ClientTypes      as WebTypes
 import           Pos.Wallet.Web.Pending.Types    (PendingTx (..), PtxCondition,
                                                   PtxSubmitTiming (..), ptxCond,
                                                   ptxSubmitTiming)
@@ -125,14 +121,14 @@ import           Pos.Wallet.Web.Pending.Updates  (cancelApplyingPtx,
 type AddressSortingKey = Int
 
 data AddressInfo = AddressInfo
-    { adiCWAddressMeta :: !CWAddressMeta
+    { adiCWAddressMeta :: !WebTypes.CWAddressMeta
     , adiSortingKey    :: !AddressSortingKey
     }
 
-type CAddresses = HashMap (CId Addr) AddressInfo
+type CAddresses = HashMap (WebTypes.CId WebTypes.Addr) AddressInfo
 
 data AccountInfo = AccountInfo
-    { _aiMeta             :: !CAccountMeta
+    { _aiMeta             :: !WebTypes.CAccountMeta
     , _aiAddresses        :: !CAddresses
     , _aiRemovedAddresses :: !CAddresses
     , _aiUnusedKey        :: !AddressSortingKey
@@ -145,8 +141,8 @@ data WalletTip
     | SyncedWith !HeaderHash
 
 data WalletInfo = WalletInfo
-    { _wiMeta         :: !CWalletMeta
-    , _wiPassphraseLU :: !PassPhraseLU
+    { _wiMeta         :: !WebTypes.CWalletMeta
+    , _wiPassphraseLU :: !WebTypes.PassPhraseLU
     , _wiCreationTime :: !POSIXTime
     , _wiSyncTip      :: !WalletTip
     , _wsPendingTxs   :: !(HashMap TxId PendingTx)
@@ -159,17 +155,17 @@ data WalletInfo = WalletInfo
 makeLenses ''WalletInfo
 
 -- | Maps addresses to their first occurrence in the blockchain
-type CustomAddresses = HashMap (CId Addr) HeaderHash
+type CustomAddresses = HashMap (WebTypes.CId WebTypes.Addr) HeaderHash
 type WalletBalances = AddrCoinMap
 type WalBalancesAndUtxo = (WalletBalances, Utxo)
 
 data WalletStorage = WalletStorage
-    { _wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
-    , _wsAccountInfos    :: !(HashMap AccountId AccountInfo)
-    , _wsProfile         :: !CProfile
-    , _wsReadyUpdates    :: [CUpdateInfo]
-    , _wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
-    , _wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
+    { _wsWalletInfos     :: !(HashMap (WebTypes.CId WebTypes.Wal) WalletInfo)
+    , _wsAccountInfos    :: !(HashMap WebTypes.AccountId AccountInfo)
+    , _wsProfile         :: !WebTypes.CProfile
+    , _wsReadyUpdates    :: [WebTypes.CUpdateInfo]
+    , _wsTxHistory       :: !(HashMap (WebTypes.CId WebTypes.Wal) (HashMap WebTypes.CTxId WebTypes.CTxMeta))
+    , _wsHistoryCache    :: !(HashMap (WebTypes.CId WebTypes.Wal) (Map TxId TxHistoryEntry))
     , _wsUtxo            :: !Utxo
     -- @_wsBalances@ depends on @_wsUtxo@,
     -- it's forbidden to update @_wsBalances@ without @_wsUtxo@
@@ -224,25 +220,25 @@ data CurrentAndRemoved a = CurrentAndRemoved
     , getRemoved :: a
     }
 
-getProfile :: Query CProfile
+getProfile :: Query WebTypes.CProfile
 getProfile = view wsProfile
 
-setProfile :: CProfile -> Update ()
+setProfile :: WebTypes.CProfile -> Update ()
 setProfile cProfile = wsProfile .= cProfile
 
-doesAccountExist :: AccountId -> Query Bool
+doesAccountExist :: WebTypes.AccountId -> Query Bool
 doesAccountExist accId = view $ wsAccountInfos . at accId . to isJust
 
-getAccountIds :: Query [AccountId]
+getAccountIds :: Query [WebTypes.AccountId]
 getAccountIds = HM.keys <$> view wsAccountInfos
 
-getAccountMetas :: Query [CAccountMeta]
+getAccountMetas :: Query [WebTypes.CAccountMeta]
 getAccountMetas = map (view aiMeta) . toList <$> view wsAccountInfos
 
-getAccountMeta :: AccountId -> Query (Maybe CAccountMeta)
+getAccountMeta :: WebTypes.AccountId -> Query (Maybe WebTypes.CAccountMeta)
 getAccountMeta accId = preview (wsAccountInfos . ix accId . aiMeta)
 
-getAccountAddrMaps :: AccountId -> Query (CurrentAndRemoved CAddresses)
+getAccountAddrMaps :: WebTypes.AccountId -> Query (CurrentAndRemoved CAddresses)
 getAccountAddrMaps accId = do
     getCurrent <- getMap aiAddresses
     getRemoved <- getMap aiRemovedAddresses
@@ -250,32 +246,32 @@ getAccountAddrMaps accId = do
   where
     getMap aiLens = fmap (fromMaybe mempty) $ preview $ wsAccountInfos . ix accId . aiLens
 
-getWalletMetas :: Query [CWalletMeta]
+getWalletMetas :: Query [WebTypes.CWalletMeta]
 getWalletMetas = toList . fmap _wiMeta . HM.filter _wiIsReady <$> view wsWalletInfos
 
-getWalletMetaIncludeUnready :: Bool -> CId Wal -> Query (Maybe CWalletMeta)
+getWalletMetaIncludeUnready :: Bool -> WebTypes.CId WebTypes.Wal -> Query (Maybe WebTypes.CWalletMeta)
 getWalletMetaIncludeUnready includeUnready cWalId = fmap _wiMeta . applyFilter <$> preview (wsWalletInfos . ix cWalId)
   where
     applyFilter xs = if includeUnready then xs else filterMaybe _wiIsReady xs
     filterMaybe :: (a -> Bool) -> Maybe a -> Maybe a
     filterMaybe p ma = ma >>= \a -> guard (p a) >> return a
 
-getWalletMeta :: CId Wal -> Query (Maybe CWalletMeta)
+getWalletMeta :: WebTypes.CId WebTypes.Wal -> Query (Maybe WebTypes.CWalletMeta)
 getWalletMeta = getWalletMetaIncludeUnready False
 
-getWalletPassLU :: CId Wal -> Query (Maybe PassPhraseLU)
+getWalletPassLU :: WebTypes.CId WebTypes.Wal -> Query (Maybe WebTypes.PassPhraseLU)
 getWalletPassLU cWalId = preview (wsWalletInfos . ix cWalId . wiPassphraseLU)
 
-getWalletSyncTip :: CId Wal -> Query (Maybe WalletTip)
+getWalletSyncTip :: WebTypes.CId WebTypes.Wal -> Query (Maybe WalletTip)
 getWalletSyncTip cWalId = preview (wsWalletInfos . ix cWalId . wiSyncTip)
 
-getWalletAddresses :: Query [CId Wal]
+getWalletAddresses :: Query [WebTypes.CId WebTypes.Wal]
 getWalletAddresses =
     map fst . sortOn (view wiCreationTime . snd) . filter (view wiIsReady . snd) . HM.toList <$>
     view wsWalletInfos
 
 getAccountWAddresses :: AddressLookupMode
-                     -> AccountId
+                     -> WebTypes.AccountId
                      -> Query (Maybe [AddressInfo])
 getAccountWAddresses mode accId =
     withAccLookupMode mode (fetch aiAddresses) (fetch aiRemovedAddresses)
@@ -284,30 +280,30 @@ getAccountWAddresses mode accId =
     fetch which = fmap HM.elems <$> preview (wsAccountInfos . ix accId . which)
 
 getWAddresses :: AddressLookupMode
-              -> CId Wal
+              -> WebTypes.CId WebTypes.Wal
               -> Query [AddressInfo]
 getWAddresses mode wid =
     withAccLookupMode mode (fetch aiAddresses) (fetch aiRemovedAddresses)
   where
     fetch :: MonadReader WalletStorage m => Lens' AccountInfo CAddresses -> m [AddressInfo]
     fetch which = do
-      accs <- HM.filterWithKey (\k _ -> aiWId k == wid) <$> view wsAccountInfos
+      accs <- HM.filterWithKey (\k _ -> WebTypes.aiWId k == wid) <$> view wsAccountInfos
       return $ HM.elems =<< accs ^.. traverse . which
 
-doesWAddressExist :: AddressLookupMode -> CWAddressMeta -> Query Bool
-doesWAddressExist mode addrMeta@(addrMetaToAccount -> wAddr) =
+doesWAddressExist :: AddressLookupMode -> WebTypes.CWAddressMeta -> Query Bool
+doesWAddressExist mode addrMeta@(WebTypes.addrMetaToAccount -> wAddr) =
     getAny <$>
         withAccLookupMode mode (exists aiAddresses) (exists aiRemovedAddresses)
   where
     exists :: Lens' AccountInfo CAddresses -> Query Any
     exists which =
         Any . isJust <$>
-        preview (wsAccountInfos . ix wAddr . which . ix (cwamId addrMeta))
+        preview (wsAccountInfos . ix wAddr . which . ix (WebTypes.cwamId addrMeta))
 
-getTxMeta :: CId Wal -> CTxId -> Query (Maybe CTxMeta)
+getTxMeta :: WebTypes.CId WebTypes.Wal -> WebTypes.CTxId -> Query (Maybe WebTypes.CTxMeta)
 getTxMeta cid ctxId = preview $ wsTxHistory . ix cid . ix ctxId
 
-getWalletTxHistory :: CId Wal -> Query (Maybe [CTxMeta])
+getWalletTxHistory :: WebTypes.CId WebTypes.Wal -> Query (Maybe [WebTypes.CTxMeta])
 getWalletTxHistory cWalId = toList <<$>> preview (wsTxHistory . ix cWalId)
 
 getWalletUtxo :: Query Utxo
@@ -327,35 +323,35 @@ setWalletUtxo utxo = do
     wsUtxo .= utxo
     wsBalances .= utxoToAddressCoinMap utxo
 
-getUpdates :: Query [CUpdateInfo]
+getUpdates :: Query [WebTypes.CUpdateInfo]
 getUpdates = view wsReadyUpdates
 
-getNextUpdate :: Query (Maybe CUpdateInfo)
+getNextUpdate :: Query (Maybe WebTypes.CUpdateInfo)
 getNextUpdate = preview (wsReadyUpdates . _head)
 
-getHistoryCache :: CId Wal -> Query (Maybe (Map TxId TxHistoryEntry))
+getHistoryCache :: WebTypes.CId WebTypes.Wal -> Query (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache cWalId = view $ wsHistoryCache . at cWalId
 
-getCustomAddresses :: CustomAddressType -> Query [CId Addr]
+getCustomAddresses :: CustomAddressType -> Query [WebTypes.CId WebTypes.Addr]
 getCustomAddresses t = HM.keys <$> view (customAddressL t)
 
-getCustomAddress :: CustomAddressType -> CId Addr -> Query (Maybe HeaderHash)
+getCustomAddress :: CustomAddressType -> WebTypes.CId WebTypes.Addr -> Query (Maybe HeaderHash)
 getCustomAddress t addr = view $ customAddressL t . at addr
 
 getPendingTxs :: Query [PendingTx]
 getPendingTxs = asks $ toListOf (wsWalletInfos . traversed . wsPendingTxs . traversed)
 
-getWalletPendingTxs :: CId Wal -> Query (Maybe [PendingTx])
+getWalletPendingTxs :: WebTypes.CId WebTypes.Wal -> Query (Maybe [PendingTx])
 getWalletPendingTxs wid =
     preview $ wsWalletInfos . ix wid . wsPendingTxs . to toList
 
-getPendingTx :: CId Wal -> TxId -> Query (Maybe PendingTx)
+getPendingTx :: WebTypes.CId WebTypes.Wal -> TxId -> Query (Maybe PendingTx)
 getPendingTx wid txId = preview $ wsWalletInfos . ix wid . wsPendingTxs . ix txId
 
-addCustomAddress :: CustomAddressType -> (CId Addr, HeaderHash) -> Update Bool
+addCustomAddress :: CustomAddressType -> (WebTypes.CId WebTypes.Addr, HeaderHash) -> Update Bool
 addCustomAddress t (addr, hh) = fmap isJust $ customAddressL t . at addr <<.= Just hh
 
-removeCustomAddress :: CustomAddressType -> (CId Addr, HeaderHash) -> Update Bool
+removeCustomAddress :: CustomAddressType -> (WebTypes.CId WebTypes.Addr, HeaderHash) -> Update Bool
 removeCustomAddress t (addr, hh) = do
     mhh' <- use $ customAddressL t . at addr
     let exists = mhh' == Just hh
@@ -363,20 +359,20 @@ removeCustomAddress t (addr, hh) = do
         customAddressL t . at addr .= Nothing
     return exists
 
-createAccount :: AccountId -> CAccountMeta -> Update ()
+createAccount :: WebTypes.AccountId -> WebTypes.CAccountMeta -> Update ()
 createAccount accId cAccMeta =
     wsAccountInfos . at accId %= Just . fromMaybe (AccountInfo cAccMeta mempty mempty 0)
 
 -- `isReady` is marked False when an additional step such as syncing is still needed.
-createWallet :: CId Wal -> CWalletMeta -> Bool -> POSIXTime -> Update ()
+createWallet :: WebTypes.CId WebTypes.Wal -> WebTypes.CWalletMeta -> Bool -> POSIXTime -> Update ()
 createWallet cWalId cWalMeta isReady curTime = do
     let info = WalletInfo cWalMeta curTime curTime NotSynced mempty isReady
     wsWalletInfos . at cWalId %= (<|> Just info)
 
-addWAddress :: CWAddressMeta -> Update ()
-addWAddress addrMeta@CWAddressMeta{..} = do
+addWAddress :: WebTypes.CWAddressMeta -> Update ()
+addWAddress addrMeta@WebTypes.CWAddressMeta{..} = do
     let accInfo :: Traversal' WalletStorage AccountInfo
-        accInfo = wsAccountInfos . ix (addrMetaToAccount addrMeta)
+        accInfo = wsAccountInfos . ix (WebTypes.addrMetaToAccount addrMeta)
     whenJustM (preuse accInfo) $ \info -> do
         let mAddr = info ^. aiAddresses . at cwamId
         when (isNothing mAddr) $ do
@@ -385,71 +381,71 @@ addWAddress addrMeta@CWAddressMeta{..} = do
             accInfo . aiAddresses . at cwamId ?= AddressInfo addrMeta key
 
 -- see also 'removeWAddress'
-addRemovedAccount :: CWAddressMeta -> Update ()
-addRemovedAccount addrMeta@CWAddressMeta{..} = do
+addRemovedAccount :: WebTypes.CWAddressMeta -> Update ()
+addRemovedAccount addrMeta@WebTypes.CWAddressMeta{..} = do
     let accInfo :: Traversal' WalletStorage AccountInfo
-        accInfo = wsAccountInfos . ix (addrMetaToAccount addrMeta)
+        accInfo = wsAccountInfos . ix (WebTypes.addrMetaToAccount addrMeta)
     whenJustM (preuse (accInfo . aiUnusedKey)) $ \key -> do
         accInfo . aiUnusedKey += 1
         accInfo . aiAddresses        . at cwamId .= Nothing
         accInfo . aiRemovedAddresses . at cwamId ?= AddressInfo addrMeta key
 
-setAccountMeta :: AccountId -> CAccountMeta -> Update ()
+setAccountMeta :: WebTypes.AccountId -> WebTypes.CAccountMeta -> Update ()
 setAccountMeta accId cAccMeta = wsAccountInfos . ix accId . aiMeta .= cAccMeta
 
-setWalletMeta :: CId Wal -> CWalletMeta -> Update ()
+setWalletMeta :: WebTypes.CId WebTypes.Wal -> WebTypes.CWalletMeta -> Update ()
 setWalletMeta cWalId cWalMeta = wsWalletInfos . ix cWalId . wiMeta .= cWalMeta
 
-setWalletReady :: CId Wal -> Bool -> Update ()
+setWalletReady :: WebTypes.CId WebTypes.Wal -> Bool -> Update ()
 setWalletReady cWalId isReady = wsWalletInfos . ix cWalId . wiIsReady .= isReady
 
-setWalletPassLU :: CId Wal -> PassPhraseLU -> Update ()
+setWalletPassLU :: WebTypes.CId WebTypes.Wal -> WebTypes.PassPhraseLU -> Update ()
 setWalletPassLU cWalId passLU = wsWalletInfos . ix cWalId . wiPassphraseLU .= passLU
 
-setWalletSyncTip :: CId Wal -> HeaderHash -> Update ()
+setWalletSyncTip :: WebTypes.CId WebTypes.Wal -> HeaderHash -> Update ()
 setWalletSyncTip cWalId hh = wsWalletInfos . ix cWalId . wiSyncTip .= SyncedWith hh
 
-addWalletTxHistory :: CId Wal -> CTxId -> CTxMeta -> Update ()
+addWalletTxHistory :: WebTypes.CId WebTypes.Wal -> WebTypes.CTxId -> WebTypes.CTxMeta -> Update ()
 addWalletTxHistory cWalId cTxId cTxMeta =
     wsTxHistory . at cWalId . non' _Empty . at cTxId ?= cTxMeta
 
-setWalletTxHistory :: CId Wal -> [(CTxId, CTxMeta)] -> Update ()
+setWalletTxHistory :: WebTypes.CId WebTypes.Wal -> [(WebTypes.CTxId, WebTypes.CTxMeta)] -> Update ()
 setWalletTxHistory cWalId cTxs = mapM_ (uncurry $ addWalletTxHistory cWalId) cTxs
 
 -- FIXME: this will be removed later (temporary solution)
-addOnlyNewTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
+addOnlyNewTxMeta :: WebTypes.CId WebTypes.Wal -> WebTypes.CTxId -> WebTypes.CTxMeta -> Update ()
 addOnlyNewTxMeta cWalId cTxId cTxMeta =
     -- Double nested HashMap update (if either or both of cWalId, cTxId don't exist, they will be created)
     wsTxHistory . at cWalId . non' _Empty . at cTxId %= Just . fromMaybe cTxMeta
 
 -- NOTE: sets transaction meta only for transactions ids that are already seen
-setWalletTxMeta :: CId Wal -> CTxId -> CTxMeta -> Update ()
+setWalletTxMeta :: WebTypes.CId WebTypes.Wal -> WebTypes.CTxId -> WebTypes.CTxMeta -> Update ()
 setWalletTxMeta cWalId cTxId cTxMeta =
     wsTxHistory . ix cWalId . at cTxId %= ($> cTxMeta)
 
-removeTxMetas :: CId Wal -> Update ()
+removeTxMetas :: WebTypes.CId WebTypes.Wal -> Update ()
 removeTxMetas cWalId = wsTxHistory . at cWalId .= Nothing
 
-addOnlyNewTxMetas :: CId Wal -> [(CTxId, CTxMeta)] -> Update ()
+addOnlyNewTxMetas :: WebTypes.CId WebTypes.Wal -> [(WebTypes.CTxId, WebTypes.CTxMeta)] -> Update ()
 addOnlyNewTxMetas = mapM_ . uncurry . addOnlyNewTxMeta
 
-removeWalletTxMetas :: CId Wal -> [CTxId] -> Update ()
+removeWalletTxMetas :: WebTypes.CId WebTypes.Wal -> [WebTypes.CTxId] -> Update ()
 removeWalletTxMetas cWalId cTxs =
     wsTxHistory . at cWalId . non' _Empty %= flip (foldr HM.delete) cTxs
 
-removeWallet :: CId Wal -> Update ()
+removeWallet :: WebTypes.CId WebTypes.Wal -> Update ()
 removeWallet cWalId = wsWalletInfos . at cWalId .= Nothing
 
-removeHistoryCache :: CId Wal -> Update ()
+removeHistoryCache :: WebTypes.CId WebTypes.Wal -> Update ()
 removeHistoryCache cWalId = wsHistoryCache . at cWalId .= Nothing
 
-removeAccount :: AccountId -> Update ()
+removeAccount :: WebTypes.AccountId -> Update ()
 removeAccount accId = wsAccountInfos . at accId .= Nothing
 
 -- see also 'addRemovedAccount'
-removeWAddress :: CWAddressMeta -> Update ()
-removeWAddress addrMeta@(addrMetaToAccount -> accId) = do
-    let addrId = cwamId addrMeta
+removeWAddress :: WebTypes.CWAddressMeta -> Update ()
+removeWAddress addrMeta@(WebTypes.addrMetaToAccount -> accId) = do
+    let addrId = WebTypes.cwamId addrMeta
     -- If the address exists, move it to 'addressesRemoved'
     whenJustM (preuse (accAddresses accId . ix addrId)) $ \addressInfo -> do
         accAddresses        accId . at addrId .= Nothing
@@ -458,12 +454,12 @@ removeWAddress addrMeta@(addrMetaToAccount -> accId) = do
     accAddresses        accId' = wsAccountInfos . ix accId' . aiAddresses
     accRemovedAddresses accId' = wsAccountInfos . ix accId' . aiRemovedAddresses
 
-totallyRemoveWAddress :: CWAddressMeta -> Update ()
-totallyRemoveWAddress addrMeta@(addrMetaToAccount -> accId) = do
-    wsAccountInfos . ix accId . aiAddresses        . at (cwamId addrMeta) .= Nothing
-    wsAccountInfos . ix accId . aiRemovedAddresses . at (cwamId addrMeta) .= Nothing
+totallyRemoveWAddress :: WebTypes.CWAddressMeta -> Update ()
+totallyRemoveWAddress addrMeta@(WebTypes.addrMetaToAccount -> accId) = do
+    wsAccountInfos . ix accId . aiAddresses        . at (WebTypes.cwamId addrMeta) .= Nothing
+    wsAccountInfos . ix accId . aiRemovedAddresses . at (WebTypes.cwamId addrMeta) .= Nothing
 
-addUpdate :: CUpdateInfo -> Update ()
+addUpdate :: WebTypes.CUpdateInfo -> Update ()
 addUpdate ui = wsReadyUpdates %= (++ [ui])
 
 removeNextUpdate :: Update ()
@@ -474,28 +470,28 @@ testReset = put def
 
 -- Legacy transaction, no longer used. For existing Db tx logs only. Now use
 -- 'removeHistoryCache', 'insertIntoHistoryCache' or 'removeFromHistoryCache'
-updateHistoryCache :: CId Wal -> [TxHistoryEntry] -> Update ()
+updateHistoryCache :: WebTypes.CId WebTypes.Wal -> [TxHistoryEntry] -> Update ()
 updateHistoryCache cWalId cTxs =
     wsHistoryCache . at cWalId ?= txHistoryListToMap cTxs
 
-insertIntoHistoryCache :: CId Wal -> Map TxId TxHistoryEntry -> Update ()
+insertIntoHistoryCache :: WebTypes.CId WebTypes.Wal -> Map TxId TxHistoryEntry -> Update ()
 insertIntoHistoryCache cWalId cTxs =
     wsHistoryCache . at cWalId . non' _Empty %= (cTxs `M.union`)
 
-removeFromHistoryCache :: CId Wal -> Map TxId () -> Update ()
+removeFromHistoryCache :: WebTypes.CId WebTypes.Wal -> Map TxId () -> Update ()
 removeFromHistoryCache cWalId cTxs =
     wsHistoryCache . at cWalId . non' _Empty %= (`M.difference` cTxs)
 
 -- This shouldn't be able to create new transaction.
 -- NOTE: If you're going to use this function, make sure 'casPtxCondition'
 -- doesn't fit your purposes better
-setPtxCondition :: CId Wal -> TxId -> PtxCondition -> Update ()
+setPtxCondition :: WebTypes.CId WebTypes.Wal -> TxId -> PtxCondition -> Update ()
 setPtxCondition wid txId cond =
     wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond .= cond
 
 -- | Compare-and-set version of 'setPtxCondition'.
 -- Returns 'True' if transaction existed and modification was applied.
-casPtxCondition :: CId Wal -> TxId -> PtxCondition -> PtxCondition -> Update Bool
+casPtxCondition :: WebTypes.CId WebTypes.Wal -> TxId -> PtxCondition -> PtxCondition -> Update Bool
 casPtxCondition wid txId expectedCond newCond = do
     oldCond <- preuse $ wsWalletInfos . ix wid . wsPendingTxs . ix txId . ptxCond
     let success = oldCond == Just expectedCond
@@ -508,7 +504,7 @@ data PtxMetaUpdate
     | PtxMarkAcknowledged
 
 -- | For simple atomic updates of meta info
-ptxUpdateMeta :: HasProtocolConstants => CId Wal -> TxId -> PtxMetaUpdate -> Update ()
+ptxUpdateMeta :: HasProtocolConstants => WebTypes.CId WebTypes.Wal -> TxId -> PtxMetaUpdate -> Update ()
 ptxUpdateMeta wid txId updType =
     wsWalletInfos . ix wid . wsPendingTxs . ix txId %=
         case updType of
@@ -555,23 +551,23 @@ flushWalletStorage = modify flushDo
                             , _wiIsReady = False
                             }
 
-deriveSafeCopySimple 0 'base ''CCoin
-deriveSafeCopySimple 0 'base ''CProfile
-deriveSafeCopySimple 0 'base ''CHash
-deriveSafeCopySimple 0 'base ''CId
-deriveSafeCopySimple 0 'base ''Wal
-deriveSafeCopySimple 0 'base ''Addr
+deriveSafeCopySimple 0 'base ''WebTypes.CCoin
+deriveSafeCopySimple 0 'base ''WebTypes.CProfile
+deriveSafeCopySimple 0 'base ''WebTypes.CHash
+deriveSafeCopySimple 0 'base ''WebTypes.CId
+deriveSafeCopySimple 0 'base ''WebTypes.Wal
+deriveSafeCopySimple 0 'base ''WebTypes.Addr
 deriveSafeCopySimple 0 'base ''BackupPhrase
-deriveSafeCopySimple 0 'base ''AccountId
-deriveSafeCopySimple 0 'base ''CWAddressMeta
-deriveSafeCopySimple 0 'base ''CWalletAssurance
-deriveSafeCopySimple 0 'base ''CAccountMeta
-deriveSafeCopySimple 0 'base ''CWalletMeta
-deriveSafeCopySimple 0 'base ''CTxId
+deriveSafeCopySimple 0 'base ''WebTypes.AccountId
+deriveSafeCopySimple 0 'base ''WebTypes.CWAddressMeta
+deriveSafeCopySimple 0 'base ''WebTypes.CWalletAssurance
+deriveSafeCopySimple 0 'base ''WebTypes.CAccountMeta
+deriveSafeCopySimple 0 'base ''WebTypes.CWalletMeta
+deriveSafeCopySimple 0 'base ''WebTypes.CTxId
 deriveSafeCopySimple 0 'base ''Timestamp
 deriveSafeCopySimple 0 'base ''TxHistoryEntry
-deriveSafeCopySimple 0 'base ''CTxMeta
-deriveSafeCopySimple 0 'base ''CUpdateInfo
+deriveSafeCopySimple 0 'base ''WebTypes.CTxMeta
+deriveSafeCopySimple 0 'base ''WebTypes.CUpdateInfo
 deriveSafeCopySimple 0 'base ''AddressLookupMode
 deriveSafeCopySimple 0 'base ''CustomAddressType
 deriveSafeCopySimple 0 'base ''CurrentAndRemoved
@@ -588,24 +584,24 @@ deriveSafeCopySimple 0 'base ''WalletInfo
 -- Legacy versions, for migrations
 
 data WalletStorage_v0 = WalletStorage_v0
-    { _v0_wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
-    , _v0_wsAccountInfos    :: !(HashMap AccountId AccountInfo)
-    , _v0_wsProfile         :: !CProfile
-    , _v0_wsReadyUpdates    :: [CUpdateInfo]
-    , _v0_wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
-    , _v0_wsHistoryCache    :: !(HashMap (CId Wal) [TxHistoryEntry])
+    { _v0_wsWalletInfos     :: !(HashMap (WebTypes.CId WebTypes.Wal) WalletInfo)
+    , _v0_wsAccountInfos    :: !(HashMap WebTypes.AccountId AccountInfo)
+    , _v0_wsProfile         :: !WebTypes.CProfile
+    , _v0_wsReadyUpdates    :: [WebTypes.CUpdateInfo]
+    , _v0_wsTxHistory       :: !(HashMap (WebTypes.CId WebTypes.Wal) (HashMap WebTypes.CTxId WebTypes.CTxMeta))
+    , _v0_wsHistoryCache    :: !(HashMap (WebTypes.CId WebTypes.Wal) [TxHistoryEntry])
     , _v0_wsUtxo            :: !Utxo
     , _v0_wsUsedAddresses   :: !CustomAddresses
     , _v0_wsChangeAddresses :: !CustomAddresses
     }
 
 data WalletStorage_v1 = WalletStorage_v1
-    { _v1_wsWalletInfos     :: !(HashMap (CId Wal) WalletInfo)
-    , _v1_wsAccountInfos    :: !(HashMap AccountId AccountInfo)
-    , _v1_wsProfile         :: !CProfile
-    , _v1_wsReadyUpdates    :: [CUpdateInfo]
-    , _v1_wsTxHistory       :: !(HashMap (CId Wal) (HashMap CTxId CTxMeta))
-    , _v1_wsHistoryCache    :: !(HashMap (CId Wal) (Map TxId TxHistoryEntry))
+    { _v1_wsWalletInfos     :: !(HashMap (WebTypes.CId WebTypes.Wal) WalletInfo)
+    , _v1_wsAccountInfos    :: !(HashMap WebTypes.AccountId AccountInfo)
+    , _v1_wsProfile         :: !WebTypes.CProfile
+    , _v1_wsReadyUpdates    :: [WebTypes.CUpdateInfo]
+    , _v1_wsTxHistory       :: !(HashMap (WebTypes.CId WebTypes.Wal) (HashMap WebTypes.CTxId WebTypes.CTxMeta))
+    , _v1_wsHistoryCache    :: !(HashMap (WebTypes.CId WebTypes.Wal) (Map TxId TxHistoryEntry))
     , _v1_wsUtxo            :: !Utxo
     , _v1_wsUsedAddresses   :: !CustomAddresses
     , _v1_wsChangeAddresses :: !CustomAddresses

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -88,6 +88,10 @@ module Pos.Wallet.Web.State.Storage
        , addOnlyNewPendingTx
        , cancelApplyingPtxs
        , cancelSpecificApplyingPtx
+         -- * Exported only for testing purposes
+       , AddressInfo_v0 (..)
+       , AccountInfo_v0 (..)
+       , WalletStorage_v2(..)
        ) where
 
 import           Universum
@@ -667,7 +671,6 @@ data WalletStorage_v2 = WalletStorage_v2
     , _v2_wsUsedAddresses   :: !CustomAddresses_v0
     , _v2_wsChangeAddresses :: !CustomAddresses_v0
     }
-
 
 deriveSafeCopySimple 0 'base ''AddressInfo_v0
 deriveSafeCopySimple 1 'extension ''AddressInfo

--- a/node/src/Pos/Wallet/Web/State/Storage.hs
+++ b/node/src/Pos/Wallet/Web/State/Storage.hs
@@ -6,6 +6,9 @@ module Pos.Wallet.Web.State.Storage
        (
          WalletStorage (..)
        , HasWalletStorage (..)
+       , WAddressMeta (..)
+       , HasWAddressMeta (..)
+       , wamAccount
        , WalletInfo (..)
        , AccountInfo (..)
        , AddressInfo (..)
@@ -89,20 +92,24 @@ module Pos.Wallet.Web.State.Storage
 
 import           Universum
 
-import           Control.Lens                    (at, ix, makeClassy, makeLenses, non', to,
-                                                  toListOf, traversed, (%=), (+=), (.=),
-                                                  (<<.=), (?=), _Empty, _head)
+import           Control.Lens                    (at, ix, lens, makeClassy, makeLenses,
+                                                  non', to, toListOf, traversed, (%=),
+                                                  (+=), (.=), (<<.=), (?=), _Empty, _head)
 import           Control.Monad.State.Class       (put)
 import           Data.Default                    (Default, def)
+import           Data.Hashable                   (Hashable)
 import qualified Data.HashMap.Strict             as HM
 import qualified Data.Map                        as M
-import           Data.SafeCopy                   (Migrate (..), base, deriveSafeCopySimple,
-                                                  extension)
+import           Data.SafeCopy                   (Migrate (..), base,
+                                                  deriveSafeCopySimple, extension)
 import           Data.Time.Clock.POSIX           (POSIXTime)
 
+import qualified Data.Text.Buildable
+import           Formatting                      ((%))
+import qualified Formatting                      as F
 import           Pos.Client.Txp.History          (TxHistoryEntry, txHistoryListToMap)
 import           Pos.Core.Configuration.Protocol (HasProtocolConstants)
-import           Pos.Core.Types                  (SlotId, Timestamp)
+import           Pos.Core.Types                  (Address, SlotId, Timestamp)
 import           Pos.Txp                         (AddrCoinMap, TxAux, TxId, Utxo,
                                                   UtxoModifier, applyUtxoModToAddrCoinMap,
                                                   utxoToAddressCoinMap)
@@ -118,14 +125,36 @@ import           Pos.Wallet.Web.Pending.Updates  (cancelApplyingPtx,
                                                   mkPtxSubmitTiming,
                                                   ptxMarkAcknowledgedPure)
 
+-- | Address with associated metadata locating it in an account in a wallet.
+data WAddressMeta = WAddressMeta
+    { _wamWalletId     :: WebTypes.CId WebTypes.Wal
+    , _wamAccountIndex :: Word32
+    , _wamAddressIndex :: Word32
+    , _wamAddress      :: Address
+    } deriving (Eq, Ord, Show, Generic, Typeable)
+
+makeClassy ''WAddressMeta
+instance Hashable WAddressMeta
+instance Buildable WAddressMeta where
+    build WAddressMeta{..} =
+        F.bprint (F.build%"@"%F.build%"@"%F.build%" ("%F.build%")")
+        _wamWalletId _wamAccountIndex _wamAddressIndex _wamAddress
+
+-- | Lens to extract the account from an 'AddressMeta'
+wamAccount :: Lens' WAddressMeta WebTypes.AccountId
+wamAccount = lens
+    (WebTypes.AccountId <$> view wamWalletId <*> view wamAccountIndex)
+    (\am (WebTypes.AccountId wid accIdx) -> set wamWalletId wid
+                                            . set wamAccountIndex accIdx $ am)
+
 type AddressSortingKey = Int
 
 data AddressInfo = AddressInfo
-    { adiCWAddressMeta :: !WebTypes.CWAddressMeta
-    , adiSortingKey    :: !AddressSortingKey
+    { adiWAddressMeta :: !WAddressMeta
+    , adiSortingKey   :: !AddressSortingKey
     }
 
-type CAddresses = HashMap (WebTypes.CId WebTypes.Addr) AddressInfo
+type CAddresses = HashMap Address AddressInfo
 
 data AccountInfo = AccountInfo
     { _aiMeta             :: !WebTypes.CAccountMeta
@@ -155,7 +184,7 @@ data WalletInfo = WalletInfo
 makeLenses ''WalletInfo
 
 -- | Maps addresses to their first occurrence in the blockchain
-type CustomAddresses = HashMap (WebTypes.CId WebTypes.Addr) HeaderHash
+type CustomAddresses = HashMap Address HeaderHash
 type WalletBalances = AddrCoinMap
 type WalBalancesAndUtxo = (WalletBalances, Utxo)
 
@@ -290,15 +319,15 @@ getWAddresses mode wid =
       accs <- HM.filterWithKey (\k _ -> WebTypes.aiWId k == wid) <$> view wsAccountInfos
       return $ HM.elems =<< accs ^.. traverse . which
 
-doesWAddressExist :: AddressLookupMode -> WebTypes.CWAddressMeta -> Query Bool
-doesWAddressExist mode addrMeta@(WebTypes.addrMetaToAccount -> wAddr) =
+doesWAddressExist :: AddressLookupMode -> WAddressMeta -> Query Bool
+doesWAddressExist mode addrMeta@(view wamAccount -> wAddr) =
     getAny <$>
         withAccLookupMode mode (exists aiAddresses) (exists aiRemovedAddresses)
   where
     exists :: Lens' AccountInfo CAddresses -> Query Any
     exists which =
         Any . isJust <$>
-        preview (wsAccountInfos . ix wAddr . which . ix (WebTypes.cwamId addrMeta))
+        preview (wsAccountInfos . ix wAddr . which . ix (addrMeta ^. wamAddress))
 
 getTxMeta :: WebTypes.CId WebTypes.Wal -> WebTypes.CTxId -> Query (Maybe WebTypes.CTxMeta)
 getTxMeta cid ctxId = preview $ wsTxHistory . ix cid . ix ctxId
@@ -332,10 +361,10 @@ getNextUpdate = preview (wsReadyUpdates . _head)
 getHistoryCache :: WebTypes.CId WebTypes.Wal -> Query (Maybe (Map TxId TxHistoryEntry))
 getHistoryCache cWalId = view $ wsHistoryCache . at cWalId
 
-getCustomAddresses :: CustomAddressType -> Query [WebTypes.CId WebTypes.Addr]
+getCustomAddresses :: CustomAddressType -> Query [Address]
 getCustomAddresses t = HM.keys <$> view (customAddressL t)
 
-getCustomAddress :: CustomAddressType -> WebTypes.CId WebTypes.Addr -> Query (Maybe HeaderHash)
+getCustomAddress :: CustomAddressType -> Address -> Query (Maybe HeaderHash)
 getCustomAddress t addr = view $ customAddressL t . at addr
 
 getPendingTxs :: Query [PendingTx]
@@ -348,10 +377,10 @@ getWalletPendingTxs wid =
 getPendingTx :: WebTypes.CId WebTypes.Wal -> TxId -> Query (Maybe PendingTx)
 getPendingTx wid txId = preview $ wsWalletInfos . ix wid . wsPendingTxs . ix txId
 
-addCustomAddress :: CustomAddressType -> (WebTypes.CId WebTypes.Addr, HeaderHash) -> Update Bool
+addCustomAddress :: CustomAddressType -> (Address, HeaderHash) -> Update Bool
 addCustomAddress t (addr, hh) = fmap isJust $ customAddressL t . at addr <<.= Just hh
 
-removeCustomAddress :: CustomAddressType -> (WebTypes.CId WebTypes.Addr, HeaderHash) -> Update Bool
+removeCustomAddress :: CustomAddressType -> (Address, HeaderHash) -> Update Bool
 removeCustomAddress t (addr, hh) = do
     mhh' <- use $ customAddressL t . at addr
     let exists = mhh' == Just hh
@@ -369,26 +398,28 @@ createWallet cWalId cWalMeta isReady curTime = do
     let info = WalletInfo cWalMeta curTime curTime NotSynced mempty isReady
     wsWalletInfos . at cWalId %= (<|> Just info)
 
-addWAddress :: WebTypes.CWAddressMeta -> Update ()
-addWAddress addrMeta@WebTypes.CWAddressMeta{..} = do
+addWAddress :: WAddressMeta -> Update ()
+addWAddress addrMeta = do
     let accInfo :: Traversal' WalletStorage AccountInfo
-        accInfo = wsAccountInfos . ix (WebTypes.addrMetaToAccount addrMeta)
+        accInfo = wsAccountInfos . ix (addrMeta ^. wamAccount)
+        addr = addrMeta ^. wamAddress
     whenJustM (preuse accInfo) $ \info -> do
-        let mAddr = info ^. aiAddresses . at cwamId
+        let mAddr = info ^. aiAddresses . at addr
         when (isNothing mAddr) $ do
             accInfo . aiUnusedKey += 1
             let key = info ^. aiUnusedKey
-            accInfo . aiAddresses . at cwamId ?= AddressInfo addrMeta key
+            accInfo . aiAddresses . at addr ?= AddressInfo addrMeta key
 
 -- see also 'removeWAddress'
-addRemovedAccount :: WebTypes.CWAddressMeta -> Update ()
-addRemovedAccount addrMeta@WebTypes.CWAddressMeta{..} = do
+addRemovedAccount :: WAddressMeta -> Update ()
+addRemovedAccount addrMeta = do
     let accInfo :: Traversal' WalletStorage AccountInfo
-        accInfo = wsAccountInfos . ix (WebTypes.addrMetaToAccount addrMeta)
+        accInfo = wsAccountInfos . ix (view wamAccount addrMeta)
+        addr = addrMeta ^. wamAddress
     whenJustM (preuse (accInfo . aiUnusedKey)) $ \key -> do
         accInfo . aiUnusedKey += 1
-        accInfo . aiAddresses        . at cwamId .= Nothing
-        accInfo . aiRemovedAddresses . at cwamId ?= AddressInfo addrMeta key
+        accInfo . aiAddresses        . at addr .= Nothing
+        accInfo . aiRemovedAddresses . at addr ?= AddressInfo addrMeta key
 
 setAccountMeta :: WebTypes.AccountId -> WebTypes.CAccountMeta -> Update ()
 setAccountMeta accId cAccMeta = wsAccountInfos . ix accId . aiMeta .= cAccMeta
@@ -443,9 +474,9 @@ removeAccount :: WebTypes.AccountId -> Update ()
 removeAccount accId = wsAccountInfos . at accId .= Nothing
 
 -- see also 'addRemovedAccount'
-removeWAddress :: WebTypes.CWAddressMeta -> Update ()
-removeWAddress addrMeta@(WebTypes.addrMetaToAccount -> accId) = do
-    let addrId = WebTypes.cwamId addrMeta
+removeWAddress :: WAddressMeta -> Update ()
+removeWAddress addrMeta@(view wamAccount -> accId) = do
+    let addrId = addrMeta ^. wamAddress
     -- If the address exists, move it to 'addressesRemoved'
     whenJustM (preuse (accAddresses accId . ix addrId)) $ \addressInfo -> do
         accAddresses        accId . at addrId .= Nothing
@@ -454,10 +485,10 @@ removeWAddress addrMeta@(WebTypes.addrMetaToAccount -> accId) = do
     accAddresses        accId' = wsAccountInfos . ix accId' . aiAddresses
     accRemovedAddresses accId' = wsAccountInfos . ix accId' . aiRemovedAddresses
 
-totallyRemoveWAddress :: WebTypes.CWAddressMeta -> Update ()
-totallyRemoveWAddress addrMeta@(WebTypes.addrMetaToAccount -> accId) = do
-    wsAccountInfos . ix accId . aiAddresses        . at (WebTypes.cwamId addrMeta) .= Nothing
-    wsAccountInfos . ix accId . aiRemovedAddresses . at (WebTypes.cwamId addrMeta) .= Nothing
+totallyRemoveWAddress :: WAddressMeta -> Update ()
+totallyRemoveWAddress addrMeta@(view wamAccount -> accId) = do
+    wsAccountInfos . ix accId . aiAddresses        . at (addrMeta ^. wamAddress) .= Nothing
+    wsAccountInfos . ix accId . aiRemovedAddresses . at (addrMeta ^. wamAddress) .= Nothing
 
 addUpdate :: WebTypes.CUpdateInfo -> Update ()
 addUpdate ui = wsReadyUpdates %= (++ [ui])
@@ -576,6 +607,7 @@ deriveSafeCopySimple 0 'base ''PtxCondition
 deriveSafeCopySimple 0 'base ''PtxSubmitTiming
 deriveSafeCopySimple 0 'base ''PtxMetaUpdate
 deriveSafeCopySimple 0 'base ''PendingTx
+deriveSafeCopySimple 0 'base ''WAddressMeta
 deriveSafeCopySimple 0 'base ''AddressInfo
 deriveSafeCopySimple 0 'base ''AccountInfo
 deriveSafeCopySimple 0 'base ''WalletTip

--- a/node/src/Pos/Wallet/Web/State/Transactions.hs
+++ b/node/src/Pos/Wallet/Web/State/Transactions.hs
@@ -19,10 +19,10 @@ import qualified Data.Map                     as M
 import           Pos.Client.Txp.History       (TxHistoryEntry)
 import           Pos.Core                     (HasProtocolConstants)
 import           Pos.Txp                      (TxId, UtxoModifier)
-import           Pos.Types                    (HeaderHash)
+import           Pos.Types                    (Address, HeaderHash)
 import           Pos.Util.Servant             (encodeCType)
-import           Pos.Wallet.Web.ClientTypes   (AccountId (..), Addr, CAccountMeta, CId,
-                                               CTxId, CTxMeta, CWAddressMeta (..), Wal)
+import           Pos.Wallet.Web.ClientTypes   (AccountId (..), CAccountMeta, CId,
+                                               CTxId, CTxMeta, Wal)
 import           Pos.Wallet.Web.Pending.Types (PtxCondition)
 import           Pos.Wallet.Web.State.Storage (Update)
 import qualified Pos.Wallet.Web.State.Storage as WS
@@ -31,7 +31,7 @@ import qualified Pos.Wallet.Web.State.Storage as WS
 createAccountWithAddress
     :: AccountId
     -> CAccountMeta
-    -> CWAddressMeta
+    -> WS.WAddressMeta
     -> Update ()
 createAccountWithAddress accId accMeta addrMeta = do
     WS.createAccount accId accMeta
@@ -56,8 +56,8 @@ removeWallet2 walId = do
 --   TODO Find out the significance of this set of modifiers and document.
 applyModifierToWallet
     :: CId Wal
-    -> [CWAddressMeta] -- ^ Wallet addresses to add
-    -> [(WS.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to add
+    -> [WS.WAddressMeta] -- ^ Wallet addresses to add
+    -> [(WS.CustomAddressType, [(Address, HeaderHash)])] -- ^ Custom addresses to add
     -> UtxoModifier
     -> [(CTxId, CTxMeta)] -- ^ Transaction metadata to add
     -> Map TxId TxHistoryEntry -- ^ Entries for the history cache
@@ -81,8 +81,8 @@ applyModifierToWallet walId wAddrs custAddrs utxoMod
 rollbackModifierFromWallet
     :: HasProtocolConstants -- Needed for ptxUpdateMeta
     => CId Wal
-    -> [CWAddressMeta] -- ^ Addresses to remove
-    -> [(WS.CustomAddressType, [(CId Addr, HeaderHash)])] -- ^ Custom addresses to remove
+    -> [WS.WAddressMeta] -- ^ Addresses to remove
+    -> [(WS.CustomAddressType, [(Address, HeaderHash)])] -- ^ Custom addresses to remove
     -> UtxoModifier
        -- We use this odd representation because Data.Map does not get 'withoutKeys'
        -- until 5.8.1

--- a/node/src/Pos/Wallet/Web/Util.hs
+++ b/node/src/Pos/Wallet/Web/Util.hs
@@ -21,23 +21,22 @@ import           Formatting                 (build, sformat, (%))
 import           Servant.Server             (err405, errReasonPhrase)
 
 import           Pos.Configuration          (HasNodeConfiguration, walletProductionApi)
-import           Pos.Core                   (BlockCount)
+import           Pos.Core                   (Address, BlockCount)
 import           Pos.Util.Servant           (FromCType (..), OriginType)
 import           Pos.Util.Util              (maybeThrow)
 import           Pos.Wallet.Web.Assurance   (AssuranceLevel (HighAssurance),
                                              assuredBlockDepth)
-import           Pos.Wallet.Web.ClientTypes (AccountId (..), Addr, CId,
-                                             CWAddressMeta (..), Wal, CAccountMeta,
+import           Pos.Wallet.Web.ClientTypes (AccountId (..), CAccountMeta, CId, Wal,
                                              cwAssurance)
 
 
 import           Pos.Wallet.Web.Error       (WalletError (..))
-import           Pos.Wallet.Web.State       (AddressLookupMode(..), AddressInfo (..),
+import           Pos.Wallet.Web.State       (AddressInfo (..), AddressLookupMode (..),
                                              CurrentAndRemoved (getCurrent, getRemoved),
-                                             WalletSnapshot,
+                                             WAddressMeta (..), WalletSnapshot,
                                              getAccountAddrMaps, getAccountIds,
-                                             getAccountWAddresses, getWAddresses, getWalletMeta,
-                                             getAccountMeta)
+                                             getAccountMeta, getAccountWAddresses,
+                                             getWAddresses, getWalletMeta)
 
 getAccountMetaOrThrow :: MonadThrow m => WalletSnapshot -> AccountId -> m CAccountMeta
 getAccountMetaOrThrow ws accId = maybeThrow noAccount (getAccountMeta ws accId)
@@ -63,14 +62,14 @@ getWalletAddrMetas
     :: WalletSnapshot
     -> AddressLookupMode
     -> CId Wal
-    -> [CWAddressMeta]
+    -> [WAddressMeta]
 getWalletAddrMetas ws lookupMode cWalId =
-  map adiCWAddressMeta $ getWAddresses ws lookupMode cWalId
+  map adiWAddressMeta $ getWAddresses ws lookupMode cWalId
 
-getWalletAddrs :: WalletSnapshot -> AddressLookupMode -> CId Wal -> [CId Addr]
-getWalletAddrs ws mode wid = cwamId <$> getWalletAddrMetas ws mode wid
+getWalletAddrs :: WalletSnapshot -> AddressLookupMode -> CId Wal -> [Address]
+getWalletAddrs ws mode wid = _wamAddress <$> getWalletAddrMetas ws mode wid
 
-getWalletAddrsDetector :: WalletSnapshot -> AddressLookupMode -> CId Wal -> (CId Addr -> Bool)
+getWalletAddrsDetector :: WalletSnapshot -> AddressLookupMode -> CId Wal -> (Address -> Bool)
 getWalletAddrsDetector ws lookupMode cWalId = do
     let accIds = getWalletAccountIds ws cWalId
     let accAddrMaps = map (getAccountAddrMaps ws) accIds

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7349,13 +7349,13 @@ inherit (pkgs) mesa;};
          , cardano-sl-update, containers, cpphs, data-default, directory
          , dlist, ether, exceptions, filepath, formatting, lens, log-warper
          , mtl, network-transport, network-transport-tcp, node-sketch
-         , optparse-applicative, parsec, purescript-bridge, random
-         , reflection, safe-exceptions, semver, serokell-util, servant
-         , servant-multipart, servant-server, servant-swagger
-         , servant-swagger-ui, stdenv, stm, stm-containers, string-qq
-         , swagger2, text, text-format, time, time-units, transformers
-         , universum, unix, unordered-containers, wai, wai-websockets
-         , websockets
+         , optparse-applicative, parsec, purescript-bridge, QuickCheck
+         , random, reflection, safe-exceptions, safecopy, semver
+         , serokell-util, servant, servant-multipart, servant-server
+         , servant-swagger, servant-swagger-ui, stdenv, stm, stm-containers
+         , string-qq, swagger2, tasty, tasty-quickcheck, text, text-format
+         , time, time-units, transformers, universum, unix
+         , unordered-containers, wai, wai-websockets, websockets
          }:
          mkDerivation {
            pname = "cardano-sl-wallet";
@@ -7392,6 +7392,10 @@ inherit (pkgs) mesa;};
              websockets
            ];
            executableToolDepends = [ cpphs ];
+           testHaskellDepends = [
+             base cardano-sl cardano-sl-core cardano-sl-txp QuickCheck safecopy
+             tasty tasty-quickcheck universum unordered-containers
+           ];
            doHaddock = false;
            description = "Cardano SL - wallet";
            license = stdenv.lib.licenses.mit;

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -26,7 +26,7 @@ import           Pos.Ssc.SscAlgo (SscAlgo (..))
 import           Pos.Util.JsonLog (jsonLogConfigFromHandle)
 import           Pos.Util.UserSecret (usVss)
 import           Pos.Wallet.SscType (WalletSscType)
-import           Pos.Wallet.Web.Mode (AddrCIdHashes (..), WalletWebModeContext (..))
+import           Pos.Wallet.Web.Mode (WalletWebModeContext (..))
 import           Pos.Wallet.Web.State.Acidic (closeState, openState)
 import           Pos.Wallet.Web.State.State (WalletDB)
 import           Pos.WorkMode (RealModeContext (..))
@@ -113,7 +113,6 @@ walletRunner
 walletRunner confOpts dbs secretKeyPath ws act = runProduction $ do
     wwmc <- WalletWebModeContext <$> pure ws
                                  <*> newTVarIO def
-                                 <*> (AddrCIdHashes <$> (newIORef mempty))
                                  <*> newRealModeContext dbs confOpts secretKeyPath
     runReaderT act wwmc
 

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -349,3 +349,26 @@ executable cardano-swagger
     buildable: False
   else
     buildable: True
+
+Test-suite unit-tests
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  hs-source-dirs:     test
+  main-is:            Test.hs
+  other-modules:      Migrations
+  ghc-options:        -Wall -threaded -pgmP cpphs -optP --cpp
+  if os(linux)
+    ghc-options:       -optl-fuse-ld=gold
+    ld-options:        -fuse-ld=gold
+  build-depends:      base
+                    , cardano-sl
+                    , cardano-sl-core
+                    , cardano-sl-txp
+                    , cardano-sl-wallet
+                    , safecopy
+                    , tasty
+                    , tasty-quickcheck
+                    , QuickCheck
+                    , unordered-containers
+                    , universum >= 0.1.11

--- a/wallet/src/Pos/Aeson/Storage.hs
+++ b/wallet/src/Pos/Aeson/Storage.hs
@@ -23,7 +23,7 @@ import           Pos.Util.Util                (eitherToFail)
 import           Pos.Wallet.Web.ClientTypes   (AccountId (..), CHash (..), CId (..),
                                                CTxId (..))
 import           Pos.Wallet.Web.Pending.Types (PendingTx, PtxCondition, PtxSubmitTiming)
-import           Pos.Wallet.Web.State.Storage (AccountInfo, AddressInfo, WalletInfo,
+import           Pos.Wallet.Web.State.Storage (AccountInfo, AddressInfo, WalletInfo, WAddressMeta,
                                                WalletStorage, WalletTip)
 
 instance FromJSON (CId a) => FromJSONKey (CId a) where
@@ -62,5 +62,6 @@ deriveJSON defaultOptions ''WalletTip
 deriveJSON defaultOptions ''AddressInfo
 deriveJSON defaultOptions ''AccountInfo
 deriveJSON defaultOptions ''AccountId
+deriveJSON defaultOptions ''WAddressMeta
 deriveJSON defaultOptions ''WalletInfo
 deriveJSON defaultOptions ''WalletStorage

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -31,7 +31,7 @@ import           Pos.Launcher.Runner            (runRealBasedMode)
 import           Pos.Util.TimeWarp              (NetworkAddress)
 import           Pos.Wallet.SscType             (WalletSscType)
 import           Pos.Wallet.Web.Methods         (addInitialRichAccount)
-import           Pos.Wallet.Web.Mode            (AddrCIdHashes (..), WalletWebMode,
+import           Pos.Wallet.Web.Mode            (WalletWebMode,
                                                  WalletWebModeContext (..),
                                                  WalletWebModeContextTag)
 import           Pos.Wallet.Web.Server.Launcher (walletApplication, walletServeImpl,
@@ -49,10 +49,9 @@ runWRealMode
     -> (ActionSpec WalletWebMode a, OutSpecs)
     -> Production a
 runWRealMode db conn res acts = do
-    ref <- newIORef mempty
     runRealBasedMode
-        (Mtl.withReaderT (WalletWebModeContext db conn $ AddrCIdHashes ref))
-        (Mtl.withReaderT (\(WalletWebModeContext _ _ _ rmc) -> rmc))
+        (Mtl.withReaderT (WalletWebModeContext db conn))
+        (Mtl.withReaderT (\(WalletWebModeContext _ _ rmc) -> rmc))
         res
         acts
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
@@ -28,14 +28,14 @@ import           Formatting                   (bprint, build, (%))
 import           Serokell.Util                (listJson, listJsonIndent)
 
 import           Pos.Client.Txp.History       (TxHistoryEntry (..))
-import           Pos.Core                     (HeaderHash)
+import           Pos.Core                     (Address, HeaderHash)
 import           Pos.Txp.Core                 (TxId)
 import           Pos.Txp.Toil                 (UtxoModifier)
 import           Pos.Util.Modifier            (MapModifier)
 import qualified Pos.Util.Modifier            as MM
 
-import           Pos.Wallet.Web.ClientTypes   (Addr, CId, CWAddressMeta)
 import           Pos.Wallet.Web.Pending.Types (PtxBlockInfo)
+import           Pos.Wallet.Web.State         (WAddressMeta)
 
 -- VoidModifier describes a difference between two states.
 -- It's (set of added k, set of deleted k) essentially.
@@ -58,9 +58,9 @@ instance (Eq a, Hashable a) => Monoid (IndexedMapModifier a) where
         IndexedMapModifier (m1 <> fmap (+ c1) m2) (c1 + c2)
 
 data CAccModifier = CAccModifier
-    { camAddresses            :: !(IndexedMapModifier CWAddressMeta)
-    , camUsed                 :: !(VoidModifier (CId Addr, HeaderHash))
-    , camChange               :: !(VoidModifier (CId Addr, HeaderHash))
+    { camAddresses            :: !(IndexedMapModifier WAddressMeta)
+    , camUsed                 :: !(VoidModifier (Address, HeaderHash))
+    , camChange               :: !(VoidModifier (Address, HeaderHash))
     , camUtxo                 :: !UtxoModifier
     , camAddedHistory         :: !(DList TxHistoryEntry)
     , camDeletedHistory       :: !(DList TxHistoryEntry)

--- a/wallet/test/Migrations.hs
+++ b/wallet/test/Migrations.hs
@@ -1,0 +1,218 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+module Migrations (tests) where
+
+import           Control.Arrow                        ((***))
+import qualified Data.HashMap.Strict                  as HM
+import           Data.SafeCopy
+import           Pos.Arbitrary.Core                   ()
+import           Pos.Wallet.Web.ClientTypes           (AccountId (..), Addr,
+                                                       CAccountMeta (..), CCoin (..),
+                                                       CHash (..), CId (..),
+                                                       CProfile (..), CTxId (..),
+                                                       CTxMeta (..), CUpdateInfo (..),
+                                                       CWAddressMeta (..),
+                                                       CWalletAssurance (..),
+                                                       CWalletMeta (..), Wal)
+import           Pos.Wallet.Web.ClientTypes.Functions (addressToCId)
+import           Pos.Wallet.Web.State.Storage
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Universum
+
+--------------------------------------------------------------------------------
+-- Reverse migrations
+--
+-- These instances serve to allow us to migrate _backwards_ from the current DB
+-- version to the previous one. The purpose of this is to verify that the
+-- migration does not introduce unwanted changes to the database.
+--------------------------------------------------------------------------------
+
+instance Migrate AddressInfo_v0 where
+  type MigrateFrom AddressInfo_v0 = AddressInfo
+  migrate AddressInfo{..} = AddressInfo_v0
+    { _v0_adiCWAddressMeta = wamToCWam adiWAddressMeta
+    , _v0_adiSortingKey = adiSortingKey
+    }
+    where
+      wamToCWam (WAddressMeta wid accIdx addrIdx cAddr)
+          = CWAddressMeta wid accIdx addrIdx $ addressToCId cAddr
+
+instance Migrate AccountInfo_v0 where
+  type MigrateFrom AccountInfo_v0 = AccountInfo
+  migrate AccountInfo{..} = AccountInfo_v0
+      { _v0_aiMeta = _aiMeta
+      , _v0_aiAddresses = mapAddrs _aiAddresses
+      , _v0_aiRemovedAddresses = mapAddrs _aiRemovedAddresses
+      , _v0_aiUnusedKey = _aiUnusedKey
+      }
+    where
+      mapAddrs =
+          HM.fromList
+        . fmap (addressToCId *** migrate)
+        . HM.toList
+
+newtype WalletStorage_Back_v2 = WalletStorage_Back_v2 WalletStorage_v2
+
+instance Migrate WalletStorage_Back_v2 where
+  type MigrateFrom WalletStorage_Back_v2 = WalletStorage
+  migrate WalletStorage{..} = WalletStorage_Back_v2 $ WalletStorage_v2
+      { _v2_wsWalletInfos = _wsWalletInfos
+      , _v2_wsAccountInfos = fmap migrate _wsAccountInfos
+      , _v2_wsProfile = _wsProfile
+      , _v2_wsReadyUpdates = _wsReadyUpdates
+      , _v2_wsTxHistory = _wsTxHistory
+      , _v2_wsHistoryCache = _wsHistoryCache
+      , _v2_wsUtxo = _wsUtxo
+      , _v2_wsBalances = _wsBalances
+      , _v2_wsUsedAddresses = mapAddrKeys _wsUsedAddresses
+      , _v2_wsChangeAddresses = mapAddrKeys _wsChangeAddresses
+      }
+    where
+      mapAddrKeys = HM.fromList . fmap (first addressToCId) . HM.toList
+
+--------------------------------------------------------------------------------
+
+deriving instance Eq CTxMeta
+deriving instance Eq CAccountMeta
+deriving instance Eq CProfile
+deriving instance Eq CUpdateInfo
+deriving instance Eq WalletTip
+deriving instance Eq WalletInfo
+deriving instance Eq AccountInfo_v0
+deriving instance Eq AddressInfo_v0
+deriving instance Eq WalletStorage_v2
+
+deriving instance Show WalletTip
+deriving instance Show WalletInfo
+deriving instance Show AccountInfo_v0
+deriving instance Show AddressInfo_v0
+deriving instance Show WalletStorage_v2
+
+deriving instance Arbitrary CHash
+deriving instance Arbitrary (CId Wal)
+deriving instance Arbitrary CTxId
+deriving instance Arbitrary CCoin
+
+instance Arbitrary CProfile where
+  arbitrary = CProfile <$> arbitrary
+
+instance Arbitrary CTxMeta where
+  arbitrary = CTxMeta <$> arbitrary
+
+instance Arbitrary CUpdateInfo where
+  arbitrary = CUpdateInfo
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary (CId Addr) where
+  arbitrary = addressToCId <$> arbitrary
+
+instance Arbitrary CAccountMeta where
+  arbitrary = CAccountMeta <$> arbitrary
+
+instance Arbitrary CWalletAssurance where
+  arbitrary = oneof
+    [ pure CWAStrict
+    , pure CWANormal
+    ]
+
+instance Arbitrary WAddressMeta where
+  arbitrary = WAddressMeta
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary CWAddressMeta where
+  arbitrary = CWAddressMeta
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary CWalletMeta where
+  arbitrary = CWalletMeta
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary AccountId where
+  arbitrary = AccountId
+    <$> arbitrary
+    <*> arbitrary
+
+instance Arbitrary WalletTip where
+  arbitrary = oneof
+    [ pure NotSynced
+    , SyncedWith <$> arbitrary
+    ]
+
+instance Arbitrary AddressInfo where
+  arbitrary = AddressInfo
+    <$> arbitrary
+    <*> arbitrary
+instance Arbitrary AddressInfo_v0 where
+  arbitrary = AddressInfo_v0
+    <$> arbitrary
+    <*> arbitrary
+
+instance Arbitrary AccountInfo where
+  arbitrary = AccountInfo
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary AccountInfo_v0 where
+  arbitrary = AccountInfo_v0
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary WalletInfo where
+  arbitrary = WalletInfo
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> pure HM.empty
+    <*> arbitrary
+
+instance Arbitrary WalletStorage_v2 where
+  arbitrary = WalletStorage_v2
+    <$> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> pure HM.empty
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+
+tests :: TestTree
+tests = testGroup "Migration"
+    [ testProperty "migration to latest version can be reversed" $ prop_backMigrate
+    ]
+  where
+    -- This test verifies that the migration to version 2 of the wallet storage is
+    -- reversible, and as such that we don't accidentally cause any data loss in
+    -- the conversion.
+    prop_backMigrate :: WalletStorage_v2 -> Bool
+    prop_backMigrate ws = let
+        WalletStorage_Back_v2 ws' = migrate . migrate $ ws
+      in ws == ws'

--- a/wallet/test/Test.hs
+++ b/wallet/test/Test.hs
@@ -1,0 +1,10 @@
+import qualified Migrations
+import           Test.Tasty
+import           Universum
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit Tests"
+  [ Migrations.tests ]


### PR DESCRIPTION
This PR removes the use of the encoded `CId Addr` from the wallet DB, replacing it with the core type `Address`.

As a consequence, a number of encoding/decoding steps are removed, and we can additionally drop the address cache layer, which further means certain functions can become pure where previously they were effectful.

