### PR TITLE
[DEVOPS-679] appveyor account/secrets change (#2595)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
       secure: m5sQYd16K8HA0zoZaD0gOl4EEWUso1D51L5rp+kT3hLaIE3tt4iT+b+iW8F4F0FU
 
 init:
-- ps: $env:CACHE_S3_READY = (("$env:CACHE_S3_VERSION" -ne "") -and ("$env:S3_BUCKET" -ne ""))
+- ps: $env:CACHE_S3_READY = (("$env:CACHE_S3_VERSION" -ne "") -and ("$env:S3_BUCKET" -ne "") -and ("$env:AWS_ACCESS_KEY_ID" -ne "") -and ("$env:AWS_SECRET_ACCESS_KEY" -ne ""))
 
 before_test:
 # Avoid long paths not to each MAX_PATH of 260 chars

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,11 @@ environment:
     WORK_DIR: "c:\\w"
     CACHE_S3_VERSION: v0.1.1
     AWS_REGION: us-west-1
-    S3_BUCKET: appveyor-ci-cache              
-    AWS_ACCESS_KEY_ID: 
-      secure: 0OtMCUmJ4V7fNRPvKjzYxSO19I200rPG8WRW/qn1QPk=
+    S3_BUCKET: appveyor-ci-cache
+    AWS_ACCESS_KEY_ID:
+      secure: sQWt5CpaN0H+jwUVoTsrET46pADUDEcrJ5D9MHmKX0M=
     AWS_SECRET_ACCESS_KEY:
-      secure: EmPAMpga8gjXxPMfJSsdq2sof8SLwyga1rrYuZDlPoriMS1iEFLvCNLA70JqHSna
+      secure: m5sQYd16K8HA0zoZaD0gOl4EEWUso1D51L5rp+kT3hLaIE3tt4iT+b+iW8F4F0FU
 
 init:
 - ps: $env:CACHE_S3_READY = (("$env:CACHE_S3_VERSION" -ne "") -and ("$env:S3_BUCKET" -ne ""))
@@ -114,11 +114,3 @@ artifacts:
   - path: daedalus/
     name: CardanoSL
     type: zip
-
-notifications:
-  - provider: Slack
-    incoming_webhook:
-      secure: 3KXYR8gCzuhyML2adCU1HayVFPi5TfDUhiQcffkf8QNcwqmZRL+IY/idxf951NNYJ8+GJQDhek7LWLhKrr4d08J9erBw8GePrCwTaBfwQkQ=
-    on_build_success: false
-    on_build_failure: false
-    on_build_status_changed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     STACK_ROOT: "c:\\s"
     STACK_WORK: ".w"
     WORK_DIR: "c:\\w"
-    CACHE_S3_VERSION: v0.1.1
+    CACHE_S3_VERSION: v0.1.3
     AWS_REGION: us-west-1
     S3_BUCKET: appveyor-ci-cache
     AWS_ACCESS_KEY_ID:

--- a/node/README.md
+++ b/node/README.md
@@ -3,7 +3,7 @@
 # Cardano SL
 
 [![Build Status](https://travis-ci.org/input-output-hk/cardano-sl.svg)](https://travis-ci.org/input-output-hk/cardano-sl)
-[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/jagajaga/cardano-sl)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/input-output/cardano-sl)
 [![Release](https://img.shields.io/github/release/input-output-hk/cardano-sl.svg)](https://github.com/input-output-hk/cardano-sl/releases)
 
 <!-- CARDANO_SL_README_BEGIN_1 -->

--- a/scripts/ci/update-cardano-sl-readme.sh
+++ b/scripts/ci/update-cardano-sl-readme.sh
@@ -32,7 +32,7 @@ echo "**** Building ${README} from documentation ****"
   echo "# Cardano SL";
   echo "";
   echo "[![Build Status](https://travis-ci.org/input-output-hk/cardano-sl.svg)](https://travis-ci.org/input-output-hk/cardano-sl)";
-  echo "[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/jagajaga/cardano-sl)";
+  echo "[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/input-output/cardano-sl)";
   echo "[![Release](https://img.shields.io/github/release/input-output-hk/cardano-sl.svg)](https://github.com/input-output-hk/cardano-sl/releases)";
   echo "";
 } >> "${README}"


### PR DESCRIPTION
Required for #2499

* Appveyor account change
* Change appveyor secrets for CI cache
* Remove Slack notification because the encrypted API token won't work.
* Update cache-s3 version
* Add check to not use cache-s3 if aws credentials are missing