### PR TITLE
[CSL-2346] remove no-ntp & NtpDrift

### DIFF
--- a/explorer/scripts/launch/qa.sh
+++ b/explorer/scripts/launch/qa.sh
@@ -15,5 +15,4 @@ stack exec -- cardano-explorer \
     --kademlia-peer 52.211.65.215:3000 \
     --listen 127.0.0.1:$((3000)) \
     --static-peers \
-    --no-ntp \
     $@

--- a/explorer/scripts/launch/staging.sh
+++ b/explorer/scripts/launch/staging.sh
@@ -25,5 +25,4 @@ stack exec -- cardano-explorer \
     --kademlia-peer cardano-node-13.aws.iohkdev.io:3000 \
     --listen 127.0.0.1:$((3000)) \
     --static-peers \
-    --no-ntp \
     $@

--- a/tools/src/launcher/launcher-config.yaml
+++ b/tools/src/launcher/launcher-config.yaml
@@ -16,7 +16,6 @@ nodeArgs:
   - "./scripts/tls-files/server.key"
   - "--tlsca"
   - "./scripts/tls-files/ca.crt"
-  - "--no-ntp"
   - "--topology"
   - "docs/network/example-topologies/mainnet-staging.yaml"
   - "--logs-prefix"


### PR DESCRIPTION
* remove `--no-ntp` from some more scripts
* `NtpDrift` should hold time difference rather than absolute value of it, added some doc strings to `NtpStatuts`.