### PR TITLE
use log-warper with important bug fix

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24751,16 +24751,20 @@ inherit (pkgs) which;};
          }) {};
       "log-warper" = callPackage
         ({ mkDerivation, aeson, ansi-terminal, base, containers, deepseq
-         , directory, dlist, errors, exceptions, extra, filepath, fmt
-         , formatting, hashable, lens, markdown-unlit, mmorph, monad-control
-         , monad-loops, mtl, network, stdenv, text, text-format, time
-         , transformers, transformers-base, universum, unix
-         , unordered-containers, vector, yaml
+         , directory, dlist, errors, exceptions, extra, fetchgit, filepath
+         , fmt, formatting, hashable, lens, markdown-unlit, mmorph
+         , monad-control, monad-loops, mtl, network, stdenv, text
+         , text-format, time, transformers, transformers-base, universum
+         , unix, unordered-containers, vector, yaml
          }:
          mkDerivation {
            pname = "log-warper";
            version = "1.8.0";
-           sha256 = "370274f1420405e34e135dfcb73b6ed90dd2d6f8704d3c25811baa43a27db32c";
+           src = fetchgit {
+             url = "https://github.com/serokell/log-warper.git";
+             sha256 = "0cc73a3rv2mzzpcbvzm408zp654j29iygi0ad44zgag5wkpfczz5";
+             rev = "4ee4e2e7b41a17cc5bb9d9d0bd2d2ba19da015fd";
+           };
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24752,30 +24752,25 @@ inherit (pkgs) which;};
       "log-warper" = callPackage
         ({ mkDerivation, aeson, ansi-terminal, base, containers, deepseq
          , directory, dlist, errors, exceptions, extra, fetchgit, filepath
-         , fmt, formatting, hashable, lens, markdown-unlit, mmorph
-         , monad-control, monad-loops, mtl, network, stdenv, text
-         , text-format, time, transformers, transformers-base, universum
-         , unix, unordered-containers, vector, yaml
+         , fmt, formatting, hashable, lens, mmorph, monad-control
+         , monad-loops, mtl, network, stdenv, text, text-format, time
+         , transformers, transformers-base, universum, unix
+         , unordered-containers, vector, yaml
          }:
          mkDerivation {
            pname = "log-warper";
            version = "1.8.0";
            src = fetchgit {
              url = "https://github.com/serokell/log-warper.git";
-             sha256 = "0cc73a3rv2mzzpcbvzm408zp654j29iygi0ad44zgag5wkpfczz5";
-             rev = "4ee4e2e7b41a17cc5bb9d9d0bd2d2ba19da015fd";
+             sha256 = "1rqpkid2c58pk813kb7wjcibsxf97cn7vjf3bv3dma1k5b818ana";
+             rev = "7f95c6990ef93a289678755cb1db71c2a4ecdfb5";
            };
-           isLibrary = true;
-           isExecutable = true;
            libraryHaskellDepends = [
              aeson ansi-terminal base containers deepseq directory dlist errors
              exceptions extra filepath fmt formatting hashable lens mmorph
              monad-control monad-loops mtl network text text-format time
              transformers transformers-base universum unix unordered-containers
              vector yaml
-           ];
-           executableHaskellDepends = [
-             base exceptions markdown-unlit text universum yaml
            ];
            doHaddock = false;
            doCheck = false;

--- a/stack.yaml
+++ b/stack.yaml
@@ -138,6 +138,10 @@ packages:
     git: https://github.com/serokell/servant-multipart.git
     commit: e7de56b5f7c39f8dc473f1bbaf534bb7affc3cf4
   extra-dep: true
+- location:
+    git: https://github.com/serokell/log-warper.git
+    commit: 4ee4e2e7b41a17cc5bb9d9d0bd2d2ba19da015fd
+  extra-dep: true
 
 nix:
   shell-file: shell.nix
@@ -149,7 +153,6 @@ extra-deps:
 - serokell-util-0.5.2
 - pvss-0.2.0
 - base58-bytestring-0.1.0
-- log-warper-1.8.0
 - concurrent-extra-0.7.0.10       # not yet on Stackage
 # - purescript-bridge-0.8.0.1
 - directory-1.3.1.0               # https://github.com/malcolmwallace/cpphs/issues/8

--- a/stack.yaml
+++ b/stack.yaml
@@ -140,7 +140,7 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/serokell/log-warper.git
-    commit: 4ee4e2e7b41a17cc5bb9d9d0bd2d2ba19da015fd
+    commit: 7f95c6990ef93a289678755cb1db71c2a4ecdfb5
   extra-dep: true
 
 nix:


### PR DESCRIPTION
The bug could cause asynchronous exceptions to be squelched and, for
instance, a fatal exception to not kill the program.

The fix was merged into log-warper-1.8.10, but that includes many new
dependency versions which are not compatible with cardano-sl's current
stack configuration. This patch points to a backport of the log-waprer
fix.