### PR TITLE
[DEVOPS-646]  staging wallet:  bump applicationVersion to 6

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14800,7 +14800,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 4
+    applicationVersion: 6
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14810,7 +14810,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 4
+    applicationVersion: 6
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1


### PR DESCRIPTION
That's the version from `1.1.0-staging` branch. After this PR is merged, `1.1.0-staging` won't be needed.