### PR TITLE
[CSL-2268] block retrieval worker exceptions

### DIFF
--- a/block/src/Pos/Block/Network/Retrieval.hs
+++ b/block/src/Pos/Block/Network/Retrieval.hs
@@ -78,7 +78,6 @@ retrievalWorker diffusion = do
                 -- No tasks & the recovery header is set => do the recovery
                 (_, Just (nodeId, rHeader))  ->
                     pure (handleRecoveryWithHandler nodeId rHeader)
-
         -- Exception handlers are installed locally, on the 'thingToDoNext',
         -- to ensure that network troubles, for instance, do not kill the
         -- worker.


### PR DESCRIPTION
The worker will log and squelch exceptions from block retrieval.

This is the same idea as the patch at int-index/csl-2268
5c33d99a05d649acb4d6e5a433ac1098ac806890

Exception handlers are installed locally, on the IO action that comes
out of the retrieval queue STM transaction: one for recovery mode, one
for normal mode.