### PR TITLE
[CSL-2193] Fix misplaced configuration options

### DIFF
--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -55,8 +55,8 @@ import           Pos.Slotting.Class (MonadSlots (..))
 import           Pos.Slotting.MemState (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Ssc.Configuration (HasSscConfiguration)
 import           Pos.Ssc.Types (HasSscContext (..))
-import           Pos.Txp (MempoolExt, MonadTxpLocal (..), txNormalize, txProcessTransaction,
-                          txProcessTransactionNoLock)
+import           Pos.Txp (HasTxpConfiguration, MempoolExt, MonadTxpLocal (..), txNormalize,
+                          txProcessTransaction, txProcessTransactionNoLock)
 import           Pos.Txp.DB.Utxo (getFilteredUtxo)
 import           Pos.Util (HasLens (..), postfixLFields)
 import           Pos.Util.CompileInfo (HasCompileInfo, withCompileInfo)
@@ -193,7 +193,12 @@ instance HasConfiguration => MonadBalances AuxxMode where
     getOwnUtxos addrs = ifM isTempDbUsed (getOwnUtxosGenesis addrs) (getFilteredUtxo addrs)
     getBalance = getBalanceFromUtxo
 
-instance (HasConfiguration, HasInfraConfiguration, HasSscConfiguration, HasCompileInfo) =>
+instance ( HasConfiguration
+         , HasInfraConfiguration
+         , HasSscConfiguration
+         , HasTxpConfiguration
+         , HasCompileInfo
+         ) =>
          MonadTxHistory AuxxMode where
     getBlockHistory = getBlockHistoryDefault
     getLocalHistory = getLocalHistoryDefault
@@ -220,7 +225,12 @@ instance MonadKeys AuxxMode where
 
 type instance MempoolExt AuxxMode = EmptyMempoolExt
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) => MonadTxpLocal AuxxMode where
+instance ( HasConfiguration
+         , HasInfraConfiguration
+         , HasTxpConfiguration
+         , HasCompileInfo
+         ) =>
+         MonadTxpLocal AuxxMode where
     txpNormalize = withReaderT acRealModeContext txNormalize
     txpProcessTx = withReaderT acRealModeContext . txProcessTransaction
 

--- a/block/src/Pos/Block/Configuration.hs
+++ b/block/src/Pos/Block/Configuration.hs
@@ -11,6 +11,15 @@ module Pos.Block.Configuration
     -- * Constants mentioned in paper
     , networkDiameter
 
+    -- * Chain quality
+    , nonCriticalCQBootstrap
+    , criticalCQBootstrap
+    , nonCriticalCQ
+    , criticalCQ
+    , criticalForkThreshold
+    , fixedTimeCQ
+    , fixedTimeCQSec
+
     -- * Other constants
     , recoveryHeadersMessage
     ) where
@@ -19,9 +28,11 @@ import           Universum
 
 import           Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import           Data.Reflection (Given (..), give)
-import           Data.Time.Units (Microsecond)
+import           Data.Time.Units (Microsecond, Second, convertUnit)
 import           Serokell.Aeson.Options (defaultOptions)
 import           Serokell.Util (sec)
+
+import           Pos.Aeson.Core ()
 
 type HasBlockConfiguration = Given BlockConfiguration
 
@@ -37,6 +48,28 @@ data BlockConfiguration = BlockConfiguration
       -- ^ Estimated time for broadcasting messages
     , ccRecoveryHeadersMessage :: !Int
       -- ^ Numbers of headers put in message in recovery mode.
+
+      -- Chain quality thresholds and other constants to detect
+      -- suspicious things.
+
+      -- | If chain quality in bootstrap era is less than this value,
+      -- non critical misbehavior will be reported.
+    , ccNonCriticalCQBootstrap :: !Double
+      -- | If chain quality in bootstrap era is less than this value,
+      -- critical misbehavior will be reported.
+    , ccCriticalCQBootstrap    :: !Double
+      -- | If chain quality after bootstrap era is less than this
+      -- value, non critical misbehavior will be reported.
+    , ccNonCriticalCQ          :: !Double
+      -- | If chain quality after bootstrap era is less than this
+      -- value, critical misbehavior will be reported.
+    , ccCriticalCQ             :: !Double
+      -- | Number of blocks such that if so many blocks are rolled
+      -- back, it requires immediate reaction.
+    , ccCriticalForkThreshold  :: !Int
+      -- | Chain quality will be also calculated for this amount of seconds.
+    , ccFixedTimeCQ            :: !Second
+
     } deriving (Show, Generic)
 
 instance ToJSON BlockConfiguration where
@@ -53,6 +86,43 @@ instance FromJSON BlockConfiguration where
 -- other nodes. Also see 'Pos.NodeConfiguration.ccNetworkDiameter'.
 networkDiameter :: HasBlockConfiguration => Microsecond
 networkDiameter = sec . ccNetworkDiameter $ blockConfiguration
+
+----------------------------------------------------------------------------
+-- Chain quality
+----------------------------------------------------------------------------
+
+-- | If chain quality in bootstrap era is less than this value,
+-- non critical misbehavior will be reported.
+nonCriticalCQBootstrap :: HasBlockConfiguration => Double
+nonCriticalCQBootstrap = ccNonCriticalCQBootstrap blockConfiguration
+
+-- | If chain quality in bootstrap era is less than this value,
+-- critical misbehavior will be reported.
+criticalCQBootstrap :: HasBlockConfiguration => Double
+criticalCQBootstrap = ccCriticalCQBootstrap blockConfiguration
+
+-- | If chain quality after bootstrap era is less than this
+-- value, non critical misbehavior will be reported.
+nonCriticalCQ :: HasBlockConfiguration => Double
+nonCriticalCQ = ccNonCriticalCQ blockConfiguration
+
+-- | If chain quality after bootstrap era is less than this
+-- value, critical misbehavior will be reported.
+criticalCQ :: HasBlockConfiguration => Double
+criticalCQ = ccCriticalCQ blockConfiguration
+
+-- | If chain quality after bootstrap era is less than this
+-- value, critical misbehavior will be reported.
+criticalForkThreshold :: (HasBlockConfiguration, Integral i) => i
+criticalForkThreshold = fromIntegral . ccCriticalForkThreshold $ blockConfiguration
+
+-- | Chain quality will be also calculated for this amount of time.
+fixedTimeCQ :: HasBlockConfiguration => Microsecond
+fixedTimeCQ = convertUnit fixedTimeCQSec
+
+-- | 'fixedTimeCQ' expressed as seconds.
+fixedTimeCQSec :: HasBlockConfiguration => Second
+fixedTimeCQSec = ccFixedTimeCQ blockConfiguration
 
 ----------------------------------------------------------------------------
 -- Other constants

