### PR TITLE
[CSL-2247] Extend the V1 API to report restoration progress

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ before_test:
     }
 
 # Install OpenSSL 1.0.2 (see https://github.com/appveyor/ci/issues/1665)
-- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2n.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
+- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2o.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
 - ps: cmd /c start /wait "$($env:USERPROFILE)\Win64OpenSSL.exe" /silent /verysilent /sp- /suppressmsgboxes /DIR=C:\OpenSSL-Win64-v102
 - ps: Install-Product node 6
 # Install stack

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7702,9 +7702,9 @@ inherit (pkgs) mesa;};
              http-api-data http-client http-types ixset-typed json-sop lens
              log-warper memory mtl QuickCheck reflection safe-exceptions
              serokell-util servant servant-client servant-client-core
-             servant-quickcheck servant-server servant-swagger-ui string-conv
-             swagger2 text text-format time time-units transformers universum
-             unordered-containers vector wai
+             servant-quickcheck servant-server servant-swagger-ui stm
+             string-conv swagger2 text text-format time time-units transformers
+             universum unordered-containers vector wai
            ];
            executableHaskellDepends = [
              aeson aeson-pretty base bytestring cardano-sl cardano-sl-client

--- a/util/Pos/Util/Util.hs
+++ b/util/Pos/Util/Util.hs
@@ -451,5 +451,4 @@ tMeasure logAction label action = do
     let d1 = d0 `div` 10
     let d2 = d0 `mod` 10
     logAction $ "tMeasure " <> label <> ": " <> show d1 <> "." <> show d2 <> "ms"
-    -- `NominalDiffTime` has up to picoseconds precision.
-    pure (x, fromMicroseconds (round $ 1000 * toRational diff))
+    pure (x, fromMicroseconds (round $ 1000000 * toRational diff))

--- a/util/Pos/Util/Util.hs
+++ b/util/Pos/Util/Util.hs
@@ -72,6 +72,7 @@ module Pos.Util.Util
 
        , tMeasureLog
        , tMeasureIO
+       , timed
        ) where
 
 import           Universum
@@ -94,7 +95,7 @@ import qualified Data.Semigroup as Smg
 import qualified Data.Serialize as Cereal
 import           Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import           Data.Time.Units (Microsecond, toMicroseconds)
+import           Data.Time.Units (Microsecond, toMicroseconds, fromMicroseconds)
 import qualified Ether
 import           Ether.Internal (HasLens (..))
 import qualified Formatting as F
@@ -426,23 +427,29 @@ sleep n = liftIO (threadDelay (truncate (n * 10^(6::Int))))
 
 -- | 'tMeasure' with 'logDebug'.
 tMeasureLog :: (MonadIO m, WithLogger m) => Text -> m a -> m a
-tMeasureLog = tMeasure logDebug
+tMeasureLog label = fmap fst . tMeasure logDebug label
 
 -- | 'tMeasure' with 'putText'. For places you don't have
 -- 'WithLogger' constraint.
 tMeasureIO :: (MonadIO m) => Text -> m a -> m a
-tMeasureIO = tMeasure putText
+tMeasureIO label = fmap fst . tMeasure putText label
+
+timed :: (MonadIO m, WithLogger m) => Text -> m a -> m (a, Microsecond)
+timed = tMeasure logDebug
 
 -- | Takes the first time sample, executes action (forcing its
 -- result), takes the second time sample, logs it.
-tMeasure :: (MonadIO m) => (Text -> m ()) -> Text -> m a -> m a
+tMeasure :: (MonadIO m) => (Text -> m ()) -> Text -> m a -> m (a, Microsecond)
 tMeasure logAction label action = do
     before <- liftIO getCurrentTime
     !x <- action
     after <- liftIO getCurrentTime
-    let d0 :: Integer
-        d0 = round $ 10000 * toRational (after `diffUTCTime` before)
+    let diff :: NominalDiffTime
+        diff = after `diffUTCTime` before
+        d0 :: Integer
+        d0 = round $ 10000 * toRational diff
     let d1 = d0 `div` 10
     let d2 = d0 `mod` 10
     logAction $ "tMeasure " <> label <> ": " <> show d1 <> "." <> show d2 <> "ms"
-    pure x
+    -- `NominalDiffTime` has up to picoseconds precision.
+    pure (x, fromMicroseconds (round $ 1000 * toRational diff))

--- a/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -4,15 +4,15 @@ import           Universum
 
 import           Cardano.Wallet.API.Response
 import           Cardano.Wallet.API.V1.Types
-import           Cardano.Wallet.Orphans.Arbitrary()
+import           Cardano.Wallet.Orphans.Arbitrary ()
 
+import           Pos.Arbitrary.Wallet.Web.ClientTypes ()
 import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
 import qualified Pos.Core.Common as Core
 import qualified Pos.Crypto.Signing as Core
 import           Pos.Util.BackupPhrase (BackupPhrase)
-import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 import           Pos.Wallet.Web.ClientTypes (CUpdateInfo)
-import           Pos.Arbitrary.Wallet.Web.ClientTypes ()
+import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 
 import           Test.QuickCheck (Arbitrary (..), Gen, listOf1)
 
@@ -48,7 +48,7 @@ instance Example WalletId
 instance Example BackupPhrase
 instance Example (V1 BackupPhrase)
 instance Example AssuranceLevel
