### PR TITLE
[CSL-2292]  Add supplimentary functionality for testing

### DIFF
--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -87,6 +87,7 @@ library
                      , text-format
                      , time-units
                      , transformers
+                     , vector
                      , universum >= 0.1.11
                      , unordered-containers
 

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -251,10 +251,26 @@ createCommandProcs hasAuxxMode printAction mSendActions = rights . fix $ \comman
         (,) <$> getArg tyInt "i"
             <*> getArgSome tyTxOut "out"
     , cpExec = \(i, outputs) -> do
-        Tx.send sendActions i outputs
+        Tx.send sendActions i outputs False
         return ValueUnit
     , cpHelp = "send from #i to specified transaction outputs \
                \ (use 'tx-out' to build them)"
+    },
+
+    let name = "send-with-fake-input" in
+    needsSendActions name >>= \sendActions ->
+    needsAuxxMode name >>= \Dict ->
+    return CommandProc
+    { cpName = name
+    , cpArgumentPrepare = identity
+    , cpArgumentConsumer =
+        (,) <$> getArg tyInt "i"
+            <*> getArgSome tyTxOut "out"
+    , cpExec = \(i, outputs) -> do
+        Tx.send sendActions i outputs True
+        return ValueUnit
+    , cpHelp = "send a transaction with non-existent input  \
+               \ (for testing purposes only)"
     },
 
     let name = "vote" in

--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -16,6 +16,7 @@ library
                         Pos.Arbitrary.Block
 
                         Pos.Block.Base
+                        Pos.Block.Behavior
                         Pos.Block.BHelpers
                         Pos.Block.BListener
                         Pos.Block.Configuration

--- a/block/src/Pos/Block/Behavior.hs
+++ b/block/src/Pos/Block/Behavior.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE RankNTypes #-}
+module Pos.Block.Behavior
+       ( BlockBehavior (..)
+       , ForgeHeaderParams (..)
+       ) where
+
+import           Universum
+
+import qualified Data.Aeson as A
+import           Data.Default (Default (..))
+import           Serokell.Aeson.Options (defaultOptions)
+
+import           Pos.Util.Util (toAesonError)
+
+----------------------------------------------------------------------------
+-- Types for the behavior config
+----------------------------------------------------------------------------
+
+-- | Block settings (a part of the behavior config).
+--
+-- The syntax of this config section is as follows:
+--
+-- @
+-- block:
+--     forgeHeader: Normal | WrongLeader
+-- @
+data BlockBehavior = BlockBehavior
+    { -- | Block header forging settings
+      bbForgeHeader :: !ForgeHeaderParams
+    }
+    deriving (Eq, Show, Generic)
+
+data ForgeHeaderParams
+    = HeaderNormal      -- ^ Do not forge anything
+    | HeaderWrongLeader -- ^ Create blocks header with a wrong slot leader
+    deriving (Eq, Show)
+
+----------------------------------------------------------------------------
+-- JSON/YAML parsing
+----------------------------------------------------------------------------
+
+instance A.FromJSON BlockBehavior where
+    parseJSON = A.genericParseJSON defaultOptions
+
+instance A.FromJSON ForgeHeaderParams where
+    parseJSON = A.withText "ForgeHeaderParams" $ toAesonError . \case
+        "Normal"          -> Right HeaderNormal
+        "WrongLeader"     -> Right HeaderWrongLeader
+        other    -> Left ("invalid value " <> show other <>
+                          ", acceptable values are Normal|WrongLeader")
+
+----------------------------------------------------------------------------
+-- Defaults
+----------------------------------------------------------------------------
+
+instance Default BlockBehavior where
+    def = BlockBehavior def
+
+instance Default ForgeHeaderParams where
+    def = HeaderNormal

--- a/generator/src/Test/Pos/Block/Logic/Mode.hs
+++ b/generator/src/Test/Pos/Block/Logic/Mode.hs
@@ -59,6 +59,7 @@ import           Test.QuickCheck (Arbitrary (..), Gen, Property, forAll, ioPrope
 import           Test.QuickCheck.Monadic (PropertyM, monadic)
 
 import           Pos.AllSecrets (AllSecrets (..), HasAllSecrets (..), mkAllSecretsSimple)
+import           Pos.Block.Behavior (BlockBehavior)
 import           Pos.Block.BListener (MonadBListener (..), onApplyBlocksStub, onRollbackBlocksStub)
 import           Pos.Block.Slog (HasSlogGState (..), mkSlogGState)
 import           Pos.Communication.Limits (HasAdoptedBlockVersionData (..))
@@ -211,6 +212,7 @@ data BlockTestContext = BlockTestContext
     , btcDelegation        :: !DelegationVar
     , btcPureDBSnapshots   :: !PureDBSnapshotsVar
     , btcAllSecrets        :: !AllSecrets
+    , btcBlockBehavior     :: !BlockBehavior
     }
 
 
