### PR TITLE
Script to run the new wallet with new impl

### DIFF
--- a/scripts/launch/demo-with-legacy-new-wallet-api.sh
+++ b/scripts/launch/demo-with-legacy-new-wallet-api.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+base=$(dirname "$0")
+
+WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo-with-new-wallet-api.sh
+++ b/scripts/launch/demo-with-new-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXTRA_ARGS="--new-wallet" WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -136,7 +136,7 @@ while [[ $i -lt $panesCnt ]]; do
           conf_file=$WALLET_CONFIG
       fi
       wallet_args=" --tlscert $base/../tls-files/server.crt --tlskey $base/../tls-files/server.key --tlsca $base/../tls-files/ca.crt $wallet_flush" # --wallet-rebuild-db'
-      wallet_args="$wallet_args --wallet-address 127.0.0.1:8090"
+      wallet_args="$WALLET_EXTRA_ARGS $wallet_args --wallet-address 127.0.0.1:8090"
       exec_name="$WALLET_EXE_NAME"
       if [[ $WALLET_DEBUG != "" ]]; then
           wallet_args="$wallet_args --wallet-debug"

--- a/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
@@ -8,6 +8,7 @@ module Cardano.Wallet.Kernel.Mode
 
 import           Control.Lens (makeLensesWith)
 import qualified Control.Monad.Reader as Mtl
+import           System.Wlog
 import           Universum
 
 import           Mockable
@@ -72,6 +73,7 @@ walletApplyBlocks :: PassiveWallet
 walletApplyBlocks _w _bs = do
     -- TODO: Call into the wallet. This should be an asynchronous operation
     -- because 'onApplyBlocks' gets called with the block lock held.
+    logError "walletApplyBlocks not implemented"
 
     -- We don't make any changes to the DB so we always return 'mempty'.
     return mempty
@@ -86,6 +88,7 @@ walletRollbackBlocks :: PassiveWallet
 walletRollbackBlocks _w _bs = do
     -- TODO: Call into the wallet. This should be an asynchronous operation
     -- because 'onRollbackBlocks' gets called with the block lock held.
+    logError "walletRollbackBlocks not implemented"
 
     -- We don't make any changes to the DB so we always return 'mempty'.
     return mempty


### PR DESCRIPTION
The existing demo-with-new-wallet-api script was starting the new wallet in "legacy mode", where it's no more than a thin wrapper around the old wallet code. The new wallet in legacy mode was just there as a proof of concept. I've renamed that script now to demo-with-legacy-new-wallet-api. The demo-with-new-wallet-api script now runs the new wallet starting the _actual_ new wallet. In order to do this I needed to add the possibility to demo.sh to pass additional arguments to the wallet executable.

This also adds some logging to the BListener hooks so that we can verify that they get called; the log will contain entries such as

```
node3.log:[*production*:ERROR:ThreadId 68] [2018-02-16 16:22:32.01 UTC] walletApplyBlocks not implemented
```

@georgeee , requesting review from you just to make sure that the change I made to `demo.sh` is benign and won't break other users.