### PR TITLE
[DEVOPS-719] docker: run cardano-node inside /wallet

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -22,6 +22,7 @@ let
       echo '/wallet volume not mounted, you need to create one with `docker volume create` and pass the correct -v flag to `docker run`'
     exit 1
     fi
+    cd /wallet
     exec ${connectToCluster}
   '';
 in pkgs.dockerTools.buildImage {


### PR DESCRIPTION
The docker init script expects `/wallet` to be the volume the wallet is in. If a user creates a custom wallet config to override the `stateDir`, this ensures that relative `stateDir` will be created within /wallet so state is properly stored in the `/wallet` volume.