### PR TITLE
[CSL-2043] Add tmeasure to critical places

### DIFF
--- a/core/Pos/Util/Chrono.hs
+++ b/core/Pos/Util/Chrono.hs
@@ -36,13 +36,13 @@ newtype NewestFirst f a = NewestFirst {getNewestFirst :: f a}
             Functor, Foldable, Traversable,
             ToList, Container,
             Binary, Bi,
-            Arbitrary)
+            Arbitrary, NFData)
 newtype OldestFirst f a = OldestFirst {getOldestFirst :: f a}
   deriving (Eq, Ord, Show,
             Functor, Foldable, Traversable,
             ToList, Container,
             Binary, Bi,
-            Arbitrary)
+            Arbitrary, NFData)
 
 makePrisms  ''NewestFirst
 makeWrapped ''NewestFirst


### PR DESCRIPTION
I was using `tMeasure` function in my local tests and decided it's actually pretty nice to have it in master. I've also added usages to some critical places -- LRC, recovery, headers/blocks/txp listeners.