### PR TITLE
[CSL-2317] Add update emulation

### DIFF
--- a/auxx/Main.hs
+++ b/auxx/Main.hs
@@ -100,7 +100,7 @@ action opts@AuxxOptions {..} command = do
       Just Dict -> do
           CLI.printInfoOnStart aoCommonNodeArgs
           (nodeParams, tempDbUsed) <-
-              correctNodeParams opts =<< CLI.getNodeParams loggerName cArgs nArgs
+              correctNodeParams opts =<< CLI.getNodeParams loggerName cArgs
           let
               toRealMode :: AuxxMode a -> RealMode EmptyMempoolExt a
               toRealMode auxxAction = do
@@ -120,8 +120,6 @@ action opts@AuxxOptions {..} command = do
   where
     cArgs@CLI.CommonNodeArgs {..} = aoCommonNodeArgs
     conf = CLI.configurationOptions (CLI.commonArgs cArgs)
-    nArgs =
-        CLI.NodeArgs {behaviorConfigPath = Nothing}
     cmdCtx = CmdCtx {ccPeers = aoPeers}
 
 main :: IO ()

--- a/explorer/src/explorer/Main.hs
+++ b/explorer/src/explorer/Main.hs
@@ -18,7 +18,7 @@ import           System.Wlog (LoggerName, logInfo)
 import           ExplorerNodeOptions (ExplorerArgs (..), ExplorerNodeArgs (..),
                                       getExplorerNodeOptions)
 import           Pos.Binary ()
-import           Pos.Client.CLI (CommonNodeArgs (..), NodeArgs (..), getNodeParams)
+import           Pos.Client.CLI (CommonNodeArgs (..), getNodeParams)
 import qualified Pos.Client.CLI as CLI
 import           Pos.Communication (OutSpecs, WorkerSpec)
 import           Pos.Explorer.DB (explorerInitDB)
@@ -56,7 +56,7 @@ action (ExplorerNodeArgs (cArgs@CommonNodeArgs{..}) ExplorerArgs{..}) =
     withCompileInfo $(retrieveCompileTimeInfo) $ do
         CLI.printInfoOnStart cArgs
         logInfo $ "Explorer is enabled!"
-        currentParams <- getNodeParams loggerName cArgs nodeArgs
+        currentParams <- getNodeParams loggerName cArgs
 
         let vssSK = fromJust $ npUserSecret currentParams ^. usVss
         let sscParams = CLI.gtSscParams cArgs vssSK (npBehaviorConfig currentParams)
@@ -87,6 +87,3 @@ action (ExplorerNodeArgs (cArgs@CommonNodeArgs{..}) ExplorerArgs{..}) =
     runExplorerRealMode nr@NodeResources{..} =
         let extraCtx = makeExtraCtx
         in runRealBasedMode (runExplorerProd extraCtx) liftToExplorerProd nr
-
-    nodeArgs :: NodeArgs
-    nodeArgs = NodeArgs { behaviorConfigPath = Nothing }

--- a/lib/src/Pos/Behavior.hs
+++ b/lib/src/Pos/Behavior.hs
@@ -11,18 +11,21 @@ import           Data.Default (Default (..))
 
 import           Pos.Security.Params (SecurityParams)
 import           Pos.Ssc.Behavior (SscBehavior)
+import           Pos.Update.Behavior (UpdateBehavior)
 
 data BehaviorConfig = BehaviorConfig
     { bcSecurityParams :: !SecurityParams    -- ^ network
     , bcSscBehavior    :: !SscBehavior       -- ^ SSC
+    , bcUpdateBehavior :: !UpdateBehavior    -- ^ Update
     }
     deriving (Eq, Show)
 
 instance Default BehaviorConfig where
-    def = BehaviorConfig def def
+    def = BehaviorConfig def def def
 
 instance A.FromJSON BehaviorConfig where
     parseJSON = A.withObject "BehaviorConfig" $ \o -> do
         bcSecurityParams <- o A..: "networkAttacks"
         bcSscBehavior    <- o A..: "ssc"
+        bcUpdateBehavior <- o A..: "update"
         pure BehaviorConfig{..}

