### PR TITLE
[CSL-2371] Write logical integration tests for wallet key import endpoint

### DIFF
--- a/wallet-new/integration/Error.hs
+++ b/wallet-new/integration/Error.hs
@@ -36,6 +36,8 @@ data WalletTestError
     | LocalTransactionsDiffer [Transaction]
     | LocalTransactionMissing Transaction [Transaction]
 
+    | PoorWalletBalanceIsZero Wallet
+
     deriving (Show, Eq, Generic)
 
 
@@ -60,5 +62,5 @@ instance Buildable WalletTestError where
     build (InvalidTransactionState t)     = bprint ("Transaction state is invalid. Transaction - ("%stext%")") (show t)
     build (LocalTransactionsDiffer t)     = bprint ("Local transactions differs. Transactions - ("%stext%")") (show t)
     build (LocalTransactionMissing t ts)  = bprint ("Local transaction ("%stext%") missing from txs history ("%stext%")") (show t) (show ts)
-
+    build (PoorWalletBalanceIsZero a)  = bprint ("Generated wallet balance is zero. Wallet - ("%stext%")") (show a)
 

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -27,9 +27,8 @@ import           Pos.Core.Configuration (genesisSecretsPoor)
 import           Pos.Core.Genesis (poorSecretToEncKey)
 import           Pos.Launcher (withConfigurations)
 import           Pos.Util.Filesystem (withSystemTempFile)
-import           Pos.Util.UserSecret (UserSecret, initializeUserSecret, mkGenesisWalletUserSecret,
-                                      takeUserSecret, usKeys, usPrimKey, usVss, usWallet,
-                                      writeUserSecretRelease)
+import           Pos.Util.UserSecret (initializeUserSecret, mkGenesisWalletUserSecret,
+                                      takeUserSecret, usKeys, usWallet, writeUserSecretRelease)
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 
 
@@ -339,8 +338,8 @@ runAction wc ws GetTransaction  = do
         & actionsNum +~ 1
 runAction wc ws ImportPoorWallet = do
     poorSecret <- pickRandomElement =<< liftIO unsafePoorSecrets
-    liftIO $ usingLoggerName "integration-test" $ withSystemTempFile "importWalletKey.sk" $ \tempFp _ -> do
-        dumpPoorSecret tempFp poorSecret
+    withSystemTempFile "importWalletKey.sk" $ \tempFp _ -> do
+        liftIO $ usingLoggerName "integration-test" $ dumpPoorSecret tempFp poorSecret
         poorWallet <- respToRes $ importWalletKey wc tempFp
 
         checkInvariant

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -10,7 +10,7 @@ import           Data.Coerce (coerce)
 import           Data.Default (def)
 import           Data.List.NonEmpty (fromList)
 
-import           Control.Lens ((+~), (?~))
+import           Control.Lens ((+~), (<>~), (?~))
 import           Test.QuickCheck (Gen, arbitrary, elements, frequency, generate)
 
 import           Cardano.Wallet.API.Response (WalletResponse (..))
@@ -348,7 +348,7 @@ runAction wc ws ImportPoorWallet = do
 
         -- Modify wallet state accordingly.
         pure $ ws
-            & wallets    .~ ws ^. wallets <> [poorWallet]
+            & wallets <>~ [poorWallet]
             & actionsNum +~ 1
   where
     unsafePoorSecrets = usingLoggerName "integration-test" $ withConfigurations def $ pure $ fromMaybe (error "GeneratedSecrets are unknown") genesisSecretsPoor

--- a/wallet-new/integration/Types.hs
+++ b/wallet-new/integration/Types.hs
@@ -32,6 +32,7 @@ type WalletTestMode m =
     ( MonadIO m
     , MonadThrow m
     , MonadPlus m
+    , MonadMask m
     )
 
 -- | The probability type that captures the chance of

--- a/wallet-new/integration/Types.hs
+++ b/wallet-new/integration/Types.hs
@@ -23,7 +23,7 @@ import           Universum
 
 import           Control.Lens (makeLenses)
 
-import           Cardano.Wallet.API.V1.Types (Account, Wallet, WalletAddress,Transaction)
+import           Cardano.Wallet.API.V1.Types (Account, Transaction, Wallet, WalletAddress)
 
 
 -- | Ideally, we would put @MonadGen@ here and remove @MonadIO@,
@@ -53,6 +53,7 @@ data Action
     = CreateWallet
     | GetWallets
     | GetWallet
+    | ImportPoorWallet
 
     | CreateAccount
     | GetAccounts

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -58,6 +58,8 @@ data WalletClient m
     , getAddressValidity
          :: Text -> Resp m AddressValidity
     -- wallets endpoints
+    , importWalletKey
+         :: FilePath -> Resp m Wallet
     , postWallet
          :: New Wallet -> Resp m Wallet
     , getWalletIndexPaged
@@ -116,6 +118,7 @@ hoistClient phi wc = WalletClient
     { getAddresses          = phi (getAddresses wc)
     , postAddress           = phi . postAddress wc
     , getAddressValidity    = phi . getAddressValidity wc
+    , importWalletKey       = phi . importWalletKey wc
     , postWallet            = phi . postWallet wc
     , getWalletIndexPaged   = \x -> phi . getWalletIndexPaged wc x
     , updateWalletPassword  = \x -> phi . updateWalletPassword wc x
@@ -173,7 +176,7 @@ instance Eq ClientError where
 
 -- | General exception instance.
 instance Exception ClientError where
-    toException   (ClientWalletError e) = toException e
-    toException   (ClientHttpError   e) = toException e
-    toException   (UnknownError      e) = toException e
+    toException (ClientWalletError e) = toException e
+    toException (ClientHttpError   e) = toException e
+    toException (UnknownError      e) = toException e
 


### PR DESCRIPTION
Issue: https://iohk.myjetbrains.com/youtrack/issue/CSL-2371

I am not happy because I had to add `MonadMask` constraint into `WalletTestMode`. I am not sure how to avoid that. The idea was to create a temporary file with `withSystemTempFile` dump poor key content into that file and do tests with import key. 

Comments are welcome.

I am also not satisfied I had to pull logging functionality - as functions used for key dumping and key creation depend on logging. Logging can probably be lifted into `MonadThrow` but I didn't spend time on this (maybe I should?)

If it is ok-ish I can create an issue to resolve these ^ and move on - or fix it asap in this issue.