-instance Example SyncProgress
+instance Example SyncPercentage
 instance Example BlockchainHeight
 instance Example LocalTimeDifference
 instance Example PaymentDistribution

--- a/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
@@ -15,6 +15,8 @@ data UnitOfMeasure =
     | Percentage100
     -- | Number of blocks.
     | Blocks
+    -- | Number of blocks per second.
+    | BlocksPerSecond
     deriving (Show, Eq)
 
 data MeasuredIn (a :: UnitOfMeasure) b = MeasuredIn b deriving (Eq, Show)

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -90,9 +90,10 @@ instance Migrate (OldStorage.SyncStatistics, Maybe Core.ChainDifficulty) V1.Sync
             toMs (Core.Timestamp microsecs) =
               V1.mkEstimatedCompletionTime (round @Double $ (realToFrac (toMicroseconds microsecs) / 1000.0))
             tput (OldStorage.SyncThroughput blocks) = V1.mkSyncThroughput blocks
+            remainingBlocks = fmap (\total -> total - wspCurrentBlockchainDepth) currentBlockchainDepth
         in V1.SyncProgress <$> pure (toMs (maybe unknownCompletionTime
                                                  (calculateEstimatedRemainingTime wspThroughput)
-                                                 currentBlockchainDepth))
+                                                 remainingBlocks))
                            <*> pure (tput wspThroughput)
                            <*> pure (V1.mkSyncPercentage (round @Double $ percentage))
 

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -86,7 +86,7 @@ instance Migrate (OldStorage.SyncStatistics, Maybe Core.ChainDifficulty) V1.Sync
             percentage = case currentBlockchainDepth of
                 Nothing -> 0.0
                 Just nd | wspCurrentBlockchainDepth >= nd -> 100
-                Just nd -> (fromIntegral wspCurrentBlockchainDepth / fromIntegral nd) * 100.0
+                Just nd -> (fromIntegral wspCurrentBlockchainDepth / max 1.0 (fromIntegral nd)) * 100.0
             toMs (Core.Timestamp microsecs) =
               V1.mkEstimatedCompletionTime (round @Double $ (realToFrac (toMicroseconds microsecs) / 1000.0))
             tput (OldStorage.SyncThroughput blocks) = V1.mkSyncThroughput blocks
@@ -152,7 +152,7 @@ instance Migrate V0.SyncProgress V1.SyncPercentage where
         let percentage = case _spNetworkCD of
                 Nothing -> (0 :: Word8)
                 Just nd | _spLocalCD >= nd -> 100
