### PR TITLE
[CSL-2331] improve synchronisation / communication between outbound queue threads and client threads

### DIFF
--- a/auxx/Main.hs
+++ b/auxx/Main.hs
@@ -126,7 +126,7 @@ action opts@AuxxOptions {..} command = do
               elimRealMode nr $ toRealMode $
                   logicLayerFull jsonLog $ \logicLayer ->
                       bracketTransportTCP networkConnectionTimeout (ncTcpAddr (npNetworkConfig nodeParams)) $ \transport ->
-                          diffusionLayerFull (npNetworkConfig nodeParams) lastKnownBlockVersion transport Nothing $ \withLogic -> do
+                          diffusionLayerFull (runProduction . elimRealMode nr . toRealMode) (npNetworkConfig nodeParams) lastKnownBlockVersion transport Nothing $ \withLogic -> do
                               diffusionLayer <- withLogic (logic logicLayer)
                               let modifier = if aoStartMode == WithNode then runNodeWithSinglePlugin nr else identity
                                   (ActionSpec auxxModeAction, _) = modifier (auxxPlugin opts command)

--- a/explorer/src/explorer/Main.hs
+++ b/explorer/src/explorer/Main.hs
@@ -91,7 +91,12 @@ action (ExplorerNodeArgs (cArgs@CommonNodeArgs{..}) ExplorerArgs{..}) =
             ekgNodeMetrics = EkgNodeMetrics
                 nrEkgStore
                 (runProduction . elim . explorerModeToRealMode)
-            serverRealMode = explorerModeToRealMode (runServer ncNodeParams ekgNodeMetrics outSpecs go)
+            serverRealMode = explorerModeToRealMode $ runServer
+                (runProduction . elim . explorerModeToRealMode)
+                ncNodeParams
+                ekgNodeMetrics
+                outSpecs
+                go
         in  elim serverRealMode
 
     nodeArgs :: NodeArgs

--- a/infra/Pos/Communication/Listener.hs
+++ b/infra/Pos/Communication/Listener.hs
@@ -39,7 +39,7 @@ listenerConv oq h = (lspec, mempty)
     lspec =
       flip ListenerSpec spec $ \ourVerInfo ->
           N.Listener $ \peerVerInfo' nNodeId conv -> checkProtocolMagic ourVerInfo peerVerInfo' $ do
-              OQ.clearFailureOf oq nNodeId
+              liftIO $ OQ.clearFailureOf oq nNodeId
               checkingInSpecs ourVerInfo peerVerInfo' spec nNodeId $
                   h ourVerInfo nNodeId conv
 

--- a/infra/Pos/Diffusion/Subscription/Common.hs
+++ b/infra/Pos/Diffusion/Subscription/Common.hs
@@ -110,9 +110,9 @@ subscriptionListener oq nodeType = listenerConv @Void oq $ \__ourVerInfo nodeId 
         Just MsgSubscribe -> do
             let peers = simplePeers [(nodeType, nodeId)]
             bracket