--- a/lib/src/Pos/Client/CLI/NodeOptions.hs
+++ b/lib/src/Pos/Client/CLI/NodeOptions.hs
@@ -7,7 +7,6 @@
 module Pos.Client.CLI.NodeOptions
        ( CommonNodeArgs (..)
        , SimpleNodeArgs (..)
-       , NodeArgs (..)
        , commonNodeArgsParser
        , getSimpleNodeOptions
        , usageExample
@@ -50,6 +49,7 @@ data CommonNodeArgs = CommonNodeArgs
     , statsdParams           :: !(Maybe StatsdParams)
     , cnaDumpGenesisDataPath :: !(Maybe FilePath)
     , cnaDumpConfiguration   :: !Bool
+    , cnaBehaviorConfigPath  :: !(Maybe FilePath)
     } deriving Show
 
 commonNodeArgsParser :: Parser CommonNodeArgs
@@ -107,26 +107,19 @@ commonNodeArgsParser = do
         long "dump-configuration" <>
         help "Dump configuration and exit."
 
+    cnaBehaviorConfigPath <- optional $ strOption $
+        long "behavior" <>
+        metavar "FILE" <>
+        help "Path to the behavior config"
+
     pure CommonNodeArgs{..}
 
-data SimpleNodeArgs = SimpleNodeArgs CommonNodeArgs NodeArgs
-
-data NodeArgs = NodeArgs
-    { behaviorConfigPath :: !(Maybe FilePath)
-    } deriving Show
+newtype SimpleNodeArgs = SimpleNodeArgs CommonNodeArgs
 
 simpleNodeArgsParser :: Parser SimpleNodeArgs
 simpleNodeArgsParser = do
     commonNodeArgs <- commonNodeArgsParser
-    behaviorConfigPath <- behaviorConfigOption
-    pure $ SimpleNodeArgs commonNodeArgs NodeArgs{..}
-
-behaviorConfigOption :: Parser (Maybe FilePath)
-behaviorConfigOption =
-    optional $ strOption $
-        long "behavior" <>
-        metavar "FILE" <>
-        help "Path to the behavior config"
+    pure $ SimpleNodeArgs commonNodeArgs
 
 getSimpleNodeOptions :: HasCompileInfo => IO SimpleNodeArgs
 getSimpleNodeOptions = execParser programInfo

--- a/lib/src/Pos/Client/CLI/Params.hs
+++ b/lib/src/Pos/Client/CLI/Params.hs
@@ -16,7 +16,7 @@ import           Mockable (Fork, Mockable)
 import           System.Wlog (LoggerName, WithLogger)
 
 import           Pos.Behavior (BehaviorConfig (..))
-import           Pos.Client.CLI.NodeOptions (CommonNodeArgs (..), NodeArgs (..))
+import           Pos.Client.CLI.NodeOptions (CommonNodeArgs (..))
 import           Pos.Client.CLI.Options (CommonArgs (..))
 import           Pos.Client.CLI.Secrets (prepareUserSecret)
 import           Pos.Core.Configuration (HasConfiguration)
@@ -66,13 +66,12 @@ getNodeParams ::
        )
     => LoggerName
     -> CommonNodeArgs
-    -> NodeArgs
     -> m NodeParams
-getNodeParams defaultLoggerName cArgs@CommonNodeArgs{..} NodeArgs{..} = do
+getNodeParams defaultLoggerName cArgs@CommonNodeArgs{..} = do
     (primarySK, userSecret) <-
         prepareUserSecret cArgs =<< peekUserSecret (getKeyfilePath cArgs)
     npNetworkConfig <- intNetworkConfigOpts networkConfigOpts
-    npBehaviorConfig <- case behaviorConfigPath of
+    npBehaviorConfig <- case cnaBehaviorConfigPath of
         Nothing -> pure def
         Just fp -> eitherToThrow =<< liftIO (Yaml.decodeFileEither fp)
     pure NodeParams

--- a/lib/src/Pos/Launcher/Param.hs
+++ b/lib/src/Pos/Launcher/Param.hs
@@ -24,6 +24,7 @@ import           Pos.Reporting.MemState (HasReportServers (..))
 import           Pos.Security.Params (SecurityParams)
 import           Pos.Ssc.Behavior (SscBehavior)
 import           Pos.Statistics (EkgParams, StatsdParams)
+import           Pos.Update.Behavior (UpdateBehavior)
 import           Pos.Update.Params (UpdateParams)
 import           Pos.Util.Lens (postfixLFields)
 import           Pos.Util.TimeWarp (NetworkAddress)
@@ -78,6 +79,8 @@ instance HasLens SecurityParams NodeParams SecurityParams where
     lensOf = npBehaviorConfig_L . bcSecurityParams_L
 instance HasLens SscBehavior NodeParams SscBehavior where
     lensOf = npBehaviorConfig_L . bcSscBehavior_L
