### PR TITLE
[CSL-2301] handle IOExceptions in DNS resolve

### DIFF
--- a/infra/Pos/Diffusion/Subscription/Common.hs
+++ b/infra/Pos/Diffusion/Subscription/Common.hs
@@ -60,6 +60,7 @@ subscribeTo
     => Timer -> SendActions m -> NodeId -> m SubscriptionTerminationReason
 subscribeTo keepAliveTimer sendActions peer = do
     logNotice $ msgSubscribingTo peer
+    -- 'try' is from safe-exceptions, so it won't catch asyncs.
     outcome <- try $ withConnectionTo sendActions peer $ \_peerData -> NE.fromList
         -- Sort conversations in descending order based on their version so that
         -- the highest available version of the conversation is picked.

--- a/infra/Pos/Diffusion/Subscription/Dns.hs
+++ b/infra/Pos/Diffusion/Subscription/Dns.hs
@@ -4,15 +4,13 @@ module Pos.Diffusion.Subscription.Dns
     ) where
 
 import           Control.Exception (IOException)
-import           Control.Monad.Catch (catch)
 import           Data.Either (partitionEithers)
 import qualified Data.Map.Strict as M
 import           Data.Time.Units (Millisecond, Second, convertUnit)
 import           Formatting (int, sformat, shown, (%))
 import qualified Network.DNS as DNS
 import           System.Wlog (logError, logNotice, logWarning)
--- Universum re-exports safe-exceptions.
-import           Universum hiding (catch)
+import           Universum
 
 import           Mockable (Concurrently, Delay, Mockable, SharedAtomic, SharedAtomicT, delay,
                            forConcurrently, modifySharedAtomic, newSharedAtomic)

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -508,6 +508,9 @@ choosePeers valency fallbacks peerType =
 type Resolver = DNS.Domain -> IO (Either DNSError [IPv4])
 
 -- | Variation on resolveDnsDomains that returns node IDs
+--
+-- This uses the network, and so may throw exceptions in case of, for instance,
+-- and unreachable network.
 resolveDnsDomains :: NetworkConfig kademlia
                   -> [NodeAddr DNS.Domain]
                   -> IO [Either DNSError [NodeId]]


### PR DESCRIPTION
Without this, the subscription thread would die if it tries to resolve
when there's no internet connection.