### PR TITLE
[CSL-2347] Add logging of servant requests in wallet new

### DIFF
--- a/infra/Pos/Util/LogSafe.hs
+++ b/infra/Pos/Util/LogSafe.hs
@@ -43,6 +43,7 @@ module Pos.Util.LogSafe
        , secureListF
        , buildSafe
        , buildSafeMaybe
+       , buildSafeList
 
          -- ** Secure log utils
        , BuildableSafe
@@ -205,6 +206,9 @@ buildSafe sl = plainOrSecureF sl build (secureF build)
 buildSafeMaybe :: BuildableSafe a => a -> LogSecurityLevel -> Format r (Maybe a -> r)
 buildSafeMaybe def sl = plainOrSecureF sl build (secureMaybeF def build)
 
+buildSafeList :: BuildableSafe a => LogSecurityLevel -> Format r ([a] -> r)
+buildSafeList sl = secureListF sl (secureF build)
+
 -- | Negates single-parameter formatter for public logs.
 secretOnlyF :: LogSecurityLevel -> Format r (a -> r) -> Format r (a -> r)
 secretOnlyF sl fmt = plainOrSecureF sl fmt (fconst "?")
@@ -330,8 +334,8 @@ logErrorSP   = logMessageSP Error
 instance Buildable [Address] where
     build = bprint listJson
 
-instance Buildable a => Buildable (SecureLog [a]) where
-    build = bprint (secureListF secure (secureF build)) . getSecureLog
+instance BuildableSafe a => Buildable (SecureLog [a]) where
+    build = bprint (buildSafeList secure) . getSecureLog
 
 instance Buildable (SecureLog Text) where
     build _ = "<hidden>"

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -177,6 +177,7 @@ library
                       , stm
                       , clock
                       , tagged
+                      , template-haskell
                       , tar
                       , text
                       , text-format

--- a/lib/src/Pos/Util/Servant.hs
+++ b/lib/src/Pos/Util/Servant.hs
@@ -335,7 +335,9 @@ data LoggingApi config api
 -- | Helper to traverse servant api and apply logging.
 data LoggingApiRec config api
 
-type ApiLoggingConfig = LoggerName
+newtype ApiLoggingConfig = ApiLoggingConfig
+    { apiLoggerName :: LoggerName
+    } deriving Show
 
 -- | Used to incrementally collect info about passed parameters.
 data ApiParamsLogInfo
@@ -569,8 +571,8 @@ applyServantLogging configP methodP paramsInfo showResponse action = do
             return $ sformat shown (endTime - startTime)
     inLogCtx :: MonadIO m => LoggerNameBox m a -> m a
     inLogCtx logAction = do
-        let loggerName = reflect configP
-        usingLoggerName loggerName logAction
+        let ApiLoggingConfig{..} = reflect configP
+        usingLoggerName apiLoggerName logAction
     eParamLogs :: Either Text SecuredText
     eParamLogs = case paramsInfo of
         ApiParamsLogInfo info -> Right $ \sl ->

--- a/lib/src/Pos/Util/Servant.hs
+++ b/lib/src/Pos/Util/Servant.hs
@@ -337,7 +337,7 @@ instance (RunClient m, HasClient m (Verb mt st ct $ ApiModifiedRes mod a)) =>
 -- If user makes request which can't be processed (e.g. with path to undefined
 -- endpoint which normally terminates with 404) it won't be logged. However,
 -- I don't find it a great problem, it may impede only in development or on
--- getting acknoledged with api.
+-- getting acknowledged with api.
 data LoggingApi config api
 
 -- | Helper to traverse servant api and apply logging.

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7334,9 +7334,9 @@ inherit (pkgs) mesa;};
          , http-client-tls, iproute, kademlia, lens, log-warper, lzma, mtl
          , network-info, network-transport, network-transport-tcp
          , optparse-applicative, parsec, QuickCheck, reflection
-         , safe-exceptions, serokell-util, stdenv, stm, tagged, tar, text
-         , text-format, time, time-units, transformers, universum, unix
-         , unordered-containers, yaml
+         , safe-exceptions, serokell-util, stdenv, stm, tagged, tar
+         , template-haskell, text, text-format, time, time-units
+         , transformers, universum, unix, unordered-containers, yaml
          }:
          mkDerivation {
            pname = "cardano-sl-infra";
@@ -7351,8 +7351,8 @@ inherit (pkgs) mesa;};
              iproute kademlia lens log-warper lzma mtl network-info
              network-transport network-transport-tcp optparse-applicative parsec
              QuickCheck reflection safe-exceptions serokell-util stm tagged tar
-             text text-format time time-units transformers universum unix
-             unordered-containers yaml
+             template-haskell text text-format time time-units transformers
+             universum unix unordered-containers yaml
            ];
            libraryToolDepends = [ cpphs ];
            doHaddock = false;
@@ -7679,8 +7679,8 @@ inherit (pkgs) mesa;};
          , http-client, http-types, insert-ordered-containers, ixset-typed
          , json-sop, lens, log-warper, memory, mmorph, mtl
          , neat-interpolation, optparse-applicative, QuickCheck
-         , quickcheck-instances, safe-exceptions, serokell-util, servant
-         , servant-client, servant-client-core, servant-quickcheck
+         , quickcheck-instances, reflection, safe-exceptions, serokell-util
+         , servant, servant-client, servant-client-core, servant-quickcheck
          , servant-server, servant-swagger, servant-swagger-ui, stdenv, stm
          , string-conv, swagger2, text, text-format, time, time-units
          , transformers, universum, unordered-containers, vector, wai
@@ -7699,10 +7699,10 @@ inherit (pkgs) mesa;};
              cardano-sl-txp cardano-sl-update cardano-sl-util cardano-sl-wallet
              containers data-default exceptions formatting generics-sop
              http-api-data http-client http-types ixset-typed json-sop lens
-             log-warper memory mtl QuickCheck safe-exceptions serokell-util
-             servant servant-client servant-client-core servant-quickcheck
-             servant-server servant-swagger-ui string-conv swagger2 text
-             text-format time time-units transformers universum
+             log-warper memory mtl QuickCheck reflection safe-exceptions
+             serokell-util servant servant-client servant-client-core
+             servant-quickcheck servant-server servant-swagger-ui string-conv
+             swagger2 text text-format time time-units transformers universum
              unordered-containers vector wai
            ];
            executableHaskellDepends = [

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -442,6 +442,7 @@ test-suite wallet-new-specs
                     , containers
                     , data-default
                     , exceptions
+                    , formatting
                     , hspec
                     , http-client
                     , http-types

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -94,6 +94,7 @@ library
                      , text
                      , text-format
                      , transformers
+                     , reflection
                      , universum
                      , unordered-containers
                      , vector
@@ -131,6 +132,7 @@ library
                       ScopedTypeVariables
                       UndecidableInstances
                       MonadFailDesugaring
+                      TupleSections
 
 executable cardano-node
   hs-source-dirs:      server

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -24,7 +24,10 @@ import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.TypeLits (KnownSymbols (..))
 import qualified Pos.Core as Core
 import           Pos.Core.Update (SoftwareVersion)
-import           Pos.Util.CompileInfo (CompileTimeInfo, ctiGitRevision)
+import           Pos.Update.Configuration (HasUpdateConfiguration, curSoftwareVersion)
+import           Pos.Util.CompileInfo (CompileTimeInfo, HasCompileInfo, compileInfo, ctiGitRevision)
+import           Pos.Util.Servant (LoggingApi)
+import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot)
 import           Pos.Wallet.Web.Swagger.Instances.Schema ()
 
 import           Control.Lens ((?~))
@@ -73,6 +76,9 @@ surroundedBy wrap context = wrap <> context <> wrap
 --
 -- Instances
 --
+
+instance HasSwagger a => HasSwagger (LoggingApi config a) where
+    toSwagger _ = toSwagger (Proxy @a)
 
 instance HasSwagger (apiType a :> res) =>
          HasSwagger (WithDefaultApiArg apiType a :> res) where

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger.hs
@@ -24,10 +24,8 @@ import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.TypeLits (KnownSymbols (..))
 import qualified Pos.Core as Core
 import           Pos.Core.Update (SoftwareVersion)
-import           Pos.Update.Configuration (HasUpdateConfiguration, curSoftwareVersion)
-import           Pos.Util.CompileInfo (CompileTimeInfo, HasCompileInfo, compileInfo, ctiGitRevision)
+import           Pos.Util.CompileInfo (CompileTimeInfo, ctiGitRevision)
 import           Pos.Util.Servant (LoggingApi)
-import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot)
 import           Pos.Wallet.Web.Swagger.Instances.Schema ()
 
 import           Control.Lens ((?~))

--- a/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
+++ b/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
@@ -29,13 +29,12 @@ import           Cardano.Wallet.Server.CLI (NewWalletBackendParams (..), RunMode
 import           Data.Aeson
 import           Formatting (build, sformat, (%))
 import           Mockable
-import           Network.HTTP.Types.Status (badRequest400)
 import           Network.HTTP.Types (hContentType)
+import           Network.HTTP.Types.Status (badRequest400)
 import           Network.Wai (Application, Middleware, Response, responseLBS)
+import           Network.Wai.Handler.Warp (defaultSettings, setOnExceptionResponse)
 import           Network.Wai.Middleware.Cors (cors, corsMethods, corsRequestHeaders,
                                               simpleCorsResourcePolicy, simpleMethods)
-import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
-import           Network.Wai.Handler.Warp (defaultSettings, setOnExceptionResponse)
 import           Pos.Diffusion.Types (Diffusion (..))
 import           Pos.Wallet.Web (cleanupAcidStatePeriodically)
 import           Pos.Wallet.Web.Pending.Worker (startPendingTxsResubmitter)
@@ -163,7 +162,7 @@ notifierPlugin = ([ActionSpec $ const V0.notifierPlugin], mempty)
 -- with a Swagger editor, locally.
 withMiddleware :: RunMode -> Application -> Application
 withMiddleware wrm app
-  | isDebugMode wrm = logStdoutDev . corsMiddleware $ app
+  | isDebugMode wrm = corsMiddleware app
   | otherwise = app
 
 corsMiddleware :: Middleware

--- a/wallet-new/spec/swagger.json
+++ b/wallet-new/spec/swagger.json
@@ -8,16 +8,9 @@
             "url": "http://mit.com",
             "name": "MIT"
         },