-              (OQ.updatePeersBucket oq BucketSubscriptionListener (<> peers))
+              (liftIO $ OQ.updatePeersBucket oq BucketSubscriptionListener (<> peers))
               (\added -> when added $ do
-                void $ OQ.updatePeersBucket oq BucketSubscriptionListener (removePeer nodeId)
+                void $ liftIO $ OQ.updatePeersBucket oq BucketSubscriptionListener (removePeer nodeId)
                 logDebug $ sformat ("subscriptionListener: removed "%shown) nodeId)
               (\added -> when added $ do -- if not added, close the conversation
                   logDebug $ sformat ("subscriptionListener: added "%shown) nodeId
@@ -142,9 +142,9 @@ subscriptionListener1 oq nodeType = listenerConv @Void oq $ \_ourVerInfo nodeId 
     whenJust mbMsg $ \MsgSubscribe1 -> do
       let peers = simplePeers [(nodeType, nodeId)]
       bracket
-          (OQ.updatePeersBucket oq BucketSubscriptionListener (<> peers))
+          (liftIO $ OQ.updatePeersBucket oq BucketSubscriptionListener (<> peers))
           (\added -> when added $ do
-              void $ OQ.updatePeersBucket oq BucketSubscriptionListener (removePeer nodeId)
+              void $ liftIO $ OQ.updatePeersBucket oq BucketSubscriptionListener (removePeer nodeId)
               logDebug $ sformat ("subscriptionListener1: removed "%shown) nodeId)
           (\added -> when added $ do -- if not added, close the conversation
               logDebug $ sformat ("subscriptionListener1: added "%shown) nodeId

--- a/infra/Pos/Diffusion/Subscription/Dht.hs
+++ b/infra/Pos/Diffusion/Subscription/Dht.hs
@@ -46,7 +46,7 @@ dhtSubscriptionWorker oq kademliaInst peerType valency fallbacks _sendActions = 
         peers' <- atomically $ updateFromKademliaNoSubscribe peers
         logNotice $
             sformat ("Kademlia peer set changed to "%shown) peers'
-        void $ OQ.updatePeersBucket oq BucketKademliaWorker (const peers')
+        void $ liftIO $ OQ.updatePeersBucket oq BucketKademliaWorker (const peers')
         updateForeverNoSubscribe peers'
 
     updateFromKademliaNoSubscribe

--- a/infra/Pos/Diffusion/Subscription/Dns.hs
+++ b/infra/Pos/Diffusion/Subscription/Dns.hs
@@ -104,7 +104,7 @@ dnsSubscriptionWorker oq networkCfg DnsDomains{..} keepaliveTimer nextSlotDurati
         dnsPeersList <- findDnsPeers index alts
         modifySharedAtomic dnsPeersVar $ \dnsPeers -> do
             let dnsPeers' = M.insert index dnsPeersList dnsPeers
-            void $ OQ.updatePeersBucket oq BucketBehindNatWorker $ \_ ->
+            void $ liftIO $ OQ.updatePeersBucket oq BucketBehindNatWorker $ \_ ->
                 peersFromList mempty ((,) NodeRelay <$> M.elems dnsPeers')
             pure (dnsPeers', ())
         -- Try to subscribe to some peer.

--- a/infra/Pos/Network/CLI.hs
+++ b/infra/Pos/Network/CLI.hs
@@ -39,8 +39,8 @@ import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS as DNS
 import qualified Network.Transport.TCP as TCP
 import qualified Options.Applicative as Opt
-import           Pos.Util.OptParse (fromParsec)
-import           System.Wlog (HasLoggerName, LoggerNameBox, WithLogger, askLoggerName, logError,
+import           Serokell.Util.OptParse (fromParsec)
+import           System.Wlog (LoggerNameBox, WithLogger, askLoggerName, logError,
                               logNotice, usingLoggerName)
 
 import qualified Pos.DHT.Real.Param as DHT (KademliaParams (..), MalformedDHTKey (..),
@@ -178,7 +178,7 @@ defaultDnsDomains = DnsDomains [
 ----------------------------------------------------------------------------
 
 data MonitorEvent
-    = MonitorRegister (Peers NodeId -> LoggerNameBox IO ())
+    = MonitorRegister (Peers NodeId -> IO ())
     | MonitorSIGHUP
 
 -- | Monitor for changes to the static config
@@ -188,6 +188,7 @@ monitorStaticConfig ::
     -> Peers NodeId -- ^ Initial value
     -> LoggerNameBox IO T.StaticPeers
 monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
+    lname <- askLoggerName
     events :: Chan MonitorEvent <- liftIO newChan
 
 #ifdef POSIX
@@ -196,12 +197,12 @@ monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
 
     return T.StaticPeers {
         T.staticPeersOnChange = writeChan events . MonitorRegister
-      , T.staticPeersMonitoring = loop events initPeers []
+      , T.staticPeersMonitoring = usingLoggerName lname $ loop events initPeers []
       }
   where
     loop :: Chan MonitorEvent
          -> Peers NodeId
-         -> [Peers NodeId -> LoggerNameBox IO ()]
+         -> [Peers NodeId -> IO ()]
          -> LoggerNameBox IO ()
     loop events peers handlers = liftIO (readChan events) >>= \case
         MonitorRegister handler -> do
@@ -232,9 +233,9 @@ monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
                 logError $ readFailed fp ex
                 loop events peers handlers
 
-    runHandler :: forall t . t -> (t -> LoggerNameBox IO ()) -> LoggerNameBox IO ()
+    runHandler :: forall t . t -> (t -> IO ()) -> LoggerNameBox IO ()
     runHandler it handler = do
-        mu <- try (handler it)
+        mu <- liftIO $ try (handler it)
         case mu of
           Left  ex -> logError $ handlerError ex
           Right () -> return ()
@@ -253,10 +254,8 @@ monitorStaticConfig cfg@NetworkConfigOpts{..} origMetadata initPeers = do
         "Exception thrown by staticPeersOnChange handler: " % shown % ". Ignored."
 
 launchStaticConfigMonitoring ::
-       (HasLoggerName m, MonadIO m) => T.Topology k -> m ()
-launchStaticConfigMonitoring topology = do
-    loggerName <- askLoggerName
-    liftIO . usingLoggerName loggerName $ action
+       (MonadIO m) => T.Topology k -> m ()
+launchStaticConfigMonitoring topology = liftIO action
   where
     action =
         case topology of

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -127,6 +127,7 @@ library
   build-depends:        MonadRandom
                       , QuickCheck
                       , aeson >= 0.11.2.1
+                      , async
                       , ansi-terminal
                       , ansi-wl-pprint
                       , base

--- a/lib/src/Pos/Diffusion/Full.hs
+++ b/lib/src/Pos/Diffusion/Full.hs
@@ -10,6 +10,9 @@ module Pos.Diffusion.Full
 import           Nub (ordNub)
 import           Universum
 
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.STM as STM
+import           Control.Exception (Exception, throwIO)
 import           Control.Monad.Fix (MonadFix)
 import qualified Data.Map as M
 import           Data.Time.Units (Millisecond, Second, convertUnit)
@@ -82,13 +85,14 @@ diffusionLayerFull
        , MonadMask m
        , WithLogger m
        )
-    => NetworkConfig KademliaParams
+    => (forall y . d y -> IO y)
+    -> NetworkConfig KademliaParams
     -> BlockVersion -- For making the VerInfo.
     -> Transport d
     -> Maybe (EkgNodeMetrics d)
     -> ((Logic d -> m (DiffusionLayer d)) -> m x)
     -> m x
-diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics expectLogic =
+diffusionLayerFull runIO networkConfig lastKnownBlockVersion transport mEkgNodeMetrics expectLogic =
     bracket acquire release $ \_ -> expectLogic $ \logic -> do
 
         -- Make the outbound queue using network policies.
@@ -229,6 +233,7 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
             -- will be very involved. Should make it top-level I think.
             runDiffusionLayer :: forall y . d y -> d y
             runDiffusionLayer = runDiffusionLayerFull
+                runIO
                 networkConfig
                 transport
                 ourVerInfo
@@ -239,10 +244,24 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
                 listeners
 
             enqueue :: EnqueueMsg d
-            enqueue = makeEnqueueMsg ourVerInfo $ \msgType k -> do
+            enqueue = makeEnqueueMsg ourVerInfo $ \msgType k -> liftIO $ do
                 itList <- OQ.enqueue oq msgType (EnqueuedConversation (msgType, k))
                 let itMap = M.fromList itList
-                return ((>>= either throwM return) <$> itMap)
+                    -- FIXME this is duplicated.
+                    -- Define once, perhaps in cardano-sl-infra near the
+                    -- definition of EnqueueMsg.
+                    waitOnIt :: STM.TVar (OQ.PacketStatus a) -> d a
+                    waitOnIt tvar = liftIO $ do
+                        it <- STM.atomically $ do
+                                  status <- STM.readTVar tvar
+                                  case status of
+                                      OQ.PacketEnqueued        -> STM.retry
+                                      OQ.PacketAborted         -> return Nothing
+                                      OQ.PacketDequeued thread -> return (Just thread)
+                        case it of
+                            Nothing -> throwIO Aborted
+                            Just thread -> Async.wait thread
+                return (waitOnIt <$> itMap)
 
             getBlocks :: NodeId
                       -> BlockHeader
@@ -293,7 +312,7 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
             healthStatus = topologyHealthStatus (ncTopology networkConfig) oq
 
             formatPeers :: forall r . (forall a . Format r a -> a) -> d (Maybe r)
-            formatPeers formatter = Just <$> OQ.dumpState oq formatter
+            formatPeers formatter = liftIO $ (Just <$> OQ.dumpState oq formatter)
 
             diffusion :: Diffusion d
             diffusion = Diffusion {..}
@@ -310,7 +329,8 @@ diffusionLayerFull networkConfig lastKnownBlockVersion transport mEkgNodeMetrics
 runDiffusionLayerFull
     :: forall d x .
        ( DiffusionWorkMode d, MonadFix d )
-    => NetworkConfig KademliaParams
+    => (forall y . d y -> IO y)
+    -> NetworkConfig KademliaParams
     -> Transport d
     -> VerInfo
     -> Maybe (EkgNodeMetrics d)
@@ -320,10 +340,10 @@ runDiffusionLayerFull
     -> (VerInfo -> [Listener d])
     -> d x
     -> d x
-runDiffusionLayerFull networkConfig transport ourVerInfo mEkgNodeMetrics oq keepaliveTimer slotDuration listeners action =
+runDiffusionLayerFull runIO networkConfig transport ourVerInfo mEkgNodeMetrics oq keepaliveTimer slotDuration listeners action =
     bracketKademlia networkConfig $ \networkConfig' ->
         timeWarpNode transport ourVerInfo listeners $ \nd converse ->
-            withAsync (OQ.dequeueThread oq (sendMsgFromConverse converse)) $ \dthread -> do
+            withAsync (liftIO $ OQ.dequeueThread oq (sendMsgFromConverse runIO converse)) $ \dthread -> do
                 link dthread
                 case mEkgNodeMetrics of
                     Just ekgNodeMetrics -> registerEkgNodeMetrics ekgNodeMetrics nd
@@ -339,9 +359,25 @@ runDiffusionLayerFull networkConfig transport ourVerInfo mEkgNodeMetrics oq keep
   where
     oqEnqueue :: Msg -> (NodeId -> VerInfo -> Conversation PackingType d t) -> d (Map NodeId (d t))
     oqEnqueue msgType k = do
-        itList <- OQ.enqueue oq msgType (EnqueuedConversation (msgType, k))
+        itList <- liftIO $ OQ.enqueue oq msgType (EnqueuedConversation (msgType, k))
         let itMap = M.fromList itList
-        return ((>>= either throwM return) <$> itMap)
+            -- Wait on the TVar until it's either aborted or dequeued.
+            -- If it's aborted, throw an exception (TBD consider giving
+            -- Nothing instead?) and if it's dequeued, wait on the thread.
+            -- FIXME we'll want to refine this a bit. Callers should be able
+            -- to get a hold of the Async instead.
+            waitOnIt :: STM.TVar (OQ.PacketStatus a) -> d a
+            waitOnIt tvar = liftIO $ do
+                it <- STM.atomically $ do
+                          status <- STM.readTVar tvar
+                          case status of
+                              OQ.PacketEnqueued        -> STM.retry
+                              OQ.PacketAborted         -> return Nothing
+                              OQ.PacketDequeued thread -> return (Just thread)
+                case it of
+                    Nothing -> throwIO Aborted
+                    Just thread -> Async.wait thread
+        return (waitOnIt <$> itMap)
     subscriptionThread nc sactions = case topologySubscriptionWorker (ncTopology nc) of
         Just (SubscriptionWorkerBehindNAT dnsDomains) ->
             dnsSubscriptionWorker oq networkConfig dnsDomains keepaliveTimer slotDuration sactions
@@ -349,11 +385,17 @@ runDiffusionLayerFull networkConfig transport ourVerInfo mEkgNodeMetrics oq keep
             dhtSubscriptionWorker oq kinst nodeType valency fallbacks sactions
         Nothing -> pure ()
 
+data Aborted = Aborted
+  deriving (Show)
+
+instance Exception Aborted
+
 sendMsgFromConverse
-    :: Converse PackingType PeerData d
-    -> OQ.SendMsg d (EnqueuedConversation d) NodeId
-sendMsgFromConverse converse (EnqueuedConversation (_, k)) nodeId =
-    converseWith converse nodeId (k nodeId)
+    :: (forall x . d x -> IO x)
+    -> Converse PackingType PeerData d
+    -> OQ.SendMsg (EnqueuedConversation d) NodeId
+sendMsgFromConverse runIO converse (EnqueuedConversation (_, k)) nodeId =
+    runIO $ converseWith converse nodeId (k nodeId)
 
 -- | Bring up a time-warp node. It will come down when the continuation ends.
 timeWarpNode

--- a/lib/src/Pos/Util/OutboundQueue.hs
+++ b/lib/src/Pos/Util/OutboundQueue.hs
@@ -39,7 +39,7 @@ updatePeersBucketReader
     -> m Bool
 updatePeersBucketReader pick buck f = asks pick >>= updateBucket
   where
-    updateBucket oq = OQ.updatePeersBucket oq buck f
+    updateBucket oq = liftIO $ OQ.updatePeersBucket oq buck f
 
 formatKnownPeersReader
     :: ( MonadReader r m, MonadIO m )
@@ -48,4 +48,4 @@ formatKnownPeersReader
     -> m (Maybe t)
 formatKnownPeersReader pick formatter = asks pick >>= dumpFormattedState
   where
-    dumpFormattedState oq = fmap Just (OQ.dumpState oq formatter)
+    dumpFormattedState oq = fmap Just (liftIO $ OQ.dumpState oq formatter)

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -66,6 +66,7 @@ Library
                       , attoparsec
                       , base
                       , containers
+                      , contravariant
                       , cryptonite
                       , binary >= 0.8
                       , bytestring

--- a/networking/src/Network/Broadcast/OutboundQueue.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue.hs
@@ -26,6 +26,7 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 {-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE RecursiveDo               #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Network.Broadcast.OutboundQueue (
@@ -53,6 +54,7 @@ module Network.Broadcast.OutboundQueue (
     -- * Enqueueing
   , Origin(..)
   , EnqueueTo (..)
+  , PacketStatus (..)
   , enqueue
   , enqueueSync'
   , enqueueSync
@@ -80,21 +82,23 @@ module Network.Broadcast.OutboundQueue (
   ) where
 
 import           Control.Concurrent
-import           Control.Exception.Safe (MonadMask, SomeException, displayException, finally, mask_,
-                                         try)
+import           Control.Concurrent.Async
+import           Control.Concurrent.STM
+import           Control.Exception (SomeException, catch, throwIO, displayException,
+                                    finally, mask_)
 import           Control.Lens
 import           Control.Monad
-import           Control.Monad.IO.Class
 import           Data.Either (rights)
 import           Data.Foldable (fold)
 import           Data.List (intercalate, sortBy)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe, maybeToList)
+import           Data.Maybe (fromMaybe, maybeToList, mapMaybe)
 import           Data.Monoid ((<>))
 import           Data.Ord (comparing)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.String (fromString)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Time
@@ -103,11 +107,10 @@ import           Formatting (Format, sformat, shown, string, (%))
 import qualified System.Metrics as Monitoring
 import           System.Metrics.Counter (Counter)
 import qualified System.Metrics.Counter as Counter
-import           System.Wlog.CanLog (WithLogger, logDebug)
+import           System.Wlog (usingLoggerName, logDebug)
 import qualified System.Wlog.CanLog as Log
 import           System.Wlog.Severity (Severity (..))
 
-import qualified Mockable as M
 import           Network.Broadcast.OutboundQueue.ConcurrentMultiQueue (MultiQueue)
 import qualified Network.Broadcast.OutboundQueue.ConcurrentMultiQueue as MQ
 import           Network.Broadcast.OutboundQueue.Types
@@ -247,11 +250,26 @@ data Packet msg nid a = Packet {
     -- | Precedence of the message
   , packetPrec     :: Precedence
 
-    -- | MVar filled with the result of the sent action
+    -- | TVar with the status of the packet.
+    -- Useful if the enqueuer wished to abort an enqueued packet, or kill a
+    -- running conversation that was dequeued.
     --
-    -- (empty when enqueued)
-  , packetSent     :: MVar (Either SomeException a)
+    -- Note: we want a TVar because then someone can wait until it changes.
+    -- However, if we use a TVar, the dequeue thread can't safely transition
+    -- from Enqueued to Dequeued while spawning the Async inside.
+    --
+    --   do atomically $ do
+    --        writeTVar thread
+    --      thread <- async ...
+  , packetStatus   :: TVar (PacketStatus a)
   }
+
+-- | Status of a packet.
+-- In the queue and not aborted.
+-- In the queue and aborted (reaching into the queue and removing it seems
+-- infeasible).
+-- Out of the queue and in-flight.
+data PacketStatus a = PacketEnqueued | PacketAborted | PacketDequeued (Async a)
 
 -- | Hide the 'a' type parameter
 data EnqPacket msg nid = forall a. EnqPacket (Packet msg nid a)
@@ -282,9 +300,9 @@ data Key nid =
 -- | MultiQueue instantiated at the types we need
 type MQ msg nid = MultiQueue (Key nid) (EnqPacket msg nid)
 
-mqEnqueue :: (MonadIO m, Ord nid)
-          => MQ msg nid -> EnqPacket msg nid -> m ()
-mqEnqueue qs p = liftIO $
+mqEnqueue :: (Ord nid)
+          => MQ msg nid -> EnqPacket msg nid -> IO ()
+mqEnqueue qs p =
   MQ.enqueue qs [ KeyByDest     (liftEnq packetDestId p)
                 , KeyByDestPrec (liftEnq packetDestId p) (liftEnq packetPrec p)
                 , KeyByPrec                              (liftEnq packetPrec p)
@@ -296,11 +314,11 @@ mqEnqueue qs p = liftIO $
 -- (i.e., number of in-flight messages is less than the max)
 type NotBusy nid = NodeType -> nid -> Bool
 
-mqDequeue :: forall m msg nid. (MonadIO m, Ord nid)
-          => MQ msg nid -> NotBusy nid -> m (Maybe (EnqPacket msg nid))
+mqDequeue :: forall msg nid. (Ord nid)
+          => MQ msg nid -> NotBusy nid -> IO (Maybe (EnqPacket msg nid))
 mqDequeue qs notBusy =
     orElseM [
-        liftIO $ MQ.dequeue (KeyByPrec prec) notBusy' qs
+        MQ.dequeue (KeyByPrec prec) notBusy' qs
       | prec <- enumPrecHighestFirst
       ]
   where
@@ -326,12 +344,12 @@ inFlightWithPrec nid prec = inFlightTo nid . at prec . anon 0 (== 0)
 
 -- | Given an update function and a `Packet`, set the `InFlight` to the new value
 -- calculated by `f`. In case no match can be found, this function is effectively a noop.
-setInFlightFor :: forall m msg nid a. (MonadIO m, Ord nid)
+setInFlightFor :: forall msg nid a. (Ord nid)
                => Packet msg nid a
                -> (Int -> Int)
                -> MVar (InFlight nid)
-               -> m ()
-setInFlightFor Packet{..} f var = liftIO $ modifyMVar_ var (return . update)
+               -> IO ()
+setInFlightFor Packet{..} f var = modifyMVar_ var (return . update)
   where
     update :: InFlight nid -> InFlight nid
     update = Map.adjust updateInnerMap packetDestId
@@ -399,10 +417,9 @@ data OutboundQ msg nid buck = ( FormatMsg msg
 -- | Use a formatter to get a dump of the state.
 -- Currently this just shows the known peers.
 dumpState
-    :: MonadIO m
-    => OutboundQ msg nid buck
+    :: OutboundQ msg nid buck
     -> (forall a . (Format r a) -> a)
-    -> m r
+    -> IO r
 dumpState outQ@OutQ{} formatter = do
     peers <- getAllPeers outQ
     let formatted = formatter format peers
@@ -411,8 +428,8 @@ dumpState outQ@OutQ{} formatter = do
     format = "OutboundQ internal state '{"%shown%"}'"
 
 -- | Debug function to return the `InFlight` map. Internal use only.
-currentlyInFlight :: forall m msg nid buck. MonadIO m => OutboundQ msg nid buck -> m (InFlight nid)
-currentlyInFlight = liftIO . readMVar . qInFlight
+currentlyInFlight :: forall msg nid buck. OutboundQ msg nid buck -> IO (InFlight nid)
+currentlyInFlight = readMVar . qInFlight
 
 -- | Type assumed for unknown nodes
 --
@@ -427,9 +444,8 @@ newtype UnknownNodeType nid = UnknownNodeType (nid -> NodeType)
 -- | Initialize the outbound queue
 --
 -- NOTE: The dequeuing thread must be started separately. See 'dequeueThread'.
-new :: forall m msg nid buck.
-       ( MonadIO m
-       , FormatMsg msg
+new :: forall msg nid buck.
+       ( FormatMsg msg
        , Ord nid
        , Show nid
        , Enum buck
@@ -443,14 +459,14 @@ new :: forall m msg nid buck.
     -> FailurePolicy nid
     -> (buck -> MaxBucketSize)
     -> UnknownNodeType nid
-    -> m (OutboundQ msg nid buck)
+    -> IO (OutboundQ msg nid buck)
 new qSelf
     qEnqueuePolicy
     qDequeuePolicy
     qFailurePolicy
     qMaxBucketSize
     (UnknownNodeType qUnknownNodeType)
-  = liftIO $ do
+  = do
     qInFlight    <- newMVar Map.empty
     qScheduled   <- MQ.new
     qBuckets     <- newMVar Map.empty
@@ -613,15 +629,18 @@ failureFormat (FailedBucketFull b) self () =
     sformat ( string % ": maximum bucket size of bucket " % shown % " exceeded" )
             self b
 
-logFailure :: (WithLogger m, MonadIO m)
-           => OutboundQ msg nid buck
+logFailure :: OutboundQ msg nid buck
            -> Failure msg nid buck fmt
            -> fmt
-           -> m ()
+           -> IO ()
 logFailure OutQ{..} failure fmt = do
-    Log.logMessage (failureSeverity failure)
-                   (failureFormat failure qSelf fmt)
-    liftIO $ Counter.inc $ failureCounter failure qHealth
+    usingLoggerName (fromString ("outboundqueue." <> qSelf)) $
+      Log.logMessage (failureSeverity failure)
+                     (failureFormat failure qSelf fmt)
+    Counter.inc $ failureCounter failure qHealth
+
+logDebugOQ :: OutboundQ msg nid buck -> Text -> IO ()
+logDebugOQ OutQ{..} = usingLoggerName (fromString ("outboundqueue." <> qSelf)) . logDebug
 
 {-------------------------------------------------------------------------------
   EKG metrics
@@ -695,8 +714,8 @@ countInFlight = sum . fmap sum
 countPeers :: Ord nid => Peers nid -> Int
 countPeers = Set.size . peersRouteSet
 
-countRecentFailures :: MonadIO m => Failures nid -> m Int
-countRecentFailures fs = liftIO $ aux <$> getCurrentTime
+countRecentFailures :: Failures nid -> IO Int
+countRecentFailures fs = aux <$> getCurrentTime
   where
     aux :: UTCTime -> Int
     aux now = Map.size (Map.filter (isRecentFailure now) fs)
@@ -708,12 +727,12 @@ countRecentFailures fs = liftIO $ aux <$> getCurrentTime
 -- | Enqueue a message to the specified set of peers
 --
 -- If no suitable peers can be found, choose one from the fallback set (if any).
-intEnqueue :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-           => OutboundQ msg nid buck
+intEnqueue :: forall msg nid buck a.
+              OutboundQ msg nid buck
            -> MsgType nid
            -> msg a
            -> Peers nid
-           -> m [Packet msg nid a]
+           -> IO [Packet msg nid a]
 intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
     forM (qEnqueuePolicy msgType) $ \case
 
@@ -724,7 +743,7 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
 
             sendAll :: [Packet msg nid a]
                     -> AllOf (Alts nid)
-                    -> m [Packet msg nid a]
+                    -> IO [Packet msg nid a]
             sendAll acc []           = return acc
             sendAll acc (alts:altss) = do
               mPacket <- sendFwdSet True -- warn on failure
@@ -741,11 +760,11 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
         -- Log an error if we didn't manage to enqueue the message to any peer
         -- at all (provided that we were configured to send it to some)
         if | null fwdSets ->
-               logDebug $ debugNotEnqueued enqNodeType -- This isn't an error
+               logDebugOQ outQ $ debugNotEnqueued enqNodeType -- This isn't an error
            | null enqueued ->
                logFailure outQ FailedEnqueueAll (enq, Some msg, fwdSets)
            | otherwise ->
-               logDebug $ debugEnqueued enqueued
+               logDebugOQ outQ $ debugEnqueued enqueued
 
         return enqueued
 
@@ -758,7 +777,7 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
 
             -- We don't warn when choosing an alternative here, as failure to
             -- choose an alternative implies failure to enqueue for 'EnqueueOne'
-            sendOne :: [(NodeType, Alts nid)] -> m [Packet msg nid a]
+            sendOne :: [(NodeType, Alts nid)] -> IO [Packet msg nid a]
             sendOne = fmap maybeToList
                     . orElseM
                     . map (sendFwdSet False [] enqMaxAhead enqPrecedence)
@@ -768,7 +787,7 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
         -- Log an error if we didn't manage to enqueue the message
         if null enqueued
           then logFailure outQ FailedEnqueueOne (enq, Some msg, fwdSets)
-          else logDebug $ debugEnqueued enqueued
+          else logDebugOQ outQ $ debugEnqueued enqueued
 
         return enqueued
   where
@@ -778,22 +797,22 @@ intEnqueue outQ@OutQ{..} msgType msg peers = fmap concat $
                -> MaxAhead             -- ^ Max allowed number of msgs ahead
                -> Precedence           -- ^ Precedence of the message
                -> (NodeType, Alts nid) -- ^ Alternatives to choose from
-               -> m (Maybe (Packet msg nid a))
+               -> IO (Maybe (Packet msg nid a))
     sendFwdSet warnOnFailure alreadyPicked maxAhead prec (nodeType, alts) = do
       mAlt <- pickAlt outQ maxAhead prec $ filter (`notElem` alreadyPicked) alts
       case mAlt of
         Nothing -> do
           when warnOnFailure $ logFailure outQ FailedChooseAlt alts
           return Nothing
-        Just alt -> liftIO $ do
-          sentVar <- newEmptyMVar
+        Just alt -> do
+          sentVar <- newTVarIO PacketEnqueued
           let packet = Packet {
                            packetPayload  = msg
                          , packetDestId   = alt
                          , packetMsgType  = msgType
                          , packetDestType = nodeType
                          , packetPrec     = prec
-                         , packetSent     = sentVar
+                         , packetStatus   = sentVar
                          }
           mqEnqueue qScheduled (EnqPacket packet)
           poke qSignal
@@ -836,11 +855,10 @@ data NodeWithStats nid = NodeWithStats {
     }
 
 -- | Compute current node statistics
-nodeWithStats :: (MonadIO m, WithLogger m)
-              => OutboundQ msg nid buck
+nodeWithStats :: OutboundQ msg nid buck
               -> Precedence -- ^ For determining number of messages ahead
               -> nid
-              -> m (NodeWithStats nid)
+              -> IO (NodeWithStats nid)
 nodeWithStats outQ prec nstatsId = do
     (nstatsAhead, nstatsInFlight) <- countAhead outQ nstatsId prec
     nstatsFailure                 <- hasRecentFailure outQ nstatsId
@@ -850,20 +868,20 @@ nodeWithStats outQ prec nstatsId = do
 --
 -- All alternatives are assumed to be of the same type; we prefer to pick
 -- nodes with a smaller number of messages ahead.
-pickAlt :: forall m msg nid buck. (MonadIO m, WithLogger m)
-        => OutboundQ msg nid buck
+pickAlt :: forall msg nid buck.
+           OutboundQ msg nid buck
         -> MaxAhead
         -> Precedence
         -> [nid]
-        -> m (Maybe nid)
+        -> IO (Maybe nid)
 pickAlt outQ@OutQ{} (MaxAhead maxAhead) prec alts = do
     alts' <- mapM (nodeWithStats outQ prec) alts
     orElseM [
         if | nstatsFailure -> do
-               logDebug $ debugFailure nstatsId
+               logDebugOQ outQ $ debugFailure nstatsId
                return Nothing
            | (nstatsAhead + nstatsInFlight) > maxAhead -> do
-               logDebug $ debugAhead nstatsId nstatsAhead nstatsInFlight maxAhead
+               logDebugOQ outQ $ debugAhead nstatsId nstatsAhead nstatsInFlight maxAhead
                return Nothing
            | otherwise -> do
                return $ Just nstatsId
@@ -890,11 +908,11 @@ pickAlt outQ@OutQ{} (MaxAhead maxAhead) prec alts = do
 -- NOTE: This is of course a highly dynamic value; by the time we get to
 -- actually enqueue the message the value might be slightly different. Bounds
 -- are thus somewhat fuzzy.
-countAhead :: forall m msg nid buck. (MonadIO m, WithLogger m)
-           => OutboundQ msg nid buck -> nid -> Precedence -> m (Int, Int)
-countAhead OutQ{..} nid prec = do
-    logDebug . debugInFlight =<< liftIO (readMVar qInFlight)
-    (inFlight, inQueue) <- liftIO $ (,)
+countAhead :: forall msg nid buck.
+              OutboundQ msg nid buck -> nid -> Precedence -> IO (Int, Int)
+countAhead outQ@OutQ{..} nid prec = do
+    logDebugOQ outQ . debugInFlight =<< (readMVar qInFlight)
+    (inFlight, inQueue) <- (,)
       <$> forM [prec .. maxBound] (\prec' ->
             view (inFlightWithPrec nid prec') <$> readMVar qInFlight)
       <*> forM [prec .. maxBound] (\prec' ->
@@ -915,21 +933,21 @@ checkMaxInFlight dequeuePolicy inFlight nodeType nid =
   where
     MaxInFlight n = deqMaxInFlight (dequeuePolicy nodeType)
 
-intDequeue :: forall m msg nid buck. WithLogger m
-           => OutboundQ msg nid buck
-           -> ThreadRegistry m
-           -> SendMsg m msg nid
-           -> m (Maybe CtrlMsg)
+intDequeue :: forall msg nid buck.
+              OutboundQ msg nid buck
+           -> ThreadRegistry
+           -> SendMsg msg nid
+           -> IO (Maybe CtrlMsg)
 intDequeue outQ@OutQ{..} threadRegistry@TR{} sendMsg = do
     mPacket <- getPacket
     case mPacket of
       Left ctrlMsg -> return $ Just ctrlMsg
       Right packet -> sendPacket packet >> return Nothing
   where
-    getPacket :: m (Either CtrlMsg (EnqPacket msg nid))
+    getPacket :: IO (Either CtrlMsg (EnqPacket msg nid))
     getPacket = retryIfNothing qSignal $ do
-      inFlight    <- liftIO $ readMVar qInFlight
-      rateLimited <- liftIO $ readMVar qRateLimited
+      inFlight    <- readMVar qInFlight
+      rateLimited <- readMVar qRateLimited
 
       let notBusy :: NotBusy nid
           notBusy nodeType nid = and [
@@ -959,50 +977,81 @@ intDequeue outQ@OutQ{..} threadRegistry@TR{} sendMsg = do
     -- device), with no real way to prioritize any one thread over the other. We
     -- will be able to solve this conumdrum properly once we move away from TCP
     -- and use the RINA network architecture instead.
-    sendPacket :: EnqPacket msg nid -> m ()
-    sendPacket (EnqPacket p) = do
-      sendStartTime <- liftIO $ getCurrentTime
+    sendPacket :: EnqPacket msg nid -> IO ()
+    sendPacket (EnqPacket p) = mdo
+      -- 😱  Does this even work?
+      -- We can't spawn the thread inside the STM transaction of course. So
+      -- instead we lazily fill it will the new status, using the old status
+      -- to determine what the new status shall be. In case the old status
+      -- is PacketEnqueued, computing the new status requires forking a
+      -- thread.
+      -- Should be fine I think.
+      oldStatus <- atomically $ do
+        status <- readTVar (packetStatus p)
+        writeTVar (packetStatus p) newStatus
+        return status
+      newStatus <- case oldStatus of
+        PacketDequeued it -> do
+          logDebugOQ outQ $ debugImpossible p
+          return (PacketDequeued it)
+        PacketAborted  -> do
+          logDebugOQ outQ $ debugAborted p
+          return PacketAborted
+        PacketEnqueued -> do
+          sendStartTime <- getCurrentTime
 
-      -- Mark the message as in-flight, limiting both enqueues and dequeues
-      setInFlightFor p (\n -> n + 1) qInFlight
+          -- Mark the message as in-flight, limiting both enqueues and dequeues
+          setInFlightFor p (\n -> n + 1) qInFlight
 
-      -- We mark the node as rate limited, making it unavailable for any
-      -- additional dequeues until the timer expires and we mark it as
-      -- available again. We start the timer /before/ the send so that the
-      -- duration of the send does not affect when the next dequeue can take
-      -- places (apart from max-in-flight, of course).
-      case deqRateLimit $ qDequeuePolicy (packetDestType p) of
-        NoRateLimiting -> return ()
-        MaxMsgPerSec n -> do
-          let delay = 1000000 `div` n
-          applyMVar_ qRateLimited $ Set.insert (packetDestId p)
-          forkThread threadRegistry $ \unmask -> unmask $
-            (liftIO $ threadDelay delay) `finally` (liftIO $ do
-              applyMVar_ qRateLimited $ Set.delete (packetDestId p)
-              poke qSignal)
+          -- We mark the node as rate limited, making it unavailable for any
+          -- additional dequeues until the timer expires and we mark it as
+          -- available again. We start the timer /before/ the send so that the
+          -- duration of the send does not affect when the next dequeue can take
+          -- places (apart from max-in-flight, of course).
+          case deqRateLimit $ qDequeuePolicy (packetDestType p) of
+            NoRateLimiting -> return ()
+            MaxMsgPerSec n -> do
+              let delay = 1000000 `div` n
+              applyMVar_ qRateLimited $ Set.insert (packetDestId p)
+              void $ forkThread threadRegistry $ \unmask -> unmask $
+                (threadDelay delay) `finally` (do
+                  applyMVar_ qRateLimited $ Set.delete (packetDestId p)
+                  poke qSignal)
 
-      forkThread threadRegistry $ \unmask -> do
-        logDebug $ debugSending p
+          theThread <- forkThread threadRegistry $ \unmask -> do
+            logDebugOQ outQ $ debugSending p
 
-        ma <- try $ unmask $ sendMsg (packetPayload p) (packetDestId p)
+            finallyWithException (unmask $ sendMsg (packetPayload p) (packetDestId p)) $ \ma -> do
 
-        -- Reduce the in-flight count ..
-        setInFlightFor p (\n -> n - 1) qInFlight
-        liftIO $ poke qSignal
+              -- Reduce the in-flight count ..
+              setInFlightFor p (\n -> n - 1) qInFlight
+              poke qSignal
 
-        -- .. /before/ notifying the sender that the send is complete.
-        -- If we did this the other way around a subsequent enqueue might fail
-        -- because of policy restrictions on the max in-flight.
-        liftIO $ putMVar (packetSent p) ma
+              -- .. /before/ notifying the sender that the send is complete.
+              -- If we did this the other way around a subsequent enqueue might fail
+              -- because of policy restrictions on the max in-flight.
 
-        case ma of
-          Left err -> do
-            logFailure outQ FailedSend (Some p, err)
-            intFailure outQ p sendStartTime err
-          Right _  ->
-            return ()
+              case ma of
+                Just err -> do
+                  logFailure outQ FailedSend (Some p, err)
+                  intFailure outQ p sendStartTime err
+                Nothing ->
+                  return ()
 
-        logDebug $ debugSent p
+              logDebugOQ outQ $ debugSent p
+
+          return (PacketDequeued theThread)
+      return ()
+
+    debugImpossible :: Packet msg nid a -> Text
+    debugImpossible Packet{..} =
+      sformat (string % ": packet " % formatMsg % " to " % shown % " sent twice. This is a bug!")
+              qSelf packetPayload packetDestId
+
+    debugAborted :: Packet msg nid a -> Text
+    debugAborted Packet{..} =
+      sformat (string % ": aborted " % formatMsg % " to " % shown)
+              qSelf packetPayload packetDestId
 
     debugSending :: Packet msg nid a -> Text
     debugSending Packet{..} =
@@ -1014,6 +1063,12 @@ intDequeue outQ@OutQ{..} threadRegistry@TR{} sendMsg = do
       sformat (string % ": sent " % formatMsg % " to " % shown)
               qSelf packetPayload packetDestId
 
+finallyWithException :: IO a -> (Maybe SomeException -> IO x) -> IO a
+finallyWithException it handler = do
+  x <- it `catch` (\e -> handler (Just e) >> throwIO e)
+  _ <- handler Nothing
+  pure x
+
 {-------------------------------------------------------------------------------
   Interpreter for failure policy
 -------------------------------------------------------------------------------}
@@ -1022,12 +1077,12 @@ intDequeue outQ@OutQ{..} threadRegistry@TR{} sendMsg = do
 --
 -- NOTE: Since we don't send messages to nodes listed in failures, we can
 -- assume that there isn't an existing failure here.
-intFailure :: forall m msg nid buck a. MonadIO m
-           => OutboundQ msg nid buck
+intFailure :: forall msg nid buck a.
+              OutboundQ msg nid buck
            -> Packet msg nid a  -- ^ Packet we failed to send
            -> UTCTime           -- ^ Time of the send
            -> SomeException     -- ^ The exception thrown by the send action
-           -> m ()
+           -> IO ()
 intFailure OutQ{..} p sendStartTime err = do
     applyMVar_ qFailures $
       Map.insert (packetDestId p) (
@@ -1037,8 +1092,8 @@ intFailure OutQ{..} p sendStartTime err = do
                          err
         )
 
-hasRecentFailure :: MonadIO m => OutboundQ msg nid buck -> nid -> m Bool
-hasRecentFailure OutQ{..} nid = liftIO $ do
+hasRecentFailure :: OutboundQ msg nid buck -> nid -> IO Bool
+hasRecentFailure OutQ{..} nid = do
     mFailure <- Map.lookup nid <$> readMVar qFailures
     case mFailure of
       Nothing      -> return False
@@ -1054,7 +1109,7 @@ isRecentFailure now (timeOfFailure, ReconsiderAfter n) =
 --
 -- This is useful when we know for external reasons that nodes may be reachable
 -- again, allowing the outbound queue to enqueue messages to those nodes.
-clearRecentFailures :: MonadIO m => OutboundQ msg nid buck -> m ()
+clearRecentFailures :: OutboundQ msg nid buck -> IO ()
 clearRecentFailures OutQ{..} = applyMVar_ qFailures $ const Map.empty
 
 -- | Clear recent failure status for a particular node
@@ -1062,7 +1117,7 @@ clearRecentFailures OutQ{..} = applyMVar_ qFailures $ const Map.empty
 -- This is useful when we know for external reasons that this particular
 -- node is reachable again (for instance, because it sent us a message),
 -- allowing the outbound queue to enqueue messages to that node again.
-clearFailureOf :: MonadIO m => OutboundQ msg nid buck -> nid -> m ()
+clearFailureOf :: OutboundQ msg nid buck -> nid -> IO ()
 clearFailureOf OutQ{..} nid = applyMVar_ qFailures $ Map.delete nid
 
 {-------------------------------------------------------------------------------
@@ -1070,26 +1125,32 @@ clearFailureOf OutQ{..} nid = applyMVar_ qFailures $ Map.delete nid
 -------------------------------------------------------------------------------}
 
 -- | Queue a message to be sent, but don't wait (asynchronous API)
-enqueue :: (MonadIO m, WithLogger m)
-        => OutboundQ msg nid buck
+enqueue :: OutboundQ msg nid buck
         -> MsgType nid -- ^ Type of the message being sent
         -> msg a       -- ^ Message to send
-        -> m [(nid, m (Either SomeException a))]
+        -> IO [(nid, TVar (PacketStatus a))]
 enqueue outQ msgType msg = do
-    waitAsync <$> intEnqueueTo outQ msgType msg (msgEnqueueTo msgType)
+    takePacketStatus <$> intEnqueueTo outQ msgType msg (msgEnqueueTo msgType)
 
--- | Queue a message and wait for it to have been sent
+-- | Queue a message and wait for it to have been sent.
 --
--- Returns for each node that the message got enqueued the result of the
--- send action (or an exception if it failed).
-enqueueSync' :: (MonadIO m, WithLogger m)
-             => OutboundQ msg nid buck
+-- A 'Nothing' means the conversation was aborted before it was dequeued.
+-- Otherwise, you get the 'Aync' of the thread that runs the conversation.
+enqueueSync' :: OutboundQ msg nid buck
              -> MsgType nid -- ^ Type of the message being sent
              -> msg a       -- ^ Message to send
-             -> m [(nid, Either SomeException a)]
+             -> IO [(nid, Maybe (Async a))]
 enqueueSync' outQ msgType msg = do
     promises <- enqueue outQ msgType msg
-    traverse (\(nid, wait) -> (,) nid <$> wait) promises
+    atomically $ traverse waitForDequeue promises
+  where
+    waitForDequeue :: (nid, TVar (PacketStatus a)) -> STM (nid, Maybe (Async a))
+    waitForDequeue (nid, tvar) = do
+      it <- readTVar tvar
+      case it of
+        PacketEnqueued -> retry
+        PacketAborted -> pure (nid, Nothing)
+        PacketDequeued thread -> pure (nid, Just thread)
 
 -- | Queue a message and wait for it to have been sent
 --
@@ -1098,36 +1159,36 @@ enqueueSync' outQ msgType msg = do
 -- warnings will be logged when individual sends fail. Additionally, we will
 -- log an error when /all/ sends failed (this doesn't currently happen in the
 -- asynchronous API).
-enqueueSync :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-            => OutboundQ msg nid buck
+enqueueSync :: forall msg nid buck a.
+               OutboundQ msg nid buck
             -> MsgType nid -- ^ Type of the message being sent
             -> msg a       -- ^ Message to send
-            -> m ()
+            -> IO ()
 enqueueSync outQ msgType msg =
-    warnIfNotOneSuccess outQ msg $ enqueueSync' outQ msgType msg
+    warnIfNotOneSuccess outQ msg $ enqueueSync' outQ msgType msg >>= waitForAll
 
 -- | Enqueue a message which really should not get lost
 --
 -- Returns 'True' if the message was successfully sent.
-enqueueCherished :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-                 => OutboundQ msg nid buck
+enqueueCherished :: forall msg nid buck a.
+                    OutboundQ msg nid buck
                  -> MsgType nid -- ^ Type of the message being sent
                  -> msg a       -- ^ Message to send
-                 -> m Bool
+                 -> IO Bool
 enqueueCherished outQ msgType msg =
-    cherish outQ $ enqueueSync' outQ msgType msg
+    cherish outQ $ enqueueSync' outQ msgType msg >>= waitForAll
 
 {-------------------------------------------------------------------------------
   Internal generalization of the enqueueing API
 -------------------------------------------------------------------------------}
 
 -- | Enqueue message to the specified set of peers
-intEnqueueTo :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-             => OutboundQ msg nid buck
+intEnqueueTo :: forall msg nid buck a.
+                OutboundQ msg nid buck
              -> MsgType nid
              -> msg a
              -> EnqueueTo nid
-             -> m [Packet msg nid a]
+             -> IO [Packet msg nid a]
 intEnqueueTo outQ@OutQ{..} msgType msg enqTo = do
     peers <- restrict <$> getAllPeers outQ
     intEnqueue outQ msgType msg peers
@@ -1151,16 +1212,18 @@ intEnqueueTo outQ@OutQ{..} msgType msg enqTo = do
 
           in  restricted <> unknown
 
-waitAsync :: MonadIO m
-          => [Packet msg nid a] -> [(nid, m (Either SomeException a))]
-waitAsync = map $ \Packet{..} -> (packetDestId, liftIO $ readMVar packetSent)
+takePacketStatus :: [Packet msg nid a] -> [(nid, TVar (PacketStatus a))]
+takePacketStatus = map $ \Packet{..} -> (packetDestId, packetStatus)
+
+waitForAll :: [(nid, Maybe (Async a))] -> IO [(nid, Maybe (Either SomeException a))]
+waitForAll = undefined
 
 -- | Make sure a synchronous send succeeds to at least one peer
-warnIfNotOneSuccess :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-                    => OutboundQ msg nid buck
+warnIfNotOneSuccess :: forall msg nid buck a.
+                       OutboundQ msg nid buck
                     -> msg a
-                    -> m [(nid, Either SomeException a)]
-                    -> m ()
+                    -> IO [(nid, Maybe (Either SomeException a))]
+                    -> IO ()
 warnIfNotOneSuccess outQ msg act = do
     attempts <- act
     -- If the attempts is null, we would already have logged an error that
@@ -1170,14 +1233,14 @@ warnIfNotOneSuccess outQ msg act = do
 
 -- | Repeatedly run an action until at least one send succeeds, we run out of
 -- options, or we reach a predetermined maximum number of iterations.
-cherish :: forall m msg nid buck a. (MonadIO m, WithLogger m)
-        => OutboundQ msg nid buck
-        -> m [(nid, Either SomeException a)]
-        -> m Bool
+cherish :: forall msg nid buck a.
+           OutboundQ msg nid buck
+        -> IO [(nid, Maybe (Either SomeException a))]
+        -> IO Bool
 cherish outQ act =
     go maxNumIterations
   where
-    go :: Int -> m Bool
+    go :: Int -> IO Bool
     go 0 = do
       logFailure outQ FailedCherishLoop ()
       return False
@@ -1204,8 +1267,8 @@ cherish outQ act =
     maxNumIterations :: Int
     maxNumIterations = 4
 
-successes :: [(nid, Either SomeException a)] -> [a]
-successes = rights . map snd
+successes :: [(nid, Maybe (Either SomeException a))] -> [a]
+successes = rights . mapMaybe id . map snd
 
 {-------------------------------------------------------------------------------
   Dequeue thread
@@ -1220,24 +1283,16 @@ successes = rights . map snd
 -- * The IO action will be run in a separate thread.
 -- * No additional timeout is applied to the 'SendMsg', so if one is
 --   needed it must be provided externally.
-type SendMsg m msg nid = forall a. msg a -> nid -> m a
+type SendMsg msg nid = forall a. msg a -> nid -> IO a
 
 -- | The dequeue thread
 --
 -- It is the responsibility of the next layer up to fork this thread; this
 -- function does not return unless told to terminate using 'waitShutdown'.
-dequeueThread :: forall m msg nid buck. (
-                   MonadIO                    m
-                 , MonadMask                  m
-                 , M.Mockable M.Async         m
-                 , M.Mockable M.LowLevelAsync m
-                 , M.Mockable M.MyThreadId    m
-                 , Ord (M.ThreadId            m)
-                 , WithLogger                 m
-                 )
-              => OutboundQ msg nid buck -> SendMsg m msg nid -> m ()
+dequeueThread :: forall msg nid buck.
+                 OutboundQ msg nid buck -> SendMsg msg nid -> IO ()
 dequeueThread outQ@OutQ{..} sendMsg = withThreadRegistry $ \threadRegistry ->
-    let loop :: m ()
+    let loop :: IO ()
         loop = do
           mCtrlMsg <- intDequeue outQ threadRegistry sendMsg
           case mCtrlMsg of
@@ -1245,8 +1300,8 @@ dequeueThread outQ@OutQ{..} sendMsg = withThreadRegistry $ \threadRegistry ->
             Just ctrlMsg -> do
               waitAllThreads threadRegistry
               case ctrlMsg of
-                Shutdown ack -> do liftIO $ putMVar ack ()
-                Flush    ack -> do liftIO $ putMVar ack ()
+                Shutdown ack -> do putMVar ack ()
+                Flush    ack -> do putMVar ack ()
                                    loop
 
     in loop
@@ -1263,16 +1318,16 @@ data CtrlMsg =
   | Flush    (MVar ())
 
 -- | Gracefully shutdown the relayer
-waitShutdown :: MonadIO m => OutboundQ msg nid buck -> m ()
-waitShutdown OutQ{..} = liftIO $ do
+waitShutdown :: OutboundQ msg nid buck -> IO ()
+waitShutdown OutQ{..} = do
     ack <- newEmptyMVar
     putMVar qCtrlMsg $ Shutdown ack
     poke qSignal
     takeMVar ack
 
 -- | Wait for all messages currently enqueued to have been sent
-flush :: MonadIO m => OutboundQ msg nid buck -> m ()
-flush OutQ{..} = liftIO $ do
+flush :: OutboundQ msg nid buck -> IO ()
+flush OutQ{..} = do
     ack <- newEmptyMVar
     putMVar qCtrlMsg $ Flush ack
     poke qSignal
@@ -1305,16 +1360,16 @@ data SpareCapacity = UnlimitedCapacity | SpareCapacity Int
 
 -- | Returns how many "free slots" the bucket `buck` still has for peers.
 -- Returns `UnlimitedCapacity` if there is no bucket size limit.
-bucketSpareCapacity :: MonadIO m => OutboundQ msg nid buck -> buck -> m SpareCapacity
+bucketSpareCapacity :: OutboundQ msg nid buck -> buck -> IO SpareCapacity
 bucketSpareCapacity OutQ{..} buck = case qMaxBucketSize buck of
   BucketSizeUnlimited        -> return UnlimitedCapacity
   BucketSizeMax maxCapacity  -> do
-    currentCapacity <- countPeers . fromMaybe mempty . Map.lookup buck <$> liftIO (readMVar qBuckets)
+    currentCapacity <- countPeers . fromMaybe mempty . Map.lookup buck <$> (readMVar qBuckets)
     return . SpareCapacity $ max 0 (maxCapacity - currentCapacity)
 
 -- | Internal method: read all buckets of peers
-getAllPeers :: MonadIO m => OutboundQ msg nid buck -> m (Peers nid)
-getAllPeers OutQ{..} = liftIO $ fold <$> readMVar qBuckets
+getAllPeers :: OutboundQ msg nid buck -> IO (Peers nid)
+getAllPeers OutQ{..} = fold <$> readMVar qBuckets
 
 -- | Update a bucket of peers
 --
@@ -1329,13 +1384,13 @@ getAllPeers OutQ{..} = liftIO $ fold <$> readMVar qBuckets
 --
 -- Returns 'False' if the update could not complete
 -- (maximum bucket size exceeded).
-updatePeersBucket :: forall m msg nid buck. (MonadIO m, WithLogger m)
-                  => OutboundQ msg nid buck
+updatePeersBucket :: forall msg nid buck.
+                     OutboundQ msg nid buck
                   -> buck
                   -> (Peers nid -> Peers nid)
-                  -> m Bool
+                  -> IO Bool
 updatePeersBucket outQ@OutQ{..} buck f = do
-    success <- liftIO $ modifyMVar qBuckets $ \buckets -> do
+    success <- modifyMVar qBuckets $ \buckets -> do
 
       let before   = fold buckets
           buckets' = Map.alter f' buck buckets
@@ -1368,54 +1423,46 @@ updatePeersBucket outQ@OutQ{..} buck f = do
   Auxiliary: starting and registering threads
 -------------------------------------------------------------------------------}
 
-data ThreadRegistry m =
-       ( MonadIO                    m
-       , M.Mockable M.Async         m
-       , M.Mockable M.LowLevelAsync m
-       , M.Mockable M.MyThreadId    m
-       , MonadMask                  m
-       , Ord (M.ThreadId            m)
-       )
-    => TR (MVar (Map (M.ThreadId m) (M.Promise m ())))
+data ThreadRegistry = TR (MVar (Map ThreadId (Some Async)))
 
 -- | Create a new thread registry, killing all threads when the action
 -- terminates.
-withThreadRegistry :: ( MonadIO                    m
-                      , M.Mockable M.Async         m
-                      , M.Mockable M.LowLevelAsync m
-                      , M.Mockable M.MyThreadId    m
-                      , MonadMask                  m
-                      , Ord (M.ThreadId            m)
-                      )
-                   => (ThreadRegistry m -> m ()) -> m ()
+withThreadRegistry :: (ThreadRegistry -> IO ()) -> IO ()
 withThreadRegistry k = do
-    threadRegistry <- liftIO $ TR <$> newMVar Map.empty
+    threadRegistry <- TR <$> newMVar Map.empty
     k threadRegistry `finally` killAllThreads threadRegistry
 
-killAllThreads :: ThreadRegistry m -> m ()
+killAllThreads :: ThreadRegistry -> IO ()
 killAllThreads (TR reg) = do
     threads <- applyMVar reg $ \threads -> (Map.empty, Map.elems threads)
-    mapM_ M.cancel threads
+    mapM_ cancelSome threads
+  where
+    cancelSome :: Some Async -> IO ()
+    cancelSome (Some it) = cancel it
 
-waitAllThreads :: ThreadRegistry m -> m ()
+waitAllThreads :: ThreadRegistry -> IO ()
 waitAllThreads (TR reg) = do
     threads <- applyMVar reg $ \threads -> (Map.empty, Map.elems threads)
-    mapM_ M.wait threads
+    mapM_ waitSome threads
+  where
+    waitSome :: Some Async -> IO ()
+    waitSome (Some it) = void (wait it)
 
-type Unmask m = forall a. m a -> m a
+type Unmask = forall a. IO a -> IO a
 
 -- | Fork a new thread, taking care of registration and unregistration
-forkThread :: ThreadRegistry m -> (Unmask m -> m ()) -> m ()
+forkThread :: ThreadRegistry -> (Unmask -> IO a) -> IO (Async a)
 forkThread (TR reg) threadBody = mask_ $ do
-    barrier <- liftIO $ newEmptyMVar
-    thread  <- M.asyncWithUnmask $ \unmask -> do
-                 tid <- M.myThreadId
-                 liftIO $ takeMVar barrier
+    barrier <- newEmptyMVar
+    thread  <- asyncWithUnmask $ \unmask -> do
+                 tid <- myThreadId
+                 takeMVar barrier
                  threadBody unmask `finally`
                    applyMVar_ reg (at tid .~ Nothing)
-    tid     <- M.asyncThreadId thread
-    applyMVar_ reg (at tid .~ Just thread)
-    liftIO $ putMVar barrier ()
+    let tid = asyncThreadId thread
+    applyMVar_ reg (at tid .~ Just (Some thread))
+    putMVar barrier ()
+    return thread
 
 {-------------------------------------------------------------------------------
   Auxiliary: Signalling
@@ -1444,11 +1491,11 @@ poke :: Signal b -> IO ()
 poke Signal{..} = void $ tryPutMVar signalPokeVar ()
 
 -- | Keep retrying an action until it succeeds, blocking between attempts.
-retryIfNothing :: forall m a b. MonadIO m
-               => Signal b -> m (Maybe a) -> m (Either b a)
+retryIfNothing :: forall a b.
+                  Signal b -> IO (Maybe a) -> IO (Either b a)
 retryIfNothing Signal{..} act = go
   where
-    go :: m (Either b a)
+    go :: IO (Either b a)
     go = do
       ma <- act
       case ma of
@@ -1464,12 +1511,12 @@ retryIfNothing Signal{..} act = go
           -- however: we run the action again in this new state, no matter how
           -- many changes took place. If in that new state the action still
           -- fails, then we will wait for further changes on the next iteration.
-          mCtrlMsg <- liftIO $ signalCtrlMsg
+          mCtrlMsg <- signalCtrlMsg
           case mCtrlMsg of
             Just ctrlMsg ->
               return (Left ctrlMsg)
             Nothing -> do
-              liftIO $ takeMVar signalPokeVar
+              takeMVar signalPokeVar
               go
 
 {-------------------------------------------------------------------------------
@@ -1482,11 +1529,11 @@ orElseM = foldr aux (return Nothing)
     aux :: m (Maybe a) -> m (Maybe a) -> m (Maybe a)
     aux f g = f >>= maybe g (return . Just)
 
-applyMVar :: MonadIO m => MVar a -> (a -> (a, b)) -> m b
-applyMVar mv f = liftIO $ modifyMVar mv $ \a -> return $! f a
+applyMVar :: MVar a -> (a -> (a, b)) -> IO b
+applyMVar mv f = modifyMVar mv $ \a -> return $! f a
 
-applyMVar_ :: MonadIO m => MVar a -> (a -> a) -> m ()
-applyMVar_ mv f = liftIO $ modifyMVar_ mv $ \a -> return $! f a
+applyMVar_ :: MVar a -> (a -> a) -> IO ()
+applyMVar_ mv f = modifyMVar_ mv $ \a -> return $! f a
 
 -- | Existential
 data Some (f :: k -> *) where

--- a/networking/src/Network/Broadcast/OutboundQueue/ConcurrentMultiQueue.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue/ConcurrentMultiQueue.hs
@@ -73,7 +73,7 @@ module Network.Broadcast.OutboundQueue.ConcurrentMultiQueue
     ) where
 
 import           Control.Concurrent
-import           Control.Exception.Safe (Exception, throwM)
+import           Control.Exception (Exception, throwIO)
 import           Control.Lens
 import           Control.Monad
 import           Data.IORef
@@ -622,7 +622,7 @@ assertEq :: HasCallStack => Eq a => a -> a -> IO ()
 assertEq expected actual =
     if expected == actual
       then return ()
-      else throwM $ AssertionFailure ?callStack
+      else throwIO $ AssertionFailure ?callStack
 
 data AssertionFailure = AssertionFailure CallStack
   deriving (Show)

--- a/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
@@ -11,65 +11,29 @@ module Network.Broadcast.OutboundQueue.Demo where
 
 
 import           Control.Concurrent
-import           Control.Exception.Safe (Exception, MonadCatch, MonadMask, MonadThrow, throwM)
+import           Control.Exception (Exception, throwIO)
 import           Control.Monad
-import           Control.Monad.IO.Class
 import           Data.Function
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.String (fromString)
 import           Data.Text (Text)
 import           Formatting (sformat, shown, (%))
 import           System.Wlog
 
-import qualified Mockable as M
 import           Network.Broadcast.OutboundQueue (OutboundQ)
 import qualified Network.Broadcast.OutboundQueue as OutQ
 import           Network.Broadcast.OutboundQueue.Types hiding (simplePeers)
 
-{-------------------------------------------------------------------------------
-  Demo monads
+type Enqueue = IO
 
-  In order to show that it's possible, we use different monads for enqueueing
-  and dequeueing.
--------------------------------------------------------------------------------}
-
-newtype Dequeue a = Dequeue { unDequeue :: M.Production a }
-  deriving ( Functor
-           , Applicative
-           , Monad
-           , MonadIO
-           , MonadThrow
-           , MonadCatch
-           , MonadMask
-           , CanLog
-           , HasLoggerName
-           )
-
-type instance M.ThreadId Dequeue = M.ThreadId M.Production
-type instance M.Promise  Dequeue = M.Promise  M.Production
-
-instance M.Mockable M.Async Dequeue where
-    liftMockable = Dequeue . M.liftMockable . M.hoist' unDequeue
-instance M.Mockable M.LowLevelAsync Dequeue where
-    liftMockable = Dequeue . M.liftMockable . M.hoist' unDequeue
-instance M.Mockable M.MyThreadId  Dequeue where
-    liftMockable = Dequeue . M.liftMockable . M.hoist' unDequeue
-
-newtype Enqueue a = Enqueue { unEnqueue :: M.Production a }
-  deriving ( Functor
-           , Applicative
-           , Monad
-           , MonadIO
-           , MonadThrow
-           , CanLog
-           , HasLoggerName
-           )
+type Dequeue = IO
 
 runDequeue :: Dequeue a -> IO a
-runDequeue = M.runProduction . unDequeue
+runDequeue = id
 
 runEnqueue :: Enqueue a -> IO a
-runEnqueue = M.runProduction . unEnqueue
+runEnqueue = id
 
 {-------------------------------------------------------------------------------
   Relay demo
@@ -81,13 +45,13 @@ relayDemo = do
 
     let block :: Text -> [Node] -> Enqueue () -> Enqueue ()
         block label nodes act = do
-          logNotice label
+          usingLoggerName (fromString "outboundqueue-production") $ logNotice label
           act
           mapM_ (OutQ.flush . nodeOutQ) nodes
-          liftIO $ threadDelay 500000
+          threadDelay 500000
 
     -- Set up some test nodes
-    (nodeC1, nodeC2, nodeR, nodeEs, nodeC3) <- M.runProduction $ do
+    (nodeC1, nodeC2, nodeR, nodeEs, nodeC3) <- do
       nodeC1 <- newNode (C 1) NodeCore  (CommsDelay 0)
       nodeC2 <- newNode (C 2) NodeCore  (CommsDelay 0)
       nodeR  <- newNode (R 1) NodeRelay (CommsDelay 0)
@@ -135,7 +99,7 @@ relayDemo = do
           send Asynchronous nodeR (MsgTransaction OriginSender)         (MsgId n)
           send Asynchronous nodeR (MsgTransaction OriginSender)         (MsgId (n + 1))
           send Asynchronous nodeR (MsgAnnounceBlockHeader OriginSender) (MsgId (n + 2))
-          liftIO $ threadDelay 2500000
+          threadDelay 2500000
 
       block "* Latency masking (and sync API)" [nodeC2] $ do
         -- Core to core communication is allowed higher concurrency
@@ -151,7 +115,7 @@ relayDemo = do
         -- Edge nodes can never send to core nodes
         send Asynchronous (nodeEs !! 0) (MsgRequestBlocks (Set.fromList (nodeId <$> [nodeC1]))) (MsgId 501)
 
-      logNotice "End of demo"
+      usingLoggerName (fromString "outboundqueue-demo") $ logNotice "End of demo"
 
 {-------------------------------------------------------------------------------
   Model of a node
@@ -171,8 +135,8 @@ instance Eq Node where
     n1 == n2 = nodeId n1 == nodeId n2
 
 -- | Create a new node, and spawn dequeue worker and forwarding listener
-newNode :: MonadIO m => NodeId_ -> NodeType -> CommsDelay -> m Node
-newNode nodeId_ nodeType commsDelay = liftIO $ do
+newNode :: NodeId_ -> NodeType -> CommsDelay -> IO Node
+newNode nodeId_ nodeType commsDelay = do
     nodeOutQ     <- OutQ.new (show nodeId_)
                              demoEnqueuePolicy
                              demoDequeuePolicy
@@ -191,8 +155,8 @@ nodeDequeueWorker :: Node -> Dequeue ()
 nodeDequeueWorker node =
     OutQ.dequeueThread (nodeOutQ node) sendMsg
   where
-    sendMsg :: OutQ.SendMsg Dequeue MsgObj_ NodeId
-    sendMsg msg nodeId = liftIO $ msgSend msg nodeId
+    sendMsg :: OutQ.SendMsg MsgObj_ NodeId
+    sendMsg msg nodeId = msgSend msg nodeId
 
 -- | Listener that forwards any new messages that arrive at the node
 nodeForwardListener :: Node -> Enqueue ()
@@ -201,9 +165,9 @@ nodeForwardListener node = forever $ do
     added   <- addToMsgPool (nodeMsgPool node) msgData
     let msgObj = mkMsgObj msgData
     if not added then
-      logDebug $ discarded msgObj
+      usingLoggerName (fromString "outboundqueue-demo") $ logDebug $ discarded msgObj
     else do
-      logNotice $ received msgObj
+      usingLoggerName (fromString "outboundqueue-demo") $ logNotice $ received msgObj
       let sender = msgSender msgData
           forwardMsgType = case msgType msgData of
             MsgAnnounceBlockHeader _ -> Just (MsgAnnounceBlockHeader (OriginForward sender))
@@ -223,7 +187,7 @@ nodeForwardListener node = forever $ do
     discarded = sformat (shown % ": discarded " % formatMsg) (nodeId node)
 
 -- | Set the peers of a node
-setPeers :: (MonadIO m, WithLogger m) => Node -> [Node] -> m ()
+setPeers :: Node -> [Node] -> IO ()
 setPeers peersOf peers =
     void $ OutQ.updatePeersBucket (nodeOutQ peersOf) () (\_ -> simplePeers peers)
 
@@ -244,9 +208,9 @@ instance Exception SendFailed
 -- | Send a message from the specified node
 send :: Sync -> Node -> MsgType NodeId -> MsgId -> Enqueue ()
 send sync from msgType msgId = do
-    logNotice $ sformat (shown % ": send " % formatMsg) (nodeId from) msgObj
+    usingLoggerName (fromString "outboundqueue-demo") $ logNotice $ sformat (shown % ": send " % formatMsg) (nodeId from) msgObj
     added <- addToMsgPool (nodeMsgPool from) msgData
-    unless added $ throwM SendFailedAddToPool
+    unless added $ throwIO SendFailedAddToPool
     enqueue (nodeOutQ from) msgType msgObj
   where
     msgData = MsgData (nodeId from) msgType msgId
@@ -262,14 +226,14 @@ send sync from msgType msgId = do
 -- | Message pool allows us to detect whether an incoming message is new or not
 type MsgPool = MVar (Set MsgId)
 
-newMsgPool :: MonadIO m => m MsgPool
-newMsgPool = liftIO $ newMVar Set.empty
+newMsgPool :: IO MsgPool
+newMsgPool = newMVar Set.empty
 
 -- | Add a message to the pool
 --
 -- Returns whether the message was new.
-addToMsgPool :: MonadIO m => MsgPool -> MsgData -> m Bool
-addToMsgPool pool MsgData{msgId} = liftIO $ modifyMVar pool $ \msgs ->
+addToMsgPool :: MsgPool -> MsgData -> IO Bool
+addToMsgPool pool MsgData{msgId} = modifyMVar pool $ \msgs ->
     return $! if Set.member msgId msgs
                 then (msgs, False)
                 else (Set.insert msgId msgs, True)
@@ -327,10 +291,10 @@ instance Eq   NodeId where (==) = (==) `on` nodeId_
 instance Ord  NodeId where (<=) = (<=) `on` nodeId_
 instance Show NodeId where show = show .    nodeId_
 
-sendNodeId :: MonadIO m => NodeId -> MsgData -> m ()
+sendNodeId :: NodeId -> MsgData -> IO ()
 sendNodeId NodeId{..} = sendSyncVar nodeSyncVar
 
-recvNodeId :: MonadIO m => NodeId -> m MsgData
+recvNodeId :: NodeId -> IO MsgData
 recvNodeId NodeId{..} = recvSyncVar nodeSyncVar nodeDelay
 
 {-------------------------------------------------------------------------------
@@ -342,17 +306,17 @@ data SyncVar a = SyncVar (MVar (a, MVar ()))
 -- | Delay models slow communication networks
 newtype CommsDelay = CommsDelay Int
 
-newSyncVar :: MonadIO m => m (SyncVar a)
-newSyncVar = liftIO $ SyncVar <$> newEmptyMVar
+newSyncVar :: IO (SyncVar a)
+newSyncVar = SyncVar <$> newEmptyMVar
 
-sendSyncVar :: MonadIO m => SyncVar a -> a -> m ()
-sendSyncVar (SyncVar v) a = liftIO $ do
+sendSyncVar :: SyncVar a -> a -> IO ()
+sendSyncVar (SyncVar v) a = do
     ack <- newEmptyMVar
     putMVar v (a, ack)
     takeMVar ack
 
-recvSyncVar :: MonadIO m => SyncVar a -> CommsDelay -> m a
-recvSyncVar (SyncVar v) (CommsDelay delay) = liftIO $ do
+recvSyncVar :: SyncVar a -> CommsDelay -> IO a
+recvSyncVar (SyncVar v) (CommsDelay delay) = do
     (a, ack) <- takeMVar v
     -- We run the acknowledgement in a separate thread, to model a node
     -- spawning a listener for each incoming request

--- a/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
@@ -137,7 +137,7 @@ instance Eq Node where
 -- | Create a new node, and spawn dequeue worker and forwarding listener
 newNode :: NodeId_ -> NodeType -> CommsDelay -> IO Node
 newNode nodeId_ nodeType commsDelay = do
-    nodeOutQ     <- OutQ.new (show nodeId_)
+    nodeOutQ     <- OutQ.new (OutQ.wlogTrace "demo" (show nodeId_))
                              demoEnqueuePolicy
                              demoDequeuePolicy
                              demoFailurePolicy

--- a/networking/test/Test/Network/Broadcast/OutboundQueueSpec.hs
+++ b/networking/test/Test/Network/Broadcast/OutboundQueueSpec.hs
@@ -7,7 +7,6 @@ import           Control.Monad
 import           Data.List (delete)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
-import qualified Mockable as M
 import qualified Network.Broadcast.OutboundQueue as OutQ
 import           Network.Broadcast.OutboundQueue.Demo
 import           Network.Broadcast.OutboundQueue.Types hiding (simplePeers)
@@ -23,7 +22,7 @@ testInFlight = do
     removeAllHandlers
 
     -- Set up some test nodes
-    allNodes <- M.runProduction $ do
+    allNodes <- do
       ns <- forM [1..4] $ \nodeIdx -> newNode (C nodeIdx) NodeCore  (CommsDelay 0)
       forM_ ns $ \theNode -> setPeers theNode  (delete theNode ns)
       return ns

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6922,32 +6922,33 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "cardano-sl" = callPackage
-        ({ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, base, binary
-         , bytestring, canonical-json, cardano-crypto, cardano-sl-binary
-         , cardano-sl-block, cardano-sl-core, cardano-sl-crypto
-         , cardano-sl-db, cardano-sl-delegation, cardano-sl-infra
-         , cardano-sl-lrc, cardano-sl-networking, cardano-sl-ssc
-         , cardano-sl-txp, cardano-sl-update, cardano-sl-util, cborg, cereal
-         , conduit, constraints, containers, cpphs, cryptonite, data-default
-         , deepseq, directory, dns, ed25519, ekg-core, ekg-statsd, ekg-wai
-         , ether, exceptions, extra, filelock, filepath, fmt, formatting
-         , generic-arbitrary, half, hashable, hspec, kademlia, lens
-         , log-warper, lrucache, memory, mmorph, monad-control, MonadRandom
-         , mtl, neat-interpolation, network-transport, network-transport-tcp
-         , optparse-applicative, parsec, plutus-prototype, pvss, QuickCheck
-         , random, reflection, resourcet, rocksdb-haskell-ng
-         , safe-exceptions, safecopy, serokell-util, servant, servant-client
-         , servant-client-core, servant-server, servant-swagger, stdenv, stm
-         , systemd, tagged, template-haskell, text, text-format, time
-         , time-units, transformers, transformers-base, universum, unix
-         , unliftio, unordered-containers, vector, wai, warp, warp-tls, yaml
+        ({ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, async, base
+         , binary, bytestring, canonical-json, cardano-crypto
+         , cardano-sl-binary, cardano-sl-block, cardano-sl-core
+         , cardano-sl-crypto, cardano-sl-db, cardano-sl-delegation
+         , cardano-sl-infra, cardano-sl-lrc, cardano-sl-networking
+         , cardano-sl-ssc, cardano-sl-txp, cardano-sl-update
+         , cardano-sl-util, cborg, cereal, conduit, constraints, containers
+         , cpphs, cryptonite, data-default, deepseq, directory, dns, ed25519
+         , ekg-core, ekg-statsd, ekg-wai, ether, exceptions, extra, filelock
+         , filepath, fmt, formatting, generic-arbitrary, half, hashable
+         , hspec, kademlia, lens, log-warper, lrucache, memory, mmorph
+         , monad-control, MonadRandom, mtl, neat-interpolation
+         , network-transport, network-transport-tcp, optparse-applicative
+         , parsec, plutus-prototype, pvss, QuickCheck, random, reflection
+         , resourcet, rocksdb-haskell-ng, safe-exceptions, safecopy
+         , serokell-util, servant, servant-client, servant-client-core
+         , servant-server, servant-swagger, stdenv, stm, systemd, tagged
+         , template-haskell, text, text-format, time, time-units
+         , transformers, transformers-base, universum, unix, unliftio
+         , unordered-containers, vector, wai, warp, warp-tls, yaml
          }:
          mkDerivation {
            pname = "cardano-sl";
            version = "1.1.0";
            src = ./../lib;
            libraryHaskellDepends = [
-             aeson ansi-terminal ansi-wl-pprint base binary bytestring
+             aeson ansi-terminal ansi-wl-pprint async base binary bytestring
              canonical-json cardano-crypto cardano-sl-binary cardano-sl-block
              cardano-sl-core cardano-sl-crypto cardano-sl-db
              cardano-sl-delegation cardano-sl-infra cardano-sl-lrc
@@ -7401,10 +7402,10 @@ inherit (pkgs) mesa;};
          }) {};
       "cardano-sl-networking" = callPackage
         ({ mkDerivation, aeson, async, attoparsec, base, binary, bytestring
-         , conduit, conduit-extra, containers, cryptonite, data-default
-         , ekg-core, exceptions, formatting, hashable, hspec, kademlia, lens
-         , log-warper, mmorph, monad-control, MonadRandom, mtl, network
-         , network-transport, network-transport-inmemory
+         , conduit, conduit-extra, containers, contravariant, cryptonite
+         , data-default, ekg-core, exceptions, formatting, hashable, hspec
+         , kademlia, lens, log-warper, mmorph, monad-control, MonadRandom
+         , mtl, network, network-transport, network-transport-inmemory
          , network-transport-tcp, optparse-simple, QuickCheck, random
          , resourcet, safe-exceptions, serokell-util, statistics, stdenv
          , stm, text, text-format, time, time-units, transformers
@@ -7417,13 +7418,13 @@ inherit (pkgs) mesa;};
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
-             aeson async attoparsec base binary bytestring containers cryptonite
-             data-default ekg-core exceptions formatting hashable kademlia lens
-             log-warper mmorph monad-control mtl network network-transport
-             network-transport-tcp QuickCheck random resourcet safe-exceptions
-             serokell-util statistics stm text text-format time time-units
-             transformers transformers-base transformers-lift universum
-             unliftio-core
+             aeson async attoparsec base binary bytestring containers
+             contravariant cryptonite data-default ekg-core exceptions
+             formatting hashable kademlia lens log-warper mmorph monad-control
+             mtl network network-transport network-transport-tcp QuickCheck
+             random resourcet safe-exceptions serokell-util statistics stm text
+             text-format time time-units transformers transformers-base
+             transformers-lift universum unliftio-core
            ];
            executableHaskellDepends = [
              attoparsec base binary bytestring conduit conduit-extra containers

--- a/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
@@ -117,7 +117,12 @@ runWalletMode nr wallet (action, outSpecs) =
           (runProduction . elimRealMode nr . walletModeToRealMode wallet)
 
     serverWalletMode :: WalletMode a
-    serverWalletMode = runServer ncNodeParams ekgNodeMetrics outSpecs action
+    serverWalletMode = runServer
+        (runProduction . elimRealMode nr . walletModeToRealMode wallet)
+        ncNodeParams
+        ekgNodeMetrics
+        outSpecs
+        action
 
     serverRealMode :: RealMode EmptyMempoolExt a
     serverRealMode = walletModeToRealMode wallet serverWalletMode

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -64,7 +64,12 @@ runWRealMode db conn ref res (action, outSpecs) =
         (nrEkgStore res)
         (runProduction . elimRealMode res . walletWebModeToRealMode db conn ref)
     serverWalletWebMode :: WalletWebMode a
-    serverWalletWebMode = runServer ncNodeParams ekgNodeMetrics outSpecs action
+    serverWalletWebMode = runServer
+        (runProduction . elimRealMode res . walletWebModeToRealMode db conn ref)
+        ncNodeParams
+        ekgNodeMetrics
+        outSpecs
+        action
     serverRealMode :: RealMode WalletMempoolExt a
     serverRealMode = walletWebModeToRealMode db conn ref serverWalletWebMode
 


### PR DESCRIPTION
Previously: when enqueueing the caller gets a `Map NodeId (m (Either SomeException t))` as soon as the outbound queue has completed _enqueueing_. The `m`s in that map will block until the relevant conversation (to the given `NodeId`) has been dequeued and completed.

1. It's impossible to abort an enqueued conversation before it is dequeued.
2. It's impossible to get a hold of the conversation's thread id and, for instance, throw exceptions to it, or link it to another thread in the `Async` style.

This implements the improved interface:

```
enqueue
    :: OutboundQ msg nid buck
    -> MsgType nid
    -> msg a
    -> IO [(nid, TVar (PacketStatus a))]

data PacketStatus a = InFlight (Async a) | Pending | Aborted

-- Abort a pending enqueued thing. No-op if it's already in flight.
-- [Not implemented in this ticket but easy to do]
abortPacket :: TVar (PacketStatus a) -> IO ()

-- Block until the packet is in flight. Give Nothing if it's aborted (outbound queue itself never aborts them).
-- [Not implemented in this ticket but easy to do]
threadForPacket :: TVar (PacketStatus a) -> IO (Maybe (Async a))
```

This will help @karknu with the implementation of CSL-2148

Part of this change is to make the outbound queue use `IO` explicitly, rather than `Mockable`/`MonadIO`/`MonadThrow`/`WithLogger` etc. Turns out it still fits nicely into cardano-sl. I think we ought to make the full diffusion layer use `IO` as well, and ditch our `Network.Transport.Abstract` shim. Fact is: whenever we need a `forall y . hugeMonadTransformer y -> IO y` we have one.