@@ -272,6 +274,7 @@ initBlockTestContext tp@TestParams {..} callback = do
                         Nothing ->
                             error "initBlockTestContext: no genesisSecretKeys"
                         Just ks -> ks
+            let btcBlockBehavior = def
             let btcAllSecrets = mkAllSecretsSimple secretKeys
             let btCtx = BlockTestContext {btcSystemStart = systemStart, ..}
             liftIO $ flip runReaderT clockVar $ unEmulation $ callback btCtx
@@ -413,6 +416,9 @@ instance HasLens TestParams BlockTestContext TestParams where
 
 instance HasLens SimpleSlottingVar BlockTestContext SimpleSlottingVar where
       lensOf = btcSSlottingVarL
+
+instance HasLens BlockBehavior BlockTestContext BlockBehavior where
+    lensOf = btcBlockBehaviorL
 
 instance HasReportingContext BlockTestContext where
     reportingContext = btcReportingContextL

--- a/lib/src/Pos/Behavior.hs
+++ b/lib/src/Pos/Behavior.hs
@@ -9,20 +9,23 @@ import           Universum
 import qualified Data.Aeson as A
 import           Data.Default (Default (..))
 
+import           Pos.Block.Behavior (BlockBehavior (..))
 import           Pos.Security.Params (SecurityParams)
 import           Pos.Ssc.Behavior (SscBehavior)
 
 data BehaviorConfig = BehaviorConfig
     { bcSecurityParams :: !SecurityParams    -- ^ network
     , bcSscBehavior    :: !SscBehavior       -- ^ SSC
+    , bcBlockBehavior  :: !BlockBehavior     -- ^ block
     }
     deriving (Eq, Show)
 
 instance Default BehaviorConfig where
-    def = BehaviorConfig def def
+    def = BehaviorConfig def def def
 
 instance A.FromJSON BehaviorConfig where
     parseJSON = A.withObject "BehaviorConfig" $ \o -> do
         bcSecurityParams <- o A..: "networkAttacks"
         bcSscBehavior    <- o A..: "ssc"
+        bcBlockBehavior  <- o A..: "block"
         pure BehaviorConfig{..}

--- a/lib/src/Pos/Launcher/Param.hs
+++ b/lib/src/Pos/Launcher/Param.hs
@@ -16,6 +16,7 @@ import           Ether.Internal (HasLens (..))
 import           System.Wlog (LoggerName)
 
 import           Pos.Behavior (BehaviorConfig (..))
+import           Pos.Block.Behavior (BlockBehavior)
 import           Pos.Core (HasPrimaryKey (..))
 import           Pos.Crypto (SecretKey)
 import           Pos.DHT.Real.Param (KademliaParams)
@@ -78,6 +79,8 @@ instance HasLens SecurityParams NodeParams SecurityParams where
     lensOf = npBehaviorConfig_L . bcSecurityParams_L
 instance HasLens SscBehavior NodeParams SscBehavior where
     lensOf = npBehaviorConfig_L . bcSscBehavior_L
+instance HasLens BlockBehavior NodeParams BlockBehavior where
+    lensOf = npBehaviorConfig_L . bcBlockBehavior_L
 
 instance HasLens (NetworkConfig KademliaParams) NodeParams (NetworkConfig KademliaParams) where
     lensOf = npNetworkConfig_L

--- a/lib/src/Pos/WorkMode/Class.hs
+++ b/lib/src/Pos/WorkMode/Class.hs
@@ -18,6 +18,7 @@ import qualified Crypto.Random as Rand
 import           Mockable (MonadMockable)
 import           System.Wlog (WithLogger)
 
+import           Pos.Block.Behavior (BlockBehavior (..))
 import           Pos.Block.BListener (MonadBListener)
 import           Pos.Block.Configuration (HasBlockConfiguration)
 import           Pos.Block.Slog (HasSlogContext, HasSlogGState)
@@ -74,6 +75,7 @@ type WorkMode ctx m
       , MonadReader ctx m
       , MonadKnownPeers m
       , MonadFormatPeers m
+      , HasLens' ctx BlockBehavior
       , HasLens' ctx StartTime
       , HasLens' ctx StateLock
       , HasLens' ctx StateLockMetrics

--- a/lib/test/Test/Pos/Types/BlockSpec.hs
+++ b/lib/test/Test/Pos/Types/BlockSpec.hs
@@ -8,6 +8,7 @@ module Test.Pos.Types.BlockSpec
 
 import           Universum
 
+import           Data.Default (def)
 import           Serokell.Util (isVerSuccess)
 import           Test.Hspec (Spec, describe, it)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
@@ -51,7 +52,7 @@ spec = withDefConfiguration $ describe "Block properties" $ do
         => NewestFirst [] T.BlockHeader
         -> Spec
     emptyHeaderChain l =
