### PR TITLE
[CSL-2132] Optimize slog apply by batching

### DIFF
--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -177,7 +177,7 @@ instance HasConfiguration => MonadDB AuxxMode where
     dbPut = realModeToAuxx ... dbPut
     dbWriteBatch = realModeToAuxx ... dbWriteBatch
     dbDelete = realModeToAuxx ... dbDelete
-    dbPutSerBlund = realModeToAuxx ... dbPutSerBlund
+    dbPutSerBlunds = realModeToAuxx ... dbPutSerBlunds
 
 instance HasConfiguration => MonadGState AuxxMode where
     gsAdoptedBVData = realModeToAuxx ... gsAdoptedBVData

--- a/db/Pos/DB/Class.hs
+++ b/db/Pos/DB/Class.hs
@@ -162,8 +162,8 @@ class MonadDBRead m => MonadDB m where
     -- with given key from DB corresponding to given tag.
     dbDelete :: DBTag -> ByteString -> m ()
 
-    -- | Put given blund into the Block DB.
-    dbPutSerBlund :: (Block, SerializedUndo) -> m ()
+    -- | Put given blunds into the Block DB.
+    dbPutSerBlunds :: NonEmpty (Block, SerializedUndo) -> m ()
 
 instance {-# OVERLAPPABLE #-}
     (MonadDB m, MonadTrans t, MonadThrow (t m)) =>
@@ -172,7 +172,7 @@ instance {-# OVERLAPPABLE #-}
     dbPut = lift ... dbPut
     dbWriteBatch = lift ... dbWriteBatch
     dbDelete = lift ... dbDelete
-    dbPutSerBlund = lift ... dbPutSerBlund
+    dbPutSerBlunds = lift ... dbPutSerBlunds
 
 ----------------------------------------------------------------------------
 -- GState abstraction

--- a/explorer/src/Pos/Explorer/ExplorerMode.hs
+++ b/explorer/src/Pos/Explorer/ExplorerMode.hs
@@ -187,7 +187,7 @@ instance HasConfigurations => DB.MonadDB ExplorerTestInitMode where
     dbPut = DB.dbPutPureDefault
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
-    dbPutSerBlund = DB.dbPutSerBlundPureDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsPureDefault
 
 ----------------------------------------------------------------------------
 -- Boilerplate ExplorerTestContext instances
@@ -259,7 +259,7 @@ instance HasConfigurations => DB.MonadDB ExplorerTestMode where
     dbPut = DB.dbPutPureDefault
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
-    dbPutSerBlund = DB.dbPutSerBlundPureDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsPureDefault
 
 instance {-# OVERLAPPING #-} HasLoggerName ExplorerTestMode where
     askLoggerName = askLoggerNameDefault

--- a/generator/src/Pos/Generator/Block/Mode.hs
+++ b/generator/src/Pos/Generator/Block/Mode.hs
@@ -41,7 +41,7 @@ import           Pos.Crypto (SecretKey)
 import           Pos.DB (DBSum, MonadDB, MonadDBRead)
 import qualified Pos.DB as DB
 import           Pos.DB.Block (dbGetSerBlockSumDefault, dbGetSerUndoSumDefault,
-                               dbPutSerBlundSumDefault)
+                               dbPutSerBlundsSumDefault)
 import qualified Pos.DB.Block as DB
 import           Pos.DB.DB (gsAdoptedBVDataDefault)
 import           Pos.Delegation (DelegationVar, HasDlgConfiguration, mkDelegationVar)
@@ -226,7 +226,7 @@ instance MonadBlockGenBase m => MonadDB (InitBlockGenMode ext m) where
     dbPut = DB.dbPutSumDefault
     dbWriteBatch = DB.dbWriteBatchSumDefault
     dbDelete = DB.dbDeleteSumDefault
-    dbPutSerBlund = dbPutSerBlundSumDefault
+    dbPutSerBlunds = dbPutSerBlundsSumDefault
 
 instance (MonadBlockGenBase m, MonadSlotsData ctx (InitBlockGenMode ext m))
       => MonadSlots ctx (InitBlockGenMode ext m)
@@ -307,7 +307,7 @@ instance MonadBlockGenBase m => MonadDB (BlockGenMode ext m) where
     dbPut = DB.dbPutSumDefault
     dbWriteBatch = DB.dbWriteBatchSumDefault
     dbDelete = DB.dbDeleteSumDefault
-    dbPutSerBlund = DB.dbPutSerBlundSumDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsSumDefault
 
 instance (MonadBlockGenBase m, MonadSlotsData ctx (BlockGenMode ext m))
       => MonadSlots ctx (BlockGenMode ext m)

--- a/generator/src/Test/Pos/Block/Logic/Mode.hs
+++ b/generator/src/Test/Pos/Block/Logic/Mode.hs
@@ -362,7 +362,7 @@ instance HasConfiguration => MonadDB TestInitMode where
     dbPut = DB.dbPutPureDefault
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
-    dbPutSerBlund = DB.dbPutSerBlundPureDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsPureDefault
 
 instance (HasConfiguration, MonadSlotsData ctx TestInitMode)
       => MonadSlots ctx TestInitMode
@@ -485,7 +485,7 @@ instance HasConfiguration => MonadDB BlockTestMode where
     dbPut = DB.dbPutPureDefault
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
-    dbPutSerBlund = DB.dbPutSerBlundPureDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsPureDefault
 
 instance HasConfiguration => MonadGState BlockTestMode where
     gsAdoptedBVData = gsAdoptedBVDataDefault

--- a/lib/src/Pos/Launcher/Mode.hs
+++ b/lib/src/Pos/Launcher/Mode.hs
@@ -31,7 +31,7 @@ import           Mockable.Production (Production)
 import           Pos.Core (HasConfiguration, Timestamp)
 import           Pos.DB (NodeDBs)
 import           Pos.DB.Block (dbGetSerBlockRealDefault, dbGetSerUndoRealDefault,
-                               dbPutSerBlundRealDefault)
+                               dbPutSerBlundsRealDefault)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
 import           Pos.DB.Rocks (dbDeleteDefault, dbGetDefault, dbIterSourceDefault, dbPutDefault,
                                dbWriteBatchDefault)
@@ -86,7 +86,7 @@ instance HasConfiguration => MonadDB InitMode where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
-    dbPutSerBlund = dbPutSerBlundRealDefault
+    dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 instance (HasConfiguration, HasInfraConfiguration, MonadSlotsData ctx InitMode) =>
          MonadSlots ctx InitMode

--- a/lib/src/Pos/Web/Mode.hs
+++ b/lib/src/Pos/Web/Mode.hs
@@ -16,7 +16,7 @@ import           Pos.Context (HasPrimaryKey (..), HasSscContext (..), NodeContex
 import           Pos.Core.Configuration (HasConfiguration)
 import           Pos.DB (NodeDBs)
 import           Pos.DB.Block (dbGetSerBlockRealDefault, dbGetSerUndoRealDefault,
-                               dbPutSerBlundRealDefault)
+                               dbPutSerBlundsRealDefault)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
 import           Pos.DB.Rocks (dbDeleteDefault, dbGetDefault, dbIterSourceDefault, dbPutDefault,
                                dbWriteBatchDefault)
@@ -62,6 +62,6 @@ instance HasConfiguration => MonadDB (WebMode ext) where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
-    dbPutSerBlund = dbPutSerBlundRealDefault
+    dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 type instance MempoolExt (WebMode ext) = ext

--- a/lib/src/Pos/WorkMode.hs
+++ b/lib/src/Pos/WorkMode.hs
@@ -29,7 +29,7 @@ import           Pos.Context (HasNodeContext (..), HasPrimaryKey (..), HasSscCon
 import           Pos.Core (HasConfiguration)
 import           Pos.DB (MonadGState (..), NodeDBs)
 import           Pos.DB.Block (dbGetSerBlockRealDefault, dbGetSerUndoRealDefault,
-                               dbPutSerBlundRealDefault)
+                               dbPutSerBlundsRealDefault)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
 import           Pos.DB.DB (gsAdoptedBVDataDefault)
 import           Pos.DB.Rocks (dbDeleteDefault, dbGetDefault, dbIterSourceDefault, dbPutDefault,
@@ -164,7 +164,7 @@ instance HasConfiguration => MonadDB (RealMode ext) where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
-    dbPutSerBlund = dbPutSerBlundRealDefault
+    dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 instance MonadBListener (RealMode ext) where
     onApplyBlocks = onApplyBlocksStub

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -64,7 +64,7 @@ import           Paths_cardano_sl (version)
 import           Pos.Client.CLI (readLoggerConfig)
 import           Pos.Core (HasConfiguration, Timestamp (..))
 import           Pos.DB.Block (dbGetSerBlockRealDefault, dbGetSerUndoRealDefault,
-                               dbPutSerBlundRealDefault)
+                               dbPutSerBlundsRealDefault)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
 import           Pos.DB.Rocks (NodeDBs, closeNodeDBs, dbDeleteDefault, dbGetDefault,
                                dbIterSourceDefault, dbPutDefault, dbWriteBatchDefault, openNodeDBs)
@@ -283,7 +283,7 @@ instance HasConfiguration => MonadDB LauncherMode where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
-    dbPutSerBlund = dbPutSerBlundRealDefault
+    dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 newtype NodeDbPath = NodeDbPath FilePath
 

--- a/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
@@ -6,36 +6,36 @@ module Cardano.Wallet.Kernel.Mode (
   , getWallet
   ) where
 
-import Universum
-import Control.Lens (makeLensesWith)
+import           Control.Lens (makeLensesWith)
 import qualified Control.Monad.Reader as Mtl
+import           Universum
 
-import Mockable
-import Pos.Block.BListener
-import Pos.Block.Slog
-import Pos.Block.Types
-import Pos.Communication
-import Pos.Context
-import Pos.Core
-import Pos.DB
-import Pos.DB.Block
-import Pos.DB.DB
-import Pos.Infra.Configuration
-import Pos.KnownPeers
-import Pos.Launcher
-import Pos.Network.Types
-import Pos.Reporting
-import Pos.Shutdown
-import Pos.Slotting
-import Pos.Txp.Logic
-import Pos.Txp.MemState
-import Pos.Util
-import Pos.Util.Chrono
-import Pos.Util.JsonLog
-import Pos.Util.TimeWarp (CanJsonLog(..))
-import Pos.WorkMode
+import           Mockable
+import           Pos.Block.BListener
+import           Pos.Block.Slog
+import           Pos.Block.Types
+import           Pos.Communication
+import           Pos.Context
+import           Pos.Core
+import           Pos.DB
+import           Pos.DB.Block
+import           Pos.DB.DB
+import           Pos.Infra.Configuration
+import           Pos.KnownPeers
+import           Pos.Launcher
+import           Pos.Network.Types
+import           Pos.Reporting
+import           Pos.Shutdown
+import           Pos.Slotting
+import           Pos.Txp.Logic
+import           Pos.Txp.MemState
+import           Pos.Util
+import           Pos.Util.Chrono
+import           Pos.Util.JsonLog
+import           Pos.Util.TimeWarp (CanJsonLog (..))
+import           Pos.WorkMode
 
-import Cardano.Wallet.Kernel (PassiveWallet)
+import           Cardano.Wallet.Kernel (PassiveWallet)
 
 {-------------------------------------------------------------------------------
   The wallet context and monad
@@ -185,7 +185,7 @@ instance HasConfiguration => MonadDB WalletMode where
   dbPut         = dbPutDefault
   dbWriteBatch  = dbWriteBatchDefault
   dbDelete      = dbDeleteDefault
-  dbPutSerBlund = dbPutSerBlundRealDefault
+  dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 instance ( HasConfiguration
          , HasInfraConfiguration

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -45,7 +45,7 @@ import           Pos.Core (Address, Coin, HasConfiguration, HasPrimaryKey (..), 
 import           Pos.Crypto (PassPhrase)
 import           Pos.DB (MonadGState (..))
 import           Pos.DB.Block (dbGetSerBlockRealDefault, dbGetSerUndoRealDefault,
-                               dbPutSerBlundRealDefault)
+                               dbPutSerBlundsRealDefault)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
 import           Pos.DB.DB (gsAdoptedBVDataDefault)
 import           Pos.DB.Rocks (dbDeleteDefault, dbGetDefault, dbIterSourceDefault, dbPutDefault,
@@ -248,7 +248,7 @@ instance HasConfiguration => MonadDB WalletWebMode where
     dbPut = dbPutDefault
     dbWriteBatch = dbWriteBatchDefault
     dbDelete = dbDeleteDefault
-    dbPutSerBlund = dbPutSerBlundRealDefault
+    dbPutSerBlunds = dbPutSerBlundsRealDefault
 
 instance HasConfiguration => MonadGState WalletWebMode where
     gsAdoptedBVData = gsAdoptedBVDataDefault

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -314,7 +314,7 @@ instance HasConfiguration => MonadDB WalletTestMode where
     dbPut = DB.dbPutPureDefault
     dbWriteBatch = DB.dbWriteBatchPureDefault
     dbDelete = DB.dbDeletePureDefault
-    dbPutSerBlund = DB.dbPutSerBlundPureDefault
+    dbPutSerBlunds = DB.dbPutSerBlundsPureDefault
 
 instance HasConfiguration => MonadGState WalletTestMode where
     gsAdoptedBVData = gsAdoptedBVDataDefault


### PR DESCRIPTION
Copying from YT:

I've managed to speed up application by 30%. I was connecting local node to the mainnet directly, built with -O2 --no-asserts, of course. For the default 2.1k blocks batch it was about 530ms, now it's 390ms. I don't think I can optimize further here, the main bottleneck seems to be the fact we store blocks in files instead of rocksdb. I must admit though, that for now the biggest problem seems to be the server side. Average main retrieval loop length is 36sec, of which verification (850ms) and application (450ms) plus extra related local thing takes about 1.4s. other 34.5 sec are diffusion.getblocks. My networking is good, so i suppose the thing is that server nodes are terribly slow.