--- a/block/src/Pos/Block/Logic/Util.hs
+++ b/block/src/Pos/Block/Logic/Util.hs
@@ -22,10 +22,11 @@ import qualified Data.List.NonEmpty as NE
 import           Formatting (int, sformat, (%))
 import           System.Wlog (WithLogger)
 
+import           Pos.Block.Configuration (HasBlockConfiguration, fixedTimeCQ)
 import           Pos.Block.Slog.Context (slogGetLastSlots)
 import           Pos.Block.Slog.Types (HasSlogGState)
 import           Pos.Core (BlockCount, FlatSlotId, HeaderHash, Timestamp (..), difficultyL,
-                           fixedTimeCQ, flattenSlotId, headerHash, prevBlockL)
+                           flattenSlotId, headerHash, prevBlockL)
 import           Pos.Core.Block (BlockHeader)
 import           Pos.Core.Configuration (HasConfiguration, blkSecurityParam)
 import qualified Pos.DB.BlockIndex as DB
@@ -133,7 +134,13 @@ calcOverallChainQuality =
 -- restrictive at all.
 -- 3. We are able to determine which slot started 'fixedTimeCQ' ago.
 calcChainQualityFixedTime ::
-       forall ctx m res. (Fractional res, MonadSlots ctx m, HasConfiguration, HasSlogGState ctx)
+       forall ctx m res.
+       ( Fractional res
+       , MonadSlots ctx m
+       , HasConfiguration
+       , HasBlockConfiguration
+       , HasSlogGState ctx
+       )
     => m (Maybe res)
 calcChainQualityFixedTime = do
     Timestamp curTime <- currentTimeSlotting

--- a/block/src/Pos/Block/Network/Logic.hs
+++ b/block/src/Pos/Block/Network/Logic.hs
@@ -29,6 +29,7 @@ import           System.Wlog (logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Txp ()
 import           Pos.Block.BlockWorkMode (BlockInstancesConstraint, BlockWorkMode)
+import           Pos.Block.Configuration (criticalForkThreshold)
 import           Pos.Block.Error (ApplyBlocksException)
 import           Pos.Block.Logic (ClassifyHeaderRes (..), classifyNewHeader, lcaWithMainChain,
                                   verifyAndApplyBlocks)
@@ -40,8 +41,8 @@ import           Pos.Block.Types (Blund, LastKnownHeaderTag)
 import           Pos.Communication.Limits.Types (recvLimited)
 import           Pos.Communication.Protocol (ConversationActions (..), NodeId, OutSpecs, convH,
                                              toOutSpecs)
-import           Pos.Core (HasHeaderHash (..), HeaderHash, criticalForkThreshold, gbHeader,
-                           headerHashG, isMoreDifficult, prevBlockL)
+import           Pos.Core (HasHeaderHash (..), HeaderHash, gbHeader, headerHashG, isMoreDifficult,
+                           prevBlockL)
 import           Pos.Core.Block (Block, BlockHeader, blockHeader)
 import           Pos.Crypto (shortHashF)
 import qualified Pos.DB.Block.Load as DB

--- a/block/src/Pos/Block/Slog/Context.hs
+++ b/block/src/Pos/Block/Slog/Context.hs
@@ -13,9 +13,10 @@ import           Universum
 import           Formatting (int, sformat, (%))
 import qualified System.Metrics as Ekg
 
+import           Pos.Block.Configuration (HasBlockConfiguration, fixedTimeCQSec)
 import           Pos.Block.Slog.Types (HasSlogGState (..), LastBlkSlots, SlogContext (..),
                                        SlogGState (..), sgsLastBlkSlots)
-import           Pos.Core (HasConfiguration, blkSecurityParam, fixedTimeCQSec)
+import           Pos.Core (HasConfiguration, blkSecurityParam)
 import           Pos.DB.Class (MonadDBRead)
 import           Pos.GState.BlockExtra (getLastSlots)
 import           Pos.Reporting (MetricMonitorState, mkMetricMonitorState)
@@ -29,7 +30,7 @@ mkSlogGState = do
 
 -- | Make new 'SlogContext' using data from DB.
 mkSlogContext ::
-    forall m. (MonadIO m, MonadDBRead m, HasConfiguration)
+    forall m. (MonadIO m, MonadDBRead m, HasConfiguration, HasBlockConfiguration)
     => Ekg.Store
     -> m SlogContext
 mkSlogContext store = do

--- a/block/src/Pos/Block/Worker.hs
+++ b/block/src/Pos/Block/Worker.hs
@@ -21,6 +21,8 @@ import           System.Wlog (logDebug, logError, logInfo, logWarning)
 
 import           Pos.Block.BlockWorkMode (BlockWorkMode)
 import           Pos.Block.Configuration (networkDiameter)
+import           Pos.Block.Configuration (HasBlockConfiguration, criticalCQ, criticalCQBootstrap,
+                                          fixedTimeCQSec, nonCriticalCQ, nonCriticalCQBootstrap)
 import           Pos.Block.Logic (calcChainQualityFixedTime, calcChainQualityM,
                                   calcOverallChainQuality, createGenesisBlockAndApply,
                                   createMainBlockAndApply)
@@ -31,14 +33,10 @@ import           Pos.Block.Slog (scCQFixedMonitorState, scCQOverallMonitorState,
                                  scEpochMonitorState, scGlobalSlotMonitorState,
                                  scLocalSlotMonitorState, slogGetLastSlots)
 import           Pos.Communication.Protocol (OutSpecs)
-import           Pos.Core (BlockVersionData (..), ChainDifficulty, FlatSlotId, SlotId (..),
-                           Timestamp (Timestamp), blkSecurityParam, difficultyL, epochOrSlotToSlot,
-                           epochSlots, fixedTimeCQSec, flattenSlotId, gbHeader, getEpochOrSlot,
-                           getSlotIndex, slotIdF, unflattenSlotId)
-import           Pos.Core.Common (addressHash)
-import           Pos.Core.Configuration (HasConfiguration, criticalCQ, criticalCQBootstrap,
-                                         nonCriticalCQ, nonCriticalCQBootstrap)
-import           Pos.Core.Context (getOurPublicKey)
+import           Pos.Core (BlockVersionData (..), ChainDifficulty, FlatSlotId, HasConfiguration,
+                           SlotId (..), Timestamp (Timestamp), addressHash, blkSecurityParam,
+                           difficultyL, epochOrSlotToSlot, epochSlots, flattenSlotId, gbHeader,
+                           getEpochOrSlot, getOurPublicKey, getSlotIndex, slotIdF, unflattenSlotId)
 import           Pos.Crypto (ProxySecretKey (pskDelegatePk))
 import           Pos.DB (gsIsBootstrapEra)
 import qualified Pos.DB.BlockIndex as DB
@@ -376,7 +374,7 @@ chainQualityChecker curSlot kThSlot = do
 
 -- Monitor for chain quality for last k blocks.
 cqkMetricMonitor ::
-       HasConfiguration
+       (HasBlockConfiguration, HasConfiguration)
     => MetricMonitorState Double
     -> Bool
     -> MetricMonitor Double
@@ -416,7 +414,10 @@ cqOverallMetricMonitor = noReportMonitor convertCQ (Just debugFormat)
   where
     debugFormat = "Overall chain quality is " %cqF
 
-cqFixedMetricMonitor :: HasConfiguration => MetricMonitorState Double -> MetricMonitor Double
+cqFixedMetricMonitor ::
+       HasBlockConfiguration
+    => MetricMonitorState Double
+    -> MetricMonitor Double
 cqFixedMetricMonitor = noReportMonitor convertCQ (Just debugFormat)
   where
     debugFormat =

--- a/core/Pos/Core/Configuration/Core.hs
+++ b/core/Pos/Core/Configuration/Core.hs
@@ -14,20 +14,13 @@ module Pos.Core.Configuration.Core
        , coreConfiguration
        , dbSerializeVersion
        , memPoolLimitTx
-       , nonCriticalCQBootstrap
-       , criticalCQBootstrap
-       , nonCriticalCQ
-       , criticalCQ
-       , criticalForkThreshold
-       , fixedTimeCQ
-       , fixedTimeCQSec
+
 
        ) where
 
 import           Universum
 
 import           Data.Reflection (Given (..), give)