+instance HasLens UpdateBehavior NodeParams UpdateBehavior where
+    lensOf = npBehaviorConfig_L . bcUpdateBehavior_L
 
 instance HasLens (NetworkConfig KademliaParams) NodeParams (NetworkConfig KademliaParams) where
     lensOf = npNetworkConfig_L

--- a/lib/src/Pos/WorkMode/Class.hs
+++ b/lib/src/Pos/WorkMode/Class.hs
@@ -45,6 +45,7 @@ import           Pos.Ssc (HasSscConfiguration)
 import           Pos.Ssc.Mem (MonadSscMem)
 import           Pos.StateLock (StateLock, StateLockMetrics)
 import           Pos.Txp.MemState (MempoolExt, MonadTxpLocal, MonadTxpMem)
+import           Pos.Update.Behavior (UpdateBehavior)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Update.Context (UpdateContext)
 import           Pos.Update.Params (UpdateParams)
@@ -82,6 +83,7 @@ type WorkMode ctx m
       , HasLens' ctx SecurityParams
       , HasLens' ctx TxpGlobalSettings
       , HasLens' ctx (NetworkConfig KademliaDHTInstance)
+      , HasLens' ctx UpdateBehavior
       , HasLens BlockRetrievalQueueTag ctx BlockRetrievalQueue
       , HasLrcContext ctx
       , HasSscContext ctx

--- a/node/Main.hs
+++ b/node/Main.hs
@@ -15,7 +15,7 @@ import           Mockable (Production, runProduction)
 import           System.Wlog (LoggerName, logInfo)
 
 import           Pos.Binary ()
-import           Pos.Client.CLI (CommonNodeArgs (..), NodeArgs (..), SimpleNodeArgs (..))
+import           Pos.Client.CLI (CommonNodeArgs (..), SimpleNodeArgs (..))
 import qualified Pos.Client.CLI as CLI
 import           Pos.Launcher (HasConfigurations, NodeParams (..), loggerBracket, runNodeReal,
                                withConfigurations)
@@ -44,10 +44,10 @@ action
        )
     => SimpleNodeArgs
     -> Production ()
-action (SimpleNodeArgs (cArgs@CommonNodeArgs {..}) (nArgs@NodeArgs {..})) = do
+action (SimpleNodeArgs (cArgs@CommonNodeArgs {..})) = do
     CLI.printInfoOnStart cArgs
     logInfo "Wallet is disabled, because software is built w/o it"
-    currentParams <- CLI.getNodeParams loggerName cArgs nArgs
+    currentParams <- CLI.getNodeParams loggerName cArgs
 
     let vssSK = fromJust $ npUserSecret currentParams ^. usVss
     let sscParams = CLI.gtSscParams cArgs vssSK (npBehaviorConfig currentParams)
@@ -56,7 +56,7 @@ action (SimpleNodeArgs (cArgs@CommonNodeArgs {..}) (nArgs@NodeArgs {..})) = do
 
 main :: IO ()
 main = withCompileInfo $(retrieveCompileTimeInfo) $ do
-    args@(CLI.SimpleNodeArgs commonNodeArgs _) <- CLI.getSimpleNodeOptions
+    args@(CLI.SimpleNodeArgs commonNodeArgs) <- CLI.getSimpleNodeOptions
     let loggingParams = CLI.loggingParams loggerName commonNodeArgs
     let conf = CLI.configurationOptions (CLI.commonArgs commonNodeArgs)
     loggerBracket loggingParams . logException "node" . runProduction $

--- a/update/Pos/Update/Behavior.hs
+++ b/update/Pos/Update/Behavior.hs
@@ -1,0 +1,24 @@
+-- | Customization of update behavior.
+
+module Pos.Update.Behavior
+       ( UpdateBehavior (..)
+       ) where
+
+import           Universum
+
+import qualified Data.Aeson as A
+import           Data.Default (Default (..))
+
+data UpdateBehavior = UpdateBehavior
+    { ubEmulateUpdate  :: !Bool
+    -- ^ Pretend there is a new update shortly after start. Can be
+    -- used for testing.
+    } deriving (Show, Eq)
+
+instance Default UpdateBehavior where
+    def = UpdateBehavior { ubEmulateUpdate = False }
+
+instance A.FromJSON UpdateBehavior where
+    parseJSON = A.withObject "UpdateBehavior" $ \o -> do
+        ubEmulateUpdate  <- fromMaybe False <$> o A..:! "emulateUpdate"
+        pure UpdateBehavior {..}

--- a/update/Pos/Update/Mode.hs
+++ b/update/Pos/Update/Mode.hs
@@ -8,7 +8,6 @@ module Pos.Update.Mode
 import           Universum
 
 import           Data.Tagged (Tagged)
