### PR TITLE
Pos.Util.Trace module defined

### DIFF
--- a/explorer/src/Pos/Explorer/Web/Transform.hs
+++ b/explorer/src/Pos/Explorer/Web/Transform.hs
@@ -31,6 +31,7 @@ import           Pos.Ssc.Configuration (HasSscConfiguration)
 import           Pos.Txp (HasTxpConfiguration, MempoolExt, MonadTxpLocal (..))
 import           Pos.Update.Configuration (HasUpdateConfiguration)
 import           Pos.Util.CompileInfo (HasCompileInfo)
+import           Pos.Util.Mockable ()
 import           Pos.Worker.Types (WorkerSpec, worker)
 import           Pos.WorkMode (RealMode, RealModeContext (..))
 

--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -67,6 +67,7 @@ import qualified Pos.Network.Policy as Policy
 import           Pos.Reporting.Health.Types (HealthStatus (..))
 import           Pos.System.Metrics.Constants (cardanoNamespace)
 import           Pos.Util.TimeWarp (addressToNodeId)
+import           Pos.Util.Trace (wlogTrace)
 import           Pos.Util.Util (HasLens', lensOf)
 
 {-------------------------------------------------------------------------------
@@ -441,7 +442,7 @@ initQueue :: (MonadIO m, FormatMsg msg)
           -> m (OutboundQ msg NodeId Bucket)
 initQueue NetworkConfig{..} loggerName mStore = liftIO $ do
     let selfName = maybe "self" toString ncSelfName
-        oqTrace  = OQ.wlogTrace loggerName selfName
+        oqTrace  = wlogTrace loggerName selfName
     oq <- OQ.new oqTrace
                  ncEnqueuePolicy
                  ncDequeuePolicy

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -98,6 +98,7 @@ library
                         -- Util code for tests
                         Test.Pos.Configuration
 
+                        Pos.Util.Mockable
                         Pos.Util.Servant
 
 
@@ -165,6 +166,7 @@ library
                       , hspec
                       , lens
                       , log-warper >= 1.1.1
+                      , mmorph
                       , monad-control
                       , mtl
                       , neat-interpolation
@@ -173,6 +175,7 @@ library
                       , plutus-prototype
                       , pvss
                       , random
+                      , resourcet
                       , reflection
                       , safe-exceptions
                       , safecopy
@@ -190,6 +193,8 @@ library
                       , time
                       , time-units
                       , transformers
+                      , transformers-base
+                      , transformers-lift
                       , universum >= 0.1.11
                       , unliftio
                       , unordered-containers

--- a/lib/src/Pos/Util/Mockable.hs
+++ b/lib/src/Pos/Util/Mockable.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE PolyKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Orphan instances for mockable stuff.
+
+module Pos.Util.Mockable
+       (
+       ) where
+
+import           Universum
+
+import           Control.Monad.Morph (MFunctor (..))
+import           Control.Monad.Trans.Identity (IdentityT (..))
+import qualified Ether
+import           Mockable (ChannelT, Counter, Distribution, Gauge, MFunctor' (..), Mockable (..),
+                           Promise, SharedAtomicT, SharedExclusiveT, ThreadId)
+
+instance {-# OVERLAPPABLE #-}
+    (Monad m, MFunctor t) => MFunctor' t m n
+  where
+    hoist' = hoist
+
+instance
+    (Mockable d m, MFunctor' d (IdentityT m) m) =>
+        Mockable d (IdentityT m)
+  where
+    liftMockable dmt = IdentityT $ liftMockable $ hoist' runIdentityT dmt
+
+unTaggedTrans :: Ether.TaggedTrans tag t m a -> t m a
+unTaggedTrans (Ether.TaggedTrans tma) = tma
+
+instance
+      (Mockable d (t m), Monad (t m),
+       MFunctor' d (Ether.TaggedTrans tag t m) (t m)) =>
+          Mockable d (Ether.TaggedTrans tag t m)
+  where
+    liftMockable dmt =
+      Ether.TaggedTrans $ liftMockable $ hoist' unTaggedTrans dmt
+
+type instance ThreadId (IdentityT m) = ThreadId m
+type instance Promise (IdentityT m) = Promise m
+type instance SharedAtomicT (IdentityT m) = SharedAtomicT m
+type instance Counter (IdentityT m) = Counter m
+type instance Distribution (IdentityT m) = Distribution m
+type instance SharedExclusiveT (IdentityT m) = SharedExclusiveT m
+type instance Gauge (IdentityT m) = Gauge m
+type instance ChannelT (IdentityT m) = ChannelT m
+
+type instance ThreadId (Ether.TaggedTrans tag t m) = ThreadId m
+type instance Promise (Ether.TaggedTrans tag t m) = Promise m
+type instance SharedAtomicT (Ether.TaggedTrans tag t m) = SharedAtomicT m
+type instance Counter (Ether.TaggedTrans tag t m) = Counter m
+type instance Distribution (Ether.TaggedTrans tag t m) = Distribution m
+type instance SharedExclusiveT (Ether.TaggedTrans tag t m) = SharedExclusiveT m
+type instance Gauge (Ether.TaggedTrans tag t m) = Gauge m
+type instance ChannelT (Ether.TaggedTrans tag t m) = ChannelT m

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -65,6 +65,7 @@ Library
                       , async
                       , attoparsec
                       , base
+                      , cardano-sl-util
                       , containers
                       , contravariant
                       , cryptonite

--- a/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue/Demo.hs
@@ -21,6 +21,8 @@ import           Data.Text (Text)
 import           Formatting (sformat, shown, (%))
 import           System.Wlog
 
+import           Pos.Util.Trace (wlogTrace)
+
 import           Network.Broadcast.OutboundQueue (OutboundQ)
 import qualified Network.Broadcast.OutboundQueue as OutQ
 import           Network.Broadcast.OutboundQueue.Types hiding (simplePeers)
@@ -137,7 +139,7 @@ instance Eq Node where
 -- | Create a new node, and spawn dequeue worker and forwarding listener
 newNode :: NodeId_ -> NodeType -> CommsDelay -> IO Node
 newNode nodeId_ nodeType commsDelay = do
-    nodeOutQ     <- OutQ.new (OutQ.wlogTrace "demo" (show nodeId_))
+    nodeOutQ     <- OutQ.new (wlogTrace "demo" (show nodeId_))
                              demoEnqueuePolicy
                              demoDequeuePolicy
                              demoFailurePolicy

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6931,14 +6931,15 @@ inherit (pkgs) mesa;};
          , conduit, constraints, containers, cpphs, cryptonite, data-default
          , directory, ed25519, ekg-core, ether, exceptions, extra, filelock
          , filepath, fmt, formatting, generic-arbitrary, half, hashable
-         , hspec, lens, log-warper, monad-control, MonadRandom, mtl
+         , hspec, lens, log-warper, mmorph, monad-control, MonadRandom, mtl
          , neat-interpolation, optparse-applicative, parsec
-         , plutus-prototype, pvss, QuickCheck, random, reflection
+         , plutus-prototype, pvss, QuickCheck, random, reflection, resourcet
          , safe-exceptions, safecopy, serokell-util, servant, servant-client
          , servant-client-core, servant-server, servant-swagger, stdenv, stm
          , systemd, tagged, template-haskell, text, text-format, time
-         , time-units, transformers, universum, unix, unliftio
-         , unordered-containers, vector, wai, warp, warp-tls, yaml
+         , time-units, transformers, transformers-base, transformers-lift
+         , universum, unix, unliftio, unordered-containers, vector, wai
+         , warp, warp-tls, yaml
          }:
          mkDerivation {
            pname = "cardano-sl";
@@ -6953,13 +6954,14 @@ inherit (pkgs) mesa;};
              cardano-sl-update cardano-sl-util cborg cereal conduit constraints
              containers cpphs cryptonite data-default directory ed25519 ekg-core
              ether exceptions filelock filepath formatting generic-arbitrary
-             hashable hspec lens log-warper monad-control mtl neat-interpolation
-             optparse-applicative parsec plutus-prototype pvss QuickCheck random
-             reflection safe-exceptions safecopy serokell-util servant
-             servant-client servant-client-core servant-server servant-swagger
-             stm systemd tagged template-haskell text text-format time
-             time-units transformers universum unix unliftio
-             unordered-containers wai warp warp-tls yaml
+             hashable hspec lens log-warper mmorph monad-control mtl
+             neat-interpolation optparse-applicative parsec plutus-prototype
+             pvss QuickCheck random reflection resourcet safe-exceptions
+             safecopy serokell-util servant servant-client servant-client-core
+             servant-server servant-swagger stm systemd tagged template-haskell
+             text text-format time time-units transformers transformers-base
+             transformers-lift universum unix unliftio unordered-containers wai
+             warp warp-tls yaml
            ];
            testHaskellDepends = [
              base bytestring canonical-json cardano-crypto cardano-sl-binary
@@ -7384,14 +7386,15 @@ inherit (pkgs) mesa;};
          }) {};
       "cardano-sl-networking" = callPackage
         ({ mkDerivation, aeson, async, attoparsec, base, binary, bytestring
-         , conduit, conduit-extra, containers, contravariant, cryptonite
-         , data-default, ekg-core, exceptions, formatting, hashable, hspec
-         , kademlia, lens, log-warper, mmorph, monad-control, MonadRandom
-         , mtl, network, network-transport, network-transport-inmemory
-         , network-transport-tcp, optparse-simple, QuickCheck, random
-         , resourcet, safe-exceptions, serokell-util, stdenv, stm, text
-         , text-format, time, time-units, transformers, transformers-base
-         , transformers-lift, universum, unliftio-core
+         , cardano-sl-util, conduit, conduit-extra, containers
+         , contravariant, cryptonite, data-default, ekg-core, exceptions
+         , formatting, hashable, hspec, kademlia, lens, log-warper, mmorph
+         , monad-control, MonadRandom, mtl, network, network-transport
+         , network-transport-inmemory, network-transport-tcp
+         , optparse-simple, QuickCheck, random, resourcet, safe-exceptions
+         , serokell-util, stdenv, stm, text, text-format, time, time-units
+         , transformers, transformers-base, transformers-lift, universum
+         , unliftio-core
          }:
          mkDerivation {
            pname = "cardano-sl-networking";
@@ -7400,13 +7403,13 @@ inherit (pkgs) mesa;};
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
-             aeson async attoparsec base binary bytestring containers
-             contravariant cryptonite data-default ekg-core exceptions
-             formatting hashable kademlia lens log-warper mmorph monad-control
-             mtl network network-transport network-transport-tcp QuickCheck
-             random resourcet safe-exceptions serokell-util stm text text-format
-             time time-units transformers transformers-base transformers-lift
-             universum unliftio-core
+             aeson async attoparsec base binary bytestring cardano-sl-util
+             containers contravariant cryptonite data-default ekg-core
+             exceptions formatting hashable kademlia lens log-warper mmorph
+             monad-control mtl network network-transport network-transport-tcp
+             QuickCheck random resourcet safe-exceptions serokell-util stm text
+             text-format time time-units transformers transformers-base
+             transformers-lift universum unliftio-core
            ];
            executableHaskellDepends = [
              attoparsec base binary bytestring conduit conduit-extra containers
@@ -7584,28 +7587,27 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.mit;
          }) {};
       "cardano-sl-util" = callPackage