-import           Data.Time.Units (Microsecond, Second, convertUnit)
 
 import           Pos.Binary.Class (Raw)
 import           Pos.Core.Genesis.Types (GenesisSpec (..))
@@ -48,34 +41,13 @@ data GenesisConfiguration
 data CoreConfiguration = CoreConfiguration
     {
       -- | Specifies the genesis
-      ccGenesis                :: !GenesisConfiguration
+      ccGenesis            :: !GenesisConfiguration
 
     , -- | Versioning for values in node's DB
-      ccDbSerializeVersion     :: !Word8
+      ccDbSerializeVersion :: !Word8
       -- | Limint on the number of transactions that can be stored in
       -- the mem pool.
-    , ccMemPoolLimitTx         :: !Int
-
-      -- Chain quality thresholds and other constants to detect
-      -- suspicious things.
-
-      -- | If chain quality in bootstrap era is less than this value,
-      -- non critical misbehavior will be reported.
-    , ccNonCriticalCQBootstrap :: !Double
-      -- | If chain quality in bootstrap era is less than this value,
-      -- critical misbehavior will be reported.
-    , ccCriticalCQBootstrap    :: !Double
-      -- | If chain quality after bootstrap era is less than this
-      -- value, non critical misbehavior will be reported.
-    , ccNonCriticalCQ          :: !Double
-      -- | If chain quality after bootstrap era is less than this
-      -- value, critical misbehavior will be reported.
-    , ccCriticalCQ             :: !Double
-      -- | Number of blocks such that if so many blocks are rolled
-      -- back, it requires immediate reaction.
-    , ccCriticalForkThreshold  :: !Int
-      -- | Chain quality will be also calculated for this amount of seconds.
-    , ccFixedTimeCQ            :: !Second
+    , ccMemPoolLimitTx     :: !Int
 
     }
     deriving (Show, Generic)
@@ -97,36 +69,3 @@ dbSerializeVersion = fromIntegral . ccDbSerializeVersion $ coreConfiguration
 -- the mem pool.
 memPoolLimitTx :: (HasCoreConfiguration, Integral i) => i
 memPoolLimitTx = fromIntegral . ccMemPoolLimitTx $ coreConfiguration
-
--- | If chain quality in bootstrap era is less than this value,
--- non critical misbehavior will be reported.
-nonCriticalCQBootstrap :: HasCoreConfiguration => Double
-nonCriticalCQBootstrap = ccNonCriticalCQBootstrap coreConfiguration
-
--- | If chain quality in bootstrap era is less than this value,
--- critical misbehavior will be reported.
-criticalCQBootstrap :: HasCoreConfiguration => Double
-criticalCQBootstrap = ccCriticalCQBootstrap coreConfiguration
-
--- | If chain quality after bootstrap era is less than this
--- value, non critical misbehavior will be reported.
-nonCriticalCQ :: HasCoreConfiguration => Double
-nonCriticalCQ = ccNonCriticalCQ coreConfiguration
-
--- | If chain quality after bootstrap era is less than this
--- value, critical misbehavior will be reported.
-criticalCQ :: HasCoreConfiguration => Double
-criticalCQ = ccCriticalCQ coreConfiguration
-
--- | If chain quality after bootstrap era is less than this
--- value, critical misbehavior will be reported.
-criticalForkThreshold :: (HasCoreConfiguration, Integral i) => i
-criticalForkThreshold = fromIntegral . ccCriticalForkThreshold $ coreConfiguration
-
--- | Chain quality will be also calculated for this amount of time.
-fixedTimeCQ :: HasCoreConfiguration => Microsecond
-fixedTimeCQ = convertUnit fixedTimeCQSec
-
--- | 'fixedTimeCQ' expressed as seconds.
-fixedTimeCQSec :: HasCoreConfiguration => Second
-fixedTimeCQSec = ccFixedTimeCQ coreConfiguration

--- a/core/Pos/Core/Configuration/Core.hs
+++ b/core/Pos/Core/Configuration/Core.hs
@@ -13,9 +13,6 @@ module Pos.Core.Configuration.Core
 
        , coreConfiguration
        , dbSerializeVersion
-       , memPoolLimitTx
-
-
        ) where
 
 import           Universum
