### PR TITLE
[SRK-91] optimizing dependecies in serokell-util

### DIFF
--- a/infra/Pos/DHT/Real/CLI.hs
+++ b/infra/Pos/DHT/Real/CLI.hs
@@ -12,7 +12,7 @@ import           Universum
 import           Control.Exception.Safe (throwString)
 import           Formatting (build, formatToString, shown, (%))
 import qualified Options.Applicative as Opt
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           Text.Parsec (eof, parse)
 
 import           Pos.DHT.Model.Types (DHTKey, DHTNode, dhtKeyParser, dhtNodeParser)

--- a/infra/Pos/HealthCheck/Route53.hs
+++ b/infra/Pos/HealthCheck/Route53.hs
@@ -4,7 +4,7 @@ module Pos.HealthCheck.Route53
 
 import qualified Options.Applicative as Opt
 import           Pos.Util.TimeWarp (NetworkAddress, addrParser)
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           Universum
 
 route53HealthCheckOption :: Opt.Parser NetworkAddress

--- a/infra/Pos/Network/CLI.hs
+++ b/infra/Pos/Network/CLI.hs
@@ -39,7 +39,7 @@ import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS as DNS
 import qualified Network.Transport.TCP as TCP
 import qualified Options.Applicative as Opt
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           System.Wlog (HasLoggerName, LoggerNameBox, WithLogger, askLoggerName, logError,
                               logNotice, usingLoggerName)
 

--- a/infra/Pos/Statistics/Ekg.hs
+++ b/infra/Pos/Statistics/Ekg.hs
@@ -7,7 +7,7 @@ module Pos.Statistics.Ekg
 
 import qualified Options.Applicative as Opt
 import           Pos.Util.TimeWarp      (NetworkAddress, addrParser)
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           Universum
 
 data EkgParams = EkgParams

--- a/infra/Pos/Statistics/Statsd.hs
+++ b/infra/Pos/Statistics/Statsd.hs
@@ -7,7 +7,7 @@ module Pos.Statistics.Statsd
 
 import qualified Options.Applicative as Opt
 import           Pos.Util.TimeWarp (NetworkAddress, addrParserNoWildcard)
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           Universum
 
 data StatsdParams = StatsdParams

--- a/lib/src/Pos/Client/CLI/Options.hs
+++ b/lib/src/Pos/Client/CLI/Options.hs
@@ -24,7 +24,7 @@ import           Data.Default (def)
 import qualified Options.Applicative as Opt
 import           Options.Applicative.Builder.Internal (HasMetavar, HasName)
 import           Serokell.Util (sec)
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 
 import           Pos.Binary.Core ()
 import           Pos.Communication (NodeId)

--- a/networking/bench/Sender/SenderOptions.hs
+++ b/networking/bench/Sender/SenderOptions.hs
@@ -13,7 +13,7 @@ import           Data.String (fromString)
 import           Data.Word (Word16)
 import           Options.Applicative.Simple (Parser, auto, help, long, metavar, option, optional,
                                              short, showDefault, some, strOption, value, readerError)
-import           Serokell.Util.OptParse (fromParsec)
+import           Pos.Util.OptParse (fromParsec)
 import           Serokell.Util.Parse (connection)
 
 data Args = Args

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7601,8 +7601,9 @@ inherit (pkgs) mesa;};
          , cardano-sl-networking, cborg, cereal, concurrent-extra
          , containers, cpphs, cryptonite, data-default, deepseq, directory
          , ether, exceptions, filepath, formatting, hashable, hspec, lens
-         , log-warper, lrucache, megaparsec, mmorph, mtl, parsec, process
-         , QuickCheck, quickcheck-instances, random, reflection, resourcet
+         , log-warper, lrucache, megaparsec, mmorph, mtl
+         , optparse-applicative, parsec, process, QuickCheck
+         , quickcheck-instances, random, reflection, resourcet
          , safe-exceptions, semigroups, serokell-util, stdenv, stm, tagged
          , template-haskell, text, text-format, th-lift-instances, time
          , time-units, transformers, transformers-base, transformers-lift
@@ -7616,12 +7617,12 @@ inherit (pkgs) mesa;};
              aeson autoexporter base bytestring cardano-sl-networking cborg
              cereal concurrent-extra containers cryptonite data-default deepseq
              directory ether exceptions filepath formatting hashable hspec lens
-             log-warper lrucache megaparsec mmorph mtl parsec process QuickCheck
-             quickcheck-instances random reflection resourcet safe-exceptions
-             semigroups serokell-util stm tagged template-haskell text
-             text-format th-lift-instances time time-units transformers
-             transformers-base transformers-lift universum unliftio-core
-             unordered-containers vector
+             log-warper lrucache megaparsec mmorph mtl optparse-applicative
+             parsec process QuickCheck quickcheck-instances random reflection
+             resourcet safe-exceptions semigroups serokell-util stm tagged
+             template-haskell text text-format th-lift-instances time time-units
+             transformers transformers-base transformers-lift universum
+             unliftio-core unordered-containers vector
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;

--- a/util/Pos/Util/OptParse.hs
+++ b/util/Pos/Util/OptParse.hs
@@ -1,0 +1,12 @@
+module Pos.Util.OptParse
+       ( fromParsec
+       ) where
+
+import Universum
+
+import Options.Applicative (ReadM, eitherReader)
+import Text.Parsec (Parsec, parse)
+
+fromParsec :: Parsec Text () a -> ReadM a
+fromParsec parser =
+    eitherReader $ first show . parse parser "<CLI options>" . toText

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -33,6 +33,7 @@ library
                        Pos.Util.LoggerName
                        Pos.Util.LRU
                        Pos.Util.Modifier
+                       Pos.Util.OptParse
                        Pos.Util.Orphans
                        Pos.Util.Queue
                        Pos.Util.Some
@@ -67,6 +68,7 @@ library
                      , megaparsec
                      , mmorph
                      , mtl
+                     , optparse-applicative
                      , parsec
                      , process
                      , quickcheck-instances


### PR DESCRIPTION
Replace `fromParsec` function from `serokell-util` into the `cardano` util according the following issue:
https://github.com/serokell/serokell-util/issues/34