### PR TITLE
[DEVOPS-712] removing --web parameter from shell scripts and default.nix

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -208,11 +208,6 @@ function node_cmd {
   if [[ "$REPORT_SERVER" != "" ]]; then
     report_server=" --report-server $REPORT_SERVER "
   fi
-  if [[ $i == "0" ]]; then
-    if [[ $CARDANO_WEB != "" ]]; then
-      web=" --web "
-    fi
-  fi
   if [[ "$CSL_RTS" != "" ]] && [[ $i -eq 0 ]]; then
     rts_opts="+RTS -N -pa -A6G -qg -RTS"
   fi

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -76,7 +76,6 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
     --no-ntp                                                       \
     --configuration-file ${configFiles}/configuration.yaml         \
     --configuration-key ${environments.${environment}.confKey}     \
-    ${ ifWallet "--web"}                                           \
     ${ ifWallet "--tlscert ${stateDir}/tls/server.cert"}           \
     ${ ifWallet "--tlskey ${stateDir}/tls/server.key"}             \
     ${ ifWallet "--tlsca ${stateDir}/tls/server.cert"}             \

--- a/scripts/launch/connect-to-cluster/mainnet-staging.sh
+++ b/scripts/launch/connect-to-cluster/mainnet-staging.sh
@@ -20,7 +20,6 @@ stack exec -- cardano-node                                 \
     --tlscert ./scripts/tls-files/server.crt               \
     --tlskey ./scripts/tls-files/server.key                \
     --tlsca ./scripts/tls-files/ca.crt                     \
-    --web                                                  \
     --no-ntp                                               \
     --topology "${TOPOLOGY_YAML}"                          \
     --log-config log-configs/connect-to-cluster.yaml       \

--- a/tools/src/launcher/launcher-config.yaml
+++ b/tools/src/launcher/launcher-config.yaml
@@ -16,7 +16,6 @@ nodeArgs:
   - "./scripts/tls-files/server.key"
   - "--tlsca"
   - "./scripts/tls-files/ca.crt"
-  - "--web"
   - "--no-ntp"
   - "--topology"
   - "docs/network/example-topologies/mainnet-staging.yaml"


### PR DESCRIPTION
Building `connectScripts.mainnetWallet` using `nix-build` results in a binary that won't start because of invalid parameter `--web`. This pull request removes it from the default.nix and all other places I saw it being used with a `git grep "\-\-web" command.