@@ -43,11 +40,8 @@ data CoreConfiguration = CoreConfiguration
       -- | Specifies the genesis
       ccGenesis            :: !GenesisConfiguration
 
-    , -- | Versioning for values in node's DB
-      ccDbSerializeVersion :: !Word8
-      -- | Limint on the number of transactions that can be stored in
-      -- the mem pool.
-    , ccMemPoolLimitTx     :: !Int
+      -- | Versioning for values in node's DB
+    , ccDbSerializeVersion :: !Word8
 
     }
     deriving (Show, Generic)
@@ -64,8 +58,3 @@ coreConfiguration = given
 -- with this constant.
 dbSerializeVersion :: HasCoreConfiguration => Word8
 dbSerializeVersion = fromIntegral . ccDbSerializeVersion $ coreConfiguration
-
--- | Limint on the number of transactions that can be stored in
--- the mem pool.
-memPoolLimitTx :: (HasCoreConfiguration, Integral i) => i
-memPoolLimitTx = fromIntegral . ccMemPoolLimitTx $ coreConfiguration

--- a/core/Pos/Core/Configuration/Core.hs
+++ b/core/Pos/Core/Configuration/Core.hs
@@ -21,7 +21,6 @@ module Pos.Core.Configuration.Core
        , criticalForkThreshold
        , fixedTimeCQ
        , fixedTimeCQSec
-       , webLoggingEnabled
 
        ) where
 
@@ -78,11 +77,6 @@ data CoreConfiguration = CoreConfiguration
       -- | Chain quality will be also calculated for this amount of seconds.
     , ccFixedTimeCQ            :: !Second
 
-      -- Web settings
-
-      -- | Whether incoming requests logging should be performed by web
-      -- part
-    , ccWebLoggingEnabled      :: !Bool
     }
     deriving (Show, Generic)
 
@@ -136,7 +130,3 @@ fixedTimeCQ = convertUnit fixedTimeCQSec
 -- | 'fixedTimeCQ' expressed as seconds.
 fixedTimeCQSec :: HasCoreConfiguration => Second
 fixedTimeCQSec = ccFixedTimeCQ coreConfiguration
-
--- | Web logging might be disabled for security concerns.
-webLoggingEnabled :: HasCoreConfiguration => Bool
-webLoggingEnabled = ccWebLoggingEnabled coreConfiguration

--- a/explorer/src/Pos/Explorer/Web/Transform.hs
+++ b/explorer/src/Pos/Explorer/Web/Transform.hs
@@ -28,11 +28,11 @@ import           Pos.Diffusion.Types (Diffusion)
 import           Pos.Infra.Configuration (HasInfraConfiguration)
 import           Pos.Recovery ()
 import           Pos.Ssc.Configuration (HasSscConfiguration)
-import           Pos.Txp (MempoolExt, MonadTxpLocal (..))
+import           Pos.Txp (HasTxpConfiguration, MempoolExt, MonadTxpLocal (..))
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Util.CompileInfo (HasCompileInfo)
-import           Pos.WorkMode (RealMode, RealModeContext (..))
 import           Pos.Worker.Types (WorkerSpec, worker)
+import           Pos.WorkMode (RealMode, RealModeContext (..))
 
 import           Pos.Explorer.BListener (ExplorerBListener, runExplorerBListener)
 import           Pos.Explorer.ExtraContext (ExtraContext, ExtraContextT, makeExtraCtx,
@@ -51,12 +51,12 @@ type ExplorerProd = ExtraContextT (ExplorerBListener RealModeE)
 
 type instance MempoolExt ExplorerProd = ExplorerExtra
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) =>
+instance (HasConfiguration, HasInfraConfiguration, HasTxpConfiguration, HasCompileInfo) =>
          MonadTxpLocal RealModeE where
     txpNormalize = eTxNormalize
     txpProcessTx = eTxProcessTransaction
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) =>
+instance (HasConfiguration, HasInfraConfiguration, HasTxpConfiguration, HasCompileInfo) =>
          MonadTxpLocal ExplorerProd where
     txpNormalize = lift $ lift txpNormalize
     txpProcessTx = lift . lift . txpProcessTx

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -59,7 +59,6 @@ dev: &dev
         avvmDistr: {}
 
     dbSerializeVersion: 0
-    memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
   infra: &dev_infra
 
@@ -93,6 +92,9 @@ dev: &dev
     mpcSendInterval: 10 # must be less than (2 * k * slotDuration - networkDiameter)
     mdNoCommitmentsEpochThreshold: 3
     noReportNoSecretsForEpoch1: False
+
+  txp: &dev_txp
+    memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
   dlg: &dev_dlg
     dlgCacheParam: 500
@@ -248,7 +250,6 @@ mainnet_base: &mainnet_base
         avvmDistr: {}
 
     dbSerializeVersion: 0
-    memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
   infra:
 
@@ -282,6 +283,9 @@ mainnet_base: &mainnet_base
     mpcSendInterval: 100 # must be less than (2 * k * slotDuration - networkDiameter)
     mdNoCommitmentsEpochThreshold: 3
     noReportNoSecretsForEpoch1: True
+
+  txp: &mainnet_base_txp
+    memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
   dlg: &mainnet_base_dlg
     dlgCacheParam: 500

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -118,7 +118,6 @@ dev: &dev
     networkConnectionTimeout: 15000 # ms
     conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100
-    propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
     walletProductionApi: false
     walletTxCreationDisabled: false
@@ -308,7 +307,6 @@ mainnet_base: &mainnet_base
     networkConnectionTimeout: 15000
     conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100
-    propagationQueueSize: 100
     pendingTxResubmissionPeriod: 7 # seconds
     walletProductionApi: true
     walletTxCreationDisabled: false

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -70,8 +70,6 @@ dev: &dev
                              # rolled back, it requires immediate response
     fixedTimeCQ: 10 # Chain quality will be also calculated for this amount
                     # of seconds.
-    # Mode-sensitive logging options
-    webLoggingEnabled: true
 
   infra: &dev_infra
 
@@ -260,9 +258,7 @@ mainnet_base: &mainnet_base
     criticalForkThreshold: 3 # number of blocks such that if so many blocks are
                              # rolled back, it requires immediate response
     fixedTimeCQ: 3600 # Chain quality will be also calculated for this amount
-                    # of seconds.
-    # Mode-sensitive logging options
-    webLoggingEnabled: true
+                      # of seconds.
 
   infra:
 

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -115,7 +115,6 @@ dev: &dev
                     # of seconds.
 
   node: &dev_node
