### PR TITLE
Stack.yaml now enables Nix to fix build of node

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -137,6 +137,7 @@ packages:
 
 nix:
   shell-file: shell.nix
+  enable: true
 
 extra-deps:
 - ekg-core-0.1.1.3                # https://github.com/tibbe/ekg-core/pull/21


### PR DESCRIPTION
If you don't have this setting, you run into the problem mention in
#2223 #2443 #1784 (and maybe more)

This fixed the issue for me also (building scripts/build/cardano-sl.sh)-. Is there any reason not to have this setting?