-                Just nd -> round @Double $ (fromIntegral _spLocalCD / fromIntegral nd) * 100.0
+                Just nd -> round @Double $ (fromIntegral _spLocalCD / max 1.0 (fromIntegral nd)) * 100.0
         in pure $ V1.mkSyncPercentage (fromIntegral percentage)
 
 -- NOTE: Migrate V1.SyncProgress V0.SyncProgress unable to do - not idempotent

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -1,7 +1,7 @@
 {- | This is a temporary module to help migration @V0@ datatypes into @V1@ datatypes.
 -}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Cardano.Wallet.API.V1.Migration.Types (
       Migrate(..)
@@ -14,6 +14,7 @@ import qualified Control.Lens as Lens
 import qualified Control.Monad.Catch as Catch
 import           Data.Map (elems)
 import           Data.Time.Clock.POSIX (POSIXTime)
+import           Data.Time.Units (fromMicroseconds, toMicroseconds)
 import           Data.Typeable (typeRep)
 import           Formatting (sformat)
 
@@ -30,7 +31,8 @@ import qualified Pos.Txp.Toil.Types as V0
 import qualified Pos.Util.Servant as V0
 import qualified Pos.Wallet.Web.ClientTypes.Instances ()
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
-import qualified Pos.Wallet.Web.State.Storage as V0
+import qualified Pos.Wallet.Web.State.Storage as OldStorage
+import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
 
 -- | 'Migrate' encapsulates migration between types, when possible.
 class Migrate from to where
@@ -60,8 +62,8 @@ instance (Migrate from to, Typeable from, Typeable to) => Migrate [from] (NonEmp
         ]
     eitherMigrate (x:xs) = (:|) <$> eitherMigrate x <*> mapM eitherMigrate xs
 
-instance Migrate (V0.CWallet, V0.WalletInfo) V1.Wallet where
-    eitherMigrate (V0.CWallet{..}, V0.WalletInfo{..}) =
+instance Migrate (V0.CWallet, OldStorage.WalletInfo, Maybe Core.ChainDifficulty) V1.Wallet where
+    eitherMigrate (V0.CWallet{..}, OldStorage.WalletInfo{..}, currentBlockchainDepth) =
         V1.Wallet <$> eitherMigrate cwId
                   <*> pure (V0.cwName cwMeta)
                   <*> eitherMigrate cwAmount
@@ -69,7 +71,30 @@ instance Migrate (V0.CWallet, V0.WalletInfo) V1.Wallet where
                   <*> eitherMigrate cwPassphraseLU
                   <*> eitherMigrate _wiCreationTime
                   <*> eitherMigrate (V0.cwAssurance _wiMeta)
+                  <*> eitherMigrate (_wiSyncState, _wiSyncStatistics, currentBlockchainDepth)
 
+instance Migrate (OldStorage.WalletSyncState, OldStorage.SyncStatistics, Maybe Core.ChainDifficulty) V1.SyncState where
+    eitherMigrate (wss, stats, currentBlockchainDepth) =
+        case wss of
+            OldStorage.NotSynced         -> V1.Restoring <$> eitherMigrate (stats, currentBlockchainDepth)
+            OldStorage.RestoringFrom _ _ -> V1.Restoring <$> eitherMigrate (stats, currentBlockchainDepth)
+            OldStorage.SyncedWith _      -> pure V1.Synced
+
+instance Migrate (OldStorage.SyncStatistics, Maybe Core.ChainDifficulty) V1.SyncProgress where
+    eitherMigrate (OldStorage.SyncStatistics{..}, currentBlockchainDepth) =
+        let unknownCompletionTime = Core.Timestamp $ fromMicroseconds (fromIntegral (maxBound :: Int))
+            percentage = case currentBlockchainDepth of
+                Nothing -> 0.0
+                Just nd | wspCurrentBlockchainDepth >= nd -> 100
+                Just nd -> (fromIntegral wspCurrentBlockchainDepth / fromIntegral nd) * 100.0
+            toMs (Core.Timestamp microsecs) =
+              V1.mkEstimatedCompletionTime (round @Double $ (realToFrac (toMicroseconds microsecs) / 1000.0))
+            tput (OldStorage.SyncThroughput blocks) = V1.mkSyncThroughput blocks
+        in V1.SyncProgress <$> pure (toMs (maybe unknownCompletionTime
+                                                 (calculateEstimatedRemainingTime wspThroughput)
+                                                 currentBlockchainDepth))
+                           <*> pure (tput wspThroughput)
+                           <*> pure (V1.mkSyncPercentage (round @Double $ percentage))
 
 -- NOTE: Migrate V1.Wallet V0.CWallet unable to do - not idempotent
 
@@ -122,13 +147,13 @@ instance Migrate V0.CAddress V1.WalletAddress where
 
 -- | Migrates to a V1 `SyncProgress` by computing the percentage as
 -- coded here: https://github.com/input-output-hk/daedalus/blob/master/app/stores/NetworkStatusStore.js#L108
-instance Migrate V0.SyncProgress V1.SyncProgress where
+instance Migrate V0.SyncProgress V1.SyncPercentage where
     eitherMigrate V0.SyncProgress{..} =
         let percentage = case _spNetworkCD of
                 Nothing -> (0 :: Word8)
                 Just nd | _spLocalCD >= nd -> 100
                 Just nd -> round @Double $ (fromIntegral _spLocalCD / fromIntegral nd) * 100.0
-        in pure $ V1.mkSyncProgress (fromIntegral percentage)
+        in pure $ V1.mkSyncPercentage (fromIntegral percentage)
 
 -- NOTE: Migrate V1.SyncProgress V0.SyncProgress unable to do - not idempotent
 

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -575,7 +575,7 @@ instance ToSchema SyncPercentage where
     declareNamedSchema _ = do
         pure $ NamedSchema (Just "SyncPercentage") $ mempty
             & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
+            & required .~ ["quantity", "unit"]
             & properties .~ (mempty
                 & at "quantity" ?~ (Inline $ mempty
                     & type_ .~ SwaggerNumber
@@ -620,11 +620,10 @@ instance ToSchema EstimatedCompletionTime where
     declareNamedSchema _ = do
         pure $ NamedSchema (Just "EstimatedCompletionTime") $ mempty
             & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
+            & required .~ ["quantity", "unit"]
             & properties .~ (mempty
                 & at "quantity" ?~ (Inline $ mempty
                     & type_ .~ SwaggerNumber
-                    & maximum_ .~ Just 100
                     & minimum_ .~ Just 0
                     )
                 & at "unit" ?~ (Inline $ mempty
@@ -661,7 +660,7 @@ instance ToSchema SyncThroughput where
     declareNamedSchema _ = do
         pure $ NamedSchema (Just "SyncThroughput") $ mempty
             & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
+            & required .~ ["quantity", "unit"]
             & properties .~ (mempty
                 & at "quantity" ?~ (Inline $ mempty
                     & type_ .~ SwaggerNumber
@@ -731,7 +730,7 @@ instance FromJSON SyncState where
 
 instance ToSchema SyncState where
     declareNamedSchema _ = do
-      syncProgress <- declareNamedSchema @SyncProgress Proxy
+      syncProgress <- declareSchemaRef @SyncProgress Proxy
       pure $ NamedSchema (Just "SyncState") $ mempty
           & type_ .~ SwaggerObject
           & required .~ ["tag"]
@@ -740,7 +739,7 @@ instance ToSchema SyncState where
                   & type_ .~ SwaggerString
                   & enum_ ?~ ["restoring", "synced"]
                   )
-              & at "data" ?~ (Inline . _namedSchemaSchema $ syncProgress)
+              & at "data" ?~ syncProgress
               )
 
 instance Arbitrary SyncState where

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -730,7 +730,8 @@ instance FromJSON SyncState where
             _           -> typeMismatch "unrecognised tag" (Object ss)
 
 instance ToSchema SyncState where
-    declareNamedSchema _ =
+    declareNamedSchema _ = do
+      syncProgress <- declareNamedSchema @SyncProgress Proxy
       pure $ NamedSchema (Just "SyncState") $ mempty
           & type_ .~ SwaggerObject
           & required .~ ["tag"]
@@ -739,9 +740,7 @@ instance ToSchema SyncState where
                   & type_ .~ SwaggerString
                   & enum_ ?~ ["restoring", "synced"]
                   )
-              & at "data" ?~ (Inline $ mempty
-                  & type_ .~ SwaggerObject
-                  )
+              & at "data" ?~ (Inline . _namedSchemaSchema $ syncProgress)
               )
 
 instance Arbitrary SyncState where

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -61,8 +61,14 @@ module Cardano.Wallet.API.V1.Types (
   , mkBlockchainHeight
   , LocalTimeDifference
   , mkLocalTimeDifference
-  , SyncProgress
-  , mkSyncProgress
+  , EstimatedCompletionTime
+  , mkEstimatedCompletionTime
+  , SyncThroughput
+  , mkSyncThroughput
+  , SyncState (..)
+  , SyncProgress (..)
+  , SyncPercentage
+  , mkSyncPercentage
   , NodeInfo (..)
   -- * Some types for the API
   , CaptureWalletId
@@ -116,6 +122,7 @@ import           Pos.Crypto (decodeHash, hashHexF)
 import qualified Pos.Crypto.Signing as Core
 import           Pos.Util.LogSafe (BuildableSafeGen (..), SecureLog (..), buildSafe, buildSafeList,
                                    buildSafeMaybe, deriveSafeBuildable, plainOrSecureF)
+import qualified Pos.Wallet.Web.State.Storage as OldStorage
 
 
 
@@ -541,6 +548,207 @@ instance BuildableSafeGen WalletUpdate where
         uwalAssuranceLevel
         uwalName
 
+-- | The sync progress with the blockchain.
+newtype SyncPercentage = SyncPercentage (MeasuredIn 'Percentage100 Word8)
+                     deriving (Show, Eq)
+
+mkSyncPercentage :: Word8 -> SyncPercentage
+mkSyncPercentage = SyncPercentage . MeasuredIn
+
+instance Ord SyncPercentage where
+    compare (SyncPercentage (MeasuredIn p1))
+            (SyncPercentage (MeasuredIn p2)) = compare p1 p2
+
+instance Arbitrary SyncPercentage where
+    arbitrary = mkSyncPercentage <$> choose (0, 100)
+
+instance ToJSON SyncPercentage where
+    toJSON (SyncPercentage (MeasuredIn w)) =
+        object [ "quantity" .= toJSON w
+               , "unit"     .= String "percent"
+               ]
+
+instance FromJSON SyncPercentage where
+    parseJSON = withObject "SyncPercentage" $ \sl -> mkSyncPercentage <$> sl .: "quantity"
+
+instance ToSchema SyncPercentage where
+    declareNamedSchema _ = do
+        pure $ NamedSchema (Just "SyncPercentage") $ mempty
+            & type_ .~ SwaggerObject
+            & required .~ ["quantity"]
+            & properties .~ (mempty
+                & at "quantity" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerNumber
+                    & maximum_ .~ Just 100
+                    & minimum_ .~ Just 0
+                    )
+                & at "unit" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerString
+                    & enum_ ?~ ["percent"]
+                    )
+                )
+
+deriveSafeBuildable ''SyncPercentage
+instance BuildableSafeGen SyncPercentage where
+    buildSafeGen _ (SyncPercentage (MeasuredIn w)) =
+        bprint (build%"%") w
+
+
+newtype EstimatedCompletionTime = EstimatedCompletionTime (MeasuredIn 'Milliseconds Word)
+  deriving (Show, Eq)
+
+mkEstimatedCompletionTime :: Word -> EstimatedCompletionTime
+mkEstimatedCompletionTime = EstimatedCompletionTime . MeasuredIn
+
+instance Ord EstimatedCompletionTime where
+    compare (EstimatedCompletionTime (MeasuredIn w1))
+            (EstimatedCompletionTime (MeasuredIn w2)) = compare w1 w2
+
+instance Arbitrary EstimatedCompletionTime where
+    arbitrary = EstimatedCompletionTime . MeasuredIn <$> arbitrary
+
+instance ToJSON EstimatedCompletionTime where
+    toJSON (EstimatedCompletionTime (MeasuredIn w)) =
+        object [ "quantity" .= toJSON w
+               , "unit"     .= String "milliseconds"
+               ]
+
+instance FromJSON EstimatedCompletionTime where
+    parseJSON = withObject "EstimatedCompletionTime" $ \sl -> mkEstimatedCompletionTime <$> sl .: "quantity"
+
+instance ToSchema EstimatedCompletionTime where
+    declareNamedSchema _ = do
+        pure $ NamedSchema (Just "EstimatedCompletionTime") $ mempty
+            & type_ .~ SwaggerObject
+            & required .~ ["quantity"]
+            & properties .~ (mempty
+                & at "quantity" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerNumber
+                    & maximum_ .~ Just 100
+                    & minimum_ .~ Just 0
+                    )
+                & at "unit" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerString
+                    & enum_ ?~ ["milliseconds"]
+                    )
+                )
+
+
+newtype SyncThroughput = SyncThroughput (MeasuredIn 'BlocksPerSecond OldStorage.SyncThroughput)
+  deriving (Show, Eq)
+
+mkSyncThroughput :: Core.BlockCount -> SyncThroughput
+mkSyncThroughput = SyncThroughput . MeasuredIn . OldStorage.SyncThroughput
+
+instance Ord SyncThroughput where
+    compare (SyncThroughput (MeasuredIn (OldStorage.SyncThroughput (Core.BlockCount b1))))
+            (SyncThroughput (MeasuredIn (OldStorage.SyncThroughput (Core.BlockCount b2)))) =
+        compare b1 b2
+
+instance Arbitrary SyncThroughput where
+    arbitrary = SyncThroughput . MeasuredIn . OldStorage.SyncThroughput <$> arbitrary
+
+instance ToJSON SyncThroughput where
+    toJSON (SyncThroughput (MeasuredIn (OldStorage.SyncThroughput (Core.BlockCount blocks)))) =
+      object [ "quantity" .= toJSON blocks
+             , "unit"     .= String "blocksPerSecond"
+             ]
+
+instance FromJSON SyncThroughput where
+    parseJSON = withObject "SyncThroughput" $ \sl -> mkSyncThroughput . Core.BlockCount <$> sl .: "quantity"
+
+instance ToSchema SyncThroughput where
+    declareNamedSchema _ = do
+        pure $ NamedSchema (Just "SyncThroughput") $ mempty
+            & type_ .~ SwaggerObject
+            & required .~ ["quantity"]
+            & properties .~ (mempty
+                & at "quantity" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerNumber
+                    )
+                & at "unit" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerString
+                    & enum_ ?~ ["blocksPerSecond"]
+                    )
+                )
+
+data SyncProgress = SyncProgress {
+    spEstimatedCompletionTime :: !EstimatedCompletionTime
+  , spThroughput              :: !SyncThroughput
+  , spPercentage              :: !SyncPercentage
+  } deriving (Show, Eq, Ord, Generic)
+
+deriveJSON Serokell.defaultOptions ''SyncProgress
+
+instance ToSchema SyncProgress where
+    declareNamedSchema =
+        genericSchemaDroppingPrefix "sp" (\(--^) props -> props
+            & "estimatedCompletionTime"
+            --^ "The estimated time the wallet is expected to be fully sync, based on the information available."
+            & "throughput"
+            --^ "The sync throughput, measured in blocks/s."
+            & "percentage"
+            --^ "The sync percentage, from 0% to 100%."
+        )
+
+deriveSafeBuildable ''SyncProgress
+-- Nothing secret to redact for a SyncProgress.
+instance BuildableSafeGen SyncProgress where
+    buildSafeGen _ sp = bprint build sp
+
+instance Arbitrary SyncProgress where
+  arbitrary = SyncProgress <$> arbitrary
+                           <*> arbitrary
+                           <*> arbitrary
+
+data SyncState =
+      Restoring SyncProgress
+    -- ^ Restoring from seed or from backup.
+    | Synced
+    -- ^ Following the blockchain.
+    deriving (Eq, Show, Ord)
+
+instance ToJSON SyncState where
+    toJSON ss = object [ "tag"  .= toJSON (renderAsTag ss)
+                       , "data" .= renderAsData ss
+                       ]
+      where
+        renderAsTag :: SyncState -> Text
+        renderAsTag (Restoring _) = "restoring"
+        renderAsTag Synced        = "synced"
+
+        renderAsData :: SyncState -> Value
+        renderAsData (Restoring sp) = toJSON sp
+        renderAsData Synced         = Null
+
+instance FromJSON SyncState where
+    parseJSON = withObject "SyncState" $ \ss -> do
+        t <- ss .: "tag"
+        case (t :: Text) of
+            "synced"    -> pure Synced
+            "restoring" -> Restoring <$> ss .: "data"
+            _           -> typeMismatch "unrecognised tag" (Object ss)
+
+instance ToSchema SyncState where
+    declareNamedSchema _ =
+      pure $ NamedSchema (Just "SyncState") $ mempty
+          & type_ .~ SwaggerObject
+          & required .~ ["tag"]
+          & properties .~ (mempty
+              & at "tag" ?~ (Inline $ mempty
+                  & type_ .~ SwaggerString
+                  & enum_ ?~ ["restoring", "synced"]
+                  )
+              & at "data" ?~ (Inline $ mempty
+                  & type_ .~ SwaggerObject
+                  )
+              )
+
+instance Arbitrary SyncState where
+  arbitrary = oneof [ Restoring <$> arbitrary
+                    , pure Synced
+                    ]
+
 
 -- | A 'Wallet'.
 data Wallet = Wallet {
@@ -551,6 +759,7 @@ data Wallet = Wallet {
     , walSpendingPasswordLastUpdate :: !(V1 Core.Timestamp)
     , walCreatedAt                  :: !(V1 Core.Timestamp)
     , walAssuranceLevel             :: !AssuranceLevel
+    , walSyncState                  :: !SyncState
     } deriving (Eq, Ord, Show, Generic)
 
 deriveJSON Serokell.defaultOptions ''Wallet
@@ -572,11 +781,14 @@ instance ToSchema Wallet where
             --^ "The timestamp that the wallet was created."
             & "assuranceLevel"
             --^ "The assurance level of the wallet."
+            & "syncState"
+            --^ "The sync state for this wallet."
         )
 
 instance Arbitrary Wallet where
   arbitrary = Wallet <$> arbitrary
                      <*> pure "My wallet"
+                     <*> arbitrary
                      <*> arbitrary
                      <*> arbitrary
                      <*> arbitrary
@@ -1389,48 +1601,6 @@ instance BuildableSafeGen LocalTimeDifference where
         bprint (build%"μs") w
 
 
--- | The sync progress with the blockchain.
-newtype SyncProgress = SyncProgress (MeasuredIn 'Percentage100 Word8)
-                     deriving (Show, Eq)
-
-mkSyncProgress :: Word8 -> SyncProgress
-mkSyncProgress = SyncProgress . MeasuredIn
-
-instance Arbitrary SyncProgress where
-    arbitrary = mkSyncProgress <$> choose (0, 100)
-
-instance ToJSON SyncProgress where
-    toJSON (SyncProgress (MeasuredIn w)) =
-        object [ "quantity" .= toJSON w
-               , "unit"     .= String "percent"
-               ]
-
-instance FromJSON SyncProgress where
-    parseJSON = withObject "SyncProgress" $ \sl -> mkSyncProgress <$> sl .: "quantity"
-
-instance ToSchema SyncProgress where
-    declareNamedSchema _ = do
-        pure $ NamedSchema (Just "SyncProgress") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    & maximum_ .~ Just 100
-                    & minimum_ .~ Just 0
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["percent"]
-                    )
-                )
-
-deriveSafeBuildable ''SyncProgress
-instance BuildableSafeGen SyncProgress where
-    buildSafeGen _ (SyncProgress (MeasuredIn w)) =
-        bprint (build%"%") w
-
-
 -- | The absolute or relative height of the blockchain, measured in number
 -- of blocks.
 newtype BlockchainHeight = BlockchainHeight (MeasuredIn 'Blocks Core.BlockCount)
@@ -1476,7 +1646,7 @@ instance BuildableSafeGen BlockchainHeight where
 
 -- | The @dynamic@ information for this node.
 data NodeInfo = NodeInfo {
-     nfoSyncProgress          :: !SyncProgress
+     nfoSyncProgress          :: !SyncPercentage
    , nfoBlockchainHeight      :: !(Maybe BlockchainHeight)
    , nfoLocalBlockchainHeight :: !BlockchainHeight
    , nfoLocalTimeDifference   :: !LocalTimeDifference

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -4,7 +4,7 @@ import           Universum
 
 import           Control.Lens (from, to)
 import           Data.Aeson
-import           Data.Time (UTCTime(..), fromGregorian)
+import           Data.Time (UTCTime (..), fromGregorian)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Typeable (typeRep)
 import           Pos.Client.Txp.Util (InputSelectionPolicy)
@@ -56,8 +56,12 @@ spec = parallel $ describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @SlotDuration Proxy
         aesonRoundtripProp @LocalTimeDifference Proxy
         aesonRoundtripProp @BlockchainHeight Proxy
-        aesonRoundtripProp @SyncProgress Proxy
+        aesonRoundtripProp @SyncPercentage Proxy
         aesonRoundtripProp @NodeInfo Proxy
+        aesonRoundtripProp @SyncState Proxy
+        aesonRoundtripProp @EstimatedCompletionTime Proxy
+        aesonRoundtripProp @SyncProgress Proxy
+        aesonRoundtripProp @SyncThroughput Proxy
 
         -- Migrate roundrips
         migrateRoundtripProp @(V1 Core.Address) @(V0.CId V0.Addr) Proxy Proxy

--- a/wallet/src/Pos/Wallet/Aeson/Storage.hs
+++ b/wallet/src/Pos/Wallet/Aeson/Storage.hs
@@ -22,7 +22,8 @@ import           Pos.Wallet.Aeson.ClientTypes ()
 import           Pos.Wallet.Web.ClientTypes (AccountId (..), CHash (..), CId (..), CTxId (..))
 import           Pos.Wallet.Web.Pending.Types (PendingTx, PtxCondition, PtxSubmitTiming)
 import           Pos.Wallet.Web.State.Storage (AccountInfo, AddressInfo, RestorationBlockDepth,
-                                               WalletInfo, WalletStorage, WalletSyncState)
+                                               SyncStatistics, SyncThroughput, WalletInfo,
+                                               WalletStorage, WalletSyncState)
 
 instance FromJSON (CId a) => FromJSONKey (CId a) where
     fromJSONKey = FromJSONKeyTextParser parser
@@ -63,3 +64,5 @@ deriveJSON defaultOptions ''AccountId
 deriveJSON defaultOptions ''WalletInfo
 deriveJSON defaultOptions ''RestorationBlockDepth
 deriveJSON defaultOptions ''WalletStorage
+deriveJSON defaultOptions ''SyncThroughput
+deriveJSON defaultOptions ''SyncStatistics

--- a/wallet/src/Pos/Wallet/Web/State/Acidic.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Acidic.hs
@@ -32,6 +32,7 @@ module Pos.Wallet.Web.State.Acidic
        , SetWalletPassLU (..)
        , SetWalletSyncTip (..)
        , SetWalletRestorationSyncTip (..)
+       , UpdateSyncStatistics (..)
        , AddOnlyNewTxMetas (..)
        , GetWalletTxHistory (..)
        , AddOnlyNewTxMeta (..)
@@ -129,6 +130,7 @@ makeAcidic ''WalletStorage
     , 'WS.setWalletPassLU
     , 'WS.setWalletSyncTip
     , 'WS.setWalletRestorationSyncTip
+    , 'WS.updateSyncStatistics
     , 'WS.addOnlyNewTxMetas
     , 'WS.getWalletTxHistory
     , 'WS.addOnlyNewTxMeta

--- a/wallet/src/Pos/Wallet/Web/State/Storage.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Storage.hs
@@ -17,9 +17,12 @@ module Pos.Wallet.Web.State.Storage
        , WalBalancesAndUtxo
        , WalletSyncState (..)
        , RestorationBlockDepth (..)
+       , SyncThroughput (..)
+       , SyncStatistics (..)
        , PtxMetaUpdate (..)
        , Query
        , Update
+       , noSyncStatistics
        , getWalletStorage
        , flushWalletStorage
        , getProfile
@@ -57,6 +60,7 @@ module Pos.Wallet.Web.State.Storage
        , setWalletPassLU
        , setWalletSyncTip
        , setWalletRestorationSyncTip
+       , updateSyncStatistics
        , getWalletTxHistory
        , getWalletUtxo
        , getWalletBalancesAndUtxo
@@ -100,7 +104,7 @@ import           Data.Time.Clock.POSIX (POSIXTime)
 import           Serokell.Util (zoom')
 
 import           Pos.Client.Txp.History (TxHistoryEntry, txHistoryListToMap)
-import           Pos.Core (ChainDifficulty, HeaderHash, SlotId, Timestamp)
+import           Pos.Core (BlockCount (..), ChainDifficulty (..), HeaderHash, SlotId, Timestamp)
 import           Pos.Core.Configuration (HasConfiguration)
 import           Pos.Core.Txp (TxAux, TxId)
 import           Pos.SafeCopy ()
@@ -178,23 +182,51 @@ data WalletSyncState
     -- ^ This wallet is tracking the blockchain up to 'HeaderHash'.
     deriving (Eq)
 
+-- The 'SyncThroughput' is computed during the syncing phase in terms of
+-- how many blocks we can sync in one second. This information can be
+-- used by consumers of the API to construct heuristics on the state of the
+-- syncing (e.g. estimated completion time, for example).
+-- We also store the 'ChainDifficulty' we have been syncing up until now so
+-- API consumers can also compute progress in terms of percentage. We don't
+-- store this information in the 'WalletSyncState' directly as we cannot
+-- calculate the 'ChainDifficulty' from a 'HeaderHash', and that requires a
+-- RocksDB lookup, which would make migration harder to perform without
+-- incidents.
+data SyncStatistics = SyncStatistics {
+      wspThroughput             :: !SyncThroughput
+    , wspCurrentBlockchainDepth :: !ChainDifficulty
+    } deriving (Eq)
+
+-- ^ | The 'SyncThroughput', in blocks/sec. This can be roughly computed
+-- during the syncing process, to provide better estimate to the frontend
+-- on how much time the restoration/syncing progress is going to take.
+newtype SyncThroughput = SyncThroughput BlockCount
+     deriving (Eq)
+
+zeroThroughput :: SyncThroughput
+zeroThroughput = SyncThroughput (BlockCount 0)
+
+noSyncStatistics :: SyncStatistics
+noSyncStatistics = SyncStatistics zeroThroughput (ChainDifficulty $ BlockCount 0)
+
 data WalletInfo = WalletInfo
     { -- | Wallet metadata (name, assurance, etc.)
-      _wiMeta         :: !CWalletMeta
+      _wiMeta           :: !CWalletMeta
       -- | Last time when wallet passphrase was updated.
-    , _wiPassphraseLU :: !PassPhraseLU
+    , _wiPassphraseLU   :: !PassPhraseLU
       -- | Wallet creation time.
-    , _wiCreationTime :: !POSIXTime
+    , _wiCreationTime   :: !POSIXTime
       -- | Incapsulate the history of this wallet in terms of "lifecycle".
-    , _wiSyncState    :: !WalletSyncState
+    , _wiSyncState      :: !WalletSyncState
+    , _wiSyncStatistics :: !(Maybe SyncStatistics)
       -- | Pending states for all created transactions (information related
       -- to transaction resubmission).
       -- See "Pos.Wallet.Web.Pending" for resubmission functionality.
-    , _wsPendingTxs   :: !(HashMap TxId PendingTx)
+    , _wsPendingTxs     :: !(HashMap TxId PendingTx)
       -- | Wallets that are being synced are marked as not ready, and
       -- are excluded from api endpoints. This info should not be leaked
       -- into a client facing data structure (for example 'CWalletMeta')
-    , _wiIsReady      :: !Bool
+    , _wiIsReady        :: !Bool
     } deriving (Eq)
 
 makeLenses ''WalletInfo
@@ -485,7 +517,7 @@ createAccount accId cAccMeta =
 -- @isReady@ should be set to @False@ when syncing is still needed.
 createWallet :: CId Wal -> CWalletMeta -> Bool -> POSIXTime -> Update ()
 createWallet cWalId cWalMeta isReady curTime = do
-    let info = WalletInfo cWalMeta curTime curTime NotSynced mempty isReady
+    let info = WalletInfo cWalMeta curTime curTime NotSynced Nothing mempty isReady
     wsWalletInfos . at cWalId %= (<|> Just info)
 
 -- | Add new address given 'CWAddressMeta' (which contains information about
@@ -526,8 +558,16 @@ setWalletSyncTip cWalId hh = wsWalletInfos . ix cWalId . wiSyncState .= SyncedWi
 
 -- | Deliberately-verbose transaction to update the 'SyncState' for this wallet during a
 -- restoration.
-setWalletRestorationSyncTip :: CId Wal -> RestorationBlockDepth -> HeaderHash -> Update ()
+setWalletRestorationSyncTip :: CId Wal
+                            -> RestorationBlockDepth
+                            -> HeaderHash
+                            -> Update ()
 setWalletRestorationSyncTip cWalId rhh hh = wsWalletInfos . ix cWalId . wiSyncState .= RestoringFrom rhh hh
+
+updateSyncStatistics :: CId Wal
+                           -> SyncStatistics
+                           -> Update ()
+updateSyncStatistics cWalId stats = wsWalletInfos . ix cWalId . wiSyncStatistics .= Just stats
 
 -- | Set meta data for transaction only if it hasn't been set already.
 -- FIXME: this will be removed later (temporary solution) (not really =\)
@@ -726,6 +766,8 @@ deriveSafeCopySimple 0 'base ''AddressInfo
 deriveSafeCopySimple 0 'base ''AccountInfo
 deriveSafeCopySimple 0 'base ''WalletInfo
 deriveSafeCopySimple 0 'base ''RestorationBlockDepth
+deriveSafeCopySimple 0 'base ''SyncThroughput
+deriveSafeCopySimple 0 'base ''SyncStatistics -- TODO(adn): migrations
 
 -- Legacy versions, for migrations
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -78,8 +78,7 @@ import           Pos.Util.LogSafe (buildSafe, logDebugSP, logErrorSP, logInfoSP,
                                    secretOnlyF, secure)
 import qualified Pos.Util.Modifier as MM
 import           Pos.Util.Servant (encodeCType)
-import           Pos.Util.Util (timed)
-import           Pos.Util.Util (HasLens (..), getKeys)
+import           Pos.Util.Util (HasLens (..), getKeys, timed)
 import           System.Wlog (CanLog, HasLoggerName, WithLogger, logDebug, logError, logInfo,
                               logWarning, modifyLoggerName)
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -37,6 +37,8 @@ module Pos.Wallet.Web.Tracking.Sync
        -- Internal & test use only
        , evalChange
        , syncWalletWithBlockchain
+       , calculateThroughput
+       , BoundedSyncTime (..)
        ) where
 
 import           Control.Monad.Except (MonadError (throwError))

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -571,14 +571,14 @@ calculateThroughput BoundedSyncTime{..} =
      in WS.SyncThroughput . BlockCount . round $ tput
 
 -- | Calculates the estimated remaining time to restore the wallet via the
--- provided 'SyncThroughput' and the total height of the blockchain.
+-- provided 'SyncThroughput' and the @remaining@ height of the blockchain.
 -- This is given by the simple proportion:
--- syncedBlocks : 1_second = actualBlockchainDepth : X
--- X = (1.0 * actualBlockchainDepth) / syncedBlocks
+-- syncedBlocks : 1_second = remainingHeight : X
+-- X = (1.0 * remainingHeight) / syncedBlocks
 calculateEstimatedRemainingTime :: WS.SyncThroughput -> ChainDifficulty -> Timestamp
-calculateEstimatedRemainingTime (WS.SyncThroughput blocks) actualBlockchainDepth =
+calculateEstimatedRemainingTime (WS.SyncThroughput blocks) remainingBlocks =
     let toDouble                = realToFrac @Integer @Double . fromIntegral . getBlockCount
-        (actualDepth :: Double) = toDouble (getChainDifficulty actualBlockchainDepth)
+        (actualDepth :: Double) = toDouble (getChainDifficulty remainingBlocks)
         (throughput :: Double)  = max 1.0 (toDouble blocks) -- Avoids division by 0.
         (microseconds :: Integer) = 1000000
         eta = actualDepth / throughput


### PR DESCRIPTION
## Summary

This PR (which is being opened against `feature/CBR-90` is virtually a feature-complete incarnation of CBR-90. *The only thing missing are DB migrations, which will be delivered with CSL-2429. This doesn't hold up the Daedalus team from start integrating the feature, as the V1 API provided here won't change*.

## Description

This PR builds upon CSL-2246 (for which the reader is encouraged to defer review up until a PR for `feature/CBR-90` won't land, to get the full picture). In a nutshell we extend the `WalletInfo` section of the `WalletStorage` to keep around some `SyncStatistics` which can be used by the V1 API to compute interesting numbers about a wallet `syncState`, for example:

- `SyncState` (Syncing? Restoring? etc)
- `SyncPercentage` (0 .. 100%)
- `EstimatedCompletionTime` (in milliseconds)
- `SyncThroughput` (in blocks/s)

Notably, `SyncProgress` has been renamed to `SyncPercentage` and `SyncProgress` is now a richer type.

## Screenshots

<img width="1915" alt="screen shot 2018-03-29 at 15 43 44" src="https://user-images.githubusercontent.com/29383371/38096454-3545f964-3373-11e8-9476-1d04206d6d26.png">

## QA Steps

Provided as part of `feature/CBR-90`, but for @darko-mijic and @nikolaglumac the best course of action is to attach the `cardano-node` to the staging cluster, like this:

```
stack build cardano-sl-wallet-new
stack exec cardano-node -- --topology=docs/network/example-topologies/mainnet-staging.yaml --configuration-key mainnet_dryrun_full --db-path ../staging-db
```

And finally play with the wallet. It's recommended to import a staging DB so that the restoration is realistic. **Note that transactions cannot be sent during a restoration (due to known limitations we discussed) so doing so will incur in unexpected behaviour.**