-    defaultPeers: []
     networkConnectionTimeout: 15000 # ms
     conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100
@@ -306,7 +305,6 @@ mainnet_base: &mainnet_base
                       # of seconds.
 
   node: &mainnet_base_node
-    defaultPeers: []
     networkConnectionTimeout: 15000
     conversationEstablishTimeout: 30000
     blockRetrievalQueueSize: 100

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -61,16 +61,6 @@ dev: &dev
     dbSerializeVersion: 0
     memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
-    # Chain quality thresholds and other constants to detect suspicious things
-    nonCriticalCQBootstrap: 0.95
-    criticalCQBootstrap: 0.8888
-    nonCriticalCQ: 0.8
-    criticalCQ: 0.654321
-    criticalForkThreshold: 2 # number of blocks such that if so many blocks are
-                             # rolled back, it requires immediate response
-    fixedTimeCQ: 10 # Chain quality will be also calculated for this amount
-                    # of seconds.
-
   infra: &dev_infra
 
     # NTP slotting
@@ -111,6 +101,16 @@ dev: &dev
   block: &dev_block
     networkDiameter: 3
     recoveryHeadersMessage: 20 # should be greater than k
+
+    # Chain quality thresholds and other constants to detect suspicious things
+    nonCriticalCQBootstrap: 0.95
+    criticalCQBootstrap: 0.8888
+    nonCriticalCQ: 0.8
+    criticalCQ: 0.654321
+    criticalForkThreshold: 2 # number of blocks such that if so many blocks are
+                             # rolled back, it requires immediate response
+    fixedTimeCQ: 10 # Chain quality will be also calculated for this amount
+                    # of seconds.
 
   node: &dev_node
     defaultPeers: []
@@ -250,16 +250,6 @@ mainnet_base: &mainnet_base
     dbSerializeVersion: 0
     memPoolLimitTx: 200 # mem pool will be limited to this many transactions
 
-    # Chain quality thresholds and other constants to detect suspicious things
-    nonCriticalCQBootstrap: 0.95
-    criticalCQBootstrap: 0.8888
-    nonCriticalCQ: 0.8
-    criticalCQ: 0.654321
-    criticalForkThreshold: 3 # number of blocks such that if so many blocks are
-                             # rolled back, it requires immediate response
-    fixedTimeCQ: 3600 # Chain quality will be also calculated for this amount
-                      # of seconds.
-
   infra:
 
     # NTP slotting
@@ -300,6 +290,16 @@ mainnet_base: &mainnet_base
   block: &mainnet_base_block
     networkDiameter: 18
     recoveryHeadersMessage: 2200 # should be greater than k
+
+    # Chain quality thresholds and other constants to detect suspicious things
+    nonCriticalCQBootstrap: 0.95
+    criticalCQBootstrap: 0.8888
+    nonCriticalCQ: 0.8
+    criticalCQ: 0.654321
+    criticalForkThreshold: 3 # number of blocks such that if so many blocks are
+                             # rolled back, it requires immediate response
+    fixedTimeCQ: 3600 # Chain quality will be also calculated for this amount
+                      # of seconds.
 
   node: &mainnet_base_node
     defaultPeers: []

--- a/lib/src/Pos/Client/CLI/Util.hs
+++ b/lib/src/Pos/Client/CLI/Util.hs
@@ -39,6 +39,7 @@ import           Pos.Infra.Configuration (infraConfiguration)
 import           Pos.Launcher.Configuration (Configuration (..), HasConfigurations)
 import           Pos.Security.Params (AttackTarget (..), AttackType (..))
 import           Pos.Ssc.Configuration (sscConfiguration)
+import           Pos.Txp.Configuration (txpConfiguration)
 import           Pos.Update.Configuration (updateConfiguration)
 import           Pos.Util.AssertMode (inAssertMode)
 import           Pos.Util.TimeWarp (addrParser)
@@ -110,6 +111,7 @@ dumpConfiguration = do
             , ccUpdate = updateConfiguration
             , ccSsc = sscConfiguration
             , ccDlg = dlgConfiguration
+            , ccTxp = txpConfiguration
             , ccBlock = blockConfiguration
             , ccNode = nodeConfiguration
             }

--- a/lib/src/Pos/Configuration.hs
+++ b/lib/src/Pos/Configuration.hs
@@ -13,7 +13,6 @@ module Pos.Configuration
        , conversationEstablishTimeout
        , blockRetrievalQueueSize
        , propagationQueueSize
-       , defaultPeers
 
        -- * Wallet constants
        , pendingTxResubmitionPeriod
@@ -28,9 +27,6 @@ import           Data.Reflection (Given (..), give)
 import           Data.Time.Units (Microsecond, Second)
 import           Serokell.Aeson.Options (defaultOptions)
 import           Serokell.Util (ms)
-import qualified Text.Parsec as P
-
-import           Pos.Util.TimeWarp (NetworkAddress, addrParser)
 
 type HasNodeConfiguration = Given NodeConfiguration
 
