### PR TITLE
Improve README files

### DIFF
--- a/auxx/README.md
+++ b/auxx/README.md
@@ -1,0 +1,7 @@
+# cardano-sl-auxx
+
+This package implements a tool and language for connecting to Cardano SL node
+running locally and performing operations like inspecting the node's state and
+sending commands to the node.
+
+It is documented more fully in the file [docs/auxx.md] of the git repository.

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/binary/README.md
+++ b/binary/README.md
@@ -1,0 +1,13 @@
+# cardano-sl-binary
+
+Binary serialisation and deserialisation for Cardano SL.
+
+This library is built on top of the [binary] and [cborg] packages and implement
+space efficient serialising and deserialising of Haskell data types to and from
+binary representations via a `Bi` type class and associated machinery.
+
+The library includes ability the derive `Bi` instances (requires a `Typeable`
+constraint).
+
+[binary]: https://hackage.haskell.org/package/binary
+[cborg]: https://hackage.haskell.org/package/cborg

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -10,6 +10,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/block/README.md
+++ b/block/README.md
@@ -1,0 +1,14 @@
+# cardano-sl-block
+
+This package defines functions that operate on blocks for Cardano SL.
+
+The block type is defined in the cardano-sl-core package, but this is the package
+with functions for:
+
+* Creating blocks.
+* Validating blocks.
+* Applying blocks to the blockchain and rolling them back.
+* Calculating chain quality (number of main blocks divided by number of slots so
+  far).
+* Code to retrieve block headers and blocks from the Cardano network.
+* Functions for iterating over a chain of blocks.

--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,9 @@
+# cardano-sl-client
+
+This package implements some of the functionality required for a client of the
+Cardano SL network. This includes:
+
+* Generation of addresses and change addresses.
+* Calculating coin balances.
+* Calculating transactions history.
+* Preparing and submitting new transactions to the network.

--- a/client/cardano-sl-client.cabal
+++ b/client/cardano-sl-client.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,15 @@
+# cardano-sl-core
+
+Core components of Cardano SL, including types and operations for the following
+concepts:
+
+* A `Coin` type which is used to denominate the currency.
+* An `Address` type which is the source and destination for transactions.
+* Blockchain related components like `Block`, `BlockHeader`, `HeaderHash` (the hash
+  of a block header) etc.
+* Handling of stakeholder and delegation (of stake) for Proof-of-Stake operations.
+* Epochs, a finite period of time for which slot leaders are predetermined.
+* Slots, a period of time during which at most one block is minted/mined.
+* Shared Seed Computation (SSC) which is used in the process of electing a slot
+  leaders where slot leaders get to mine/mint the block for the slot they lead.
+* Software updates, including proposals for updating and voting on updates.

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 flag asserts

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,0 +1,20 @@
+# cardano-sl-crypto
+
+The cryptographic primitives used in Cardano SL.
+
+* A simplified interface to access the AES encryption functionality in the
+  [cryptonite] library. It uses AES256 CTR mode with IV = 0.
+* Cryptographic hashing (again using the [cryptonite] library).
+* A wrapper around the [scrypt] library used for password-based key derivation
+  functions.
+* A wrapper around [pvss-haskell] for Verifiable Secret Sharing (VSS).
+* Secure generation of cryptographically random numbers and `ByteString`s.
+* Hierarchical derivation functionality for Hierarchical Deterministic key
+  creation (ie for the wallet).
+* Cryptographic signing and signature checking.
+* `Aeson` and `Bi` (serialisation, see the cardano-sl-binary package) instances
+  for the cryptographic data types.
+
+[cryptonite]: https://hackage.haskell.org/package/cryptonite
+[pvss-haskell]: https://github.com/input-output-hk/pvss-haskell
+[scrypt]: https://hackage.haskell.org/package/scrypt

