### PR TITLE
Fix /accounts endpoints not accessible because of param inversion

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers.hs
@@ -12,8 +12,10 @@ import           Ntp.Client (NtpStatus)
 import           Pos.Diffusion.Types (Diffusion (sendTx))
 
 import qualified Cardano.Wallet.API.V1 as V1
+import qualified Cardano.Wallet.API.V1.Accounts as Accounts
 import qualified Cardano.Wallet.API.V1.Addresses as Addresses
 import qualified Cardano.Wallet.API.V1.Info as Info
+import qualified Cardano.Wallet.API.V1.LegacyHandlers.Accounts as Accounts
 import qualified Cardano.Wallet.API.V1.LegacyHandlers.Addresses as Addresses
 import qualified Cardano.Wallet.API.V1.LegacyHandlers.Info as Info
 import qualified Cardano.Wallet.API.V1.LegacyHandlers.Settings as Settings
@@ -42,6 +44,7 @@ handlers :: ( HasConfigurations
 handlers naturalTransformation diffusion ntpStatus =
          hoistServer (Proxy @Addresses.API) naturalTransformation Addresses.handlers
     :<|> hoistServer (Proxy @Wallets.API) naturalTransformation Wallets.handlers
+    :<|> hoistServer (Proxy @Accounts.API) naturalTransformation Accounts.handlers
     :<|> hoistServer (Proxy @Transactions.API) naturalTransformation (Transactions.handlers (sendTx diffusion))
     :<|> hoistServer (Proxy @Settings.API) naturalTransformation Settings.handlers
     :<|> hoistServer (Proxy @Info.API) naturalTransformation (Info.handlers ntpStatus)

--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -7,7 +7,6 @@ import qualified Pos.Wallet.Web.Methods as V0
 
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
-import qualified Cardano.Wallet.API.V1.LegacyHandlers.Accounts as Accounts
 import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
@@ -23,13 +22,12 @@ handlers :: ( HasConfigurations
             , HasCompileInfo
             )
          => ServerT Wallets.API MonadV1
-handlers = (newWallet
+handlers = newWallet
     :<|> listWallets
     :<|> updatePassword
     :<|> deleteWallet
     :<|> getWallet
     :<|> updateWallet
-    ) :<|> Accounts.handlers
 
 -- | Creates a new or restores an existing @wallet@ given a 'NewWallet' payload.
 -- Returns to the client the representation of the created or restored

--- a/wallet-new/src/Cardano/Wallet/API/V1.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1.hs
@@ -3,6 +3,7 @@ module Cardano.Wallet.API.V1 where
 
 import           Servant ((:<|>))
 
+import qualified Cardano.Wallet.API.V1.Accounts as Accounts
 import qualified Cardano.Wallet.API.V1.Addresses as Addresses
 import qualified Cardano.Wallet.API.V1.Info as Info
 import qualified Cardano.Wallet.API.V1.Settings as Settings
@@ -11,6 +12,7 @@ import qualified Cardano.Wallet.API.V1.Wallets as Wallets
 
 type API =  Addresses.API
        :<|> Wallets.API
+       :<|> Accounts.API
        :<|> Transactions.API
        :<|> Settings.API
        :<|> Info.API

--- a/wallet-new/src/Cardano/Wallet/API/V1/Accounts.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Accounts.hs
@@ -9,26 +9,26 @@ import           Cardano.Wallet.API.V1.Types
 
 
 type API
-    = Tags '["Accounts"] :> "accounts" :> (
-        CaptureWalletId
+    = Tags '["Accounts"] :>
+    (    "wallets" :> CaptureWalletId :> "accounts"
           :> CaptureAccountId
           :> Summary "Deletes an Account."
           :> DeleteNoContent '[ValidJSON] NoContent
-        :<|> CaptureWalletId
+    :<|> "wallets" :> CaptureWalletId :> "accounts"
           :> CaptureAccountId
           :> Summary "Retrieves a specific Account."
           :> Get '[ValidJSON] (WalletResponse Account)
-        :<|> CaptureWalletId
+    :<|> "wallets" :> CaptureWalletId :> "accounts"
           :> WalletRequestParams
           :> Summary "Retrieves the full list of Accounts."
           :> Get '[ValidJSON] (WalletResponse [Account])
-        :<|> CaptureWalletId
+    :<|> "wallets" :> CaptureWalletId :> "accounts"
           :> Summary "Creates a new Account for the given Wallet."
           :> ReqBody '[ValidJSON] (New Account)
           :> Post '[ValidJSON] (WalletResponse Account)
-        :<|> CaptureWalletId
+    :<|> "wallets" :> CaptureWalletId :> "accounts"
           :> CaptureAccountId
           :> Summary "Update an Account for the given Wallet."
           :> ReqBody '[ValidJSON] (Update Account)
           :> Put '[ValidJSON] (WalletResponse Account)
-      )
+    )