@@ -43,9 +39,7 @@ withNodeConfiguration = give
 -- | Top-level node configuration. See example in /configuration.yaml/ file.
 data NodeConfiguration = NodeConfiguration
     {
-      ccDefaultPeers                 :: ![Text]
-      -- ^ List of default peers
-    , ccNetworkConnectionTimeout     :: !Int
+      ccNetworkConnectionTimeout     :: !Int
       -- ^ Network connection timeout in milliseconds
     , ccConversationEstablishTimeout :: !Int
       -- ^ Conversation acknowledgement timeout in milliseconds.
@@ -87,16 +81,6 @@ blockRetrievalQueueSize =
 propagationQueueSize :: (HasNodeConfiguration, Integral a) => a
 propagationQueueSize =
     fromIntegral $ ccPropagationQueueSize $ nodeConfiguration
-
--- | See 'Pos.NodeConfiguration.ccDefaultPeers'.
-defaultPeers :: HasNodeConfiguration => [NetworkAddress]
-defaultPeers = map parsePeer . ccDefaultPeers $ nodeConfiguration
-  where
-    parsePeer :: Text -> NetworkAddress
-    parsePeer =
-        either (error . show) identity .
-        P.parse addrParser "Compile time config"
-
 
 ----------------------------------------------------------------------------
 -- Wallet parameters

--- a/lib/src/Pos/Configuration.hs
+++ b/lib/src/Pos/Configuration.hs
@@ -12,7 +12,6 @@ module Pos.Configuration
        , networkConnectionTimeout
        , conversationEstablishTimeout
        , blockRetrievalQueueSize
-       , propagationQueueSize
 
        -- * Wallet constants
        , pendingTxResubmitionPeriod
@@ -46,8 +45,6 @@ data NodeConfiguration = NodeConfiguration
       -- Default 30 seconds.
     , ccBlockRetrievalQueueSize      :: !Int
       -- ^ Block retrieval queue capacity
-    , ccPropagationQueueSize         :: !Int
-      -- ^ InvMsg propagation queue capacity
     , ccPendingTxResubmissionPeriod  :: !Int
       -- ^ Minimal delay between pending transactions resubmission
     , ccWalletProductionApi          :: !Bool
@@ -77,10 +74,6 @@ conversationEstablishTimeout = ms . fromIntegral . ccConversationEstablishTimeou
 blockRetrievalQueueSize :: (HasNodeConfiguration, Integral a) => a
 blockRetrievalQueueSize =
     fromIntegral . ccBlockRetrievalQueueSize $ nodeConfiguration
-
-propagationQueueSize :: (HasNodeConfiguration, Integral a) => a
-propagationQueueSize =
-    fromIntegral $ ccPropagationQueueSize $ nodeConfiguration
 
 ----------------------------------------------------------------------------
 -- Wallet parameters

--- a/lib/src/Pos/Launcher/Configuration.hs
+++ b/lib/src/Pos/Launcher/Configuration.hs
@@ -27,17 +27,17 @@ import           System.Wlog (WithLogger, logInfo)
 -- FIXME consistency on the locus of the JSON instances for configuration.
 -- Core keeps them separate, infra update and ssc define them on-site.
 import           Pos.Aeson.Core.Configuration ()
+import           Pos.Core.Slotting (Timestamp (..))
+import           Pos.Util.Config (parseYamlConfig)
 
 import           Pos.Block.Configuration
-import           Pos.Configuration (HasNodeConfiguration, NodeConfiguration (..),
-                                    withNodeConfiguration)
+import           Pos.Configuration
 import           Pos.Core.Configuration
-import           Pos.Core.Slotting (Timestamp (..))
 import           Pos.Delegation.Configuration
 import           Pos.Infra.Configuration
 import           Pos.Ssc.Configuration
+import           Pos.Txp.Configuration
 import           Pos.Update.Configuration
-import           Pos.Util.Config (parseYamlConfig)
 
 -- | Product of all configurations required to run a node.
 data Configuration = Configuration
@@ -46,6 +46,7 @@ data Configuration = Configuration
     , ccUpdate :: !UpdateConfiguration
     , ccSsc    :: !SscConfiguration
     , ccDlg    :: !DlgConfiguration
+    , ccTxp    :: !TxpConfiguration
     , ccBlock  :: !BlockConfiguration
     , ccNode   :: !NodeConfiguration
     } deriving (Show, Generic)
@@ -62,6 +63,7 @@ type HasConfigurations =
     , HasUpdateConfiguration
     , HasSscConfiguration
     , HasBlockConfiguration
+    , HasTxpConfiguration
     , HasDlgConfiguration
     , HasNodeConfiguration
     )
@@ -115,5 +117,6 @@ withConfigurations co@ConfigurationOptions{..} act = do
         withUpdateConfiguration ccUpdate $
         withSscConfiguration ccSsc $
         withDlgConfiguration ccDlg $
+        withTxpConfiguration ccTxp $
         withBlockConfiguration ccBlock $
         withNodeConfiguration ccNode $ act

--- a/lib/src/Pos/Launcher/Resource.hs
+++ b/lib/src/Pos/Launcher/Resource.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP            #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE Rank2Types     #-}
 {-# LANGUAGE TypeOperators  #-}
-{-# LANGUAGE KindSignatures #-}
 
 -- | Resources used by node and ways to deal with them.
 
@@ -27,11 +27,12 @@ import           Formatting (sformat, shown, (%))
 import           Mockable (Production (..))
 import           System.IO (BufferMode (..), Handle, hClose, hSetBuffering)
 import qualified System.Metrics as Metrics
-import           System.Wlog (LoggerConfig (..), WithLogger, consoleActionB,
-                              defaultHandleAction, logDebug, logInfo, maybeLogsDirB,
-                              productionB, removeAllHandlers, setupLogging, showTidB)
+import           System.Wlog (LoggerConfig (..), WithLogger, consoleActionB, defaultHandleAction,
+                              logDebug, logInfo, maybeLogsDirB, productionB, removeAllHandlers,
+                              setupLogging, showTidB)
 
 import           Pos.Binary ()
+import           Pos.Block.Configuration (HasBlockConfiguration)
 import           Pos.Block.Slog (mkSlogContext)
 import           Pos.Client.CLI.Util (readLoggerConfig)
 import           Pos.Configuration
@@ -97,6 +98,7 @@ allocateNodeResources
        , HasInfraConfiguration
        , HasSscConfiguration
        , HasDlgConfiguration
+       , HasBlockConfiguration
        )
     => NetworkConfig KademliaParams
     -> NodeParams
@@ -185,6 +187,7 @@ bracketNodeResources :: forall ext a.
       , HasInfraConfiguration
       , HasSscConfiguration
       , HasDlgConfiguration
+      , HasBlockConfiguration
       )
     => NodeParams
     -> SscParams
@@ -243,7 +246,7 @@ data AllocateNodeContextData ext = AllocateNodeContextData
 
 allocateNodeContext
     :: forall ext .
-      (HasConfiguration, HasNodeConfiguration, HasInfraConfiguration)
+      (HasConfiguration, HasNodeConfiguration, HasInfraConfiguration, HasBlockConfiguration)
     => AllocateNodeContextData ext
     -> TxpGlobalSettings
     -> Metrics.Store

