### PR TITLE
[CSL-2134] Block verification optimizations

### DIFF
--- a/delegation/src/Pos/Delegation/Logic/Common.hs
+++ b/delegation/src/Pos/Delegation/Logic/Common.hs
@@ -18,17 +18,15 @@ module Pos.Delegation.Logic.Common
 import           Universum
 
 import           Control.Exception.Safe (Exception (..))
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Buildable as B
-import           Formatting (bprint, build, sformat, stext, (%))
+import           Formatting (bprint, stext, (%))
 import           UnliftIO (MonadUnliftIO)
 
-import           Pos.Core (ProxySKHeavy, StakeholderId, addressHash)
+import           Pos.Core (ProxySKHeavy, StakeholderId)
 import           Pos.Crypto (ProxySecretKey (..), PublicKey)
-import           Pos.DB (DBError (DBMalformed), MonadDBRead)
-import           Pos.Delegation.Cede (getPskChain, runDBCede)
+import           Pos.DB (MonadDBRead)
+import           Pos.Delegation.Cede (dlgLastPsk, getPsk, runDBCede)
 import           Pos.Delegation.Class (DelegationWrap (..), MonadDelegation, askDelegationState)
-import           Pos.Delegation.DB (getDlgTransitive)
 import           Pos.Exception (cardanoExceptionFromException, cardanoExceptionToException)
 
 ----------------------------------------------------------------------------
@@ -79,21 +77,12 @@ runDelegationStateAction action = do
 ----------------------------------------------------------------------------
 
 -- | Retrieves last PSK in chain of delegation started by public key
--- and resolves the passed issuer to a public key. Doesn't check that
--- user himself didn't delegate. Uses database only.
+-- and resolves the passed issuer to a public key. Uses database only.
 getDlgTransPsk
     :: (MonadDBRead m, MonadUnliftIO m)
     => StakeholderId -> m (Maybe (PublicKey, ProxySKHeavy))
-getDlgTransPsk issuer = getDlgTransitive issuer >>= \case
-    Nothing -> pure Nothing
-    Just dPk -> do
-        chain <- runDBCede $ HM.elems <$> getPskChain issuer
-        let finalPsk =
-                find (\psk -> addressHash (pskDelegatePk psk) == dPk) chain
-        let iPk = pskIssuerPk <$>
-                  find (\psk -> addressHash (pskIssuerPk psk) == issuer) chain
-        let throwEmpty = throwM $ DBMalformed $
-                sformat ("getDlgTransPk: couldn't find psk with dlgPk "%build%
-                         " and issuer "%build)
-                        dPk issuer
-        maybe throwEmpty (pure . Just) $ (,) <$> iPk <*> finalPsk
+getDlgTransPsk issuer =
+    runDBCede $ do
+        lastPsk <- dlgLastPsk issuer
+        firstPskIssuer <- fmap pskIssuerPk <$> getPsk issuer
+        pure $ (,) <$> firstPskIssuer <*> lastPsk

--- a/delegation/src/Pos/Delegation/Logic/VAR.hs
+++ b/delegation/src/Pos/Delegation/Logic/VAR.hs
@@ -34,10 +34,10 @@ import           Pos.DB (DBError (DBMalformed), MonadDBRead, SomeBatchOp (..))
 import qualified Pos.DB as DB
 import qualified Pos.DB.GState.Common as GS
 import           Pos.Delegation.Cede (CedeModifier (..), CheckForCycle (..), DlgEdgeAction (..),
-                                      MapCede, MonadCede (..), MonadCedeRead (..),
+                                      MapCede, MonadCede (..), MonadCedeRead (..), cmPskMods,
                                       detectCycleOnAddition, dlgEdgeActionIssuer, dlgVerifyHeader,
-                                      dlgVerifyPskHeavy, evalMapCede, getPskChain, getPskPk, modPsk,
-                                      pskToDlgEdgeAction, runDBCede)
+                                      dlgVerifyPskHeavy, emptyCedeModifier, evalMapCede,
+                                      getPskChain, getPskPk, modPsk, pskToDlgEdgeAction, runDBCede)
 import           Pos.Delegation.Class (MonadDelegation, dwProxySKPool, dwTip)
 import qualified Pos.Delegation.DB as GS
 import           Pos.Delegation.Logic.Common (DelegationError (..), runDelegationStateAction)
@@ -256,10 +256,10 @@ calculateTransCorrections eActions = do
 
             eActionsHM :: CedeModifier
             eActionsHM =
