### PR TITLE
[CSL-1786] Implement download timeout

### DIFF
--- a/update/Pos/Update/Download.hs
+++ b/update/Pos/Update/Download.hs
@@ -15,6 +15,7 @@ import           Control.Monad.Except (ExceptT (..))
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.HashMap.Strict as HM
+import           Data.Time.Units (Minute, toMicroseconds)
 import           Formatting (build, sformat, stext, (%))
 import           Network.HTTP.Client (Manager, newManager)
 import           Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -22,7 +23,9 @@ import           Network.HTTP.Simple (getResponseBody, getResponseStatus, getRes
                                       httpLBS, parseRequest, setRequestManager)
 import qualified Serokell.Util.Base16 as B16
 import           Serokell.Util.Text (listJsonIndent, mapJson)
-import           System.Directory (doesFileExist, removeFile)
+import           System.Directory (doesFileExist)
+import           System.Timeout (timeout)
+
 import           System.Wlog (WithLogger, logDebug, logInfo, logWarning)
 
 import           Pos.Binary.Class (Raw)
@@ -167,10 +170,12 @@ downloadUpdateDo updHash cps@ConfirmedProposalState {..} = do
   where
     handleErr e =
         Left (pretty e) <$ reportOrLogW "Update downloading failed: " e
+
     logDownloadError e =
         logWarning $ sformat
             ("Failed to download update proposal "%build%": "%stext)
             cpsUpdateProposal e
+
     -- Check that we really should download an update with given
     -- 'SoftwareVersion'.
     isVersionAppropriate :: SoftwareVersion -> Bool
@@ -188,11 +193,13 @@ downloadHash ::
 downloadHash updateServers h = do
     manager <- liftIO $ newManager tlsManagerSettings
 
-    let -- try all servers in turn until there's a Right
+    let
+        maxLatency = 30 :: Minute
+        -- try all servers in turn until there's a Right
         go errs (serv:rest) = do
             let uri = toString serv <//> showHash h
             logDebug $ "Trying url " <> show uri
-            liftIO (downloadUri manager uri h) >>= \case
+            liftIO (withTimeOut ((fromInteger . toMicroseconds) maxLatency) (downloadUri manager uri h)) >>= \case
                 Left e -> go (e:errs) rest
                 Right r -> return (Right r)
 
@@ -208,6 +215,14 @@ downloadHash updateServers h = do
   where
     showHash :: Hash a -> FilePath
     showHash = toString . B16.encode . BA.convert
+
+    withTimeOut :: Int
+                -> IO (Either Text LByteString)
+                -> IO (Either Text LByteString)
+    withTimeOut maxLatency action = do
+        timeout maxLatency action <&> \case
+            Nothing -> Left "Timeout occured while downloading an update"
+            Just anything -> anything
 
 -- Download a file and check its hash.
 downloadUri :: Manager
@@ -225,9 +240,8 @@ downloadUri manager uri h = do
 
 {- TODO
 
-* check timeouts?
 * how should we in general deal with e.g. 1B/s download speed?
 * if we expect updates to be big, use laziness/conduits (httpLBS isn't lazy,
-  despite the “L” in its name)
+despite the “L” in its name)
 
 -}


### PR DESCRIPTION
Implemented withTimeOut according to https://iohk.myjetbrains.com/youtrack/issue/CSL-1786.
If maxLatency time (30 min for now) exceded Timeout error returned as (Left <Text> ) and logged with other errors.