### PR TITLE
[CSL-2328] generate block without configurations

### DIFF
--- a/block/src/Pos/Arbitrary/Block/Generate.hs
+++ b/block/src/Pos/Arbitrary/Block/Generate.hs
@@ -1,7 +1,8 @@
 -- | Utility to generate a random block using an Arbitrary instance.
 
 module Pos.Arbitrary.Block.Generate
-    ( generateBlock
+    ( generateMainBlock
+    , generateMainBlockWithConfiguration
     ) where
 
 import           Universum
@@ -10,19 +11,38 @@ import           Test.QuickCheck (arbitrary)
 import qualified Test.QuickCheck.Gen as QC
 import qualified Test.QuickCheck.Random as QC
 
-import           Pos.Core (MainBlock, HasConfiguration)
-import qualified Pos.Arbitrary.Block ()
+import           Pos.Core (MainBlock, HasProtocolConstants, HasProtocolMagic,
+                           HasGenesisHash, ProtocolConstants, ProtocolMagic)
+-- Also brings in the 'Arbitrary' instance for 'MainBlock'.
+import           Pos.Arbitrary.Block (genMainBlock)
 
--- The arbitrary instances requires configuration, unfortunately.
--- That's because it does verification. Yes, indeed, the arbitrary instance
--- does verification, which uses a protocol magic, epoch slot data, etc. etc.
-
-
-generateBlock
-    :: ( HasConfiguration )
+-- | Use 'Arbitrary' instances to generate a 'MainBlock'.
+-- These require magical configurations.
+generateMainBlockWithConfiguration
+    :: ( HasProtocolConstants
+       , HasProtocolMagic
+       , HasGenesisHash
+       )
     => Int -- ^ Seed for random generator.
     -> Int -- ^ Size of the generated value (see QuickCheck docs).
     -> MainBlock
-generateBlock genSeed = QC.unGen arbitrary qcGen
+generateMainBlockWithConfiguration genSeed = QC.unGen arbitrary qcGen
   where
     qcGen = QC.mkQCGen genSeed
+
+-- | Get some arbitrary (probably invalid) 'MainBlock'. The previous header
+-- hash and difficulty, body, etc. are all chosen at random.
+generateMainBlock
+    :: ( )
+    => ProtocolMagic
+    -> ProtocolConstants
+    -> Int
+    -> Int
+    -> MainBlock
+generateMainBlock pm pc genSeed = QC.unGen generator qcGen
+  where
+    qcGen = QC.mkQCGen genSeed
+    generator = do
+        prevHash <- arbitrary
+        difficulty <- arbitrary
+        genMainBlock pm pc prevHash difficulty

--- a/block/src/Pos/Block/Base.hs
+++ b/block/src/Pos/Block/Base.hs
@@ -1,7 +1,9 @@
 -- | Block constructors and basic functions.
 
 module Pos.Block.Base
-       ( mkMainBlock
+       ( mkMainBlockExplicit
+       , mkMainBlock
+       , mkMainHeaderExplicit
        , mkMainHeader
        , emptyMainBody
 
@@ -16,7 +18,8 @@ import           Data.Default (Default (def))
 
 import           Pos.Block.BHelpers ()
 import           Pos.Core (BlockVersion, EpochIndex, HasDifficulty (..), LocalSlotIndex, SlotId,
-                           SlotLeaders, SoftwareVersion, GenesisHash (..), HasProtocolConstants)
+                           SlotLeaders, SoftwareVersion, GenesisHash (..), HasProtocolConstants,
+                           ChainDifficulty, HeaderHash, headerHash)
 import           Pos.Core.Block (BlockHeader, BlockSignature (..), GenesisBlock, GenesisBlockHeader,
                                  GenesisBlockchain, GenesisExtraBodyData (..),
                                  GenesisExtraHeaderData (..), MainBlock, MainBlockHeader,
@@ -44,25 +47,42 @@ mkMainHeader
     -> Body MainBlockchain
     -> MainExtraHeaderData
     -> MainBlockHeader
-mkMainHeader pm prevHeader slotId sk pske body extra =
-    mkGenericHeader pm prevHeader body consensus extra
+mkMainHeader pm prevHeader =
+    mkMainHeaderExplicit pm prevHash difficulty
   where
+    prevHash = either getGenesisHash headerHash prevHeader
     difficulty = either (const 0) (succ . view difficultyL) prevHeader
+
+-- | Make a 'MainBlockHeader' for a given slot, with a given body, parent hash,
+-- and difficulty. This takes care of some signing and consensus data.
+mkMainHeaderExplicit
+    :: ProtocolMagic
+    -> HeaderHash -- ^ Parent
+    -> ChainDifficulty
+    -> SlotId
+    -> SecretKey
+    -> ProxySKBlockInfo
+    -> Body MainBlockchain
+    -> MainExtraHeaderData
+    -> MainBlockHeader
+mkMainHeaderExplicit pm prevHash difficulty slotId sk pske body extra =
+    mkGenericHeader pm prevHash body consensus extra
+  where
     makeSignature toSign (psk,_) =
         BlockPSignatureHeavy $ proxySign pm SignMainBlockHeavy sk psk toSign
-    signature prevHash proof =
+    signature proof =
         let toSign = MainToSign prevHash proof slotId difficulty extra
         in maybe
                (BlockSignature $ sign pm SignMainBlock sk toSign)
                (makeSignature toSign)
                pske
     leaderPk = maybe (toPublic sk) snd pske
-    consensus prevHash proof =
+    consensus proof =
         MainConsensusData
         { _mcdSlot = slotId
         , _mcdLeaderKey = leaderPk
         , _mcdDifficulty = difficulty
-        , _mcdSignature = signature prevHash proof
+        , _mcdSignature = signature proof
         }
 
 -- | Smart constructor for 'MainBlock'.
@@ -76,9 +96,29 @@ mkMainBlock
     -> ProxySKBlockInfo
     -> Body MainBlockchain
     -> MainBlock
-mkMainBlock pm bv sv prevHeader slotId sk pske body =
+mkMainBlock pm bv sv prevHeader = mkMainBlockExplicit pm bv sv prevHash difficulty
+  where
+    prevHash = either getGenesisHash headerHash prevHeader
+    difficulty = either (const 0) (succ . view difficultyL) prevHeader
+
+-- | Smart constructor for 'MainBlock', without requiring the entire previous
+-- 'BlockHeader'. Instead, you give its hash and the difficulty of this block.
+-- These are derived from the previous header in 'mkMainBlock' so if you have
+-- the previous header, consider using that one.
+mkMainBlockExplicit
+    :: ProtocolMagic
+    -> BlockVersion
+    -> SoftwareVersion
+    -> HeaderHash
+    -> ChainDifficulty
+    -> SlotId
+    -> SecretKey
+    -> ProxySKBlockInfo
+    -> Body MainBlockchain
+    -> MainBlock
+mkMainBlockExplicit pm bv sv prevHash difficulty slotId sk pske body =
     UnsafeGenericBlock
-        (mkMainHeader pm prevHeader slotId sk pske body extraH)
+        (mkMainHeaderExplicit pm prevHash difficulty slotId sk pske body extraH)
         body
         extraB
   where
@@ -120,14 +160,13 @@ mkGenesisHeader pm prevHeader epoch body =
     -- here we know that genesis header construction can not fail
     mkGenericHeader
         pm
-        prevHeader
+        (either getGenesisHash headerHash prevHeader)
         body
         consensus
         (GenesisExtraHeaderData $ mkAttributes ())
   where
     difficulty = either (const 0) (view difficultyL) prevHeader
-    consensus _ _ =
-        GenesisConsensusData {_gcdEpoch = epoch, _gcdDifficulty = difficulty}
+    consensus = const (GenesisConsensusData {_gcdEpoch = epoch, _gcdDifficulty = difficulty})
 
 -- | Smart constructor for 'GenesisBlock'.
 mkGenesisBlock

--- a/core/Pos/Core/Txp.hs
+++ b/core/Pos/Core/Txp.hs
@@ -287,13 +287,9 @@ mkTxProof UnsafeTxPayload {..} =
 data TxPayload = UnsafeTxPayload
     { -- | Transactions are the main payload.
       _txpTxs       :: ![Tx]
-    , -- | Witnesses for each transaction. The length of this field is
-      -- checked during deserialisation; we can't put witnesses into the same
-      -- Merkle tree with transactions, as the whole point of SegWit is to
-      -- separate transactions and witnesses.
-      --
-      -- TODO: should they be put into a separate Merkle tree or left as
-      -- a list?
+    , -- | Witnesses for each transaction.
+      -- The payload is invalid if this list is not of the same length
+      -- as '_txpTxs'. See 'mkTxPayload'r
       _txpWitnesses :: ![TxWitness]
     } deriving (Show, Eq, Generic)
 

--- a/crypto/Pos/Arbitrary/Crypto.hs
+++ b/crypto/Pos/Arbitrary/Crypto.hs
@@ -1,7 +1,12 @@
 -- | `Arbitrary` instances for using in tests and benchmarks
 
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Pos.Arbitrary.Crypto
        ( SharedSecrets (..)
+       , genSignature
+       , genSignatureEncoded
+       , genRedeemSignature
        ) where
 
 import           Universum
@@ -9,7 +14,7 @@ import           Universum
 import           Control.Monad (zipWithM)
 import qualified Data.ByteArray as ByteArray
 import           Data.List.NonEmpty (fromList)
-import           Test.QuickCheck (Arbitrary (..), elements, oneof, vector)
+import           Test.QuickCheck (Arbitrary (..), Gen, elements, oneof, vector)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
 import           Pos.Arbitrary.Crypto.Unsafe ()
@@ -26,7 +31,7 @@ import           Pos.Crypto.SecretSharing (DecShare, EncShare, Secret, SecretPro
                                            toVssPublicKey, vssKeyGen)
 import           Pos.Crypto.Signing (ProxyCert, ProxySecretKey, ProxySignature, PublicKey,
                                      SecretKey, Signature, Signed, keyGen, mkSigned, proxySign,
-                                     sign, toPublic)
+                                     sign, signEncoded, toPublic)
 import           Pos.Crypto.Signing.Redeem (RedeemPublicKey, RedeemSecretKey, RedeemSignature,
                                             redeemKeyGen, redeemSign)
 import           Pos.Crypto.Signing.Safe (PassPhrase, createProxyCert, createPsk)
@@ -35,6 +40,8 @@ import           Pos.Crypto.Signing.Types.Tag (SignTag (..))
 import           Pos.Util.Orphans ()
 import           Pos.Util.QuickCheck.Arbitrary (Nonrepeating (..), arbitraryUnsafe, runGen,
                                                 sublistN)
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 deriving instance Arbitrary ProtocolMagic
 
@@ -120,11 +127,48 @@ instance Nonrepeating VssPublicKey where
 -- Arbitrary signatures
 ----------------------------------------------------------------------------
 
+-- hlint thinks that the where clauses in the following 3 definitions are
+-- unnecessary duplication. I disagree completely.
+
+{-# ANN genSignatureEncoded ("HLint: ignore Reduce duplication" :: Text) #-}
+
+-- | Generate a signature with a given 'ProtocolMagic', for some generated
+-- bytes. The 'SignTag' and 'SecretKey' are generated using their
+-- 'Arbitrary' instances.
+genSignatureEncoded :: ProtocolMagic -> Gen ByteString -> Gen (Signature a)
+genSignatureEncoded pm genBytes = signEncoded pm <$> genSignTag <*> genSecretKey <*> genBytes
+  where
+    genSignTag :: Gen SignTag
+    genSignTag = arbitrary
+    genSecretKey :: Gen SecretKey
+    genSecretKey = arbitrary
+
+{-# ANN genSignature ("HLint: ignore Reduce duplication" :: Text) #-}
+
+-- | Like 'genSignatureEncoded' but use an 'a' that can be serialized.
+genSignature :: Bi a => ProtocolMagic -> Gen a -> Gen (Signature a)
+genSignature pm genA = sign pm <$> genSignTag <*> genSecretKey <*> genA
+  where
+    genSignTag :: Gen SignTag
+    genSignTag = arbitrary
+    genSecretKey :: Gen SecretKey
+    genSecretKey = arbitrary
+
+{-# ANN genRedeemSignature ("HLint: ignore Reduce duplication" :: Text) #-}
+
+genRedeemSignature :: Bi a => ProtocolMagic -> Gen a -> Gen (RedeemSignature a)
+genRedeemSignature pm genA = redeemSign pm <$> genSignTag <*> genSecretKey <*> genA
+  where
+    genSignTag :: Gen SignTag
+    genSignTag = arbitrary
+    genSecretKey :: Gen RedeemSecretKey
+    genSecretKey = arbitrary
+
 instance (HasProtocolMagic, Bi a, Arbitrary a) => Arbitrary (Signature a) where
-    arbitrary = sign protocolMagic <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = genSignature protocolMagic arbitrary
 
 instance (HasProtocolMagic, Bi a, Arbitrary a) => Arbitrary (RedeemSignature a) where
-    arbitrary = redeemSign protocolMagic <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = genRedeemSignature protocolMagic arbitrary
 
 instance (HasProtocolMagic, Bi a, Arbitrary a) => Arbitrary (Signed a) where
     arbitrary = mkSigned protocolMagic <$> arbitrary <*> arbitrary <*> arbitrary

--- a/crypto/Pos/Crypto/Signing/Signing.hs
+++ b/crypto/Pos/Crypto/Signing/Signing.hs
@@ -9,6 +9,7 @@ module Pos.Crypto.Signing.Signing
 
        -- * Signing and verification
        , sign
+       , signEncoded
        , checkSig                      -- reexport
        , fullSignatureHexF
        , parseFullSignature
@@ -101,6 +102,15 @@ sign
     -> a
     -> Signature a
 sign pm t k = coerce . signRaw pm (Just t) k . Bi.serialize'
+
+-- | Like 'sign' but without the 'Bi' constraint.
+signEncoded
+    :: ProtocolMagic
+    -> SignTag
+    -> SecretKey
+    -> ByteString
+    -> Signature a
+signEncoded pm t k = coerce . signRaw pm (Just t) k
 
 -- | Sign a bytestring.
 signRaw

--- a/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
@@ -22,12 +22,12 @@ import           Pos.Block.Logic (RawPayload (..), createMainBlockPure)
 import qualified Pos.Communication ()
 import           Pos.Core (BlockVersionData (bvdMaxBlockSize), HasConfiguration, SlotId (..),
                            blkSecurityParam, genesisBlockVersionData, mkVssCertificatesMapLossy,
-                           unsafeMkLocalSlotIndex, protocolConstants)
+                           unsafeMkLocalSlotIndex, protocolMagic, protocolConstants)
 import           Pos.Core.Block (BlockHeader, MainBlock)
 import           Pos.Core.Ssc (SscPayload (..))
 import           Pos.Core.Txp (TxAux)
 import           Pos.Core.Update (UpdatePayload (..))
-import           Pos.Crypto (SecretKey, protocolMagic)
+import           Pos.Crypto (SecretKey)
 import           Pos.Delegation (DlgPayload, ProxySKBlockInfo)
 import           Pos.Ssc.Base (defaultSscPayload)
 import           Pos.Update.Configuration (HasUpdateConfiguration)
@@ -150,7 +150,8 @@ spec = withDefConfiguration $ withDefUpdateConfiguration $
 
 validSscPayloadGen :: HasConfiguration => Gen (SscPayload, SlotId)
 validSscPayloadGen = do
-    vssCerts <- makeSmall $ fmap mkVssCertificatesMapLossy $ listOf $ vssCertificateEpochGen protocolMagic protocolConstants 0
+    vssCerts <- makeSmall $ fmap mkVssCertificatesMapLossy $ listOf $
+        vssCertificateEpochGen protocolMagic protocolConstants 0
     let mkSlot i = SlotId 0 (unsafeMkLocalSlotIndex (fromIntegral i))
     oneof [ do commMap <- makeSmall $ commitmentMapEpochGen protocolMagic 0
                pure (CommitmentsPayload commMap vssCerts, SlotId 0 minBound)

--- a/txp/Pos/Txp/Toil/Utxo/Functions.hs
+++ b/txp/Pos/Txp/Toil/Utxo/Functions.hs
@@ -17,8 +17,8 @@ import           Formatting (int, sformat, (%))
 import           Serokell.Util (allDistinct, enumerate)
 
 import           Pos.Binary.Core ()
-import           Pos.Core (AddrType (..), Address (..), HasConfiguration, integerToCoin,
-                           isRedeemAddress, isUnknownAddressType, sumCoins)
+import           Pos.Core (AddrType (..), Address (..), integerToCoin, isRedeemAddress,
+                           isUnknownAddressType, sumCoins)
 import           Pos.Core.Common (checkPubKeyAddress, checkRedeemAddress, checkScriptAddress)
 import           Pos.Core.Txp (Tx (..), TxAttributes, TxAux (..), TxIn (..), TxInWitness (..),
                                TxOut (..), TxOutAux (..), TxSigData (..), TxUndo, TxWitness,
@@ -76,8 +76,8 @@ data VerifyTxUtxoRes = VerifyTxUtxoRes
 -- blocks when we're creating a block (because transactions for
 -- inclusion into blocks are verified with 'vtcVerifyAllIsKnown'
 -- set to 'True', so unknown script versions are rejected).
-verifyTxUtxo ::
-       HasConfiguration
+verifyTxUtxo
+    :: ( HasProtocolMagic )
     => VTxContext
     -> TxAux
     -> ExceptT ToilVerFailure UtxoM VerifyTxUtxoRes

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -78,7 +78,7 @@ initCardanoContext = CardanoContext{..}
   where
     ccLeaders  = genesisLeaders
     ccStakes   = genesisStakes
-    ccBlock0   = genesisBlock0 protocolMagic (GenesisHash genesisHash) genesisLeaders
+    ccBlock0   = genesisBlock0 protocolMagic (GenesisHash genesisHash) ccLeaders
     ccData     = genesisData
     ccUtxo     = unGenesisUtxo genesisUtxo
     ccSecrets  = fromMaybe (error "initCardanoContext: secrets unavailable") $


### PR DESCRIPTION
You can give your ProtocolMagic and ProtocolConstants as regular plain
old vanilla first class values!

The block benchmarks now don't need all of that tedious configuration
stuff.