### PR TITLE
[CBR-49] Fix CBOR decoding issues

### DIFF
--- a/binary/Pos/Binary/Class/Core.hs
+++ b/binary/Pos/Binary/Class/Core.hs
@@ -122,14 +122,14 @@ instance Bi Bool where
 
 instance Bi Char where
     encode c = E.encodeString (Text.singleton c)
-    decode = do t <- D.decodeString
+    decode = do t <- D.decodeStringCanonical
                 toCborError $ if Text.length t == 1
                   then Right (Text.head t)
                   else Left "expected a single char, found a string"
 
     -- For [Char]/String we have a special encoding
     encodeList cs = E.encodeString (toText cs)
-    decodeList    = do txt <- D.decodeString
+    decodeList    = do txt <- D.decodeStringCanonical
                        return (toString txt) -- unpack lazily
 
 ----------------------------------------------------------------------------
@@ -233,11 +233,11 @@ instance (Bi a, Bi b, Bi c, Bi d) => Bi (a,b,c,d) where
 
 instance Bi BS.ByteString where
     encode = E.encodeBytes
-    decode = D.decodeBytes
+    decode = D.decodeBytesCanonical
 
 instance Bi Text.Text where
     encode = E.encodeString
-    decode = D.decodeString
+    decode = D.decodeStringCanonical
 
 instance Bi BS.Lazy.ByteString where
     encode = encode . BS.Lazy.toStrict

--- a/binary/Pos/Binary/Class/Primitive.hs
+++ b/binary/Pos/Binary/Class/Primitive.hs
@@ -240,7 +240,7 @@ decodeKnownCborDataItem = do
 decodeUnknownCborDataItem :: D.Decoder s ByteString
 decodeUnknownCborDataItem = do
     decodeCborDataItemTag
-    D.decodeBytes
+    D.decodeBytesCanonical
 
 -- | Encodes a type `a` , protecting it from tampering/network-transport-alteration by
 -- protecting it with a CRC.

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -16,6 +16,7 @@ import           Universum
 
 import qualified Cardano.Crypto.Wallet as CC
 import           Crypto.Hash (Blake2b_224, Blake2b_256)
+import           Data.Bits (shiftL)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Fixed (Nano)
@@ -72,6 +73,28 @@ import           Pos.Util.UserSecret (UserSecret, WalletUserSecret)
 import qualified Test.Pos.Cbor.RefImpl as R
 import           Test.Pos.Configuration (withDefConfiguration, withDefInfraConfiguration)
 import           Test.Pos.Helpers (binaryTest, msgLenLimitedTest)
+
+-- | Wrapper for Integer with Arbitrary instance that can generate "proper" big
+-- integers, i.e. ones that don't fit in Int64. This really needs to be fixed
+-- within QuickCheck though (https://github.com/nick8325/quickcheck/issues/213).
+newtype LargeInteger = LargeInteger Integer
+    deriving (Eq, Show)
+
+instance Arbitrary LargeInteger where
+    arbitrary = sized $ \sz -> do
+        n <- choose (1, sz)
+        sign <- arbitrary
+        LargeInteger . (if sign then negate else identity) . foldr f 0
+            <$> replicateM n arbitrary
+      where
+        f :: Word8 -> Integer -> Integer
+        f w acc = (acc `shiftL` 8) + fromIntegral w
+
+instance Bi LargeInteger where
+    encode (LargeInteger n) = encode n
+    decode = LargeInteger <$> decode
+
+----------------------------------------
 
 data User
     = Login { login :: String
@@ -383,6 +406,7 @@ spec = withDefInfraConfiguration $ withDefConfiguration $ do
                 binaryTest @Bool
                 binaryTest @Char
                 binaryTest @Integer
+                binaryTest @LargeInteger
                 binaryTest @Word
                 binaryTest @Word8
                 binaryTest @Word16

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -400,6 +400,8 @@ spec = withDefInfraConfiguration $ withDefConfiguration $ do
                 binaryTest @(HashMap Int Int)
                 binaryTest @(Set Int)
                 binaryTest @(HashSet Int)
+                binaryTest @ByteString
+                binaryTest @Text
 
         describe "Types" $ do
           -- 100 is not enough to catch some bugs (e.g. there was a bug with

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7900,20 +7900,20 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.bsd3;
          }) {};
       "cborg" = callPackage
-        ({ mkDerivation, array, base, bytestring, containers, fetchgit
-         , ghc-prim, half, integer-gmp, primitive, stdenv, text
+        ({ mkDerivation, array, base, bytestring, containers, deepseq
+         , fetchgit, ghc-prim, half, integer-gmp, primitive, stdenv, text
          }:
          mkDerivation {
            pname = "cborg";
            version = "0.2.0.0";
            src = fetchgit {
              url = "https://github.com/well-typed/cborg";
-             sha256 = "0i38fzyj34cg5i6n0kk05zv255hbz2544rxknsxlvdz90cr2rk51";
-             rev = "8bddf97abe613d4eb523ed6b0ff8eabbd713c744";
+             sha256 = "1w06annk6nm01brd60hzl15143cvjvsaam9lhwzpmppyvgb0cdyz";
+             rev = "3d274c14ca3077c3a081ba7ad57c5182da65c8c1";
            };
            postUnpack = "sourceRoot+=/cborg; echo source root reset to $sourceRoot";
            libraryHaskellDepends = [
-             array base bytestring containers ghc-prim half integer-gmp
+             array base bytestring containers deepseq ghc-prim half integer-gmp
              primitive text
            ];
            doHaddock = false;

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,7 @@ packages:
 - location:
     git: https://github.com/well-typed/cborg
     # Has support for canonical cbor
-    commit: 8bddf97abe613d4eb523ed6b0ff8eabbd713c744
+    commit: 3d274c14ca3077c3a081ba7ad57c5182da65c8c1
   subdirs:
   - cborg
   extra-dep: true


### PR DESCRIPTION
Fixes https://iohk.myjetbrains.com/youtrack/issue/CBR-49.

Details:
- Uses cborg revision with fixes for errors found by auditors
- Completes canonicity checks during decoding of Integer and adds tests for them
- Extends canonicity tests with testing length encoding of collections, strings etc.