-        "description": "This is the specification for the Cardano Wallet API, automatically generated\nas a [Swagger](https://swagger.io/) spec from the [Servant](http://haskell-servant.readthedocs.io/en/stable/) API\nof [Cardano](https://github.com/input-output-hk/cardano-sl).\n\nGit revision: **6f69e2e0033d51ff803630469b5749f85a3e2228**\nSoftware version: **cardano-sl:0**\n\n\n## Request format (all versions)\n\nIssuing requests against this API is conceptually not very different from any other web service out there. The API\nis **versioned**, meaning that is possible to access different versions of the API by adding the _version number_\nin the URL.\n\n**For the sake of backward compatibility, we expose the legacy version of the API, available simply as\nunversioned endpoints.**\n\nThis means that _omitting_ the version number would call the old version of the API. Examples:\n\n```\n/api/version\n```\n\nCompatibility between major versions is not _guaranteed_, i.e. the request & response formats might differ.\n\n## Response format (V1 onwards)\n\n**All GET requests of the API are paginated by default**. Whilst this can be a source of surprise, is\nthe best way of ensuring the performance of GET requests is not affected by the size of the data storage.\n\nVersion `V1` introduced a different way of requesting information to the API. In particular, GET requests\nwhich returns a _collection_ (i.e. typically a JSON array of resources) lists extra parameters which can be\nused to modify the shape of the response. In particular, those are:\n\n* `page`: (Default value: **1**).\n* `per_page`: (Default value: **10**)\n\nFor a more accurate description, see the section `Parameters` of each GET request, but as a brief overview\nthe first two control how many results and which results to access in a paginated request.\n\nThis is an example of a typical (successful) response from the API:\n\n``` json\n{\n    \"status\": \"success\",\n    \"data\": [\n        {\n            \"amount\": 29208924123228353,\n            \"addresses\": [\n                \"5FCjkr138i9qs2EEjvmXF37aSLiZdwQsALPMmvVDgx8PQ31nJTh9p35ZfnDFn6hfWdyY6XuFQXY23kfUjSuwBSEd4912knFgJSSZSBCt2yo\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"index\": 1\n        },\n        {\n            \"amount\": 28089727180413548,\n            \"addresses\": [\n                \"7J1MaQmKydNUyekmvgR3VNZLeLYkTNpDTKz4Z5SHfnJxDVgCN3tjixySxMNKNULKaV5XBBngc1e5BNzrePahs1Tuo7xcnKUyvkUm8HNcHuufC5q\",\n                \"7fiTbReGezWKbx8zhrjdMekrd8kziXqofdzzGPHWKgRXd24pDM7TZSFfnarpCsHy67ZW3AgFRAfFEGuRSd1VSYP5dDyNJJLwKB29vxsFnGq9GPB8x2RittGrrjNXPpgB8b4Y3yBFbpcXeDF7FG13u5gFHrcXwU86MN2CaCpLaaynjRvnitwGnd\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"index\": 0\n        }\n    ],\n    \"meta\": {\n        \"pagination\": {\n            \"page\": 1,\n            \"perPage\": 46,\n            \"totalPages\": 1,\n            \"totalEntries\": 2\n        }\n    }\n}\n```\n\n## Filtering and sorting\n\n`GET` endpoints which list collection of resources supports filters & sort operations, which are clearly marked\nin the swagger docs with the `FILTER` or `SORT` labels. The query format is quite simple, and it goes this way:\n\n### Filter operators\n\n| Operator | Description                                                               | Example                |\n|----------|---------------------------------------------------------------------------|------------------------|\n| -        | If **no operator** is passed, this is equivalent to `EQ` (see below).     | `balance=10`           |\n| `EQ`     | Retrieves the resources with index _equal to the one provided.            | `balance=EQ[10]`       |\n| `LT`     | Retrieves the resources with index _less than_ the one provided.          | `balance=LT[10]`       |\n| `LTE`    | Retrieves the resources with index _less than equal_ the one provided.    | `balance=LTE[10]`      |\n| `GT`     | Retrieves the resources with index _greater than_ the one provided.       | `balance=GT[10]`       |\n| `GTE`    | Retrieves the resources with index _greater than equal_ the one provided. | `balance=GTE[10]`      |\n| `RANGE`  | Retrieves the resources with index _within the inclusive range_ [k,k].    | `balance=RANGE[10,20]` |\n\n### Sort operators\n\n| Operator | Description                                                               | Example                |\n|----------|---------------------------------------------------------------------------|------------------------|\n| `ASC`    | Sorts the resources with the given index in _ascending_ order.            | `sort_by=ASC[balance]` |\n| `DES`    | Sorts the resources with the given index in _descending_ order.           | `sort_by=DES[balance]` |\n| -        | If **no operator** is passed, this is equivalent to `DES` (see above).    | `sort_by=balance`      |\n\n## Dealing with errors (V1 onwards)\n\nIn case a request cannot be served by the API, a non-2xx HTTP response will be issue, together with a\n[JSend-compliant](https://labs.omniti.com/labs/jsend) JSON Object describing the error in detail together\nwith a numeric error code which can be used by API consumers to implement proper error handling in their\napplication. For example, here's a typical error which might be issued:\n\n``` json\n{\n    \"status\": \"error\",\n    \"diagnostic\": {},\n    \"message\": \"WalletNotFound\"\n}\n```\n\n### Existing wallet errors\n\nError Name|HTTP Error code|Example\n---|---|---\n`NotEnoughMoney`|-|-\n`OutputIsRedeem`|-|-\n`SomeOtherError`|-|-\n`MigrationFailed`|-|-\n`JSONValidationFailed`|-|-\n`UnkownError`|-|-\n`WalletNotFound`|-|-\n"
+        "description": "This is the specification for the Cardano Wallet API, automatically generated\nas a [Swagger](https://swagger.io/) spec from the [Servant](http://haskell-servant.readthedocs.io/en/stable/) API\nof [Cardano](https://github.com/input-output-hk/cardano-sl).\n\nGit revision: **9db3874435ea045dc8a6bd8c371bb16aa5c4c86c**\nSoftware version: **cardano-sl:0**\n\n\n## Request format (all versions)\n\nIssuing requests against this API is conceptually not very different from any other web service out there. The API\nis **versioned**, meaning that is possible to access different versions of the API by adding the _version number_\nin the URL.\n\n**For the sake of backward compatibility, we expose the legacy version of the API, available simply as\nunversioned endpoints.**\n\nThis means that _omitting_ the version number would call the old version of the API. Examples:\n\n```\n/api/version\n```\n\nCompatibility between major versions is not _guaranteed_, i.e. the request & response formats might differ.\n\n## Response format (V1 onwards)\n\n**All GET requests of the API are paginated by default**. Whilst this can be a source of surprise, is\nthe best way of ensuring the performance of GET requests is not affected by the size of the data storage.\n\nVersion `V1` introduced a different way of requesting information to the API. In particular, GET requests\nwhich returns a _collection_ (i.e. typically a JSON array of resources) lists extra parameters which can be\nused to modify the shape of the response. In particular, those are:\n\n* `page`: (Default value: **1**).\n* `per_page`: (Default value: **10**)\n\nFor a more accurate description, see the section `Parameters` of each GET request, but as a brief overview\nthe first two control how many results and which results to access in a paginated request.\n\nThis is an example of a typical (successful) response from the API:\n\n``` json\n{\n    \"status\": \"success\",\n    \"data\": [\n        {\n            \"amount\": 29208924123228353,\n            \"addresses\": [\n                \"5FCjkr138i9qs2EEjvmXF37aSLiZdwQsALPMmvVDgx8PQ31nJTh9p35ZfnDFn6hfWdyY6XuFQXY23kfUjSuwBSEd4912knFgJSSZSBCt2yo\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"index\": 1\n        },\n        {\n            \"amount\": 28089727180413548,\n            \"addresses\": [\n                \"7J1MaQmKydNUyekmvgR3VNZLeLYkTNpDTKz4Z5SHfnJxDVgCN3tjixySxMNKNULKaV5XBBngc1e5BNzrePahs1Tuo7xcnKUyvkUm8HNcHuufC5q\",\n                \"7fiTbReGezWKbx8zhrjdMekrd8kziXqofdzzGPHWKgRXd24pDM7TZSFfnarpCsHy67ZW3AgFRAfFEGuRSd1VSYP5dDyNJJLwKB29vxsFnGq9GPB8x2RittGrrjNXPpgB8b4Y3yBFbpcXeDF7FG13u5gFHrcXwU86MN2CaCpLaaynjRvnitwGnd\"\n            ],\n            \"name\": \"My account\",\n            \"walletId\": \"J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg\",\n            \"index\": 0\n        }\n    ],\n    \"meta\": {\n        \"pagination\": {\n            \"page\": 1,\n            \"perPage\": 46,\n            \"totalPages\": 1,\n            \"totalEntries\": 2\n        }\n    }\n}\n```\n\n## Filtering and sorting\n\n`GET` endpoints which list collection of resources supports filters & sort operations, which are clearly marked\nin the swagger docs with the `FILTER` or `SORT` labels. The query format is quite simple, and it goes this way:\n\n### Filter operators\n\n| Operator | Description                                                               | Example                |\n|----------|---------------------------------------------------------------------------|------------------------|\n| -        | If **no operator** is passed, this is equivalent to `EQ` (see below).     | `balance=10`           |\n| `EQ`     | Retrieves the resources with index _equal to the one provided.            | `balance=EQ[10]`       |\n| `LT`     | Retrieves the resources with index _less than_ the one provided.          | `balance=LT[10]`       |\n| `LTE`    | Retrieves the resources with index _less than equal_ the one provided.    | `balance=LTE[10]`      |\n| `GT`     | Retrieves the resources with index _greater than_ the one provided.       | `balance=GT[10]`       |\n| `GTE`    | Retrieves the resources with index _greater than equal_ the one provided. | `balance=GTE[10]`      |\n| `RANGE`  | Retrieves the resources with index _within the inclusive range_ [k,k].    | `balance=RANGE[10,20]` |\n\n### Sort operators\n\n| Operator | Description                                                               | Example                |\n|----------|---------------------------------------------------------------------------|------------------------|\n| `ASC`    | Sorts the resources with the given index in _ascending_ order.            | `sort_by=ASC[balance]` |\n| `DES`    | Sorts the resources with the given index in _descending_ order.           | `sort_by=DES[balance]` |\n| -        | If **no operator** is passed, this is equivalent to `DES` (see above).    | `sort_by=balance`      |\n\n## Dealing with errors (V1 onwards)\n\nIn case a request cannot be served by the API, a non-2xx HTTP response will be issue, together with a\n[JSend-compliant](https://labs.omniti.com/labs/jsend) JSON Object describing the error in detail together\nwith a numeric error code which can be used by API consumers to implement proper error handling in their\napplication. For example, here's a typical error which might be issued:\n\n``` json\n{\n    \"status\": \"error\",\n    \"diagnostic\": {},\n    \"message\": \"WalletNotFound\"\n}\n```\n\n### Existing wallet errors\n\nError Name|HTTP Error code|Example\n---|---|---\n`NotEnoughMoney`|-|-\n`OutputIsRedeem`|-|-\n`SomeOtherError`|-|-\n`MigrationFailed`|-|-\n`JSONValidationFailed`|-|-\n`WalletNotFound`|-|-\n"
     },
     "definitions": {
-        "TransactionType": {
-            "type": "string",
-            "enum": [
-                "local",
-                "foreign"
-            ]
-        },
         "CPtxCondition": {
             "type": "string",
             "enum": [
@@ -27,49 +20,6 @@
                 "CPtxWontApply",
                 "CPtxNotTracked"
             ]
-        },
-        "WalletResponse<[Transaction]>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "items": {
-                        "$ref": "#/definitions/Transaction"
-                    },
-                    "type": "array"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
-        "V1Coin": {
-            "maximum": 45000000000000000,
-            "type": "number"
-        },
-        "AddressValidity": {
-            "required": [
-                "valid"
-            ],
-            "type": "object",
-            "properties": {
-                "valid": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "V1BackupPhrase": {
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
         },
         "PendingTxsSummary": {
             "type": "string"
@@ -119,90 +69,147 @@
                 }
             }
         },
