### PR TITLE
[CSL-2343] Add missing logException to cardano-node

### DIFF
--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -12,8 +12,8 @@ import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import           Data.Maybe (fromJust)
 import           Mockable (Production (..), runProduction)
-import           Pos.Communication (ActionSpec (..))
 import qualified Pos.Client.CLI as CLI
+import           Pos.Communication (ActionSpec (..))
 import           Pos.DB.DB (initNodeDBs)
 import           Pos.Launcher (NodeParams (..), NodeResources (..), bpLoggingParams,
                                bracketNodeResources, loggerBracket, lpDefaultName, runNode,
@@ -22,6 +22,7 @@ import           Pos.Launcher.Configuration (ConfigurationOptions, HasConfigurat
 import           Pos.Ssc.Types (SscParams)
 import           Pos.Txp (txpGlobalSettings)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
+import           Pos.Util (logException)
 import           Pos.Util.CompileInfo (HasCompileInfo, retrieveCompileTimeInfo, withCompileInfo)
 import           Pos.Util.UserSecret (usVss)
 import           Pos.Wallet.Web (AddrCIdHashes (..), bracketWalletWS, bracketWalletWebDB, getSKById,
@@ -31,17 +32,17 @@ import           Pos.Wallet.Web.State (flushWalletStorage)
 import           Servant.Swagger (HasSwagger)
 import           System.Wlog (LoggerName, Severity, logInfo, logMessage, usingLoggerName)
 
-import qualified Cardano.Wallet.API.V1.Swagger as Swagger
 import           Cardano.Wallet.API (walletAPI)
+import qualified Cardano.Wallet.API.V1.Swagger as Swagger
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 import           Cardano.Wallet.Server.CLI (ChooseWalletBackend (..), NewWalletBackendParams (..),
                                             WalletBackendParams (..), WalletStartupOptions (..),
-                                            getWalletNodeOptions, isDebugMode,
-                                            walletDbPath, walletFlushDb, walletRebuildDb)
+                                            getWalletNodeOptions, isDebugMode, walletDbPath,
+                                            walletFlushDb, walletRebuildDb)
 import qualified Cardano.Wallet.Server.Plugins as Plugins
 
-import Cardano.Wallet.API.V1.Swagger ()
+import           Cardano.Wallet.API.V1.Swagger ()
 
 -- | Default logger name when one is not provided on the command line
 defaultLoggerName :: LoggerName
@@ -182,9 +183,9 @@ generateSwaggerDocumentation api = liftIO $ do
 -- | The main entrypoint for the Wallet.
 main :: IO ()
 main = withCompileInfo $(retrieveCompileTimeInfo) $ do
-  cfg <- getWalletNodeOptions
-  putText "Wallet is starting..."
-  let loggingParams = CLI.loggingParams defaultLoggerName (wsoNodeArgs cfg)
-  loggerBracket loggingParams . runProduction $ do
-    logInfo "[Attention] Software is built with the wallet backend"
-    startEdgeNode cfg
+    cfg <- getWalletNodeOptions
+    putText "Wallet is starting..."
+    let loggingParams = CLI.loggingParams defaultLoggerName (wsoNodeArgs cfg)
+    loggerBracket loggingParams . logException "node" . runProduction $ do
+        logInfo "[Attention] Software is built with the wallet backend"
+        startEdgeNode cfg


### PR DESCRIPTION
`logException` was used in old `cardano-node`, but for some reason is not used in new `cardano-node`.