-        ({ mkDerivation, aeson, autoexporter, base, bytestring
-         , cardano-sl-networking, cborg, cereal, concurrent-extra
-         , containers, cpphs, cryptonite, data-default, deepseq, directory
-         , ether, exceptions, filepath, formatting, hashable, hspec, lens
-         , log-warper, lrucache, megaparsec, mmorph, mtl
-         , optparse-applicative, parsec, process, QuickCheck
-         , quickcheck-instances, reflection, resourcet, safe-exceptions
-         , serokell-util, stdenv, stm, tagged, template-haskell, text
-         , text-format, th-lift-instances, time, time-units, transformers
-         , transformers-base, transformers-lift, universum, unliftio-core
-         , unordered-containers
+        ({ mkDerivation, aeson, autoexporter, base, bytestring, cborg
+         , cereal, concurrent-extra, containers, contravariant, cpphs
+         , cryptonite, data-default, deepseq, directory, ether, exceptions
+         , filepath, formatting, hashable, hspec, lens, log-warper, lrucache
+         , megaparsec, mtl, optparse-applicative, parsec, process
+         , QuickCheck, quickcheck-instances, reflection, resourcet
+         , safe-exceptions, serokell-util, stdenv, stm, tagged
+         , template-haskell, text, text-format, th-lift-instances, time
+         , time-units, transformers, transformers-base, transformers-lift
+         , universum, unliftio-core, unordered-containers
          }:
          mkDerivation {
            pname = "cardano-sl-util";
            version = "1.1.0";
            src = ./../util;
            libraryHaskellDepends = [
-             aeson autoexporter base bytestring cardano-sl-networking cborg
-             cereal concurrent-extra containers cryptonite data-default deepseq
-             directory ether exceptions filepath formatting hashable hspec lens
-             log-warper lrucache megaparsec mmorph mtl optparse-applicative
-             parsec process QuickCheck quickcheck-instances reflection resourcet
+             aeson autoexporter base bytestring cborg cereal concurrent-extra
+             containers contravariant cryptonite data-default deepseq directory
+             ether exceptions filepath formatting hashable hspec lens log-warper
+             lrucache megaparsec mtl optparse-applicative parsec process
+             QuickCheck quickcheck-instances reflection resourcet
              safe-exceptions serokell-util stm tagged template-haskell text
              text-format th-lift-instances time time-units transformers
              transformers-base transformers-lift universum unliftio-core

--- a/util/Pos/Util/Orphans.hs
+++ b/util/Pos/Util/Orphans.hs
@@ -31,7 +31,6 @@ import           Universum
 
 import           Control.Monad.Base (MonadBase)
 import           Control.Monad.IO.Unlift (MonadUnliftIO (..), UnliftIO (..), unliftIO, withUnliftIO)
-import           Control.Monad.Morph (MFunctor (..))
 import           Control.Monad.Trans.Identity (IdentityT (..))
 import           Control.Monad.Trans.Lift.Local (LiftLocal (..))
 import           Control.Monad.Trans.Resource (MonadResource (..), ResourceT, transResourceT)
@@ -48,8 +47,6 @@ import           Data.Typeable (typeRep)
 import qualified Ether
 import qualified Formatting as F
 import qualified Language.Haskell.TH.Syntax as TH
-import           Mockable (ChannelT, Counter, Distribution, Gauge, MFunctor' (..), Mockable (..),
-                           Promise, SharedAtomicT, SharedExclusiveT, ThreadId)
 import           Serokell.Data.Memory.Units (Byte, fromBytes, toBytes)
 import           System.Wlog (CanLog, HasLoggerName (..), LoggerNameBox (..))
 import qualified Test.QuickCheck as QC
@@ -191,46 +188,6 @@ instance
     modifyLoggerName = liftLocal askLoggerName modifyLoggerName
 
 deriving instance LiftLocal LoggerNameBox
-
-instance {-# OVERLAPPABLE #-}
-    (Monad m, MFunctor t) => MFunctor' t m n
-  where
-    hoist' = hoist
-
-instance
-    (Mockable d m, MFunctor' d (IdentityT m) m) =>
-        Mockable d (IdentityT m)
-  where
-    liftMockable dmt = IdentityT $ liftMockable $ hoist' runIdentityT dmt
-
-unTaggedTrans :: Ether.TaggedTrans tag t m a -> t m a
-unTaggedTrans (Ether.TaggedTrans tma) = tma
-
-instance
-      (Mockable d (t m), Monad (t m),
-       MFunctor' d (Ether.TaggedTrans tag t m) (t m)) =>
-          Mockable d (Ether.TaggedTrans tag t m)
-  where
-    liftMockable dmt =
-      Ether.TaggedTrans $ liftMockable $ hoist' unTaggedTrans dmt
-
-type instance ThreadId (IdentityT m) = ThreadId m
-type instance Promise (IdentityT m) = Promise m
-type instance SharedAtomicT (IdentityT m) = SharedAtomicT m
-type instance Counter (IdentityT m) = Counter m
-type instance Distribution (IdentityT m) = Distribution m
-type instance SharedExclusiveT (IdentityT m) = SharedExclusiveT m
-type instance Gauge (IdentityT m) = Gauge m
-type instance ChannelT (IdentityT m) = ChannelT m
-
-type instance ThreadId (Ether.TaggedTrans tag t m) = ThreadId m
-type instance Promise (Ether.TaggedTrans tag t m) = Promise m
-type instance SharedAtomicT (Ether.TaggedTrans tag t m) = SharedAtomicT m
-type instance Counter (Ether.TaggedTrans tag t m) = Counter m
-type instance Distribution (Ether.TaggedTrans tag t m) = Distribution m
-type instance SharedExclusiveT (Ether.TaggedTrans tag t m) = SharedExclusiveT m
-type instance Gauge (Ether.TaggedTrans tag t m) = Gauge m
-type instance ChannelT (Ether.TaggedTrans tag t m) = ChannelT m
 
 instance MonadUnliftIO (t m) => MonadUnliftIO (Ether.TaggedTrans tag t m) where
     {-# INLINE askUnliftIO #-}

--- a/util/Pos/Util/Trace.hs
+++ b/util/Pos/Util/Trace.hs
@@ -1,0 +1,42 @@
+
+module Pos.Util.Trace
+    ( Trace (..)
+    , trace
+    , traceWith
+    , noTrace
+    -- TODO put wlog tracing into its own module.
+    , wlogTrace
+    , Wlog.Severity (..)
+    ) where
+
+import           Universum hiding (trace)
+import           Data.Functor.Contravariant (Contravariant (..), Op (..))
+import           Formatting (sformat, string, stext, (%))
+import qualified System.Wlog as Wlog
+
+-- | Abstracts logging.
+newtype Trace m s = Trace
+    { runTrace :: Op (m ()) s
+    }
+
+instance Contravariant (Trace m) where
+    contramap f = Trace . contramap f . runTrace
+
+trace :: Trace m s -> s -> m ()
+trace = getOp . runTrace
+
+-- | Alias to 'trace' so that you don't clash with 'Debug.trace' in case it's
+-- imported (Universum exports it).
+traceWith :: Trace m s -> s -> m ()
+traceWith = trace
+
+-- | A 'Trace' that ignores everything. NB this actually turns off logging: it
+-- doesn't force the logged messages.
+noTrace :: Applicative m => Trace m a
+noTrace = Trace $ Op $ const (pure ())
+
+-- | A 'Trace' that uses log-warper.
+wlogTrace :: Wlog.LoggerName -> String -> Trace IO (Wlog.Severity, Text)
+wlogTrace loggerName selfName = Trace $ Op $ \(severity, txt) ->
+  let txtWithName = sformat (string%": "%stext) selfName txt
+  in  Wlog.usingLoggerName loggerName $ Wlog.logMessage severity txtWithName

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -34,11 +34,12 @@ library
                        Pos.Util.LoggerName
                        Pos.Util.LRU
                        Pos.Util.Modifier
-                       Pos.Util.OptParse
                        Pos.Util.Orphans
+                       Pos.Util.OptParse
                        Pos.Util.Queue
                        Pos.Util.Some
                        Pos.Util.Timer
+                       Pos.Util.Trace
                        Pos.Util.Util
 
   other-modules:
@@ -48,11 +49,11 @@ library
                      , autoexporter
                      , base
                      , bytestring
-                     , cardano-sl-networking
                      , cborg
                      , cereal
                      , containers
                      , concurrent-extra
+                     , contravariant
                      , cryptonite
                      , data-default
                      , deepseq
@@ -67,7 +68,6 @@ library
                      , log-warper >= 1.0.3
                      , lrucache
                      , megaparsec
-                     , mmorph
                      , mtl
                      , optparse-applicative
                      , parsec


### PR DESCRIPTION
Purpose: we can use one of these instead of demanding a
`WithLogger`/`HasLoggerName` constraint thereby forcing
us not to use `IO`.

Had to shuffle the Pos.Util.Orphans module around: it defined Mockable
stuff which was dependent upon cardano-sl-networking. My solution is
still awful but the plan is to gradually dump Mockable anyway.