### PR TITLE
[DEVOPS-660] relay enqueue policy for edge node block req

### DIFF
--- a/infra/Pos/Network/Policy.hs
+++ b/infra/Pos/Network/Policy.hs
@@ -61,13 +61,14 @@ defaultEnqueuePolicyRelay = go
         EnqueueAll NodeCore  (MaxAhead 2) PHigh
       , EnqueueAll NodeRelay (MaxAhead 2) PHigh
       ]
+    -- We can request for headers from edge nodes, if we received one
+    -- unsolicited from them. In that case, we'll have 'Just' here.
     go (MsgRequestBlockHeaders (Just _)) = [
-        -- We never ask for data from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 3) PHigh
+        EnqueueOne [NodeRelay, NodeCore, NodeEdge] (MaxAhead 3) PHigh
       ]
+    -- Just as for headers, we can request blocks from edge nodes as well.
     go (MsgRequestBlocks _) = [
-        -- We never ask for blocks from edge nodes
-        EnqueueOne [NodeRelay, NodeCore] (MaxAhead 3) PHigh
+        EnqueueOne [NodeRelay, NodeCore, NodeEdge] (MaxAhead 3) PHigh
       ]
     go (MsgTransaction _) = [
         EnqueueAll NodeCore  (MaxAhead 200) PLow


### PR DESCRIPTION
~~A relay yaml policy was included just for the record. It matches the old
relay policy (also changed in this commit) but it seems that the yaml
file can't express everything that the Haskell datatype can: in
particular, a different policy for block header requests depending on
whether we know the NodeIds of peers to request from.~~

Default relay policy updated so that they will make requests from edge node for block headers and blocks.