-import           Ether.Internal (HasLens (..))
 import           Mockable (MonadMockable)
 import           Node.Message.Class (Message)
 import           System.Wlog (WithLogger)
@@ -26,9 +25,11 @@ import           Pos.Reporting (MonadReporting)
 import           Pos.Shutdown.Class (HasShutdownContext)
 import           Pos.Slotting.Class (MonadSlots)
 import           Pos.StateLock (StateLock)
+import           Pos.Update.Behavior (UpdateBehavior)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Update.Context (UpdateContext)
 import           Pos.Update.Params (UpdateParams)
+import           Pos.Util.Util (HasLens, HasLens')
 
 type UpdateMode ctx m
     = ( WithLogger m
@@ -42,6 +43,7 @@ type UpdateMode ctx m
       , HasLens UpdateContext ctx UpdateContext
       , HasLens UpdateParams ctx UpdateParams
       , HasLens StateLock ctx StateLock
+      , HasLens' ctx UpdateBehavior
       , HasShutdownContext ctx
       , HasConfiguration
       , HasUpdateConfiguration

--- a/update/cardano-sl-update.cabal
+++ b/update/cardano-sl-update.cabal
@@ -24,9 +24,9 @@ library
                        -- Aeson
                        Pos.Aeson.Update
 
-                       Pos.Update.BlockVersion
-
                        -- Misc
+                       Pos.Update.Behavior
+                       Pos.Update.BlockVersion
                        Pos.Update.Configuration
                        Pos.Update.Constants
                        Pos.Update.DB

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -97,7 +97,7 @@ startEdgeNode WalletStartupOptions{..} = do
     getParameters :: HasConfigurations => Production (SscParams, NodeParams)
     getParameters = do
 
-      currentParams <- CLI.getNodeParams loggerName wsoNodeArgs nodeArgs
+      currentParams <- CLI.getNodeParams loggerName wsoNodeArgs
       let vssSK = fromJust $ npUserSecret currentParams ^. usVss
       let gtParams = CLI.gtSscParams wsoNodeArgs vssSK (npBehaviorConfig currentParams)
 
@@ -108,9 +108,6 @@ startEdgeNode WalletStartupOptions{..} = do
 
     conf :: ConfigurationOptions
     conf = CLI.configurationOptions $ CLI.commonArgs wsoNodeArgs
-
-    nodeArgs :: CLI.NodeArgs
-    nodeArgs = CLI.NodeArgs { CLI.behaviorConfigPath = Nothing }
 
 -- | Generates the updated spec and store it in the appropriate folder.
 -- the reason why we don't generate a yaml file is because for swagger-ui is actually

--- a/wallet/node/Main.hs
+++ b/wallet/node/Main.hs
@@ -17,7 +17,7 @@ import           Mockable (Production, runProduction)
 import           System.Wlog (LoggerName, logInfo, modifyLoggerName)
 
 import           Pos.Binary ()
-import           Pos.Client.CLI (CommonNodeArgs (..), NodeArgs (..), getNodeParams)
+import           Pos.Client.CLI (CommonNodeArgs (..), getNodeParams)
 import qualified Pos.Client.CLI as CLI
 import           Pos.Communication (ActionSpec (..), OutSpecs, WorkerSpec, worker)
 import           Pos.Configuration (walletProductionApi, walletTxCreationDisabled)
@@ -132,19 +132,15 @@ action (WalletNodeArgs (cArgs@CommonNodeArgs{..}) (wArgs@WalletArgs{..})) =
     withConfigurations conf $ do
         CLI.printInfoOnStart cArgs
         logInfo $ "Wallet is enabled!"
-        currentParams <- getNodeParams loggerName cArgs nodeArgs
+        currentParams <- getNodeParams loggerName cArgs
 
         let vssSK = fromJust $ npUserSecret currentParams ^. usVss
         let sscParams = CLI.gtSscParams cArgs vssSK (npBehaviorConfig currentParams)
 
         actionWithWallet sscParams currentParams wArgs
   where
-    nodeArgs :: NodeArgs
-    nodeArgs = NodeArgs { behaviorConfigPath = Nothing }
-
     conf :: ConfigurationOptions
     conf = CLI.configurationOptions $ CLI.commonArgs cArgs
-
 
 main :: IO ()
 main = withCompileInfo $(retrieveCompileTimeInfo) $ do


### PR DESCRIPTION
This commit adds configuration of update system behavior (akin to
already existing ssc behavior). The only supported option now
allows to pretend there is a new update.
It's needed for testing.