### PR TITLE
Simplify WithCommandAction in auxx

### DIFF
--- a/auxx/Main.hs
+++ b/auxx/Main.hs
@@ -89,7 +89,7 @@ runNodeWithSinglePlugin nr (plugin, plOuts) =
 action :: HasCompileInfo => AuxxOptions -> Either WithCommandAction Text -> Production ()
 action opts@AuxxOptions {..} command = do
     let runWithoutNode = rawExec Nothing opts Nothing command
-    printAction <- either getPrintAction (const $ return putText) command
+    printAction <- return $ either printAction (const putText) command
 
     let configToDict :: HasConfigurations => Production (Maybe (Dict HasConfigurations))
         configToDict = return (Just Dict)

--- a/auxx/src/Plugin.hs
+++ b/auxx/src/Plugin.hs
@@ -65,7 +65,6 @@ rawExec ::
     -> m ()
 rawExec mHasAuxxMode AuxxOptions{..} mDiffusion = \case
     Left WithCommandAction{..} -> do
-        printAction <- getPrintAction
         printAction "... the auxx plugin is ready"
         forever $ withCommand $ runCmd mHasAuxxMode mDiffusion printAction
     Right cmd -> runWalletCmd mHasAuxxMode mDiffusion cmd


### PR DESCRIPTION
Read from MVar on each print. I expect the overhead to be negligible, but it makes the types simpler.