--- a/wallet-new/src/Cardano/Wallet/API/V1/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Wallets.hs
@@ -3,7 +3,6 @@ module Cardano.Wallet.API.V1.Wallets where
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
 import           Cardano.Wallet.API.Types
-import qualified Cardano.Wallet.API.V1.Accounts as Accounts
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Types
 import           Pos.Core as Core
@@ -38,5 +37,3 @@ type API = Tags '["Wallets"] :>
                    :> ReqBody '[ValidJSON] (Update Wallet)
                    :> Put '[ValidJSON] (WalletResponse Wallet)
     )
-    -- Nest the Accounts API, note that it is left out of the "Wallets" tag purposedly
-    :<|> "wallets" :> Accounts.API

--- a/wallet-new/src/Cardano/Wallet/Client/Http.hs
+++ b/wallet-new/src/Cardano/Wallet/Client/Http.hs
@@ -74,8 +74,11 @@ mkHttpClient baseUrl manager = WalletClient
     unNoContent = map void
     clientEnv = ClientEnv manager baseUrl
     run       = fmap (over _Left ClientHttpError) . (`runClientM` clientEnv)
-    (getAddressIndexR :<|> postAddressR :<|> getAddressValidityR) =
-        addressesAPI
+
+    getAddressIndexR
+        :<|> postAddressR
+        :<|> getAddressValidityR
+        = addressesAPI
 
     postWalletR
         :<|> getWalletIndexFilterSortsR
@@ -84,19 +87,22 @@ mkHttpClient baseUrl manager = WalletClient
         :<|> getWalletR
         :<|> updateWalletR
         = walletsAPI
+
     deleteAccountR
         :<|> getAccountR
         :<|> getAccountIndexPagedR
         :<|> postAccountR
         :<|> updateAccountR
         = accountsAPI
+
     postTransactionR
         :<|> getTransactionIndexFilterSortsR
         :<|> getTransactionFeeR
         = transactionsAPI
 
     addressesAPI
-        :<|> (walletsAPI :<|> accountsAPI)
+        :<|> walletsAPI
+        :<|> accountsAPI
         :<|> transactionsAPI
         :<|> getNodeSettingsR
         :<|> getNodeInfoR


### PR DESCRIPTION
Accounts endpoints were accessible on:

`/wallets/accounts/{{walletId}}/{{accountId}}`

instead of

`/wallets/{{walletId}}/accounts/{{accountId}}`

which is rather unconventional. I believe it was not intended and happened during a refactoring of the routes when creating the Servant client if I am not mistaken. If it's done on purpose, I am curious to know why ^.^ ?

Note that to keep server & client declaration simple, I've introduced a bit of duplication in the routes declarations. It's a small repetition within a same file for a greater good. 

I recall [a nice blog post](http://www.parsonsmatt.org/2018/03/14/servant_route_smooshing.html) on the topic ;), but in the immediate future, we need a fix.