--- a/lib/src/Pos/WorkMode.hs
+++ b/lib/src/Pos/WorkMode.hs
@@ -47,8 +47,8 @@ import           Pos.Slotting.Impl.Sum (currentTimeSlottingSum, getCurrentSlotBl
 import           Pos.Slotting.MemState (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Ssc.Mem (SscMemTag)
 import           Pos.Ssc.Types (SscState)
-import           Pos.Txp (GenericTxpLocalData, MempoolExt, MonadTxpLocal (..), TxpHolderTag,
-                          txNormalize, txProcessTransaction)
+import           Pos.Txp (GenericTxpLocalData, HasTxpConfiguration, MempoolExt, MonadTxpLocal (..),
+                          TxpHolderTag, txNormalize, txProcessTransaction)
 import           Pos.Util.CompileInfo (HasCompileInfo)
 import           Pos.Util.JsonLog (HasJsonLogConfig (..), JsonLogConfig, jsonLogDefault)
 import           Pos.Util.Lens (postfixLFields)
@@ -175,7 +175,7 @@ instance MonadFormatPeers (RealMode ext) where
 
 type instance MempoolExt (RealMode ext) = ext
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) =>
+instance (HasConfiguration, HasInfraConfiguration, HasTxpConfiguration, HasCompileInfo) =>
          MonadTxpLocal (RealMode ()) where
     txpNormalize = txNormalize
     txpProcessTx = txProcessTransaction

--- a/lib/src/Test/Pos/Configuration.hs
+++ b/lib/src/Test/Pos/Configuration.hs
@@ -31,6 +31,7 @@ import           Pos.Delegation (HasDlgConfiguration, withDlgConfiguration)
 import           Pos.Infra.Configuration (HasInfraConfiguration, withInfraConfiguration)
 import           Pos.Launcher.Configuration (Configuration (..), HasConfigurations)
 import           Pos.Ssc.Configuration (HasSscConfiguration, withSscConfiguration)
+import           Pos.Txp (HasTxpConfiguration, withTxpConfiguration)
 import           Pos.Update.Configuration (HasUpdateConfiguration, withUpdateConfiguration)
 import           Pos.Util.Config (embedYamlConfigCT)
 
@@ -62,6 +63,7 @@ type HasStaticConfigurations =
     , HasBlockConfiguration
     , HasNodeConfiguration
     , HasDlgConfiguration
+    , HasTxpConfiguration
     )
 
 withDefNodeConfiguration :: (HasNodeConfiguration => r) -> r
@@ -82,6 +84,9 @@ withDefBlockConfiguration = withBlockConfiguration (ccBlock defaultTestConf)
 withDefDlgConfiguration :: (HasDlgConfiguration => r) -> r
 withDefDlgConfiguration = withDlgConfiguration (ccDlg defaultTestConf)
 
+withDefTxpConfiguration :: (HasTxpConfiguration => r) -> r
+withDefTxpConfiguration = withTxpConfiguration (ccTxp defaultTestConf)
+
 withDefConfiguration :: (HasConfiguration => r) -> r
 withDefConfiguration = withGenesisSpec 0 (ccCore defaultTestConf)
 
@@ -92,6 +97,7 @@ withStaticConfigurations patak =
     withDefUpdateConfiguration $
     withDefBlockConfiguration $
     withDefDlgConfiguration $
+    withDefTxpConfiguration $
     withDefInfraConfiguration patak
 
 withDefConfigurations :: (HasConfigurations => r) -> r

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7526,9 +7526,10 @@ inherit (pkgs) mesa;};
          , containers, cpphs, data-default, ekg-core, ether, exceptions, fmt
          , formatting, generic-arbitrary, hashable, lens, log-warper, memory
          , mmorph, mtl, neat-interpolation, plutus-prototype, QuickCheck
-         , resourcet, rocksdb-haskell-ng, safe-exceptions, serokell-util
-         , stdenv, stm, tagged, template-haskell, text, text-format
-         , transformers, universum, unliftio, unordered-containers, vector
+         , reflection, resourcet, rocksdb-haskell-ng, safe-exceptions
+         , serokell-util, stdenv, stm, tagged, template-haskell, text
+         , text-format, transformers, universum, unliftio
+         , unordered-containers, vector
          }:
          mkDerivation {
            pname = "cardano-sl-txp";
@@ -7540,7 +7541,7 @@ inherit (pkgs) mesa;};
              cardano-sl-networking cardano-sl-util conduit containers
              data-default ekg-core ether exceptions fmt formatting
              generic-arbitrary hashable lens log-warper memory mmorph mtl
-             neat-interpolation plutus-prototype QuickCheck resourcet
+             neat-interpolation plutus-prototype QuickCheck reflection resourcet
              rocksdb-haskell-ng safe-exceptions serokell-util stm tagged
              template-haskell text text-format transformers universum unliftio
              unordered-containers vector

--- a/txp/Pos/Txp.hs
+++ b/txp/Pos/Txp.hs
@@ -3,6 +3,7 @@
 module Pos.Txp
        ( module Pos.Core.Txp
        , module Pos.Txp.Base
+       , module Pos.Txp.Configuration
        , module Pos.Txp.Error
        , module Pos.Txp.Logic
        , module Pos.Txp.MemState
@@ -18,6 +19,7 @@ import           Pos.Arbitrary.Txp.Network ()
 import           Pos.Binary.Txp ()
 import           Pos.Core.Txp
 import           Pos.Txp.Base
+import           Pos.Txp.Configuration
 import           Pos.Txp.Error
 import           Pos.Txp.GenesisUtxo
 import           Pos.Txp.Logic

--- a/txp/Pos/Txp/Configuration.hs
+++ b/txp/Pos/Txp/Configuration.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Configuration for the txp package.
+
+module Pos.Txp.Configuration
+       ( HasTxpConfiguration
+       , withTxpConfiguration
+       , txpConfiguration
+       , TxpConfiguration(..)
+       , memPoolLimitTx
+       ) where
+
+import           Universum
+
+import           Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
+import           Data.Reflection (Given (..), give)
+import           Serokell.Aeson.Options (defaultOptions)
+
+
+type HasTxpConfiguration = Given TxpConfiguration
+
+withTxpConfiguration :: TxpConfiguration -> (HasTxpConfiguration => r) -> r
+withTxpConfiguration = give
+
+txpConfiguration :: HasTxpConfiguration => TxpConfiguration
+txpConfiguration = given
+
+-- | Delegation configruation part.
+data TxpConfiguration = TxpConfiguration
+    { -- | Limit on the number of transactions that can be stored in
+      -- the mem pool.
+      ccMemPoolLimitTx     :: !Int
+    } deriving (Eq,Show,Generic)
+
+instance ToJSON TxpConfiguration where
+    toJSON = genericToJSON defaultOptions
+
+instance FromJSON TxpConfiguration where
+    parseJSON = genericParseJSON defaultOptions
+
+----------------------------------------------------------------------------
+-- Constants
+----------------------------------------------------------------------------
+
+-- | Limint on the number of transactions that can be stored in
+-- the mem pool.
+memPoolLimitTx :: (HasTxpConfiguration, Integral i) => i
+memPoolLimitTx = fromIntegral . ccMemPoolLimitTx $ txpConfiguration

--- a/txp/Pos/Txp/MemState/Class.hs
+++ b/txp/Pos/Txp/MemState/Class.hs
@@ -36,6 +36,7 @@ import           Pos.Core.Txp (TxAux, TxId, TxUndo)
 import           Pos.DB.Class (MonadDBRead, MonadGState (..))
 import           Pos.Reporting (MonadReporting)
 import           Pos.Slotting (MonadSlots (..))
+import           Pos.Txp.Configuration (HasTxpConfiguration)
 import           Pos.Txp.MemState.Types (GenericTxpLocalData (..), GenericTxpLocalDataPure)
 import           Pos.Txp.Toil.Failure (ToilVerFailure)
 import           Pos.Txp.Toil.Types (MemPool (..), UtxoModifier)
@@ -146,4 +147,5 @@ type TxpLocalWorkMode ctx m =
     , MonadMask m
     , MonadReporting ctx m
     , HasConfiguration
+    , HasTxpConfiguration
     )

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -31,11 +31,11 @@ import           Pos.Core (AddrAttributes (..), AddrStakeDistribution (..), Addr
                            isRedeemAddress)
 import           Pos.Core.Common (integerToCoin)
 import qualified Pos.Core.Common as Fee (TxFeePolicy (..), calculateTxSizeLinear)