--- a/crypto/cardano-sl-crypto.cabal
+++ b/crypto/cardano-sl-crypto.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,22 @@
+# cardano-sl-db
+
+Database operations for Cardano SL.
+
+A Cardano node has a database that is used to store:
+
+  * The blocks that make up the blockchain and a block index to make queries on
+    the blocks easier and more efficient.
+  * UTXOs (unspent transaction outputs).
+  * LRC (leaders and richmen computation) data required for Proof-of-Stake.
+  * Other miscellaneous data.
+
+A cardano node stores its data in a [RocksDB] database. Since [RocksDB] is
+written in C++, it is accessed from Haskell via the [rocksdb-haskell-ng] library.
+
+In addition, this library provides a pure database interface built on top
+of `Data.Map` that mirrors the RocksDB data base so that one can be tested
+against the other.
+
+
+[RocksDB]: http://rocksdb.org/
+[rocksdb-haskell-ng]: https://github.com/input-output-hk/rocksdb-haskell-ng

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/delegation/README.md
+++ b/delegation/README.md
@@ -1,0 +1,7 @@
+# cardano-sl-delegation
+
+This library implements the mechanisms by which a holder of coins can delegate
+their their stake to a staking pool for delegated Proof-of-Stake. Stake delegation
+is described more fully in [this document](https://cardanodocs.com/technical/delegation/).
+
+

--- a/delegation/cardano-sl-delegation.cabal
+++ b/delegation/cardano-sl-delegation.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,4 @@
+# cardano-sl-generator
+
+This package defines types and functions to generate random but valid blocks
+for Cardano SL.

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,19 @@
+# cardano-sl-infra
+
+A library implementing the network infrastructure for the Cardano SL network.
+
+This library contains:
+
+* The diffusion layer; the mechanism by which nodes on the Cardano network
+  communicate with one another.
+* An implementation of peer discovery using using Kademlia Distributed Hash Table
+  using the [kademlia] library.
+* Management of a list of peers on the Cardano network.
+* Code for checking that the system clock on a node is not too far out of sync
+  with others on the network using NTP (Network Time Protocol).
+* Code for safely shutting down a node.
+* Code for monitoring and collecting the internal state of a node, generating
+  statistics and reporting this data.
+* Code for dealing with slots within an epoch.
+
+[kademlia]: https://hackage.haskell.org/package/kademlia

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,31 +1,14 @@
-# Cardano SL
+# cardano-sl-lib
 
-[![Build status](https://badge.buildkite.com/9c3141d21214ff3ea95d0a38a0e1dab59b206159d2841dee44.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-sl)
-[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/input-output/cardano-sl)
-[![Release](https://img.shields.io/github/release/input-output-hk/cardano-sl.svg)](https://github.com/input-output-hk/cardano-sl/releases)
+Higher level components of Cardano SL, including types and operations for the
+following concepts:
 
-## What is Cardano SL?
-
-Cardano SL (or Cardano Settlement Layer) is a cryptographic currency designed
-and developed by [IOHK](https://iohk.io/team). Please read [Cardano SL Introduction](https://cardanodocs.com/introduction/)
-for more information.
-
-## Supported Platforms
-
-Please see [Cardano SL Installation](https://cardanodocs.com/installation/) for more
-information.
-
-## Building Cardano SL from Source Code
-
-Please see [this guide](https://cardanodocs.com/for-contributors/building-from-source/) for
-more information.
-
-## For Contributors
-
-Please see [CONTRIBUTING.md](https://github.com/input-output-hk/cardano-sl/blob/develop/CONTRIBUTING.md)
-for more information.
-
-## License
-
-Please see [LICENSE](https://github.com/input-output-hk/cardano-sl/blob/master/LICENSE) for
-more information.
+* Higher level inter node message definitions.
+* Management of the run-time context of a node.
+* Searching the UTXO set for addresses which correspond to specified HD passphrase.
+* High level code for setting up and running the diffusion layer.
+* High level code for dealing with GState (the result of applying some blocks the
+  initial genesis state).
+* Code for configuring and launching a node.
+* Higher level crypto and blockchain code.
+* Definitions of the REST API endpoints exposed by a node.

--- a/lrc/README.md
+++ b/lrc/README.md
@@ -1,0 +1,7 @@
+# cardano-sl-lrc
+
+Leaders and Richmen Computation (LRC) for Cardano SL. LRC is part of the
+[Ouroborous] Proof-of-Stake protocol including the "Follow the Satoshi"
+procedures for selecting slot leaders for the next epoch.
+
+[Ouroborous]: https://eprint.iacr.org/2016/889.pdf

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -4,6 +4,7 @@ license:             MIT
 license-file:        LICENSE
 category:            Network
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.20
 
 flag benchmarks

--- a/ssc/README.md
+++ b/ssc/README.md
@@ -1,0 +1,16 @@
+# cardano-sl-ssc
+
+A library to do the Shared Seed Computation (SSC) required for selection of
+slot leaders in the [Ouroborous] Proof-of-Stake protocol for Cardano SL.
+
+Code in this library types and functions for:
+
+* Generating random seeds
+* Communicating SSC state (using SSC specific messaging protocols) to other nodes
+  in the network.
+* Storing and retrieving SSC state from the database.
+* Interacting with the LRC (Leaders and Richment Computation)
+* Ability to ignore network addresses and public key addresses which are thought
+  to be attacking the Cardano network at the Proof-of-Stake protocol level.
+
+[Ouroborous]: https://eprint.iacr.org/2016/889.pdf

--- a/ssc/cardano-sl-ssc.cabal
+++ b/ssc/cardano-sl-ssc.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,17 @@
+# cardano-sl-tools
+
+A collection of tools for interacting with the Cardano SL network. The tools
+include:
+
+* `cardano-dht-keygen` - Generate a DHT key.
+* `cardano-genupdate` - Generate an update for the Cardano SL network.
+* `cardano-keygen` - Generate keyfiles for the Cardano SL network.
+* `cardano-launcher` - A program that launches the Cardano SL code and the Daedalus
+  wallet.
+* `cardano-addr-convert` - A tool to convert vending addresses between mainnet and
+  testnet address format.
+* `cardano-cli-docs` - A tool to generate markdown documentation for Cardano SL
+  executables.
+* `cardano-post-mortem` - Analyzes JSON logs.
+* `cardano-blockchain-analyser` - A tool to analyze a blockchain and spit out useful
+  metrics.

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 -- Note: for components that we don't want to build, we add both "buildable:

--- a/txp/README.md
+++ b/txp/README.md
@@ -1,0 +1,14 @@
+# cardano-sl-txp
+
+This library implements transaction processing for Cardano SL. It includes:
+
+* Logic for verifying transactions, applying them the blockchain and rolling
+  them back.
+* Logic for local and global transactions. Global transactions are ones that
+  have already been added to the blockchain while local ones have not yet been
+  added.
+* A database interface that stores UTXOs and stakes.
+* A wrapper over [Plutus], the scripting language used in transactions.
+* The mempool which holds the UTXOs (unspent transaction outputs) for a node.
+
+[Plutus]: https://github.com/input-output-hk/plutus-prototype

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/update/README.md
+++ b/update/README.md
@@ -1,0 +1,8 @@
+# cardano-sl-update
+
+This package contains the code which implements the mechanisms by which the
+Cardano SL network proposes software and protocol upgrades, votes on whether
+these upgrades should go ahead and applies them when voting has decided in
+favour of a proposal. Users of the network vote on proposals weighted by the
+amount of stake they hold and these voting rights can be delegated to other
+stakeholders.

--- a/update/cardano-sl-update.cabal
+++ b/update/cardano-sl-update.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,19 @@
+# cardano-sl-util
+
+A library of utility data types are functions for Cardano SL, including:
+
+* Functions for collecting compile time version information.
+* Extra concurrency primitives, including more operations on `MVar`s, `RWLock`s
+  lifted to `MonadIO` and a `PriorityLock`.
+* File system related utility functions.
+* A futures capability.
+* Utility function for left justifying/aligning text.
+* A `LoggerName` capability used in the generator, explorer, wallet and elsewhere.
+* Utility functions to extend the `LRU` functionality defined in the `lrucache`
+  package.
+* A `MapModifier` type that collects modifications (insertions and deletions) on
+  a `Map` like type.
+* A collection of orphan instances for external data types.
+* A collection of QuickCheck helpers and Arbitrary instances.
+* A `Some` data type that allows a constraint to turned into an existential type.
+* A restart-able, STM-based timer.

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -11,6 +11,7 @@ maintainer:          hi@serokell.io
 copyright:           2016 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -10,6 +10,7 @@ license:             MIT
 license-file:        LICENSE
 category:            Web
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -1,0 +1,4 @@
+# cardano-sl-wallet
+
+This package implements the old version of the wallet which will be replaced
+with the version in the `wallet-new` package in this same repository.

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -9,6 +9,7 @@ maintainer:          hi@serokell.io
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
+extra-source-files:  README.md
 cabal-version:       >=1.10
 
 Flag for-installer


### PR DESCRIPTION
Add a new README for `cardano-sl-core`.

Replace existing README for `cardano-sl-lib`. The old README was an exact duplicate of the file one directory level up.
