### PR TITLE
[CSL-2340] Implement a client DSL for testing the wallet

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -52,6 +52,9 @@ library
                        Cardano.Wallet.API.V1.Migration.Types
                        Cardano.Wallet.API.V0
                        Cardano.Wallet.API.V0.Types
+
+                       Cardano.Wallet.Client
+
                        Cardano.Wallet.Util
 
   ghc-options:         -Wall

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -54,6 +54,7 @@ library
                        Cardano.Wallet.API.V0.Types
 
                        Cardano.Wallet.Client
+                       Cardano.Wallet.Client.Http
 
                        Cardano.Wallet.Util
 

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -1,0 +1,76 @@
+-- | This module defines a client for the Cardano new-wallet.
+module Cardano.Wallet.Client
+    ( -- * The abstract client
+      WalletClient(..)
+    , getWalletIndex
+    , Resp
+    -- * The type of errors that the client might return
+    , WalletError(..)
+    -- * Reexports
+    , module Cardano.Wallet.API.V1.Types
+    , module Cardano.Wallet.API.V1.Parameters
+    , module Cardano.Wallet.API.Request.Pagination
+    ) where
+
+import           Universum
+
+import           Cardano.Wallet.API.Response
+
+import           Cardano.Wallet.API.Request.Pagination
+import           Cardano.Wallet.API.V1.Errors
+import           Cardano.Wallet.API.V1.Parameters
+import           Cardano.Wallet.API.V1.Types
+import qualified Pos.Core as Core
+
+-- | A representation of a wallet client parameterized over some effect
+-- type @m@.
+--
+-- The record fields serve as the API to the wallet client. Note that the
+-- field 'getAddressIndex' has the type:
+--
+-- @
+-- 'getAddressIndex'
+--     :: 'WalletClient' m
+--     -> m ('Either' 'WalletError' ('WalletResponse' ['Address']))
+-- @
+--
+-- Other functions may be defined in terms of this 'WalletClient' -- see
+-- 'getWalletIndex' as a convenience helper for 'getWalletIndexPaged'.
+data WalletClient m
+    = WalletClient
+    { -- address endpoints
+      getAddressIndex :: Resp m [Address]
+    , postAddress :: NewAddress -> Resp m WalletAddress
+    , getAddressValidity :: Text -> Resp m AddressValidity
+    -- wallets endpoints
+    , postWallet :: New Wallet -> Resp m Wallet
+    , getWalletIndexPaged :: Maybe Page -> Maybe PerPage -> Resp m [Wallet]
+    , updateWalletPassword :: WalletId -> PasswordUpdate -> Resp m Wallet
+    , deleteWallet :: WalletId -> Resp m ()
+    , getWallet :: WalletId -> Resp m Wallet
+    , updateWallet :: WalletId -> Update Wallet -> Resp m Wallet
+    -- account endpoints
+    , deleteAccount :: WalletId -> AccountIndex -> Resp m ()
+    , getAccount :: WalletId -> AccountIndex -> Resp m Account
+    , getAccountIndexPaged :: WalletId -> Maybe Page -> Maybe PerPage -> Resp m [Account]
+    , updateAccount :: WalletId -> AccountIndex -> Update Account -> Resp m Account
+    -- transactions endpoints
+    , postTransaction :: Payment -> Resp m Transaction
+    , getTranasactionIndex :: WalletId -> Maybe AccountIndex -> Maybe (V1 Core.Address) -> Maybe Page -> Maybe PerPage -> Resp m [Transaction]
+    , getTransactionFee :: Payment -> Resp m EstimatedFees
+    -- updates
+    , getNextUpdate :: Resp m WalletUpdate
+    , postWalletUpdate :: Resp m WalletUpdate
+    -- settings
+    , getNodeSettings :: Resp m NodeSettings
+    -- info
+    , getNodeInfo :: Resp m NodeInfo
+    }
+
+-- | Calls 'getWalletIndexPaged' using the 'Default' values for 'Page' and
+-- 'PerPage'.
+getWalletIndex :: WalletClient m -> Resp m [Wallet]
+getWalletIndex wc = getWalletIndexPaged wc Nothing Nothing
+
+-- | A type alias shorthand for the response from the 'WalletClient'.
+type Resp m a = m (Either WalletError (WalletResponse a))

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StrictData #-}
 
