### PR TITLE
[CSL-2344] Rename `cardano-node-new` executable to `cardano-new`

### DIFF
--- a/scripts/launch/demo-with-legacy-new-wallet-api.sh
+++ b/scripts/launch/demo-with-legacy-new-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXE_NAME='cardano-new' WALLET_TEST=1 "$base"/demo.sh $@

--- a/scripts/launch/demo-with-new-wallet-api.sh
+++ b/scripts/launch/demo-with-new-wallet-api.sh
@@ -2,4 +2,4 @@
 
 base=$(dirname "$0")
 
-WALLET_EXTRA_ARGS="--new-wallet" WALLET_EXE_NAME='cardano-node-new' WALLET_TEST=1 "$base"/demo.sh $@
+WALLET_EXTRA_ARGS="--new-wallet" WALLET_EXE_NAME='cardano-new' WALLET_TEST=1 "$base"/demo.sh $@

--- a/wallet-new/README.md
+++ b/wallet-new/README.md
@@ -18,11 +18,11 @@ committing new work.
 This will be made automatic as part of [this issue](https://iohk.myjetbrains.com/youtrack/issue/CSL-1939) but
 for now requires self-enforced discipline.
 
-Currently the only way to generate an updated `swagger.json` is to run the `cardano-node-new` node, so that
+Currently the only way to generate an updated `swagger.json` is to run the `cardano-new` node, so that
 the updated Swagger file will be written on disk. For example:
 
 ```
-stack exec cardano-node-new -- --topology=wallet-new/topology-examples/testnet.yaml --configuration-key mainnet_staging_short_epoch_full --wallet-debug --rebuild-db
+stack exec cardano-new -- --topology=wallet-new/topology-examples/testnet.yaml --configuration-key mainnet_staging_short_epoch_full --wallet-debug --rebuild-db
 ```
 
 Running the command above *from the root of the Cardano project* will store an updated `swagger.json` into

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -125,7 +125,7 @@ library
                       UndecidableInstances
                       MonadFailDesugaring
 
-executable cardano-node-new
+executable cardano-new
   hs-source-dirs:      server
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts


### PR DESCRIPTION
This was needed due to limit on paths size in Windows, and e.g.
`.w\dist\ca59d0ab\build\cardano-node-new\cardano-node-new.exe`
was too long for linker and caused appveyor to fail.

Example of failed build:
https://ci.appveyor.com/project/jagajaga/cardano-sl/build/1.0.21472