### PR TITLE
Slightly update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,8 +30,6 @@ scripts/set_nixpath.sh          @iohk-devops
 
 Delegation/                     @volhovm
 
-Wallet/                         @akegalj @adinapoli-iohk
-
 txp/                            @gromakovsky @pva701 @neongreen
 update/                         @gromakovsky @pva701
 lrc/                            @pva701
@@ -60,12 +58,9 @@ networking/                     @dcoutts @avieth
 scripts/bench                   @kantp @avieth
 
 # Wallet
-wallet/src                      @martoon @akegalj @adinapoli-iohk
-wallet/purescript               @akegalj @adinapoli-iohk
+wallet/                         @martoon @akegalj @adinapoli-iohk
 wallet/web-api-swagger          @martoon @adinapoli-iohk
 wallet-new/                     @adinapoli-iohk
 
 ## Auxx
 auxx                            @int-index
-
-genesis-info/                   @georgeee

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,21 +30,10 @@ scripts/set_nixpath.sh          @iohk-devops
 
 Delegation/                     @volhovm
 
-txp/                            @gromakovsky @pva701 @neongreen
+txp/                            @gromakovsky @pva701
 update/                         @gromakovsky @pva701
 lrc/                            @pva701
-ssc/                            @gromakovsky @neongreen
-
-core/Pos/Binary/                @neongreen
-core/Pos/Crypto/                @neongreen
-core/Pos/Merkle.hs              @neongreen
-
-core/Pos/Util/Config.hs         @neongreen
-core/Pos/Util/Config/           @neongreen
-lib/src/Pos/CompileConfig/      @neongreen
-
-scripts/build/cardano-sl.sh     @neongreen
-HLint.hs                        @neongreen
+ssc/                            @gromakovsky
 
 lib/test/                       @rockbmb
 lib/test/Test/Pos/Block/Logic/  @gromakovsky


### PR DESCRIPTION
1. `wallet/purescript` and `genesis-info` folders do not exist anymore.
2. Ownership of whole `wallet/` was passed to wallet developers (e. g.
   `cardano-sl-wallet.cabal` previously was owned by me, now it is not).
3. 'Wallet/' entry was removed. Previously some Wallet code was in `lib/`, now
   it is not.