### PR TITLE
Restore top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-lib/README.md
+# Cardano SL
+
+[![Build status](https://badge.buildkite.com/9c3141d21214ff3ea95d0a38a0e1dab59b206159d2841dee44.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-sl)
+[![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/cardano-sl?branch=master&svg=true)](https://ci.appveyor.com/project/input-output/cardano-sl)
+[![Release](https://img.shields.io/github/release/input-output-hk/cardano-sl.svg)](https://github.com/input-output-hk/cardano-sl/releases)
+
+## What is Cardano SL?
+
+Cardano SL (or Cardano Settlement Layer) is a cryptographic currency designed
+and developed by [IOHK](https://iohk.io/team). Please read [Cardano SL Introduction](https://cardanodocs.com/introduction/)
+for more information.
+
+## Supported Platforms
+
+Please see [Cardano SL Installation](https://cardanodocs.com/installation/) for more
+information.
+
+## Building Cardano SL from Source Code
+
+Please see [this guide](https://cardanodocs.com/for-contributors/building-from-source/) for
+more information.
+
+## For Contributors
+
+Please see [CONTRIBUTING.md](https://github.com/input-output-hk/cardano-sl/blob/develop/CONTRIBUTING.md)
+for more information.
+
+## License
+
+Please see [LICENSE](https://github.com/input-output-hk/cardano-sl/blob/master/LICENSE) for
+more information.


### PR DESCRIPTION
This used to be symlink to the file `lib/README.md` so when that changed so did this.

The two files are now different.