### PR TITLE
Update build-cardano-sl-and-daedalus-from-source-code.md

### DIFF
--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -97,7 +97,7 @@ Enter `nix-shell`:
 
 After that, in order to build Cardano SL with wallet capabilities, run the following script:
 
-    [nix-shell:~/cardano-sl]$ ./scripts/build/cardano-sl.sh
+    [nix-shell:~/cardano-sl]$ ./scripts/build/cardano-sl.sh --system-ghc
 
 Dependency version collisions have been encountered on macOS. If you run into something
 [like this](https://github.com/input-output-hk/cardano-sl/issues/2230#issuecomment-354881696),


### PR DESCRIPTION
On recent NixOS master within nix-shell, i need to add the --system-ghc flag to get past the error when running scripts/build/cardano-sl.sh

No compiler found, expected minor version match with ghc-8.0.2 (x86_64) (based on resolver setting in /home/alab/ws/cardano-sl/stack.yaml).
To install the correct GHC into /home/alab/.stack/programs/x86_64-linux-nix/, try running "stack setup" or use the "--install-ghc" flag. To use your system GHC installation, run "stack config set system-ghc --global true", or use the "--system-ghc" flag.