-        "ResponseStatus": {
-            "type": "string",
-            "enum": [
-                "success",
-                "fail",
-                "error"
-            ]
-        },
-        "WalletResponse<WalletAddress>": {
+        "WalletResponse NodeInfo": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "blockchainHeight": {
+                        "quantity": 9631745999145585284,
+                        "unit": "blocks"
+                    },
+                    "localTimeDifference": {
+                        "quantity": -3,
+                        "unit": "microseconds"
+                    },
+                    "syncProgress": {
+                        "quantity": 77,
+                        "unit": "percent"
+                    },
+                    "localBlockchainHeight": {
+                        "quantity": 1.2513853667654321111e19,
+                        "unit": "blocks"
+                    }
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
             "required": [
-                "data",
                 "status",
+                "data",
                 "meta"
             ],
             "type": "object",
             "properties": {
                 "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/WalletAddress"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
-        "Wallet": {
-            "required": [
-                "id",
-                "name",
-                "balance"
-            ],
-            "type": "object",
-            "properties": {
-                "balance": {
-                    "$ref": "#/definitions/V1Coin"
-                },
-                "name": {
                     "type": "string"
                 },
-                "id": {
-                    "$ref": "#/definitions/WalletId"
-                }
-            }
-        },
-        "WalletResponse<[Wallet]>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
                 "data": {
-                    "items": {
-                        "$ref": "#/definitions/Wallet"
-                    },
-                    "type": "array"
+                    "required": [
+                        "blockchainHeight",
+                        "localTimeDifference",
+                        "syncProgress",
+                        "localBlockchainHeight"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "blockchainHeight": {
+                            "required": [
+                                "quantity",
+                                "unit"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "number"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "localTimeDifference": {
+                            "required": [
+                                "quantity",
+                                "unit"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "number"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "syncProgress": {
+                            "required": [
+                                "quantity",
+                                "unit"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "number"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "localBlockchainHeight": {
+                            "required": [
+                                "quantity",
+                                "unit"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "number"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
-        "WalletResponse<Account>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/Account"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -232,42 +239,28 @@
                 }
             }
         },
-        "WalletResponse<Transaction>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/Transaction"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
         "NewAddress": {
+            "example": {
+                "accountIndex": 2,
+                "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg",
+                "spendingPassword": "0001010001010101010200020001010201000200010201020202000200010000"
+            },
             "required": [
                 "accountIndex",
-                "walletId"
+                "walletId",
+                "spendingPassword"
             ],
             "type": "object",
+            "description": "A type represending an request for creating a(n) WalletAddress.",
             "properties": {
                 "accountIndex": {
-                    "maximum": 4294967295,
-                    "minimum": 0,
-                    "type": "integer"
+                    "type": "number"
                 },
                 "walletId": {
-                    "$ref": "#/definitions/WalletId"
+                    "type": "string"
                 },
                 "spendingPassword": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
                 }
             }
         },
@@ -282,23 +275,6 @@
                 }
             }
         },
-        "V1SoftwareVersion": {
-            "required": [
-                "applicationName",
-                "version"
-            ],
-            "type": "object",
-            "properties": {
-                "version": {
-                    "maximum": 4294967295,
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "applicationName": {
-                    "type": "string"
-                }
-            }
-        },
         "ApiVersion": {
             "type": "string",
             "enum": [
@@ -306,68 +282,342 @@
             ]
         },
         "Payment": {
+            "example": {
+                "groupingPolicy": "OptimizeForHighThroughput",
+                "destinations": [
+                    {
+                        "amount": 27889372662178400,
+                        "address": "7J1MaQmKydNdKZ8ASMptqTpSiq6k8QwjD5w8hsnMF6iGQSFLZNbjgVjDhKtAa2vWYNCXvRixXTeuxKAfSHUBcjoieTUHcDaFPMgUtnhVnwk2rbz"
+                    },
+                    {
+                        "amount": 33829516096667581,
+                        "address": "2cWKMJemoBamMBMBYJWe5aQR3xitBLbjVbt4yxQUWUWC8KGGHvYF8BfUQwmAs5je5fSii"
+                    }
+                ],
+                "source": {
+                    "accountIndex": 2,
+                    "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+                },
+                "spendingPassword": "0000010001010101000001000202010200010202000102000000000100000100"
+            },
             "required": [
+                "groupingPolicy",
+                "destinations",
                 "source",
-                "destinations"
+                "spendingPassword"
             ],
             "type": "object",
+            "description": "A transfer of `Coin`(s) from one source to one or more destinations.",
             "properties": {
                 "groupingPolicy": {
-                    "$ref": "#/definitions/V1InputSelectionPolicy"
+                    "type": "string"
                 },
                 "destinations": {
-                    "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/PaymentDistribution"
+                        "required": [
+                            "amount",
+                            "address"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "amount": {
+                                "type": "number"
+                            },
+                            "address": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "type": "array"
                 },
                 "source": {
-                    "$ref": "#/definitions/PaymentSource"
+                    "required": [
+                        "accountIndex",
+                        "walletId"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "accountIndex": {
+                            "type": "number"
+                        },
+                        "walletId": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "spendingPassword": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
                 }
             }
         },
         "CTxId": {
             "type": "string"
         },
-        "NodeSettings": {
+        "WalletResponse Account": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "amount": 7328081618979461,
+                    "addresses": [
+                        "NBimUZYpm3G6AbNtqWY4PEvRQCLjErwu3hj1DfmZSgUJXtrnyYHCcFGDnT1rr7mPWmx",
+                        "Ae2tdPwUPEZJfGVFz1ugT1kJs2mbWp9692jB8BTzt7ZJRoHjrUQ2rEuBmLP"
+                    ],
+                    "name": "My account",
+                    "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg",
+                    "index": 1
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
             "required": [
-                "slotDuration",
-                "softwareInfo",
-                "projectVersion",
-                "gitRevision"
+                "status",
+                "data",
+                "meta"
             ],
             "type": "object",
             "properties": {
-                "projectVersion": {
-                    "$ref": "#/definitions/Version"
-                },
-                "gitRevision": {
+                "status": {
                     "type": "string"
                 },
-                "slotDuration": {
-                    "$ref": "#/definitions/SlotDuration"
+                "data": {
+                    "required": [
+                        "amount",
+                        "addresses",
+                        "name",
+                        "walletId",
+                        "index"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "number"
+                        },
+                        "addresses": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "walletId": {
+                            "type": "string"
+                        },
+                        "index": {
+                            "type": "number"
+                        }
+                    }
                 },
-                "softwareInfo": {
-                    "$ref": "#/definitions/V1SoftwareVersion"
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
-        "PaymentDistribution": {
+        "WalletResponse [Wallet]": {
+            "example": {
+                "status": "success",
+                "data": [
+                    {
+                        "balance": 7893389421760074,
+                        "name": "My wallet",
+                        "id": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+                    },
+                    {
+                        "balance": 18464205877436744,
+                        "name": "My wallet",
+                        "id": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+                    }
+                ],
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
             "required": [
-                "address",
-                "amount"
+                "status",
+                "data",
+                "meta"
             ],
             "type": "object",
             "properties": {
-                "amount": {
-                    "$ref": "#/definitions/V1Coin"
+                "status": {
+                    "type": "string"
                 },
-                "address": {
-                    "$ref": "#/definitions/V1Address"
+                "data": {
+                    "items": {
+                        "required": [
+                            "balance",
+                            "name",
+                            "id"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "balance": {
+                                "type": "number"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "WalletResponse WalletAddress": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "used": true,
+                    "changeAddress": true,
+                    "balance": 7328081618979461,
+                    "id": "7J1MaQmKydNVpjPB6LXvNnF933LckE2va7s53RGzRFX891nLfEcN5fGWjq9XU7JwSphzf6GAZ75WPkqEfFWJm4fktedfuzG2cVbMWKxJcvRkKjD"
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "required": [
+                        "used",
+                        "changeAddress",
+                        "balance",
+                        "id"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "used": {
+                            "type": "boolean"
+                        },
+                        "changeAddress": {
+                            "type": "boolean"
+                        },
+                        "balance": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -386,6 +636,75 @@
                 }
             }
         },
+        "WalletResponse AddressValidity": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "valid": false
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "required": [
+                        "valid"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "valid": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "CProfile": {
             "required": [
                 "cpLocale"
@@ -397,65 +716,10 @@
                 }
             }
         },
-        "WalletResponse<WalletUpdate>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/WalletUpdate"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
         "FilePath": {
             "example": "keys/1.key",
             "type": "string",
             "description": "Path to file.\n Note that it is represented as JSON-string, one may need to properly escape content. For instance:\n curl ... -X \"\\\\\"1.key\"\\\\\".\nAlso, when on Windows, don't forget to double-escape  backslashes, e.g.  \"C:\\\\\\\\\\\\\\\\keys\\\\\\\\1.key\""
-        },
-        "BlockchainHeight": {
-            "required": [
-                "quantity"
-            ],
-            "type": "object",
-            "properties": {
-                "quantity": {
-                    "maximum": 1.8446744073709551615e19,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "unit": {
-                    "pattern": "blocks",
-                    "type": "string"
-                }
-            }
-        },
-        "WalletResponse<NodeSettings>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/NodeSettings"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
         },
         "CWalletAssurance": {
             "type": "string",
@@ -464,14 +728,84 @@
                 "CWANormal"
             ]
         },
-        "V1PassPhrase": {
-            "pattern": "abcd",
-            "type": "string"
-        },
-        "Page": {
-            "default": 1,
-            "minimum": 1,
-            "type": "integer"
+        "WalletResponse Wallet": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "balance": 11091176260625603,
+                    "name": "My wallet",
+                    "id": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "required": [
+                        "balance",
+                        "name",
+                        "id"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "balance": {
+                            "type": "number"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "BackupPhrase": {
             "required": [
@@ -512,8 +846,196 @@
                 }
             }
         },
-        "Address": {
-            "type": "string"
+        "WalletResponse [Transaction]": {
+            "example": {
+                "status": "success",
+                "data": [
+                    {
+                        "amount": 19321208996093113,
+                        "inputs": [
+                            {
+                                "amount": 12068145532878000,
+                                "address": "NBimUZYpm3GTGLq6w1Pc99wieJXwEWLJcGEhiQELFbvcDEzwohgssz8Zu5Lk3J82jrA"
+                            },
+                            {
+                                "amount": 1825893375695764,
+                                "address": "37btjrVyb4KBmXJFEfFDEj6fbs7oKaekei9eWBxWmZ3t5xw6Yup5tuceqJnF9zT8hpJHWNmuSWoqRRzrRFzgap3nXYKVTpRb7Pr8ihbT2GP4UCwafo"
+                            },
+                            {
+                                "amount": 13134164389923293,
+                                "address": "AL91N9VXRTCv6vVsbxTwceaCTzGS1Q393kVjyorVcgMQpKBUxsDcXw4rTvwBXgNkomv1R6vF3jYgendY3Z6YS2Z6yE7p74Anm77NhxzSbgVavLVhDAg"
+                            }
+                        ],
+                        "direction": "outgoing",
+                        "outputs": [
+                            {
+                                "amount": 18810694513310357,
+                                "address": "2reD6PLk2vQ6SgGfupzB3MpyjmzfnfCnQyujonnorUR2k5PppWqTV4Tsb9yVpYrghCGyrfVEpJ2AaFnpmqQc5JN7mDk5b8kRc3aj2HWtXyNJmmawyDgws4GMzvdEDoPArwVGoeGaiZ8534juXyYEgFkwhJFpfqua3yiiSQvM5pNYJFDXRQr9aDiRtkyDPSt9VR3yXKRNkFsVY5x5YpGcb4sEUVCXBvy2wexfzXsEMuzUmaCJVsj7czfPvRzTQvEJC12mTv8ZXDE3yRCnRKTQPWeGGN6c7sZ3YrnyaeGgxg4jkjVWeXUwUv4VMSggVuDkD78AAxZP7fuei2Mzih"
+                            },
+                            {
+                                "amount": 6214896163653048,
+                                "address": "5oP9ib6ym3XZZWYoC4YVU4UXrw1AfVDhNMrHhCcK6HPbXKFx9Up9jBrmTrdDdvyHeH"
+                            }
+                        ],
+                        "confirmations": 0,
+                        "id": "d827de094565984c09b06ac4953a2666c6385ed2b88635936d3d78bd28ed93b8",
+                        "type": "foreign"
+                    },
+                    {
+                        "amount": 34638161102038470,
+                        "inputs": [
+                            {
+                                "amount": 37567904243452455,
+                                "address": "42wmHXYSz61HK9W9Tj5fi9MbQQ8LCoaMDzQS1nt1n8gda3shKejNrjJGoud6Ttp4goj2VncciNsBUY8F7c6eY1Ny7EpLpSg6axJtPTKieQRKAC8bFabqUMqn1s8nfhaPQDiFFxPyV6J3c8AUxtcJcGmreBk11HMPLiZuDL8asqAhvY"
+                            },
+                            {
+                                "amount": 11070649850752079,
+                                "address": "2Fc9FhbWKyhDXPvLTSFAmwqPQst4arNECkBkfkkVyS7ZAf1MLJe1aZtsKZuspuD7pq4Bmv53yyTt9ZmgvbMmjsW6765BhALUKJ2wEz5pShXi3i7aYuscZtzcDsi7ZnTo4fpdfDX3jNG4AwhLWDFNNNZQSx9EKFYFxqfk7REfaCE4ebXYpEakkdnqx6NVXB8ULcE6sMiVeGWVXC7kHHuxFdvyoKCRm2J9Su7PzED8HH5R7HBnZuMkCwJ4L9XkVf9VWAe8aTzS9jdAexR8jRR7JhZXksyfEzDwFstMAfiBfX7VEaVJGUSmPNpBt5Kg9oaP4gUQFbsdKQhYac"
+                            }
+                        ],
+                        "direction": "outgoing",
+                        "outputs": [
+                            {
+                                "amount": 22593715837565850,
+                                "address": "2Tp1cYozcWTniexFcd7XUHE1yZm6SXU99fxmKByYS9FW3EwQLwtcoYCoakitfGVfuVnDp5eng8a7UiLr2C7yMN41LtNYXsm7RAqsD15iMPwBShTL3zx1hQxBY8N4U6i3z2LhuTaPyjFKFAzVnuc7FGA6rwvnxZDqfbbCXg5yP5vSmCemyLcjBh7gdfSBnE87idrBDxrDwtmpd1owvW4n9Fs7uSYwk2UzHA58WAxRTwh51"
+                            },
+                            {
+                                "amount": 118816001855782,
+                                "address": "5FCjkr138i9v69ZJ5xnkLkmrnqL4TbBju6PbiYn6onnCSnjoq5hSc7b1Q31S1hYeCtd87wNAS42K1px6x2zybb9P6vNesVL4euu6PMx9s7k"
+                            },
+                            {
+                                "amount": 10816341180192159,
+                                "address": "5MVkCEKjiviVcj4o7aFLZfu4jXeZ3YcYg7WoydzH7tb9MRGeDPrwd5gGfyNGxYy7kYQ2YNt7UHAabDFs24b8rmKDgyKVoCqfz37N4qm3hNhjJybVLxP7doKU6UtWyFpbTNsdMwgz6KrDAWLfdcVrTC3VdoKJuSRkpri7YSnrdzMBANJSc3qRh2D1efmLU9TMp7CdZjBaFFdRFkEK4FfND6KDejiMbQTH64TwHMc1Yb"
+                            },
+                            {
+                                "amount": 34537982561642603,
+                                "address": "5oP9ib6ym3XkBSbZuy7Xhs1GTPwZ2xmUwiQHJuoPQmuyACkeEjS8YZvqErTFWt7tRh"
+                            }
+                        ],
+                        "confirmations": 1,
+                        "id": "f5c79aba1f0102dce829e331574141be10d3db93e6b13f8a70d463124dc0bd8f",
+                        "type": "local"
+                    }
+                ],
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "items": {
+                        "required": [
+                            "amount",
+                            "inputs",
+                            "direction",
+                            "outputs",
+                            "confirmations",
+                            "id",
+                            "type"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "amount": {
+                                "type": "number"
+                            },
+                            "inputs": {
+                                "items": {
+                                    "required": [
+                                        "amount",
+                                        "address"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "amount": {
+                                            "type": "number"
+                                        },
+                                        "address": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "type": "array"
+                            },
+                            "direction": {
+                                "type": "string"
+                            },
+                            "outputs": {
+                                "items": {
+                                    "required": [
+                                        "amount",
+                                        "address"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "amount": {
+                                            "type": "number"
+                                        },
+                                        "address": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "type": "array"
+                            },
+                            "confirmations": {
+                                "type": "number"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "CWalletInit": {
             "required": [
@@ -531,14 +1053,19 @@
             }
         },
         "WalletUpdate": {
+            "example": {
+                "assuranceLevel": "normal",
+                "name": "My Wallet"
+            },
             "required": [
                 "assuranceLevel",
                 "name"
             ],
             "type": "object",
+            "description": "A type represending an update for an existing Wallet.",
             "properties": {
                 "assuranceLevel": {
-                    "$ref": "#/definitions/AssuranceLevel"
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -554,29 +1081,6 @@
                 "OptimizeForSecurity",
                 "OptimizeForHighThroughput"
             ]
-        },
-        "WalletAddress": {
-            "required": [
-                "id",
-                "balance",
-                "used",
-                "changeAddress"
-            ],
-            "type": "object",
-            "properties": {
-                "used": {
-                    "type": "boolean"
-                },
-                "changeAddress": {
-                    "type": "boolean"
-                },
-                "balance": {
-                    "$ref": "#/definitions/V1Coin"
-                },
-                "id": {
-                    "$ref": "#/definitions/V1Address"
-                }
-            }
         },
         "CWalletMeta": {
             "required": [
@@ -599,64 +1103,182 @@
                 }
             }
         },
-        "AssuranceLevel": {
-            "type": "string",
-            "enum": [
-                "normal",
-                "strict"
-            ]
-        },
-        "Account": {
-            "required": [
-                "index",
-                "addresses",
-                "amount",
-                "name",
-                "walletId"
-            ],
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "$ref": "#/definitions/V1Coin"
-                },
-                "addresses": {
-                    "items": {
-                        "$ref": "#/definitions/V1Address"
+        "WalletResponse NodeSettings": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "projectVersion": "1.1",
+                    "gitRevision": "0e1c9322a",
+                    "slotDuration": {
+                        "quantity": 77,
+                        "unit": "milliseconds"
                     },
-                    "type": "array"
+                    "softwareInfo": {
+                        "version": 2,
+                        "applicationName": ""
+                    }
                 },
-                "name": {
-                    "type": "string"
-                },
-                "walletId": {
-                    "$ref": "#/definitions/WalletId"
-                },
-                "index": {
-                    "maximum": 4294967295,
-                    "minimum": 0,
-                    "type": "integer"
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
                 }
-            }
-        },
-        "V1Address": {
-            "type": "string"
-        },
-        "WalletResponse<Wallet>": {
+            },
             "required": [
-                "data",
                 "status",
+                "data",
                 "meta"
             ],
             "type": "object",
             "properties": {
                 "status": {
-                    "$ref": "#/definitions/ResponseStatus"
+                    "type": "string"
                 },
                 "data": {
-                    "$ref": "#/definitions/Wallet"
+                    "required": [
+                        "projectVersion",
+                        "gitRevision",
+                        "slotDuration",
+                        "softwareInfo"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "projectVersion": {
+                            "type": "string"
+                        },
+                        "gitRevision": {
+                            "type": "string"
+                        },
+                        "slotDuration": {
+                            "required": [
+                                "quantity",
+                                "unit"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "number"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "softwareInfo": {
+                            "required": [
+                                "version",
+                                "applicationName"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "type": "number"
+                                },
+                                "applicationName": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "meta": {
-                    "$ref": "#/definitions/Metadata"
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "WalletResponse [Address]": {
+            "example": {
+                "status": "success",
+                "data": [
+                    "7J1MaQmKydNjjDZjGJbyjnSLtj6H6irfYqx3sxUd4a8L5umQi4UNa3Z88QECYEkCd4eShHE9Sd5fGR5xkz8sn6of5nrjEvS11WjiGSw37XV45v2",
+                    "AL91N9VXRTCdEAuNHNij1dpotEjcotTHaAavVpXoR1ckgokd1g4owdYN2WCjyRs1u4ChP4fezGK5oviUge4nSaJUdiCFesqnSHcR8vPTepYsscTtgqm"
+                ],
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -693,57 +1315,6 @@
                 }
             }
         },
-        "Transaction": {
-            "required": [
-                "id",
-                "confirmations",
-                "amount",
-                "inputs",
-                "outputs",
-                "type",
-                "direction"
-            ],
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "$ref": "#/definitions/V1Coin"
-                },
-                "inputs": {
-                    "minItems": 1,
-                    "items": {
-                        "$ref": "#/definitions/PaymentDistribution"
-                    },
-                    "type": "array"
-                },
-                "direction": {
-                    "$ref": "#/definitions/TransactionDirection"
-                },
-                "outputs": {
-                    "minItems": 1,
-                    "items": {
-                        "$ref": "#/definitions/PaymentDistribution"
-                    },
-                    "type": "array"
-                },
-                "confirmations": {
-                    "maximum": 1.8446744073709551615e19,
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/TransactionType"
-                }
-            }
-        },
-        "PerPage": {
-            "maximum": 50,
-            "default": 10,
-            "minimum": 1,
-            "type": "integer"
-        },
         "WalletStateSnapshot": {
             "type": "string"
         },
@@ -760,21 +1331,6 @@
         },
         "CAccountId": {
             "type": "string"
-        },
-        "LocalTimeDifference": {
-            "required": [
-                "quantity"
-            ],
-            "type": "object",
-            "properties": {
-                "quantity": {
-                    "type": "number"
-                },
-                "unit": {
-                    "pattern": "microseconds",
-                    "type": "string"
-                }
-            }
         },
         "CTx": {
             "required": [
@@ -847,23 +1403,6 @@
                 }
             }
         },
-        "PaymentSource": {
-            "required": [
-                "walletId",
-                "accountIndex"
-            ],
-            "type": "object",
-            "properties": {
-                "accountIndex": {
-                    "maximum": 4294967295,
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "walletId": {
-                    "$ref": "#/definitions/WalletId"
-                }
-            }
-        },
         "ClientInfo": {
             "required": [
                 "ciApiVersion",
@@ -887,17 +1426,6 @@
                 }
             }
         },
-        "EstimatedFees": {
-            "required": [
-                "estimatedAmount"
-            ],
-            "type": "object",
-            "properties": {
-                "estimatedAmount": {
-                    "$ref": "#/definitions/V1Coin"
-                }
-            }
-        },
         "CInitialized": {
             "required": [
                 "cTotalTime",
@@ -917,13 +1445,6 @@
                 }
             }
         },
-        "WalletOperation": {
-            "type": "string",
-            "enum": [
-                "create",
-                "restore"
-            ]
-        },
         "BlockCount": {
             "required": [
                 "getBlockCount"
@@ -934,21 +1455,6 @@
                     "maximum": 1.8446744073709551615e19,
                     "minimum": 0,
                     "type": "integer"
-                }
-            }
-        },
-        "SlotDuration": {
-            "required": [
-                "quantity"
-            ],
-            "type": "object",
-            "properties": {
-                "quantity": {
-                    "type": "number"
-                },
-                "unit": {
-                    "pattern": "milliseconds",
-                    "type": "string"
                 }
             }
         },
@@ -1010,30 +1516,102 @@
                 }
             }
         },
-        "WalletResponse<AddressValidity>": {
+        "Version": {
             "required": [
-                "data",
+                "versionBranch",
+                "versionTags"
+            ],
+            "type": "object",
+            "properties": {
+                "versionTags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "versionBranch": {
+                    "items": {
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "type": "integer"
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "WalletResponse WalletUpdate": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "assuranceLevel": "normal",
+                    "name": "My Wallet"
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
                 "status",
+                "data",
                 "meta"
             ],
             "type": "object",
             "properties": {
                 "status": {
-                    "$ref": "#/definitions/ResponseStatus"
+                    "type": "string"
                 },
                 "data": {
-                    "$ref": "#/definitions/AddressValidity"
+                    "required": [
+                        "assuranceLevel",
+                        "name"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "assuranceLevel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "meta": {
-                    "$ref": "#/definitions/Metadata"
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
-        },
-        "Version": {
-            "type": "string"
-        },
-        "WalletId": {
-            "type": "string"
         },
         "CWalletRedeem": {
             "required": [
@@ -1052,37 +1630,21 @@
         },
         "SyncProgress": {
             "required": [
-                "quantity"
+                "_spLocalCD",
+                "_spPeers"
             ],
             "type": "object",
             "properties": {
-                "quantity": {
-                    "maximum": 100,
+                "_spPeers": {
+                    "maximum": 1.8446744073709551615e19,
                     "minimum": 0,
-                    "type": "number"
+                    "type": "integer"
                 },
-                "unit": {
-                    "pattern": "percent",
-                    "type": "string"
-                }
-            }
-        },
-        "WalletResponse<V1 WalletStateSnapshot>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
+                "_spNetworkCD": {
+                    "$ref": "#/definitions/ChainDifficulty"
                 },
-                "data": {
-                    "$ref": "#/definitions/V1 WalletStateSnapshot"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
+                "_spLocalCD": {
+                    "$ref": "#/definitions/ChainDifficulty"
                 }
             }
         },
@@ -1137,17 +1699,6 @@
                 }
             }
         },
-        "Metadata": {
-            "required": [
-                "pagination"
-            ],
-            "type": "object",
-            "properties": {
-                "pagination": {
-                    "$ref": "#/definitions/PaginationMetadata"
-                }
-            }
-        },
         "CPaperVendWalletRedeem": {
             "required": [
                 "pvWalletId",
@@ -1168,46 +1719,184 @@
             }
         },
         "NewAccount": {
+            "example": {
+                "name": "¯",
+                "spendingPassword": ""
+            },
             "required": [
-                "name"
+                "name",
+                "spendingPassword"
             ],
             "type": "object",
+            "description": "A type represending an request for creating a(n) Account.",
             "properties": {
                 "name": {
                     "type": "string"
                 },
                 "spendingPassword": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
                 }
             }
         },
         "AccountUpdate": {
+            "example": {
+                "name": "myAccount"
+            },
             "required": [
                 "name"
             ],
             "type": "object",
+            "description": "A type represending an update for an existing Account.",
             "properties": {
                 "name": {
                     "type": "string"
                 }
             }
         },
-        "WalletResponse<NodeInfo>": {
+        "WalletResponse Transaction": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "amount": 28311699119270855,
+                    "inputs": [
+                        {
+                            "amount": 13019322832706804,
+                            "address": "AL91N9VXRTCwikvJJVEQeGTH4wwxtSY8d7m26bFyWD7PmfqUpdYgCV1jigD5ivbzh88BR8FFvdpkU8P3uuispBsdZNXCurGREicGjMW74F7GitSX4oc"
+                        }
+                    ],
+                    "direction": "outgoing",
+                    "outputs": [
+                        {
+                            "amount": 14984536053034711,
+                            "address": "2657WMsDfac6JxtEAjpN9KnwE9kfc6jUzhYXRyY3FFPwEyM5nNjPUBHDbFUwndGNx"
+                        },
+                        {
+                            "amount": 13290197696443539,
+                            "address": "2657WMsDfac6VJfxAHRezMNbBhvYzrDVf5F2W7s7LGAgtp6m9B5Df8EQkwktLsEee"
+                        },
+                        {
+                            "amount": 21095182977599617,
+                            "address": "Un4ZpTvXtoL29niUxfBPFJN3eR135cu799S3t8Pq1Vv48GwBuSEzUPHLDz6SwpewGafkin1iF6itRkKBK4VUiEDZeEH5EKBPg9agUUr9NNKKTsRm"
+                        }
+                    ],
+                    "confirmations": 4,
+                    "id": "848d6fadc04dcd9af1bc462df5938ecfbe810c5ecb50971db1cf7ae224bb5955",
+                    "type": "foreign"
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
             "required": [
-                "data",
                 "status",
+                "data",
                 "meta"
             ],
             "type": "object",
             "properties": {
                 "status": {
-                    "$ref": "#/definitions/ResponseStatus"
+                    "type": "string"
                 },
                 "data": {
-                    "$ref": "#/definitions/NodeInfo"
+                    "required": [
+                        "amount",
+                        "inputs",
+                        "direction",
+                        "outputs",
+                        "confirmations",
+                        "id",
+                        "type"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "number"
+                        },
+                        "inputs": {
+                            "items": {
+                                "required": [
+                                    "amount",
+                                    "address"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "amount": {
+                                        "type": "number"
+                                    },
+                                    "address": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "direction": {
+                            "type": "string"
+                        },
+                        "outputs": {
+                            "items": {
+                                "required": [
+                                    "amount",
+                                    "address"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "amount": {
+                                        "type": "number"
+                                    },
+                                    "address": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "confirmations": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "meta": {
-                    "$ref": "#/definitions/Metadata"
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -1222,47 +1911,252 @@
                 }
             }
         },
-        "V1 WalletStateSnapshot": {
-            "type": "string"
-        },
         "NewWallet": {
+            "example": {
+                "operation": "restore",
+                "backupPhrase": [
+                    "shell",
+                    "also",
+                    "throw",
+                    "ramp",
+                    "grape",
+                    "chest",
+                    "setup",
+                    "mandate",
+                    "spare",
+                    "verb",
+                    "lemon",
+                    "test"
+                ],
+                "assuranceLevel": "strict",
+                "name": "My Wallet",
+                "spendingPassword": "0202020100010202000000020201010100020202000202000002010201020201"
+            },
             "required": [
+                "operation",
                 "backupPhrase",
                 "assuranceLevel",
                 "name",
-                "operation"
+                "spendingPassword"
             ],
             "type": "object",
+            "description": "A type represending an request for creating a(n) Wallet.",
             "properties": {
                 "operation": {
-                    "$ref": "#/definitions/WalletOperation"
+                    "type": "string"
                 },
                 "backupPhrase": {
-                    "$ref": "#/definitions/V1BackupPhrase"
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "assuranceLevel": {
-                    "$ref": "#/definitions/AssuranceLevel"
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
                 },
                 "spendingPassword": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
+                }
+            }
+        },
+        "WalletResponse EstimatedFees": {
+            "example": {
+                "status": "success",
+                "data": {
+                    "estimatedAmount": 25132995790248024
+                },
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "required": [
+                        "estimatedAmount"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "estimatedAmount": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "WalletResponse [Account]": {
+            "example": {
+                "status": "success",
+                "data": [
+                    {
+                        "amount": 29208924123228353,
+                        "addresses": [
+                            "5FCjkr138i9qs2EEjvmXF37aSLiZdwQsALPMmvVDgx8PQ31nJTh9p35ZfnDFn6hfWdyY6XuFQXY23kfUjSuwBSEd4912knFgJSSZSBCt2yo"
+                        ],
+                        "name": "My account",
+                        "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg",
+                        "index": 1
+                    },
+                    {
+                        "amount": 28089727180413548,
+                        "addresses": [
+                            "7J1MaQmKydNUyekmvgR3VNZLeLYkTNpDTKz4Z5SHfnJxDVgCN3tjixySxMNKNULKaV5XBBngc1e5BNzrePahs1Tuo7xcnKUyvkUm8HNcHuufC5q",
+                            "7fiTbReGezWKbx8zhrjdMekrd8kziXqofdzzGPHWKgRXd24pDM7TZSFfnarpCsHy67ZW3AgFRAfFEGuRSd1VSYP5dDyNJJLwKB29vxsFnGq9GPB8x2RittGrrjNXPpgB8b4Y3yBFbpcXeDF7FG13u5gFHrcXwU86MN2CaCpLaaynjRvnitwGnd"
+                        ],
+                        "name": "My account",
+                        "walletId": "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg",
+                        "index": 0
+                    }
+                ],
+                "meta": {
+                    "pagination": {
+                        "page": 1,
+                        "perPage": 46,
+                        "totalPages": 1,
+                        "totalEntries": 2
+                    }
+                }
+            },
+            "required": [
+                "status",
+                "data",
+                "meta"
+            ],
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "data": {
+                    "items": {
+                        "required": [
+                            "amount",
+                            "addresses",
+                            "name",
+                            "walletId",
+                            "index"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "amount": {
+                                "type": "number"
+                            },
+                            "addresses": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "walletId": {
+                                "type": "string"
+                            },
+                            "index": {
+                                "type": "number"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "meta": {
+                    "required": [
+                        "pagination"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "pagination": {
+                            "required": [
+                                "page",
+                                "perPage",
+                                "totalPages",
+                                "totalEntries"
+                            ],
+                            "type": "object",
+                            "properties": {
+                                "page": {
+                                    "type": "number"
+                                },
+                                "perPage": {
+                                    "type": "number"
+                                },
+                                "totalPages": {
+                                    "type": "number"
+                                },
+                                "totalEntries": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
         "PasswordUpdate": {
+            "example": {
+                "old": "",
+                "new": "0000010001010101000001000202010200010202000102000000000100000100"
+            },
             "required": [
                 "old",
                 "new"
             ],
             "type": "object",
+            "description": "A PasswordUpdate incapsulate a request for changing a Wallet's password.",
             "properties": {
                 "old": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
                 },
                 "new": {
-                    "$ref": "#/definitions/V1PassPhrase"
+                    "type": "string"
                 }
             }
         },
@@ -1279,132 +2173,6 @@
         },
         "CId": {
             "type": "string"
-        },
-        "NodeInfo": {
-            "required": [
-                "syncProgress",
-                "localBlockchainHeight",
-                "localTimeDifference"
-            ],
-            "type": "object",
-            "properties": {
-                "blockchainHeight": {
-                    "$ref": "#/definitions/BlockchainHeight"
-                },
-                "localTimeDifference": {
-                    "$ref": "#/definitions/LocalTimeDifference"
-                },
-                "syncProgress": {
-                    "$ref": "#/definitions/SyncProgress"
-                },
-                "localBlockchainHeight": {
-                    "$ref": "#/definitions/BlockchainHeight"
-                }
-            }
-        },
-        "WalletResponse<[Address]>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "items": {
-                        "$ref": "#/definitions/Address"
-                    },
-                    "type": "array"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
-        "WalletResponse<[Account]>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "items": {
-                        "$ref": "#/definitions/Account"
-                    },
-                    "type": "array"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
-        },
-        "V1InputSelectionPolicy": {
-            "type": "string",
-            "enum": [
-                "OptimizeForSecurity",
-                "OptimizeForHighThroughput"
-            ]
-        },
-        "PaginationMetadata": {
-            "required": [
-                "totalPages",
-                "page",
-                "perPage",
-                "totalEntries"
-            ],
-            "type": "object",
-            "properties": {
-                "page": {
-                    "$ref": "#/definitions/Page"
-                },
-                "perPage": {
-                    "$ref": "#/definitions/PerPage"
-                },
-                "totalPages": {
-                    "maximum": 9223372036854775807,
-                    "minimum": -9223372036854775808,
-                    "type": "integer"
-                },
-                "totalEntries": {
-                    "maximum": 9223372036854775807,
-                    "minimum": -9223372036854775808,
-                    "type": "integer"
-                }
-            }
-        },
-        "TransactionDirection": {
-            "type": "string",
-            "enum": [
-                "outgoing",
-                "incoming"
-            ]
-        },
-        "WalletResponse<EstimatedFees>": {
-            "required": [
-                "data",
-                "status",
-                "meta"
-            ],
-            "type": "object",
-            "properties": {
-                "status": {
-                    "$ref": "#/definitions/ResponseStatus"
-                },
-                "data": {
-                    "$ref": "#/definitions/EstimatedFees"
-                },
-                "meta": {
-                    "$ref": "#/definitions/Metadata"
-                }
-            }
         }
     },
     "paths": {
@@ -1417,7 +2185,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Account>"
+                            "$ref": "#/definitions/WalletResponse Account"
                         },
                         "description": ""
                     }
@@ -1496,7 +2264,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Account>"
+                            "$ref": "#/definitions/WalletResponse Account"
                         },
                         "description": ""
                     }
@@ -1871,7 +2639,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Wallet>"
+                            "$ref": "#/definitions/WalletResponse Wallet"
                         },
                         "description": ""
                     }
@@ -1932,7 +2700,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Wallet>"
+                            "$ref": "#/definitions/WalletResponse Wallet"
                         },
                         "description": ""
                     }
@@ -2093,7 +2861,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Account>"
+                            "$ref": "#/definitions/WalletResponse Account"
                         },
                         "description": ""
                     }
@@ -2134,7 +2902,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<[Account]>"
+                            "$ref": "#/definitions/WalletResponse [Account]"
                         },
                         "description": ""
                     }
@@ -2180,7 +2948,7 @@
                 "responses": {
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<WalletUpdate>"
+                            "$ref": "#/definitions/WalletResponse WalletUpdate"
                         },
                         "description": ""
                     }
@@ -2227,41 +2995,6 @@
                 ],
                 "tags": [
                     "V0 (Deprecated)"
-                ]
-            }
-        },
-        "/api/development/dump-wallet-state": {
-            "get": {
-                "summary": "Dump wallet state.",
-                "responses": {
-                    "200": {
-                        "schema": {
-                            "$ref": "#/definitions/WalletResponse<V1 WalletStateSnapshot>"
-                        },
-                        "description": ""
-                    }
-                },
-                "produces": [
-                    "application/octet-stream"
-                ],
-                "tags": [
-                    "Development"
-                ]
-            }
-        },
-        "/api/development/secret-keys": {
-            "delete": {
-                "summary": "Clear wallet state and delete all the secret keys.",
-                "responses": {
-                    "204": {
-                        "description": ""
-                    }
-                },
-                "produces": [
-                    "application/json;charset=utf-8"
-                ],
-                "tags": [
-                    "Development"
                 ]
             }
         },
@@ -2566,7 +3299,7 @@
                     },
                     "201": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Wallet>"
+                            "$ref": "#/definitions/WalletResponse Wallet"
                         },
                         "description": ""
                     }
@@ -2597,7 +3330,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<[Wallet]>"
+                            "$ref": "#/definitions/WalletResponse [Wallet]"
                         },
                         "description": ""
                     }
@@ -2678,7 +3411,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<[Transaction]>"
+                            "$ref": "#/definitions/WalletResponse [Transaction]"
                         },
                         "description": ""
                     }
@@ -2787,7 +3520,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Wallet>"
+                            "$ref": "#/definitions/WalletResponse Wallet"
                         },
                         "description": ""
                     }
@@ -2869,7 +3602,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<Transaction>"
+                            "$ref": "#/definitions/WalletResponse Transaction"
                         },
                         "description": ""
                     }
@@ -2958,7 +3691,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<AddressValidity>"
+                            "$ref": "#/definitions/WalletResponse AddressValidity"
                         },
                         "description": ""
                     }
@@ -3026,7 +3759,7 @@
                 "responses": {
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<WalletUpdate>"
+                            "$ref": "#/definitions/WalletResponse WalletUpdate"
                         },
                         "description": ""
                     }
@@ -3154,7 +3887,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<EstimatedFees>"
+                            "$ref": "#/definitions/WalletResponse EstimatedFees"
                         },
                         "description": ""
                     }
@@ -3216,7 +3949,7 @@
                 "responses": {
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<NodeSettings>"
+                            "$ref": "#/definitions/WalletResponse NodeSettings"
                         },
                         "description": ""
                     }
@@ -3242,7 +3975,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<WalletAddress>"
+                            "$ref": "#/definitions/WalletResponse WalletAddress"
                         },
                         "description": ""
                     }
@@ -3273,7 +4006,7 @@
                     },
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<[Address]>"
+                            "$ref": "#/definitions/WalletResponse [Address]"
                         },
                         "description": ""
                     }
@@ -3392,7 +4125,7 @@
                 "responses": {
                     "200": {
                         "schema": {
-                            "$ref": "#/definitions/WalletResponse<NodeInfo>"
+                            "$ref": "#/definitions/WalletResponse NodeInfo"
                         },
                         "description": ""
                     }
@@ -3455,22 +4188,6 @@
                 ],
                 "tags": [
                     "V0 (Deprecated)"
-                ]
-            }
-        },
-        "/api/development/fail": {
-            "get": {
-                "summary": "Throw a generic error",
-                "responses": {
-                    "204": {
-                        "description": ""
-                    }
-                },
-                "produces": [
-                    "application/json;charset=utf-8"
-                ],
-                "tags": [
-                    "Development"
                 ]
             }
         },

--- a/wallet-new/src/Cardano/Wallet/API.hs
+++ b/wallet-new/src/Cardano/Wallet/API.hs
@@ -51,10 +51,10 @@ type DevAPI = "api" :> "development" :> Dev.API
 devAPI :: Proxy DevAPI
 devAPI = Proxy
 
-type WalletAPI = LoggingApi WalletLoggingConfig (V0Doc :<|> V1Doc :<|> V0API :<|> V1API)
+type WalletAPI = V0Doc :<|> V1Doc :<|> LoggingApi WalletLoggingConfig (V0API :<|> V1API)
 walletAPI :: Proxy WalletAPI
 walletAPI = Proxy
 
-type WalletDevAPI = LoggingApi WalletLoggingConfig (DevDoc :<|> DevAPI :<|> WalletAPI)
+type WalletDevAPI = DevDoc :<|> DevAPI :<|> WalletAPI
 walletDevAPI :: Proxy WalletDevAPI
 walletDevAPI = Proxy

--- a/wallet-new/src/Cardano/Wallet/API.hs
+++ b/wallet-new/src/Cardano/Wallet/API.hs
@@ -11,6 +11,8 @@ module Cardano.Wallet.API
        , walletDevAPI
        ) where
 
+import           Cardano.Wallet.API.Types (WalletLoggingConfig)
+import           Pos.Util.Servant (LoggingApi)
 import           Servant ((:<|>), (:>), Proxy (..))
 import           Servant.Swagger.UI (SwaggerSchemaUI)
 
@@ -49,10 +51,10 @@ type DevAPI = "api" :> "development" :> Dev.API
 devAPI :: Proxy DevAPI
 devAPI = Proxy
 
-type WalletAPI = V0Doc :<|> V1Doc :<|> V0API :<|> V1API
+type WalletAPI = LoggingApi WalletLoggingConfig (V0Doc :<|> V1Doc :<|> V0API :<|> V1API)
 walletAPI :: Proxy WalletAPI
 walletAPI = Proxy
 
-type WalletDevAPI = DevDoc :<|> DevAPI :<|> WalletAPI
+type WalletDevAPI = LoggingApi WalletLoggingConfig (DevDoc :<|> DevAPI :<|> WalletAPI)
 walletDevAPI :: Proxy WalletDevAPI
 walletDevAPI = Proxy

--- a/wallet-new/src/Cardano/Wallet/API/Indices.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Indices.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FunctionalDependencies    #-}
 {-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE RankNTypes                #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans      #-}
@@ -13,9 +13,9 @@ import           Universum
 
 import           Cardano.Wallet.API.V1.Types
 import           Data.String.Conv (toS)
+import           GHC.TypeLits
 import qualified Pos.Core as Core
 import           Pos.Crypto (decodeHash)
-import           GHC.TypeLits
 
 import           Data.IxSet.Typed (Indexable (..), IsIndexOf, IxSet, ixFun, ixList)
 
@@ -122,4 +122,3 @@ type family IndexToQueryParam resource ix where
         ':$$: 'Text "Perhaps you mismatched a resource and an index?"
         ':$$: 'Text "Or, maybe you need to add a type instance to `IndexToQueryParam'."
         )
-

--- a/wallet-new/src/Cardano/Wallet/API/Request.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase    #-}
+
 module Cardano.Wallet.API.Request (
     RequestParams (..)
   -- * Handly re-exports
@@ -7,6 +8,10 @@ module Cardano.Wallet.API.Request (
   , module Cardano.Wallet.API.Request.Filter
   , module Cardano.Wallet.API.Request.Sort
   ) where
+
+
+import           Formatting (bprint, build, (%))
+import           Pos.Util.LogSafe (BuildableSafeGen (..), deriveSafeBuildable)
 
 import           Cardano.Wallet.API.Request.Filter
 import           Cardano.Wallet.API.Request.Pagination (PaginationMetadata (..), PaginationParams)
@@ -16,3 +21,9 @@ data RequestParams = RequestParams
     { rpPaginationParams :: PaginationParams
     -- ^ The pagination-related parameters
     }
+
+instance BuildableSafeGen RequestParams where
+    buildSafeGen _sl RequestParams{..} =
+        bprint ("pagination: "%build) rpPaginationParams
+
+deriveSafeBuildable ''RequestParams

--- a/wallet-new/src/Cardano/Wallet/API/Request.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request.hs
@@ -22,8 +22,7 @@ data RequestParams = RequestParams
     -- ^ The pagination-related parameters
     }
 
+deriveSafeBuildable ''RequestParams
 instance BuildableSafeGen RequestParams where
     buildSafeGen _sl RequestParams{..} =
         bprint ("pagination: "%build) rpPaginationParams
-
-deriveSafeBuildable ''RequestParams

--- a/wallet-new/src/Cardano/Wallet/API/Request/Filter.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Filter.hs
@@ -65,8 +65,9 @@ instance Eq (FilterOperations a) where
     _ == _ =
         False
 
-instance Buildable (FilterOperations a) where
-    build = bprint listJson . flattenOperations (bprint build)
+-- NOTE Derived after, see comment below
+instance BuildableSafeGen (FilterOperations a) where
+    buildSafeGen _ = bprint listJson . flattenOperations (bprint build)
 
 -- | Handy helper function to transform 'FilterOperation'(s) into list.
 flattenOperations :: (forall ix. FilterOperation ix a -> b)
@@ -145,10 +146,12 @@ instance Show (FilterOperation ix a) where
     show (FilterByRange _ _)          = "FilterByRange"
     show                              = formatToString build
 
+deriveSafeBuildableExt $ \v -> [t| FilterOperation $v $v |]
 instance BuildableSafeGen (FilterOperation ix a) where
     buildSafeGen _ = bprint build . show
 
-deriveSafeBuildableExt $ \newVar -> [t| FilterOperation $newVar $newVar |]
+-- TH needs to happen after FilterOperation is defined
+deriveSafeBuildableExt $ \v -> [t| FilterOperations $v |]
 
 -- | Represents a filter operation on the data model.
 --

--- a/wallet-new/src/Cardano/Wallet/API/Request/Filter.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Filter.hs
@@ -18,9 +18,9 @@ import           Data.Typeable
 import           Formatting (bprint, build, formatToString, sformat, (%))
 import qualified Generics.SOP as SOP
 import           GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
-import           Pos.Util.LogSafe (BuildableSafeGen (..), buildSafe, deriveSafeBuildableExt)
+import           Pos.Util.LogSafe (BuildableSafe, BuildableSafeGen (..), SecureLog (..), buildSafe,
+                                   secure, unsecure)
 import           Pos.Util.Servant (ApiCanLogArg (..), ApiHasArgClass (..))
-import           Serokell.Util (listJson)
 
 import           Network.HTTP.Types (parseQueryText)
 import           Network.Wai (rawQueryString)
@@ -32,7 +32,6 @@ import           Servant.Server.Internal
 import           Cardano.Wallet.API.Indices
 import qualified Cardano.Wallet.API.Request.Parameters as Param
 import           Cardano.Wallet.API.V1.Types
-import           Cardano.Wallet.TypeLits (KnownSymbols, symbolVals)
 
 --
 -- Filtering data
@@ -42,7 +41,13 @@ import           Cardano.Wallet.TypeLits (KnownSymbols, symbolVals)
 -- the inner closure of 'FilterOp'.
 data FilterOperations a where
     NoFilters  :: FilterOperations a
-    FilterOp   :: (IndexRelation a ix, FromHttpApiData ix, ToHttpApiData ix, Eq ix)
+    FilterOp   :: ( IndexRelation a ix
+                  , KnownSymbol (IndexToQueryParam a ix)
+                  , BuildableSafe ix
+                  , FromHttpApiData ix
+                  , ToHttpApiData ix
+                  , Eq ix
+                  )
                => FilterOperation ix a
                -> FilterOperations a
                -> FilterOperations a
@@ -50,7 +55,7 @@ data FilterOperations a where
 infixr 6 `FilterOp`
 
 instance Show (FilterOperations a) where
-    show = show @_ @[String] . flattenOperations show
+    show = formatToString build
 
 instance Eq (FilterOperations a) where
     NoFilters == NoFilters =
@@ -64,16 +69,19 @@ instance Eq (FilterOperations a) where
     _ == _ =
         False
 
--- NOTE Derived after, see comment below
 instance BuildableSafeGen (FilterOperations a) where
-    buildSafeGen _ = bprint listJson . flattenOperations (bprint build)
+    buildSafeGen _ NoFilters =
+        "-"
+    buildSafeGen sl (FilterOp op NoFilters) =
+        bprint (buildSafe sl) op
+    buildSafeGen sl (FilterOp op rest) =
+        bprint (buildSafe sl) op <> ", " <> bprint (buildSafe sl) rest
 
--- | Handy helper function to transform 'FilterOperation'(s) into list.
-flattenOperations :: (forall ix. FilterOperation ix a -> b)
-                  -> FilterOperations a
-                  -> [b]
-flattenOperations _ NoFilters           = mempty
-flattenOperations trans (FilterOp f fs) = trans f : flattenOperations trans fs
+instance Buildable (FilterOperations a) where
+    build = buildSafeGen unsecure
+
+instance Buildable (SecureLog (FilterOperations a)) where
+    build = buildSafeGen secure . getSecureLog
 
 
 -- A custom ordering for a 'FilterOperation'. Conceptually theh same as 'Ordering' but with the ">=" and "<="
@@ -86,20 +94,14 @@ data FilterOrdering =
     | LesserThanEqual
     deriving (Show, Eq, Enum, Bounded)
 
-renderFilterOrdering :: FilterOrdering -> Text
-renderFilterOrdering = \case
-    Equal -> "EQ"
-    GreaterThan -> "GT"
-    GreaterThanEqual -> "GTE"
-    LesserThan -> "LT"
-    LesserThanEqual -> "LTE"
-
 instance Buildable FilterOrdering where
-    build Equal            = "=="
-    build GreaterThan      = ">"
-    build GreaterThanEqual = ">="
-    build LesserThan       = "<"
-    build LesserThanEqual  = "<="
+    build = \case
+        Equal            -> "EQ"
+        GreaterThan      -> "GT"
+        GreaterThanEqual -> "GTE"
+        LesserThan       -> "LT"
+        LesserThanEqual  -> "LTE"
+
 
 -- A filter operation on the data model
 data FilterOperation ix a =
@@ -111,17 +113,32 @@ data FilterOperation ix a =
     -- ^ Filter by range, in the form [from,to]
     deriving Eq
 
-instance ToHttpApiData ix => ToHttpApiData (FilterOperation ix a) where
-    toQueryParam = renderFilterOperation
+instance (BuildableSafe ix, sym ~ IndexToQueryParam a ix, KnownSymbol sym) => Show (FilterOperation ix a) where
+    show = formatToString build
 
-renderFilterOperation :: ToHttpApiData ix => FilterOperation ix a -> Text
-renderFilterOperation = \case
-    FilterByIndex ix ->
-        toQueryParam ix
-    FilterByPredicate p ix ->
-        mconcat [renderFilterOrdering p, "[", toQueryParam ix, "]"]
-    FilterByRange lo hi  ->
-        mconcat ["RANGE", "[", toQueryParam lo, ",", toQueryParam hi, "]"]
+instance ToHttpApiData ix => ToHttpApiData (FilterOperation ix a) where
+    toQueryParam = \case
+        FilterByIndex ix ->
+            toQueryParam ix
+        FilterByPredicate p ix ->
+            mconcat [sformat build p, "[", toQueryParam ix, "]"]
+        FilterByRange lo hi  ->
+            mconcat ["RANGE", "[", toQueryParam lo, ",", toQueryParam hi, "]"]
+
+instance (BuildableSafe ix, sym ~ IndexToQueryParam a ix, KnownSymbol sym) =>
+    BuildableSafeGen (FilterOperation ix a) where
+    buildSafeGen sl (FilterByIndex ix) =
+        bprint (build%"="%buildSafe sl) (symbolVal (Proxy @sym)) ix
+    buildSafeGen sl (FilterByPredicate o ix) =
+        bprint (build%"="%build%"["%buildSafe sl%"]") (symbolVal (Proxy @sym)) o ix
+    buildSafeGen sl (FilterByRange lo hi) =
+        bprint (build%"=RANGE["%buildSafe sl%","%buildSafe sl%"]") (symbolVal (Proxy @sym)) lo hi
+
+instance (BuildableSafeGen (FilterOperation ix a)) => Buildable (FilterOperation ix a) where
+    build = buildSafeGen unsecure
+
+instance (BuildableSafeGen (FilterOperation ix a)) => Buildable (SecureLog (FilterOperation ix a)) where
+    build = buildSafeGen secure . getSecureLog
 
 findMatchingFilterOp
     :: forall needle a
@@ -139,17 +156,6 @@ findMatchingFilterOp filters =
                 Nothing ->
                     findMatchingFilterOp rest
 
-instance Show (FilterOperation ix a) where
-    show = formatToString build
-
-deriveSafeBuildableExt $ \v -> [t| FilterOperation $v $v |]
-instance BuildableSafeGen (FilterOperation ix a) where
-    buildSafeGen  _ (FilterByIndex _)       = "FilterByIndex"
-    buildSafeGen  _ (FilterByPredicate o _) = "FilterByPredicate[" <> bprint build o <> "]"
-    buildSafeGen  _ (FilterByRange _ _)     = "FilterByRange"
-
--- TH needs to happen after FilterOperation is defined
-deriveSafeBuildableExt $ \v -> [t| FilterOperations $v |]
 
 -- | Represents a filter operation on the data model.
 --
@@ -195,6 +201,7 @@ instance Indexable' a => ToFilterOperations ('[]) a where
 instance ( IndexRelation a ix
          , ToHttpApiData ix
          , FromHttpApiData ix
+         , BuildableSafe ix
          , ToFilterOperations ixs a
          , sym ~ IndexToQueryParam a ix
          , KnownSymbol sym
@@ -222,19 +229,13 @@ instance ( HasServer subApi ctx
                           return $ toFilterOperations (parseQueryText $ rawQueryString req) (Proxy @params)
         in route (Proxy :: Proxy subApi) context delayed
 
--- | Defines name of @FilterBy syms res@ as sum of @syms@,
--- and specifies parameter 'FilterBy' provides.
--- Used in e.g. logging.
-instance (KnownSymbols syms, syms ~ ParamNames res params) => ApiHasArgClass (FilterBy params res) where
+-- | Defines name of @FilterBy syms res@
+instance ApiHasArgClass (FilterBy params res) where
     type ApiArg (FilterBy params res) = FilterOperations res
+    apiArgName _ = "filter_by"
 
-    apiArgName _ =
-        let filterNames = mconcat . intersperse ", " $ symbolVals (Proxy @syms)
-        in  formatToString ("filters: ("%build%")") filterNames
-
--- | Defines how 'FilterBy' is logged by just refering to
--- 'instance Buildable SortOperations'.
-instance (KnownSymbols syms, syms ~ ParamNames res params) => ApiCanLogArg (FilterBy params res) where
+-- | Defines how 'FilterBy' is logged by just refering to instance Buildable FilterOperations.
+instance ApiCanLogArg (FilterBy params res) where
     toLogParamInfo _ param = \sl -> sformat (buildSafe sl) param
 
 -- | Parse the filter operations, failing silently if the query is malformed.

--- a/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
@@ -20,6 +20,8 @@ import           Data.Aeson.TH
 import qualified Data.Char as Char
 import           Data.Default
 import           Data.Swagger as S
+import qualified Data.Text.Buildable
+import           Formatting (bprint, build, (%))
 import qualified Serokell.Aeson.Options as Serokell
 import           Test.QuickCheck (Arbitrary (..), choose, getPositive)
 import           Web.HttpApiData
@@ -140,3 +142,9 @@ data PaginationParams = PaginationParams
     { ppPage    :: Page
     , ppPerPage :: PerPage
     } deriving (Show, Eq, Generic)
+
+instance Buildable PaginationParams where
+    build PaginationParams{..} =
+        let Page page = ppPage
+            PerPage perPage = ppPerPage
+        in  bprint ("p #"%build%" / pp "%build) page perPage

--- a/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
@@ -59,6 +59,9 @@ instance ToParamSchema Page where
 instance Default Page where
     def = Page 1
 
+instance Buildable Page where
+  build (Page p) = bprint build p
+
 -- | A `PerPage` is used to specify the number of entries which should be returned
 -- as part of a paginated response.
 newtype PerPage = PerPage Int
@@ -104,6 +107,9 @@ instance ToHttpApiData PerPage where
 instance Default PerPage where
     def = PerPage defaultPerPageEntries
 
+instance Buildable PerPage where
+  build (PerPage p) = bprint build p
+
 -- | Extra information associated with pagination
 data PaginationMetadata = PaginationMetadata
   { metaTotalPages   :: Int     -- ^ The total pages returned by this query.
@@ -136,6 +142,14 @@ instance ToSchema PaginationMetadata where
         & at "totalPages" ?~ totalSchema
         & at "totalEntries" ?~ totalSchema
 
+instance Buildable PaginationMetadata where
+    build PaginationMetadata{..} =
+        bprint ("p #"%build%" / "%build%" ("%build%" total / "%build%" pp)")
+            metaPage
+            metaTotalPages
+            metaTotalEntries
+            metaPerPage
+
 -- | `PaginationParams` is datatype which combines request params related
 -- to pagination together.
 data PaginationParams = PaginationParams
@@ -145,6 +159,6 @@ data PaginationParams = PaginationParams
 
 instance Buildable PaginationParams where
     build PaginationParams{..} =
-        let Page page = ppPage
-            PerPage perPage = ppPerPage
-        in  bprint ("p #"%build%" / pp "%build) page perPage
+      bprint ("p #"%build%" / pp "%build)
+          ppPage
+          ppPerPage

--- a/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Pagination.hs
@@ -144,7 +144,7 @@ instance ToSchema PaginationMetadata where
 
 instance Buildable PaginationMetadata where
     build PaginationMetadata{..} =
-        bprint ("p #"%build%" / "%build%" ("%build%" total / "%build%" pp)")
+        bprint (build%"/"%build%" total="%build%" per_page="%build)
             metaPage
             metaTotalPages
             metaTotalEntries
@@ -159,6 +159,6 @@ data PaginationParams = PaginationParams
 
 instance Buildable PaginationParams where
     build PaginationParams{..} =
-      bprint ("p #"%build%" / pp "%build)
+      bprint ("page="%build%", per_page="%build)
           ppPage
           ppPerPage

--- a/wallet-new/src/Cardano/Wallet/API/Request/Sort.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Sort.hs
@@ -14,7 +14,6 @@ import           Universum
 import qualified Data.Text as T
 import qualified Data.Text.Buildable
 import           Data.Typeable
-import           Data.Typeable (Typeable)
 import           Formatting (bprint, build, formatToString, sformat)
 import qualified Generics.SOP as SOP
 import           GHC.TypeLits (KnownSymbol, symbolVal)

--- a/wallet-new/src/Cardano/Wallet/API/Request/Sort.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Request/Sort.hs
@@ -10,12 +10,23 @@ module Cardano.Wallet.API.Request.Sort where
 import qualified Prelude
 import           Universum
 
+import           Cardano.Wallet.API.Indices
+import           Cardano.Wallet.API.Types
+import           Cardano.Wallet.API.V1.Types
+import           Cardano.Wallet.TypeLits (KnownSymbols, symbolVals)
+import qualified Data.List as List
 import qualified Data.Text as T
+import qualified Data.Text.Buildable
 import           Data.Typeable
+import           Data.Typeable (Typeable)
+import           Formatting (bprint, build, builder, stext, (%))
 import qualified Generics.SOP as SOP
 import           GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import           Network.HTTP.Types (parseQueryText)
 import           Network.Wai (Request, rawQueryString)
+import           Pos.Core as Core
+import           Pos.Util.Servant (HasLoggingServer (..), LoggingApiRec, addParamLogInfo)
+import           Serokell.Util.ANSI (Color (..), colorizeDull)
 import           Servant
 import           Servant.Client
 import           Servant.Client.Core (appendToQueryString)
@@ -66,6 +77,10 @@ renderSortDir sd = case sd of
     SortAscending  -> "ASC"
     SortDescending -> "DESC"
 
+instance Buildable SortDirection where
+    build SortAscending  = "asc."
+    build SortDescending = "desc."
+
 -- | A sort operation on an index @ix@ for a resource 'a'.
 data SortOperation ix a
     = SortByIndex SortDirection (Proxy ix)
@@ -86,8 +101,9 @@ instance
                     , "]"
                     ]
 
-instance Show (SortOperations a) where
-    show = show . flattenSortOperations
+instance Show (SortOperation ix a) where
+    show (SortByIndex dir _) = "SortByIndex[" <> show dir <> "]"
+    show SortIdentity        = "SortIdentity"
 
 -- | A "bag" of sort operations, where the index constraint are captured in
 -- the inner closure of 'SortOp'.
@@ -110,6 +126,9 @@ instance Eq (SortOperations a) where
     _ == _ =
         False
 
+instance Show (SortOperations a) where
+    show = show @_ @[Text] . flattenSortOperations show
+
 findMatchingSortOp
     :: forall (needle :: *) (a :: *)
     . Typeable needle
@@ -121,14 +140,12 @@ findMatchingSortOp (SortOp (sop :: SortOperation ix a) rest) =
         Just Refl -> pure sop
         Nothing   -> findMatchingSortOp rest
 
-instance Show (SortOperation ix a) where
-    show (SortByIndex dir _) = "SortByIndex[" <> show dir <> "]"
-
--- | Handy helper function to show opaque 'FilterOperation'(s), mostly for
--- debug purposes.
-flattenSortOperations :: SortOperations a -> [String]
-flattenSortOperations NoSorts       = mempty
-flattenSortOperations (SortOp f fs) = show f : flattenSortOperations fs
+-- | Handy helper function to convert 'SortOperation'(s) into list.
+flattenSortOperations :: (forall ix. SortOperation ix a -> b)
+                      -> SortOperations a
+                      -> [b]
+flattenSortOperations _     NoSorts       = mempty
+flattenSortOperations trans (SortOp f fs) = trans f : flattenSortOperations trans fs
 
 -- | This is a slighly boilerplat-y type family which maps symbols to
 -- indices, so that we can later on reify them into a list of valid indices.
@@ -182,6 +199,50 @@ instance ( HasServer subApi ctx
                         return $ toSortOperations req (Proxy @params)
 
         in route (Proxy :: Proxy subApi) context delayed
+
+-- | Logs all non-identity sorting parameters.
+--
+-- Example: @filter: asc id, desc balance@.
+--
+-- Default implementation of this instance for 'SortBy syms res'
+-- (note OVERLAPPING) would print logs in format of
+-- "<some name dependant on 'syms'>: <prettified SortOperations>".
+-- With current implementation of 'SortOperations' the best logs we can get
+-- would be like "filter: asc, desc, none",
+-- or "filter (id, created_at, balance): asc, desc, none",
+-- because 'SortOperations' itself doesn't remember name of parameter it sorts
+-- upon and those logs seem a bit cumbersome with growth of number of parameters
+-- we allow to sort on.
+-- Thus custom instance which cuts off "none"s is used.
+instance {-# OVERLAPPING #-}
+         ( HasLoggingServer config subApi ctx
+         , SortParams syms res ~ ixs
+         , KnownSymbols syms
+         , ToSortOperations ixs res
+         , SOP.All (ToIndex res) ixs
+         ) =>
+         HasLoggingServer config (SortBy syms res :> subApi) ctx where
+    routeWithLog =
+        mapRouter @(SortBy syms res :> LoggingApiRec config subApi) route $
+            \(paramsInfo, f) sortOps ->
+            (updateParamsInfo sortOps paramsInfo, f sortOps)
+      where
+        updateParamsInfo sortOps =
+            addParamLogInfo $ \_sl -> colorizeDull White $ buildSortOps sortOps
+        allParams = map toText $ symbolVals (Proxy @syms)
+        buildSortOps sortOps =
+            let builtOps = flattenSortOperations buildSortOp sortOps
+                namedOps = zipWith mergeNameAndOp allParams builtOps
+                activeOps = catMaybes namedOps
+            in  case activeOps of
+                    [] -> "no sort"
+                    ss -> pretty . mconcat $ intersperse ", " ss
+        buildSortOp sortOp =
+            case sortOp of
+                SortIdentity           -> Nothing
+                SortByIndex sortType _ -> Just $ bprint build sortType
+        mergeNameAndOp _ Nothing      = Nothing
+        mergeNameAndOp name (Just op) = Just $ bprint (builder%" "%stext) op name
 
 -- | Parse the incoming HTTP query param into a 'SortOperation', failing if the input is not a valid operation.
 parseSortOperation

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -100,10 +100,11 @@ instance (ToSchema a, Typeable a) => ToSchema (WalletResponse a) where
                 ]
 
 instance Buildable a => Buildable (WalletResponse a) where
-    build WalletResponse{..} = bprint ("({"
+    build WalletResponse{..} = bprint ("{"
         %" status="%build
         %" meta="%build
-        %" data="%build)
+        %" data="%build
+        %" }")
         wrStatus
         wrMeta
         wrData

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -24,8 +24,7 @@ import qualified Data.Char as Char
 import           Data.Swagger as S
 import qualified Data.Text.Buildable
 import           Data.Typeable
-import           Formatting (build, (%))
-import           Formatting (bprint)
+import           Formatting (bprint, build, (%))
 import           GHC.Generics (Generic)
 import qualified Serokell.Aeson.Options as Serokell
 import           Servant.API.ContentTypes (Accept (..), JSON, MimeRender (..), MimeUnrender (..),
@@ -100,11 +99,11 @@ instance (ToSchema a, Typeable a) => ToSchema (WalletResponse a) where
                 ]
 
 instance Buildable a => Buildable (WalletResponse a) where
-    build WalletResponse{..} = bprint ("{"
-        %" status="%build
-        %" meta="%build
-        %" data="%build
-        %" }")
+    build WalletResponse{..} = bprint
+        ("\n\tstatus="%build
+        %"\n\tmeta="%build
+        %"\n\tdata="%build
+        )
         wrStatus
         wrMeta
         wrData

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -13,7 +13,7 @@ module Cardano.Wallet.API.Response (
   ) where
 
 import           Prelude
-import           Universum (decodeUtf8, toText, (<>))
+import           Universum (Buildable, decodeUtf8, toText, (<>))
 
 import           Cardano.Wallet.API.Response.JSend (ResponseStatus (..))
 import           Control.Lens
@@ -22,7 +22,10 @@ import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.Aeson.TH
 import qualified Data.Char as Char
 import           Data.Swagger as S
+import qualified Data.Text.Buildable
 import           Data.Typeable
+import           Formatting (build, (%))
+import           Formatting (bprint)
 import           GHC.Generics (Generic)
 import qualified Serokell.Aeson.Options as Serokell
 import           Servant.API.ContentTypes (Accept (..), JSON, MimeRender (..), MimeUnrender (..),
@@ -55,6 +58,10 @@ instance ToSchema Metadata where
         { S.fieldLabelModifier =
             over (ix 0) Char.toLower . drop 4 -- length "meta"
         }
+
+instance Buildable Metadata where
+  build Metadata{..} =
+    bprint ("{ pagination="%build%" }") metaPagination
 
 -- | An `WalletResponse` models, unsurprisingly, a response (successful or not)
 -- produced by the wallet backend.
@@ -91,6 +98,15 @@ instance (ToSchema a, Typeable a) => ToSchema (WalletResponse a) where
                 , ("status", respRef)
                 , ("meta", metaRef)
                 ]
+
+instance Buildable a => Buildable (WalletResponse a) where
+    build WalletResponse{..} = bprint ("({"
+        %" status="%build
+        %" meta="%build
+        %" data="%build)
+        wrStatus
+        wrMeta
+        wrData
 
 -- | Inefficient function to build a response out of a @generator@ function. When the data layer will
 -- be rewritten the obvious solution is to slice & dice the data as soon as possible (aka out of the DB), in this order:

--- a/wallet-new/src/Cardano/Wallet/API/Response/JSend.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response/JSend.hs
@@ -1,4 +1,3 @@
-
 module Cardano.Wallet.API.Response.JSend where
 
 import           Universum
@@ -7,6 +6,7 @@ import           Data.Aeson
 import           Data.Aeson.TH
 import qualified Data.Char as Char
 import           Data.Swagger hiding (constructorTagModifier)
+import qualified Data.Text.Buildable
 import           Test.QuickCheck (Arbitrary (..), elements)
 
 data ResponseStatus =
@@ -25,3 +25,8 @@ instance ToSchema ResponseStatus where
         pure $ NamedSchema (Just "ResponseStatus") $ mempty
             & type_ .~ SwaggerString
             & enum_ .~ Just ["success", "fail", "error"]
+
+instance Buildable ResponseStatus where
+    build SuccessStatus = "success"
+    build FailStatus    = "fail"
+    build ErrorStatus   = "error"

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -1170,7 +1170,7 @@ instance ToSchema SlotDuration where
 deriveSafeBuildable ''SlotDuration
 instance BuildableSafeGen SlotDuration where
     buildSafeGen _ (SlotDuration (MeasuredIn w)) =
-        bprint (build%" milliseconds") w
+        bprint (build%"ms") w
 
 
 -- | The @static@ settings for this wallet node. In particular, we could group
@@ -1291,7 +1291,7 @@ instance ToSchema LocalTimeDifference where
 deriveSafeBuildable ''LocalTimeDifference
 instance BuildableSafeGen LocalTimeDifference where
     buildSafeGen _ (LocalTimeDifference (MeasuredIn w)) =
-        bprint (build%" microseconds") w
+        bprint (build%"μs") w
 
 
 -- | The sync progress with the blockchain.
@@ -1333,7 +1333,7 @@ instance ToSchema SyncProgress where
 deriveSafeBuildable ''SyncProgress
 instance BuildableSafeGen SyncProgress where
     buildSafeGen _ (SyncProgress (MeasuredIn w)) =
-        bprint (build%" %") w
+        bprint (build%"%") w
 
 
 -- | The absolute or relative height of the blockchain, measured in number

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -114,8 +114,8 @@ import           Pos.Core (addressF)
 import qualified Pos.Core as Core
 import           Pos.Crypto (decodeHash, hashHexF)
 import qualified Pos.Crypto.Signing as Core
-import           Pos.Util.LogSafe (BuildableSafeGen (..), SecureLog (..), buildSafe, buildSafeMaybe,
-                                   deriveSafeBuildable, plainOrSecureF)
+import           Pos.Util.LogSafe (BuildableSafeGen (..), SecureLog (..), buildSafe, buildSafeList,
+                                   buildSafeMaybe, deriveSafeBuildable, plainOrSecureF)
 
 
 
@@ -215,9 +215,6 @@ instance Bounded a => Bounded (V1 a) where
 
 instance Buildable a => Buildable (V1 a) where
     build (V1 x) = bprint build x
-
-instance Buildable a => Buildable [V1 a] where
-    build = bprint listJson
 
 instance Buildable (SecureLog a) => Buildable (SecureLog (V1 a)) where
     build = bprint build
@@ -578,6 +575,8 @@ instance BuildableSafeGen Wallet where
     walName
     walBalance
 
+instance Buildable [Wallet] where
+    build = bprint listJson
 
 --------------------------------------------------------------------------------
 -- Addresses
@@ -639,7 +638,7 @@ instance BuildableSafeGen Account where
     buildSafeGen sl Account{..} = bprint ("{"
         %" index="%buildSafe sl
         %" name="%buildSafe sl
-        %" addresses="%buildSafe sl
+        %" addresses="%buildSafeList sl
         %" amount="%buildSafe sl
         %" walletId="%buildSafe sl
         %" }")
@@ -649,6 +648,8 @@ instance BuildableSafeGen Account where
         accAmount
         accWalletId
 
+instance Buildable [Account] where
+    build = bprint listJson
 
 -- | Account Update
 data AccountUpdate = AccountUpdate {
@@ -857,6 +858,9 @@ instance BuildableSafeGen PaymentDistribution where
         pdAddress
         pdAmount
 
+-- instance Buildable [PaymentDistribution] where
+--     build = bprint listJson
+
 
 -- | A 'PaymentSource' encapsulate two essentially piece of data to reach for some funds:
 -- a 'WalletId' and an 'AccountIndex' within it.
@@ -870,6 +874,7 @@ deriveJSON Serokell.defaultOptions ''PaymentSource
 instance ToSchema PaymentSource where
   declareNamedSchema =
     genericSchemaDroppingPrefix "ps" (\(--^) props -> props
+
       & ("walletId"     --^ "Target wallet identifier to reach")
       & ("accountIndex" --^ "Corresponding account's index on the wallet")
     )
@@ -936,7 +941,7 @@ deriveSafeBuildable ''Payment
 instance BuildableSafeGen Payment where
     buildSafeGen sl (Payment{..}) = bprint ("{"
         %" source="%buildSafe sl
-        %" destinations="%buildSafe sl
+        %" destinations="%buildSafeList sl
         %" groupingPolicty="%build
         %" spendingPassword="%(buildSafeMaybe mempty sl)
         %" }")
@@ -1076,8 +1081,8 @@ instance BuildableSafeGen Transaction where
         %" id="%buildSafe sl
         %" confirmations="%build
         %" amount="%buildSafe sl
-        %" inputs="%buildSafe sl
-        %" outputs="%buildSafe sl
+        %" inputs="%buildSafeList sl
+        %" outputs="%buildSafeList sl
         %" type="%buildSafe sl
         %" direction"%buildSafe sl
         %" }")
@@ -1088,6 +1093,9 @@ instance BuildableSafeGen Transaction where
         (toList txOutputs)
         txType
         txDirection
+
+instance Buildable [Transaction] where
+    build = bprint listJson
 
 
 -- | A type representing an upcoming wallet update.

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -217,7 +217,7 @@ instance Buildable a => Buildable (V1 a) where
     build (V1 x) = bprint build x
 
 instance Buildable (SecureLog a) => Buildable (SecureLog (V1 a)) where
-    build = bprint build
+    build (SecureLog (V1 x)) = bprint build (SecureLog x)
 
 
 --

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -858,9 +858,6 @@ instance BuildableSafeGen PaymentDistribution where
         pdAddress
         pdAmount
 
--- instance Buildable [PaymentDistribution] where
---     build = bprint listJson
-
 
 -- | A 'PaymentSource' encapsulate two essentially piece of data to reach for some funds:
 -- a 'WalletId' and an 'AccountIndex' within it.

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -82,8 +82,10 @@ import           Data.Swagger as S hiding (constructorTagModifier)
 import           Data.Swagger.Declare (Declare, look)
 import           Data.Swagger.Internal.Schema (GToSchema)
 import           Data.Text (Text, dropEnd, toLower)
+import qualified Data.Text.Buildable
 import           Data.Version (Version)
 import           Formatting (build, int, sformat, (%))
+import           Formatting (bprint)
 import           GHC.Generics (Generic, Rep)
 import qualified Prelude
 import qualified Serokell.Aeson.Options as Serokell
@@ -112,6 +114,7 @@ import           Pos.Core (addressF)
 import qualified Pos.Core as Core
 import           Pos.Crypto (decodeHash, hashHexF)
 import qualified Pos.Crypto.Signing as Core
+import           Pos.Util.LogSafe (BuildableSafeGen (..), SecureLog (..))
 
 
 -- | Declare generic schema, while documenting properties
@@ -207,6 +210,12 @@ instance Enum a => Enum (V1 a) where
 instance Bounded a => Bounded (V1 a) where
     minBound = V1 $ minBound @a
     maxBound = V1 $ maxBound @a
+
+instance Buildable a => Buildable (V1 a) where
+    build (V1 x) = bprint build x
+
+instance Buildable (SecureLog a) => Buildable (SecureLog (V1 a)) where
+    build (SecureLog vx) = bprint build (SecureLog vx)
 
 --
 -- Benign instances
@@ -383,6 +392,10 @@ data AssuranceLevel =
   | StrictAssurance
   deriving (Eq, Show, Enum, Bounded)
 
+instance BuildableSafeGen AssuranceLevel where
+    buildSafeGen _sl NormalAssurance = "normal assurance"
+    buildSafeGen _sl StrictAssurance = "strict assurance"
+
 instance Arbitrary AssuranceLevel where
     arbitrary = elements [minBound .. maxBound]
 
@@ -407,6 +420,12 @@ instance Arbitrary WalletId where
   arbitrary =
       let wid = "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
           in WalletId <$> elements [wid]
+
+instance Buildable WalletId where
+    build (WalletId wid) = bprint build wid
+
+instance Buildable (SecureLog WalletId) where
+    build _ = "<wallet id>"
 
 instance FromHttpApiData WalletId where
     parseQueryParam = Right . WalletId

--- a/wallet-new/test/RequestSpec.hs
+++ b/wallet-new/test/RequestSpec.hs
@@ -3,6 +3,7 @@ module RequestSpec where
 import           Universum
 
 import           Data.Either (isLeft)
+import           Formatting (build, sformat)
 import           Test.Hspec
 
 import           Cardano.Wallet.API.Request.Filter
@@ -58,7 +59,7 @@ filterSpec = do
             forM_ [minBound .. maxBound] $ \p ->
                 it ("supports predicate: " <> show p) $ do
                     parseFilterOperation pw pwid
-                        (renderFilterOrdering p <> "[asdf]")
+                        (sformat build p <> "[asdf]")
                         `shouldBe`
                             Right (FilterByPredicate p (WalletId "asdf"))
 

--- a/wallet/src/Pos/Util/BackupPhrase.hs
+++ b/wallet/src/Pos/Util/BackupPhrase.hs
@@ -20,6 +20,7 @@ import           Pos.Binary (Bi (..), serialize')
 import           Pos.Crypto (AbstractHash, EncryptedSecretKey, PassPhrase, SecretKey, VssKeyPair,
                              deterministicKeyGen, deterministicVssKeyGen, safeDeterministicKeyGen,
                              unsafeAbstractHash)
+import           Pos.Util.LogSafe (SecureLog)
 import           Pos.Util.Mnemonics (fromMnemonic, toMnemonic)
 
 -- | Datatype to contain a valid backup phrase
@@ -51,6 +52,9 @@ instance Show BackupPhrase where
     show _ = "<backup phrase>"
 
 instance Buildable BackupPhrase where
+    build _ = "<backup phrase>"
+
+instance Buildable (SecureLog BackupPhrase) where
     build _ = "<backup phrase>"
 
 instance Read BackupPhrase where

--- a/wallet/src/Pos/Wallet/Web/Api.hs
+++ b/wallet/src/Pos/Wallet/Web/Api.hs
@@ -60,8 +60,8 @@ import           Servant.Swagger.UI (SwaggerSchemaUI)
 
 import           Pos.Client.Txp.Util (InputSelectionPolicy)
 import           Pos.Core (Coin, SoftwareVersion)
-import           Pos.Util.Servant (ApiLoggingConfig, CCapture, CQueryParam, CReqBody, DCQueryParam,
-                                   DReqBody, LoggingApi, ModifiesApiRes (..),
+import           Pos.Util.Servant (ApiLoggingConfig (..), CCapture, CQueryParam, CReqBody,
+                                   DCQueryParam, DReqBody, LoggingApi, ModifiesApiRes (..),
                                    ReportDecodeError (..), VerbMod, serverHandlerL')
 import           Pos.Wallet.Web.ClientTypes (Addr, CAccount, CAccountId, CAccountInit, CAccountMeta,
                                              CAddress, CCoin, CFilePath, CId, CInitialized,
@@ -92,7 +92,7 @@ data WalletLoggingConfig
 -- If logger config will ever be determined in runtime, 'Data.Reflection.reify'
 -- can be used.
 instance Reifies WalletLoggingConfig ApiLoggingConfig where
-    reflect _ = "node" <> "wallet" <> "servant"
+    reflect _ = ApiLoggingConfig ("node" <> "wallet" <> "servant")
 
 -- | Shortcut for common api result types.
 type WRes verbType a = WalletVerb (verbType '[JSON] a)

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Types.hs
@@ -69,7 +69,6 @@ import           Control.Lens (makeLenses)
 import           Data.Default (Default, def)
 import           Data.Hashable (Hashable (..))
 import qualified Data.Text.Buildable
-import           Data.Text.Lazy.Builder (Builder)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Typeable (Typeable)
 import           Data.Version (Version)
@@ -82,8 +81,8 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy)
 import           Pos.Core (BlockVersion, ChainDifficulty, Coin, ScriptVersion, SoftwareVersion,
                            unsafeGetCoin)
 import           Pos.Util.BackupPhrase (BackupPhrase)
-import           Pos.Util.LogSafe (LogSecurityLevel, SecureLog (..), buildUnsecure, secretOnlyF,
-                                   secure, secureListF, unsecure)
+import           Pos.Util.LogSafe (BuildableSafeGen (..), SecureLog (..), buildUnsecure,
+                                   deriveSafeBuildable, secretOnlyF, secureListF)
 import           Pos.Util.Servant (HasTruncateLogPolicy, WithTruncatedLog (..))
 
 data SyncProgress = SyncProgress
@@ -503,22 +502,18 @@ data NewBatchPayment = NewBatchPayment
     , npbInputSelectionPolicy :: InputSelectionPolicy
     } deriving (Show, Generic)
 
-buildNewBatchPayment :: LogSecurityLevel -> NewBatchPayment -> Builder
-buildNewBatchPayment sl NewBatchPayment {..} =
-    bprint ("{ from="%secretOnlyF sl build
-            -- TODO: use https://github.com/serokell/serokell-util/pull/19 instead of `later mapBuilder`
-            %" to="%secureListF sl (later mapBuilder)
-            %" inputSelectionPolicy="%secretOnlyF sl build
-            %" }")
-    npbFrom
-    npbTo
-    npbInputSelectionPolicy
+instance BuildableSafeGen NewBatchPayment where
+    buildSafeGen sl NewBatchPayment {..} =
+        bprint ("{ from="%secretOnlyF sl build
+                -- TODO: use https://github.com/serokell/serokell-util/pull/19 instead of `later mapBuilder`
+                %" to="%secureListF sl (later mapBuilder)
+                %" inputSelectionPolicy="%secretOnlyF sl build
+                %" }")
+        npbFrom
+        npbTo
+        npbInputSelectionPolicy
 
-instance Buildable NewBatchPayment where
-    build = buildNewBatchPayment unsecure
-
-instance Buildable (SecureLog NewBatchPayment) where
-    build = buildNewBatchPayment secure . getSecureLog
+deriveSafeBuildable ''NewBatchPayment
 
 -- | Update system data
 data CUpdateInfo = CUpdateInfo

--- a/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Modifier.hs
@@ -23,8 +23,6 @@ module Pos.Wallet.Web.Tracking.Modifier
 import           Universum
 
 import           Data.DList (DList)
-import qualified Data.Text.Buildable
-import           Data.Text.Lazy.Builder (Builder)
 import           Formatting (bprint, build, (%))
 import           Serokell.Util (listJson, listJsonIndent)
 
@@ -32,8 +30,8 @@ import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Core (HeaderHash)
 import           Pos.Core.Txp (TxId)
 import           Pos.Txp.Toil (UtxoModifier)
-import           Pos.Util.LogSafe (LogSecurityLevel, SecureLog, getSecureLog, secretOnlyF, secure,
-                                   secureListF, unsecure)
+import           Pos.Util.LogSafe (BuildableSafeGen (..), deriveSafeBuildable, secretOnlyF,
+                                   secureListF)
 import           Pos.Util.Modifier (MapModifier)
 import qualified Pos.Util.Modifier as MM
 
@@ -83,33 +81,29 @@ instance Monoid CAccModifier where
     mempty = CAccModifier mempty mempty mempty mempty mempty mempty mempty mempty
     mappend = (<>)
 
-buildCAccModifier :: LogSecurityLevel -> CAccModifier -> Builder
-buildCAccModifier sl CAccModifier{..} =
-    bprint
-        ( "\n    added addresses: "%secureListF sl (listJsonIndent 8)
-        %",\n    deleted addresses: "%secureListF sl (listJsonIndent 8)
-        %",\n    used addresses: "%secureListF sl listJson
-        %",\n    change addresses: "%secureListF sl listJson
-        %",\n    local utxo (difference): "%secretOnlyF sl build
-        %",\n    added history entries: "%secureListF sl (listJsonIndent 8)
-        %",\n    deleted history entries: "%secureListF sl (listJsonIndent 8)
-        %",\n    added pending candidates: "%secureListF sl listJson
-        %",\n    deleted pending candidates: "%secureListF sl listJson)
-    (sortedInsertions camAddresses)
-    (indexedDeletions camAddresses)
-    (map (fst . fst) $ MM.insertions camUsed)
-    (map (fst . fst) $ MM.insertions camChange)
-    camUtxo
-    camAddedHistory
-    camDeletedHistory
-    (map fst camAddedPtxCandidates)
-    (map fst camDeletedPtxCandidates)
+instance BuildableSafeGen CAccModifier where
+    buildSafeGen sl CAccModifier{..} =
+        bprint
+            ( "\n    added addresses: "%secureListF sl (listJsonIndent 8)
+            %",\n    deleted addresses: "%secureListF sl (listJsonIndent 8)
+            %",\n    used addresses: "%secureListF sl listJson
+            %",\n    change addresses: "%secureListF sl listJson
+            %",\n    local utxo (difference): "%secretOnlyF sl build
+            %",\n    added history entries: "%secureListF sl (listJsonIndent 8)
+            %",\n    deleted history entries: "%secureListF sl (listJsonIndent 8)
+            %",\n    added pending candidates: "%secureListF sl listJson
+            %",\n    deleted pending candidates: "%secureListF sl listJson)
+        (sortedInsertions camAddresses)
+        (indexedDeletions camAddresses)
+        (map (fst . fst) $ MM.insertions camUsed)
+        (map (fst . fst) $ MM.insertions camChange)
+        camUtxo
+        camAddedHistory
+        camDeletedHistory
+        (map fst camAddedPtxCandidates)
+        (map fst camDeletedPtxCandidates)
 
-instance Buildable CAccModifier where
-    build = buildCAccModifier unsecure
-
-instance Buildable (SecureLog CAccModifier) where
-    build = buildCAccModifier secure . getSecureLog
+deriveSafeBuildable ''CAccModifier
 
 -- | `txMempoolToModifier`, once evaluated, is passed around under this type in
 -- scope of single request.


### PR DESCRIPTION
This is attempt to use same logging mechanism as one we have in old wallet.

#### Previously

Old logging was implemented following such principles:
* Automatic logging - no need to print anything explicitly in implementation.
* No secret info should be revealed (like password) - thus logging requires `instance Buildable` for all types used in API, they should mask content where appropriate.
* No sensitive info should go to public logs (like address) - thus logging in addition requires `instance Buildable (SecureLog ...)` for your type, which masks potentially de-anonymazing info.
* Parameters of request are logged to secret/public logs with `Buildable / Buildable (SecureLog)` instances accordingly. However, responses are not logged at all into public logs (we didn't have time to solve this appropriately previously).

You can see how it looked like e.g. here #1874.

#### This pull request

First, I performed a couple of refactorings:
* Introduce `class BuildableSafeGen` which facilitates simultaneous creation of similar `instance Buildable` for secret logs and `instance Buildable (SecureLog ...)` for public logs via template haskell.
* Modify existing servant type-level combinators from `Pos.Util.Servant`, to work not only with types of form `apiType a` (like `Capture "name" a`), but with arbitrary one.
It will play its role if one day someone needs unusual types like `QueryFlag "name"` to appear in API.

Also logging is implemented for wallet-new-specific servant combinators (`Tags`, `FilterBy`, `SortBy`).
I expect resulting logs to look like
```
Request #1
GET
    :> api
    :> v1
    :> transactions
    :> walletId: <id>
    :> filters (id, balance): [FilterByRange, FilterIdentity]
    :> sort: balance desc
...
Response #1
Status OK > [<transactions here>]
```

There is inconsistency in filters and sorts representation. To artist within me, logs for sorting look good, but logs for filtering are cumbersome (numerous `FilterIdentity`s are not cut away) and incomplete (knowing that filtering mode is `FilterByRange` is good, but which exactly range do we sort by?) but making similar thing as for sorting would be a bit hard and require some arguable decisions (add `Buildable ix` [here](https://goo.gl/PN2ewz)?), see implementation for details. Generally I'd like this to be discussed and caught up in separate PR (unless one finds the inconsistency too dramatic).

**What remains:** PR is WIP, to my knowledge it only requires to go through `Cardano.Wallet.API.V1.Types` and to define `instance Buildable` and `instance Buildable (SecureLog ..)` for every type mentioned in API - I have just started over this process. For types which serve as response slightly another instance is required, follow compiler. I didn't manage to do this part within this week.

Also I suppose I took many arguable decisions here. Including one about `class BuildableSafeGen` introduction - it should be approved before work on this PR can be continued.