### PR TITLE
[CSL-2374] ensure log files exist before compressing

### DIFF
--- a/infra/Pos/Reporting/Methods.hs
+++ b/infra/Pos/Reporting/Methods.hs
@@ -148,6 +148,11 @@ retrieveLogFiles lconfig = fromLogTree $ lconfig ^. lcTree
 -- | Pass a list of absolute paths to log files. This function will
 -- archive and compress these files and put resulting file into log
 -- directory (returning filepath is absolute).
+--
+-- It will throw a PackingError in case:
+--   - Any of the file paths given does not point to an existing file.
+--   - Any of the file paths could not be converted to a tar path, for instance
+--     because it is too long.
 compressLogs :: (MonadIO m) => [FilePath] -> m FilePath
 compressLogs files = liftIO $ do
     tar <- tarPackIndependently files


### PR DESCRIPTION
If any of the hypthetical log file paths (determined purely from a
LoggerConfig) do not point to existing files, compressLogs will throw an
exception and the real reason for "crashing" will not be apparent: the
program will crash because it could not report the actual crash.
"crashing" for a client apparently means that the node thread finished
before the wallet thread, which is a very loose characterisation... what
if they both finished normally?