### PR TITLE
[DEVOPS-652] remove all usage of import-from-derivation in release.nix when nix 1.12 is present

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -94,7 +94,7 @@ let
       args: import ./scripts/launch/connect-to-cluster (args // walletConfig // { inherit gitrev; });
   other = rec {
     mkDocker = { environment, connectArgs ? {} }: import ./docker.nix { inherit environment connect gitrev pkgs connectArgs; };
-    stack2nix = import (pkgs.fetchFromGitHub {
+    stack2nix = import (localLib.fetchFromGitHub {
       owner = "input-output-hk";
       repo = "stack2nix";
       rev = "486a88f161a08df8af42cb4c84f44e99fa9a98d8";

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,23 +1,48 @@
-let
-  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
-  src = import <nix/fetchurl.nix> {
-    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
-    inherit (spec) sha256;
-  };
-  nixcfg = import <nix/config.nix>;
-in builtins.derivation {
+with rec {
+  ifThenElse = { bool, thenValue, elseValue }: (
+    if bool then thenValue else elseValue);
   system = builtins.currentSystem;
-  name = "${src.name}-unpacked";
-  builder = builtins.storePath nixcfg.shell;
-  inherit src;
-  args = [
-    (builtins.toFile "builder" ''
-      $coreutils/mkdir $out
-      cd $out
-      $gzip -d < $src | $tar -x --strip-components=1
-    '')
-  ];
-  coreutils = builtins.storePath nixcfg.coreutils;
-  tar = builtins.storePath nixcfg.tar;
-  gzip = builtins.storePath nixcfg.gzip;
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+};
+
+ifThenElse {
+  bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12pre");
+
+  # In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+  thenValue = (
+    builtins.fetchTarball {
+      url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+      sha256 = spec.unpackedsha256;
+    });
+
+  # This hack should at least work for Nix 1.11
+  elseValue = (
+    (rec {
+      tarball = import <nix/fetchurl.nix> {
+        url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+        sha256 = spec.tarsha256;
+      };
+
+      builtin-paths = import <nix/config.nix>;
+
+      script = builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" "$out"
+        cd "$out"
+        "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+      '';
+
+      nixpkgs = builtins.derivation {
+        name = "nixpkgs-${builtins.substring 0 6 spec.rev}";
+
+        builder = builtins.storePath builtin-paths.shell;
+
+        args = [ script ];
+
+        inherit tarball system;
+
+        tar       = builtins.storePath builtin-paths.tar;
+        gzip      = builtins.storePath builtin-paths.gzip;
+        coreutils = builtins.storePath builtin-paths.coreutils;
+      };
+    }).nixpkgs);
 }

--- a/lib.nix
+++ b/lib.nix
@@ -16,4 +16,13 @@ let
   lib = pkgs.lib;
 in lib // (rec {
   inherit fetchNixPkgs;
+  ifThenElse = { bool, thenValue, elseValue }: (if bool then thenValue else elseValue);
+  fetchFromGitHub = ifThenElse {
+    bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12pre");
+    thenValue = { owner, repo, rev, sha256 }: builtins.fetchTarball {
+      url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+    elseValue = pkgs.fetchFromGitHub;
+  };
 })

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -2,5 +2,6 @@
     "owner":  "NixOS",
     "repo":   "nixpkgs",
     "rev":    "61fbdb47a69f78998f55207e64122a0798047b5d",
-    "sha256": "050r55sgpy121j5qs00jw43rg5pnqidbdbvvj4lr1i9lmv9f1vfv"
+    "tarsha256": "050r55sgpy121j5qs00jw43rg5pnqidbdbvvj4lr1i9lmv9f1vfv",
+    "unpackedsha256": "14kl3g27hapfmnzjclhdc4aglyg4dhmz09syzx4ab1mfyfw7d06n"
 }

--- a/nixpkgs-src.readme
+++ b/nixpkgs-src.readme
@@ -1,0 +1,16 @@
+due to conflicts within nix and fetch-nixpkgs.nix, we currently need 2 hashes
+tarsha256 is the `nix-hash --flat --type sha256 --base32` over the raw .tar.gz, from a URL like https://github.com/NixOS/nixpkgs/archive/5c09cdc187b014143302551e62d4973b5bf52814.tar.gz
+unpackedsha256 is the `nix-hash --type sha256 --base32` over the directory that results from unpacking the previous tar
+
+builtins.fetchTarball wont tell you the correct unpackedsha256 if its wrong
+but <nix/fetchurl.nix> will give the correct tarsha256 if that is wrong
+
+DEVOPS-675 will simplify this
+
+an example:
+```
+store path mismatch in file downloaded from 'https://github.com/NixOS/nixpkgs/archive/61fbdb47a69f78998f55207e64122a0798047b5d.tar.gz'
+[clever@amd-nixos:/tmp]$ curl -L https://github.com/NixOS/nixpkgs/archive/61fbdb47a69f78998f55207e64122a0798047b5d.tar.gz | tar -xz
+[clever@amd-nixos:/tmp]$ nix-hash --type sha256 --base32 nixpkgs-61fbdb47a69f78998f55207e64122a0798047b5d/
+14kl3g27hapfmnzjclhdc4aglyg4dhmz09syzx4ab1mfyfw7d06n
+```

--- a/nixpkgs-src.readme
+++ b/nixpkgs-src.readme
@@ -1,16 +1,8 @@
 due to conflicts within nix and fetch-nixpkgs.nix, we currently need 2 hashes
-tarsha256 is the `nix-hash --flat --type sha256 --base32` over the raw .tar.gz, from a URL like https://github.com/NixOS/nixpkgs/archive/5c09cdc187b014143302551e62d4973b5bf52814.tar.gz
-unpackedsha256 is the `nix-hash --type sha256 --base32` over the directory that results from unpacking the previous tar
+tarsha256 is the `nix-prefetch-url` hash from a URL like https://github.com/NixOS/nixpkgs/archive/5c09cdc187b014143302551e62d4973b5bf52814.tar.gz
+unpackedsha256 is the `nix-prefetch-url --unpack` hash from the same URL
 
 builtins.fetchTarball wont tell you the correct unpackedsha256 if its wrong
 but <nix/fetchurl.nix> will give the correct tarsha256 if that is wrong
 
 DEVOPS-675 will simplify this
-
-an example:
-```
-store path mismatch in file downloaded from 'https://github.com/NixOS/nixpkgs/archive/61fbdb47a69f78998f55207e64122a0798047b5d.tar.gz'
-[clever@amd-nixos:/tmp]$ curl -L https://github.com/NixOS/nixpkgs/archive/61fbdb47a69f78998f55207e64122a0798047b5d.tar.gz | tar -xz
-[clever@amd-nixos:/tmp]$ nix-hash --type sha256 --base32 nixpkgs-61fbdb47a69f78998f55207e64122a0798047b5d/
-14kl3g27hapfmnzjclhdc4aglyg4dhmz09syzx4ab1mfyfw7d06n
-```

--- a/scripts/ci/check-hydra.sh
+++ b/scripts/ci/check-hydra.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-nix-build '<nixpkgs>' -A hydra
-echo '~~~ Evaluation release.nix'
-./result/bin/hydra-eval-jobs -I . release.nix
+set -x
+set -e
+
+nix-build fetch-nixpkgs.nix
+nix-build -E 'import (import ./fetch-nixpkgs.nix) { config = {}; }' -A hydra
+echo '~~~ Evaluating release.nix'
+./result/bin/hydra-eval-jobs -I . --option allowed-uris 'https://github.com/NixOS/nixpkgs/archive/ https://github.com/input-output-hk/stack2nix/archive' release.nix --show-trace

--- a/scripts/ci/nix-shell.sh
+++ b/scripts/ci/nix-shell.sh
@@ -20,4 +20,7 @@ export NIX_REMOTE=daemon
 export NIX_PATH="nixpkgs=$(${NIX_BUILD} fetch-nixpkgs.nix -o nixpkgs)"
 export NIX_BUILD_SHELL
 
+# the pure way, causes some errors
+# ${NIX_SHELL} -E 'with import (import ./fetch-nixpkgs.nix) { config = {}; }; stdenv.mkDerivation { name = "shell"; buildInputs = [ nix bash coreutils zlib gmp ncurses purescript ]; }' "$@"
+
 ${NIX_SHELL} -p nix bash coreutils zlib gmp ncurses purescript "$@"


### PR DESCRIPTION
this has been tested on both nixpkgs `61fbdb47a69f78998f55207e64122a0798047b5d`

and also the `5c09cdc187b014143302551e62d4973b5bf52814` where the problem originally occured