-import           Pos.Core.Configuration (HasConfiguration, memPoolLimitTx)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxOut (..), TxUndo, TxpUndo, toaOut,
                                txInputs, txOutAddress)
 import           Pos.Crypto (WithHash (..), hash)
 import           Pos.DB.Class (MonadGState (..), gsIsBootstrapEra)
+import           Pos.Txp.Configuration (HasTxpConfiguration, memPoolLimitTx)
 import           Pos.Txp.Toil.Class (MonadStakes (..), MonadTxPool (..), MonadUtxo (..),
                                      MonadUtxoRead (..))
 import           Pos.Txp.Toil.Failure (ToilVerFailure (..))
@@ -104,7 +104,7 @@ type LocalToilMode m =
     , MonadGState m
     , MonadTxPool m
     , WithLogger m
-    , HasConfiguration
+    , HasTxpConfiguration
     )
 
 -- CHECK: @processTx

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -19,6 +19,8 @@ library
     Pos.Txp.DB.Stakes
     Pos.Txp.DB.Utxo
 
+    Pos.Txp.Configuration
+
     Pos.Txp.GenesisUtxo
     Pos.Txp.Toil
     Pos.Txp.Toil.Stakes
@@ -99,6 +101,7 @@ library
                      , safe-exceptions
                      , serokell-util
                      , stm
+                     , reflection
                      , tagged
                      , template-haskell
                      , text

--- a/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-module Cardano.Wallet.Kernel.Mode (
-    WalletMode
-  , WalletContext -- opaque
-  , runWalletMode
-  , getWallet
-  ) where
+module Cardano.Wallet.Kernel.Mode
+    ( WalletMode
+    , WalletContext -- opaque
+    , runWalletMode
+    , getWallet
+    ) where
 
 import           Control.Lens (makeLensesWith)
 import qualified Control.Monad.Reader as Mtl
@@ -27,6 +27,7 @@ import           Pos.Network.Types
 import           Pos.Reporting
 import           Pos.Shutdown
 import           Pos.Slotting
+import           Pos.Txp.Configuration
 import           Pos.Txp.Logic
 import           Pos.Txp.MemState
 import           Pos.Util
@@ -208,7 +209,7 @@ instance MonadFormatPeers WalletMode where
 instance {-# OVERLAPPING #-} CanJsonLog WalletMode where
   jsonLog = jsonLogDefault
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo)
+instance (HasConfiguration, HasInfraConfiguration, HasTxpConfiguration, HasCompileInfo)
       => MonadTxpLocal WalletMode where
   txpNormalize = txNormalize
   txpProcessTx = txProcessTransaction

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -65,8 +65,8 @@ import           Pos.Slotting.MemState (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Ssc (HasSscConfiguration)
 import           Pos.Ssc.Types (HasSscContext (..))
 import           Pos.StateLock (StateLock)
-import           Pos.Txp (MempoolExt, MonadTxpLocal (..), MonadTxpMem, Utxo, addrBelongsToSet,
-                          applyUtxoModToAddrCoinMap, getUtxoModifier)
+import           Pos.Txp (HasTxpConfiguration, MempoolExt, MonadTxpLocal (..), MonadTxpMem, Utxo,
+                          addrBelongsToSet, applyUtxoModToAddrCoinMap, getUtxoModifier)
 import qualified Pos.Txp.DB as DB
 import           Pos.Util (postfixLFields)
 import           Pos.Util.CompileInfo (HasCompileInfo)
@@ -310,7 +310,7 @@ instance HasConfiguration => MonadBalances WalletWebMode where
     getOwnUtxos = getOwnUtxosDefault
     getBalance = getBalanceDefault
 
-instance (HasConfiguration, HasSscConfiguration, HasInfraConfiguration, HasCompileInfo)
+instance (HasConfiguration, HasSscConfiguration, HasTxpConfiguration, HasInfraConfiguration, HasCompileInfo)
         => MonadTxHistory WalletWebMode where
     getBlockHistory = getBlockHistoryDefault
     getLocalHistory = getLocalHistoryDefault
@@ -322,7 +322,7 @@ instance MonadFormatPeers WalletWebMode where
 
 type instance MempoolExt WalletWebMode = WalletMempoolExt
 
-instance (HasConfiguration, HasInfraConfiguration, HasCompileInfo) =>
+instance (HasConfiguration, HasInfraConfiguration, HasTxpConfiguration, HasCompileInfo) =>
          MonadTxpLocal WalletWebMode where
     txpNormalize = txpNormalizeWebWallet
     txpProcessTx = txpProcessTxWebWallet


### PR DESCRIPTION
Some options were misplaced, some were obsolete. I recommend reviewing per-commit.

@avieth do you know anything about why `propagationQueueSize` and `defaultPeers` are unused? Is it a bug? 