### PR TITLE
[CSL-2117] Allow careful usage of ExceptT over IO

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -182,7 +182,7 @@ they add additional exception mechanisms to the one that `IO` has, and
 Do *not*:
 
 * use `error` or `impureThrow`
-* use `ExceptT`, `MaybeT`, or `CatchT`
+* use `CatchT`
 * use `MonadError`
 * use `throwIO`
 * return `m (Either e a)` if `e` has `Exception` instance
@@ -192,12 +192,11 @@ Do:
 * create a custom exception type
 * use `throwM` (`MonadThrow`)
 
-If you want to return `m (Either e a)` from a function, it's
-recommended to define `instance TypeError "NOT AN EXC" => Exception e`
-for your type `e`. If the meaning of `e` type is not related to
-exceptional situations at all, it's not needed to define such
-instance. But for example if `e` denotes a `ParseError`, please do
-define it.
+If you want to return `m (Either e a)` from a function or to use `ExceptT e m
+a`, it's required to define `instance TypeError "NOT AN EXC" => Exception e` for
+your type `e`. Do not use `ExceptT e m a` in exported top-level functions,
+convert to `m (Either e a)` using `runExceptT`. As of now, using `ExceptT` robs
+us of `bracket`, but this will be fixed in the next release of `exceptions`.
 
 We disallow the use of `throwIO` only because it is redundant in the presence of
 `throwM` and requires a stronger constraint (`MonadIO` rather than


### PR DESCRIPTION
There are two reasons to avoid `ExceptT` over `IO`:

* it creates a separate exception handling mechanism overlapping with `IO` exceptions
* it doesn't have a `MonadMask` instance, so `bracket` cannot be used with it

The first reason can be mitigated by making the sets of `ExceptT` and `IO` exceptions disjoint:

* `throwError` must be used only with types that have a `TypeError "Not an exception" => Exception e` instance (requirement of our guidelines)
* `throwM` and `throwIO` require a working `Exception e` instance

This means that the two mechanisms are not in conflict, but actually complement each other. One is useful for checked exceptions and general control flow, while the other — for unchecked exceptions.

As to `MonadMask`, this will be fixed in the next `exceptions` release.