-        it verifyEmptyHsDesc $ isVerSuccess $ T.verifyHeaders Nothing l
+        it verifyEmptyHsDesc $ isVerSuccess $ T.verifyHeaders def Nothing l
 
 -- | Both of the following tests are boilerplate - they use `mkGenericHeader` to create
 -- headers and then compare these with manually built headers.
@@ -147,10 +148,10 @@ validateGoodMainHeader
     :: HasConfiguration
     => T.HeaderAndParams -> Bool
 validateGoodMainHeader (T.getHAndP -> (params, header)) =
-    isVerSuccess $ T.verifyHeader params header
+    isVerSuccess $ T.verifyHeader def params header
 
 validateGoodHeaderChain
     :: HasConfiguration
     => T.BlockHeaderList -> Bool
 validateGoodHeaderChain (T.BHL (l, _)) =
-    isVerSuccess $ T.verifyHeaders Nothing (NewestFirst l)
+    isVerSuccess $ T.verifyHeaders def Nothing (NewestFirst l)

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6974,7 +6974,7 @@ inherit (pkgs) mesa;};
          , parser-combinators, QuickCheck, quickcheck-instances, random
          , reflection, safe-exceptions, scientific, serokell-util, split
          , stdenv, stm, temporary, text, text-format, time-units
-         , transformers, universum, unix, unordered-containers
+         , transformers, universum, unix, unordered-containers, vector
          }:
          mkDerivation {
            pname = "cardano-sl-auxx";
@@ -6993,7 +6993,7 @@ inherit (pkgs) mesa;};
              neat-interpolation optparse-applicative parser-combinators
              QuickCheck quickcheck-instances random reflection safe-exceptions
              scientific serokell-util split stm text text-format time-units
-             transformers universum unix unordered-containers
+             transformers universum unix unordered-containers vector
            ];
            libraryToolDepends = [ cpphs ];
            executableHaskellDepends = [

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -35,6 +35,7 @@ import           Test.QuickCheck.Gen (Gen)
 import           Test.QuickCheck.Monadic (PropertyM (..), monadic)
 
 import           Pos.AllSecrets (HasAllSecrets (..))
+import           Pos.Block.Behavior (BlockBehavior (..))
 import           Pos.Block.BListener (MonadBListener (..))
 import           Pos.Block.Slog (HasSlogGState (..))
 import           Pos.Block.Types (LastKnownHeader, LastKnownHeaderTag, ProgressHeader,
@@ -88,7 +89,7 @@ import           Pos.Wallet.Web.Networking (MonadWalletSendActions (..))
 import           Pos.Wallet.WalletMode (MonadBlockchainInfo (..), MonadUpdates (..),
                                         WalletMempoolExt)
 import           Pos.Wallet.Web.ClientTypes (AccountId)
-import           Pos.Wallet.Web.Methods (AddrCIdHashes(..))
+import           Pos.Wallet.Web.Methods (AddrCIdHashes (..))
 import           Pos.Wallet.Web.Mode (getBalanceDefault, getNewAddressWebWallet, getOwnUtxosDefault)
 import           Pos.Wallet.Web.State (MonadWalletDB, WalletState, openMemState)
 import           Pos.Wallet.Web.Tracking.BListener (onApplyBlocksWebWallet,
@@ -154,6 +155,7 @@ data WalletTestContext = WalletTestContext
     -- ^ Sent transactions via MonadWalletSendActions
     , wtcHashes           :: !AddrCIdHashes
     -- ^ Address hashes ref
+    , wtcBlockBehavior    :: !BlockBehavior
     }
 
 makeLensesWith postfixLFields ''WalletTestContext
@@ -191,7 +193,7 @@ initWalletTestContext WalletTestParams {..} callback =
             wtcLastKnownHeader <- STM.newTVarIO Nothing
             wtcSentTxs <- STM.newTVarIO mempty
             wtcHashes <- AddrCIdHashes <$> newIORef mempty
-            pure WalletTestContext {..}
+            pure WalletTestContext {wtcBlockBehavior = def, ..}
         callback wtc
 
 runWalletTestMode ::
@@ -355,6 +357,9 @@ instance HasLens ProgressHeaderTag WalletTestContext ProgressHeader where
 
 instance HasLens ConnectedPeers WalletTestContext ConnectedPeers where
     lensOf = wtcConnectedPeers_L
+
+instance HasLens BlockBehavior WalletTestContext BlockBehavior where
+    lensOf = wtcBlockBehavior_L
 
 -- For reporting
 instance HasNodeType WalletTestContext where


### PR DESCRIPTION
This adds two thnigs:
* `send-with-fake-input` command in auxx, to be able to send transactions with nonexistant inputs
* Make node create blocks signed by a wrong slot leader