-                CedeModifier
-                    (HM.fromList $ map (\x -> (dlgEdgeActionIssuer x, x)) $
-                                      HS.toList eActions)
-                    mempty
+                emptyCedeModifier &
+                    cmPskMods .~
+                        (HM.fromList $ map (\x -> (dlgEdgeActionIssuer x, x))
+                                           (HS.toList eActions))
 
         in void $ StateT $ \s -> evalMapCede eActionsHM $ runStateT (loop iSId) s
 
@@ -287,9 +287,8 @@ calculateTransCorrections eActions = do
 -- longer rich in the given epoch, but were rich in the previous one.
 getNoLongerRichmen ::
        forall m ctx.
-       ( Monad m
+       ( MonadDBRead m
        , MonadIO m
-       , MonadDBRead m
        , MonadReader ctx m
        , HasLrcContext ctx
        )
@@ -315,7 +314,7 @@ getNoLongerRichmen newEpoch =
 dlgVerifyBlocks ::
        forall ctx m.
        ( MonadDBRead m
-       , MonadIO m
+       , MonadIO m -- needed to get richmen
        , MonadUnliftIO m
        , MonadReader ctx m
        , HasLrcContext ctx
@@ -325,7 +324,7 @@ dlgVerifyBlocks ::
     -> ExceptT Text m (OldestFirst NE DlgUndo)
 dlgVerifyBlocks blocks = do
     richmen <- lift $ getDlgRichmen "dlgVerifyBlocks" headEpoch
-    hoist (evalMapCede mempty) $ mapM (verifyBlock richmen) blocks
+    hoist (evalMapCede emptyCedeModifier) $ mapM (verifyBlock richmen) blocks
   where
     headEpoch = blocks ^. _Wrapped . _neHead . epochIndexL
 
@@ -354,43 +353,49 @@ dlgVerifyBlocks blocks = do
         ------------- [Payload] -------------
 
         let proxySKs = getDlgPayload $ view mainBlockDlgPayload blk
-            allIssuers = map pskIssuerPk proxySKs
+        let verifyPayload = do
+                let allIssuers = map pskIssuerPk proxySKs
 
-        -- Collect rollback info (all certificates we'll
-        -- delete/override), apply new psks.
-        toRollback <- fmap catMaybes $ forM proxySKs $ \psk ->do
-            dlgVerifyPskHeavy
-                richmen
-                (CheckForCycle False)
-                (blk ^. mainBlockSlot . to siEpoch)
-                psk
-            modPsk $ pskToDlgEdgeAction psk
-            getPskPk $ pskIssuerPk psk
+                -- Collect rollback info (all certificates we'll
+                -- delete/override), apply new psks.
+                toRollback <- fmap catMaybes $ forM proxySKs $ \psk ->do
+                    dlgVerifyPskHeavy
+                        richmen
+                        (CheckForCycle False)
+                        (blk ^. mainBlockSlot . to siEpoch)
+                        psk
+                    modPsk $ pskToDlgEdgeAction psk
+                    getPskPk $ pskIssuerPk psk
 
-        -- Check 7: applying psks won't create a cycle.
-        --
-        -- Lemma 1: Removing edges from acyclic graph doesn't create cycles.
-        --
-        -- Lemma 2: Let G = (E₁,V₁) be acyclic graph and F = (E₂,V₂) another one,
-        -- where E₁ ∩ E₂ ≠ ∅ in general case. Then if G ∪ F has a loop C, then
-        -- ∃ a ∈ C such that a ∈ E₂.
-        --
-        -- Hence in order to check whether S=G∪F has cycle, it's sufficient to
-        -- validate that dfs won't re-visit any vertex, starting it on
-        -- every s ∈ E₂.
-        --
-        -- In order to do it we should resolve with db, 'dvPskChanged' and
-        -- 'proxySKs' together. So it's alright to first apply 'proxySKs'
-        -- to 'dvPskChanged' and then perform the check.
+                -- Check 7: applying psks won't create a cycle.
+                --
+                -- Lemma 1: Removing edges from acyclic graph doesn't create cycles.
+                --
+                -- Lemma 2: Let G = (E₁,V₁) be acyclic graph and F = (E₂,V₂) another one,
+                -- where E₁ ∩ E₂ ≠ ∅ in general case. Then if G ∪ F has a loop C, then
+                -- ∃ a ∈ C such that a ∈ E₂.
+                --
+                -- Hence in order to check whether S=G∪F has cycle, it's sufficient to
+                -- validate that dfs won't re-visit any vertex, starting it on
+                -- every s ∈ E₂.
+                --
+                -- In order to do it we should resolve with db, 'dvPskChanged' and
+                -- 'proxySKs' together. So it's alright to first apply 'proxySKs'
+                -- to 'dvPskChanged' and then perform the check.
 
-        cyclePoints <- catMaybes <$> mapM detectCycleOnAddition proxySKs
-        unless (null cyclePoints) $
-            throwError $
-            sformat ("Block "%build%" leads to psk cycles, at least in these certs: "%listJson)
-                    (headerHash blk)
-                    (take 5 $ cyclePoints) -- should be enough
+                cyclePoints <- catMaybes <$> mapM detectCycleOnAddition proxySKs
+                unless (null cyclePoints) $
+                    throwError $
+                    sformat ("Block "%build%" leads to psk cycles, at "%
+                             "least in these certs: "%listJson)
+                            (headerHash blk)
+                            (take 5 $ cyclePoints) -- should be enough
 
-        mapM_ (addThisEpochPosted . addressHash) allIssuers
+                mapM_ (addThisEpochPosted . addressHash) allIssuers
+                pure toRollback
+
+        -- We don't want to verify empty payload
+        toRollback <- if null proxySKs then pure mempty else verifyPayload
 
         pure $ DlgUndo toRollback mempty
 

--- a/update/Pos/Update/Poll/Logic/Apply.hs
+++ b/update/Pos/Update/Poll/Logic/Apply.hs
@@ -1,4 +1,3 @@
-
 -- | Logic of application and verification of data in Poll.
 
 module Pos.Update.Poll.Logic.Apply
@@ -7,7 +6,7 @@ module Pos.Update.Poll.Logic.Apply
        , verifyAndApplyVoteDo
        ) where
 
-import           Control.Monad.Except (MonadError, throwError, runExceptT)
+import           Control.Monad.Except (MonadError, runExceptT, throwError)
 import qualified Data.HashSet as HS
 import           Data.List (partition)
 import qualified Data.List.NonEmpty as NE
@@ -21,7 +20,7 @@ import           Pos.Core (ChainDifficulty (..), Coin, EpochIndex, HeaderHash, I
                            blockVersionL, coinToInteger, difficultyL, epochIndexL, flattenSlotId,
                            headerHashG, headerSlotL, sumCoins, unflattenSlotId, unsafeIntegerToCoin)
 import           Pos.Core.Configuration (HasConfiguration, blkSecurityParam)
-import           Pos.Core.Update (BlockVersionData (..), UpId, UpdatePayload (..),
+import           Pos.Core.Update (BlockVersion, BlockVersionData (..), UpId, UpdatePayload (..),
                                   UpdateProposal (..), UpdateVote (..), bvdUpdateProposalThd,
                                   checkUpdatePayload)
 import           Pos.Crypto (hash, shortHashF)
@@ -58,35 +57,41 @@ type ApplyMode m =
 -- When it is 'Right header', it means that payload from block with
 -- given header is applied and in this case threshold for update proposal is
 -- checked.
-verifyAndApplyUSPayload
-    :: ApplyMode m
-    => Bool -> Either SlotId (Some IsMainHeader) -> UpdatePayload -> m ()
-verifyAndApplyUSPayload verifyAllIsKnown slotOrHeader upp@UpdatePayload {..} = do
+verifyAndApplyUSPayload ::
+       ApplyMode m
+    => BlockVersion
+    -> Bool
+    -> Either SlotId (Some IsMainHeader)
+    -> UpdatePayload
+    -> m ()
+verifyAndApplyUSPayload lastAdopted verifyAllIsKnown slotOrHeader upp@UpdatePayload {..} = do
     -- First of all, we verify data.
     either (throwError . PollInvalidUpdatePayload) pure =<< runExceptT (checkUpdatePayload upp)
-    whenRight slotOrHeader verifyHeader
-    -- Then we split all votes into groups. One group consists of
-    -- votes for proposal from payload. Each other group consists of
-    -- votes for other proposals.
-    let upId = hash <$> upProposal
-    let votePredicate vote = maybe False (uvProposalId vote ==) upId
-    let (curPropVotes, otherVotes) = partition votePredicate upVotes
-    let otherGroups = NE.groupWith uvProposalId otherVotes
-    -- When there is proposal in payload, it's verified and applied.
-    whenJust upProposal $
-        verifyAndApplyProposal verifyAllIsKnown slotOrHeader curPropVotes
-    -- Then we also apply votes from other groups.
-    -- ChainDifficulty is needed, because proposal may become approved
-    -- and then we'll need to track whether it becomes confirmed.
-    let cd = case slotOrHeader of
-            Left  _ -> Nothing
-            Right h -> Just (h ^. difficultyL, h ^. headerHashG)
-    mapM_ (verifyAndApplyVotesGroup cd) otherGroups
+    whenRight slotOrHeader $ verifyHeader lastAdopted
+
+    unless isEmptyPayload $ do
+        -- Then we split all votes into groups. One group consists of
+        -- votes for proposal from payload. Each other group consists of
+        -- votes for other proposals.
+        let upId = hash <$> upProposal
+        let votePredicate vote = maybe False (uvProposalId vote ==) upId
+        let (curPropVotes, otherVotes) = partition votePredicate upVotes
+        let otherGroups = NE.groupWith uvProposalId otherVotes
+        -- When there is proposal in payload, it's verified and applied.
+        whenJust upProposal $
+            verifyAndApplyProposal verifyAllIsKnown slotOrHeader curPropVotes
+        -- Then we also apply votes from other groups.
+        -- ChainDifficulty is needed, because proposal may become approved
+        -- and then we'll need to track whether it becomes confirmed.
+        let cd = case slotOrHeader of
+                Left  _ -> Nothing
+                Right h -> Just (h ^. difficultyL, h ^. headerHashG)
+        mapM_ (verifyAndApplyVotesGroup cd) otherGroups
     -- If we are applying payload from block, we also check implicit
     -- agreement rule and depth of decided proposals (they can become
     -- confirmed/discarded).
     case slotOrHeader of
-        Left _ -> pass
+        Left _           -> pass
         Right mainHeader -> do
             applyImplicitAgreement
                 (mainHeader ^. headerSlotL)
@@ -96,15 +101,16 @@ verifyAndApplyUSPayload verifyAllIsKnown slotOrHeader upp@UpdatePayload {..} = d
                 (mainHeader ^. epochIndexL)
                 (mainHeader ^. headerHashG)
                 (mainHeader ^. difficultyL)
+  where
+    isEmptyPayload = isNothing upProposal && null upVotes
 
 -- Here we verify all US-related data from header.
 verifyHeader
     :: (MonadError PollVerFailure m, MonadPoll m, IsMainHeader mainHeader)
-    => mainHeader -> m ()
-verifyHeader header = do
-    lastAdopted <- getAdoptedBV
+    => BlockVersion -> mainHeader -> m ()
+verifyHeader lastAdopted header = do
     let versionInHeader = header ^. blockVersionL
-    unlessM (canCreateBlockBV versionInHeader) $
+    unlessM (canCreateBlockBV lastAdopted versionInHeader) $ do
         throwError
             PollWrongHeaderBlockVersion
             {pwhpvGiven = versionInHeader, pwhpvAdopted = lastAdopted}
@@ -320,7 +326,7 @@ applyDepthCheck epoch hh (ChainDifficulty cd)
         let winners =
                 concatMap (toList . discardAllExceptHead . NE.sortBy proposalCmp) $
                 NE.groupWith groupCriterion deepProposals
-        mapM_ applyDepthCheckDo winners
+        unless (null deepProposals) $ mapM_ applyDepthCheckDo winners
   where
     upsAppName = svAppName . upSoftwareVersion . upsProposal
     discardAllExceptHead (a:|xs) = a :| map (\x->x {dpsDecision = False}) xs

--- a/update/Pos/Update/Poll/Logic/Base.hs
+++ b/update/Pos/Update/Poll/Logic/Base.hs
@@ -81,11 +81,11 @@ confirmBlockVersion confirmedEpoch bv =
 -- Specifically, one of the following conditions must be true.
 -- • Given block version is equal to last adopted block version.
 -- • Given block version is competing
-canCreateBlockBV :: MonadPollRead m => BlockVersion -> m Bool
-canCreateBlockBV bv = do
-    lastAdopted <- getAdoptedBV
+canCreateBlockBV :: MonadPollRead m => BlockVersion -> BlockVersion -> m Bool
+canCreateBlockBV lastAdopted bv = do
     isCompeting <- isCompetingBV bv
     pure (bv == lastAdopted || isCompeting)
+
 
 -- | Check whether given 'BlockVersion' can be proposed according to
 -- current Poll.


### PR DESCRIPTION
Verification for an average mainnet 2100b batch now takes about 0.5-0.6s, which was about 1s before. I've lowered the delegation component overhead by adding the cache into `CedeModifier`, but other optimizations were helpful as well. Update component should be a little bit quicker also now, but it's something like 10%, not much. The bottleneck in update component is still there (every time we apply a block, we call `applyImplicitAgreement`, `applyDepthCheck` and also record block issuance, this is very expensive), and it's really hard to fix (more of an update system design drawback), so I doubt we need to do it right now. 