--- | This module defines a client for the Cardano new-wallet.
+-- | This module defines a client interface for the Cardano wallet.
 module Cardano.Wallet.Client
     ( -- * The abstract client
       WalletClient(..)
@@ -47,57 +47,82 @@ import qualified Pos.Core as Core
 data WalletClient m
     = WalletClient
     { -- address endpoints
-      getAddressIndex :: Resp m [Address]
-    , postAddress :: NewAddress -> Resp m WalletAddress
-    , getAddressValidity :: Text -> Resp m AddressValidity
+      getAddressIndex
+         :: Resp m [Address]
+    , postAddress
+         :: NewAddress -> Resp m WalletAddress
+    , getAddressValidity
+         :: Text -> Resp m AddressValidity
     -- wallets endpoints
-    , postWallet :: New Wallet -> Resp m Wallet
-    , getWalletIndexPaged :: Maybe Page -> Maybe PerPage -> Resp m [Wallet]
-    , updateWalletPassword :: WalletId -> PasswordUpdate -> Resp m Wallet
-    , deleteWallet :: WalletId -> Resp m ()
-    , getWallet :: WalletId -> Resp m Wallet
-    , updateWallet :: WalletId -> Update Wallet -> Resp m Wallet
+    , postWallet
+         :: New Wallet -> Resp m Wallet
+    , getWalletIndexPaged
+         :: Maybe Page -> Maybe PerPage -> Resp m [Wallet]
+    , updateWalletPassword
+         :: WalletId -> PasswordUpdate -> Resp m Wallet
+    , deleteWallet
+         :: WalletId -> Resp m ()
+    , getWallet
+         :: WalletId -> Resp m Wallet
+    , updateWallet
+         :: WalletId -> Update Wallet -> Resp m Wallet
     -- account endpoints
-    , deleteAccount :: WalletId -> AccountIndex -> Resp m ()
-    , getAccount :: WalletId -> AccountIndex -> Resp m Account
-    , getAccountIndexPaged :: WalletId -> Maybe Page -> Maybe PerPage -> Resp m [Account]
-    , updateAccount :: WalletId -> AccountIndex -> Update Account -> Resp m Account
+    , deleteAccount
+         :: WalletId -> AccountIndex -> Resp m ()
+    , getAccount
+         :: WalletId -> AccountIndex -> Resp m Account
+    , getAccountIndexPaged
+         :: WalletId -> Maybe Page -> Maybe PerPage -> Resp m [Account]
+    , updateAccount
+         :: WalletId -> AccountIndex -> Update Account -> Resp m Account
     -- transactions endpoints
-    , postTransaction :: Payment -> Resp m Transaction
-    , getTranasactionIndex :: WalletId -> Maybe AccountIndex -> Maybe (V1 Core.Address) -> Maybe Page -> Maybe PerPage -> Resp m [Transaction]
-    , getTransactionFee :: Payment -> Resp m EstimatedFees
+    , postTransaction
+         :: Payment -> Resp m Transaction
+    , getTransactionIndex
+         :: WalletId
+         -> Maybe AccountIndex
+         -> Maybe (V1 Core.Address)
+         -> Maybe Page
+         -> Maybe PerPage
+         -> Resp m [Transaction]
+    , getTransactionFee
+         :: Payment -> Resp m EstimatedFees
     -- updates
-    , getNextUpdate :: Resp m WalletUpdate
-    , postWalletUpdate :: Resp m WalletUpdate
+    , getNextUpdate
+         :: Resp m WalletUpdate
+    , postWalletUpdate
+         :: Resp m WalletUpdate
     -- settings
-    , getNodeSettings :: Resp m NodeSettings
+    , getNodeSettings
+         :: Resp m NodeSettings
     -- info
-    , getNodeInfo :: Resp m NodeInfo
+    , getNodeInfo
+         :: Resp m NodeInfo
     }
 
 -- | Run the given natural transformation over the 'WalletClient'.
 hoistClient :: (forall x. m x -> n x) -> WalletClient m -> WalletClient n
 hoistClient phi wc = WalletClient
-    { getAddressIndex      = phi (getAddressIndex wc)
-    , postAddress          = phi . postAddress wc
-    , getAddressValidity   = phi . getAddressValidity wc
-    , postWallet           = phi . postWallet wc
-    , getWalletIndexPaged  = \x -> phi . getWalletIndexPaged wc x
-    , updateWalletPassword = \x -> phi . updateWalletPassword wc x
-    , deleteWallet         = phi . deleteWallet wc
-    , getWallet            = phi . getWallet wc
-    , updateWallet         = \x -> phi . updateWallet wc x
-    , deleteAccount        = \x -> phi . deleteAccount wc x
-    , getAccount           = \x -> phi . getAccount wc x
-    , getAccountIndexPaged = \x mp -> phi . getAccountIndexPaged wc x mp
-    , updateAccount        = \x y -> phi . updateAccount wc x y
-    , postTransaction      = phi . postTransaction wc
-    , getTranasactionIndex = \wid maid maddr mp -> phi . getTranasactionIndex wc wid maid maddr mp
-    , getTransactionFee    = phi . getTransactionFee wc
-    , getNextUpdate        = phi (getNextUpdate wc)
-    , postWalletUpdate     = phi (postWalletUpdate wc)
-    , getNodeSettings      = phi (getNodeSettings wc)
-    , getNodeInfo          = phi (getNodeInfo wc)
+    { getAddressIndex       = phi (getAddressIndex wc)
+    , postAddress           = phi . postAddress wc
+    , getAddressValidity    = phi . getAddressValidity wc
+    , postWallet            = phi . postWallet wc
+    , getWalletIndexPaged   = \x -> phi . getWalletIndexPaged wc x
+    , updateWalletPassword  = \x -> phi . updateWalletPassword wc x
+    , deleteWallet          = phi . deleteWallet wc
+    , getWallet             = phi . getWallet wc
+    , updateWallet          = \x -> phi . updateWallet wc x
+    , deleteAccount         = \x -> phi . deleteAccount wc x
+    , getAccount            = \x -> phi . getAccount wc x
+    , getAccountIndexPaged  = \x mp -> phi . getAccountIndexPaged wc x mp
+    , updateAccount         = \x y -> phi . updateAccount wc x y
+    , postTransaction       = phi . postTransaction wc
+    , getTransactionIndex   = \wid maid maddr mp -> phi . getTransactionIndex wc wid maid maddr mp
+    , getTransactionFee     = phi . getTransactionFee wc
+    , getNextUpdate         = phi (getNextUpdate wc)
+    , postWalletUpdate      = phi (postWalletUpdate wc)
+    , getNodeSettings       = phi (getNodeSettings wc)
+    , getNodeInfo           = phi (getNodeInfo wc)
     }
 
 -- | Generalize a @'WalletClient' 'IO'@ into a @('MonadIO' m) =>

--- a/wallet-new/src/Cardano/Wallet/Client/Http.hs
+++ b/wallet-new/src/Cardano/Wallet/Client/Http.hs
@@ -1,6 +1,6 @@
 module Cardano.Wallet.Client.Http
     ( module Cardano.Wallet.Client.Http
-      -- * Absract Client export
+      -- * Abstract Client export
     , module Cardano.Wallet.Client
     ) where
 

--- a/wallet-new/src/Cardano/Wallet/Client/Http.hs
+++ b/wallet-new/src/Cardano/Wallet/Client/Http.hs
@@ -1,0 +1,22 @@
+module Cardano.Wallet.Client.Http
+    ( module Cardano.Wallet.Client.Http
+      -- * Absract Client export
+    , module Cardano.Wallet.Client
+    ) where
+
+import Universum
+
+import Servant.Client (BaseUrl)
+import Network.HTTP.Client (Manager)
+
+import Cardano.Wallet.Client
+
+-- | Given a 'BaseUrl' and an @http-client@ 'Manager', this returns
+-- a 'WalletClient' that operates in 'IO'.
+mkHttpClient
+    :: BaseUrl
+    -> Manager
+    -> WalletClient IO
+mkHttpClient _baseUrl _manager = error "implement me" -- WalletClient{..}
+
+


### PR DESCRIPTION
This PR implements a client abstraction for the wallet.

The implementation is left as a stub to be picked up in `CSL-2342`.

The ticket `CSL-2341` can now be implemented in terms of this wallet abstraction, while the actual implementation of the HTTP client can be done in parallel. Testing functions can be written as:

```haskell
testSomeInvariant :: (MonadIO m) => WalletClient m -> m ()
testSomeInvariant wc = ...
```