### PR TITLE
wallet-new: Add Setup.hs and default.nix files for easing Cabal usage

### DIFF
--- a/wallet-new/Setup.hs
+++ b/wallet-new/Setup.hs
@@ -1,2 +1,4 @@
+#! /usr/bin/env nix-shell
+#! nix-shell ./default.nix -i runghc
 import Distribution.Simple
 main = defaultMain

--- a/wallet-new/default.nix
+++ b/wallet-new/default.nix
@@ -1,0 +1,10 @@
+# Running `nix-shell` on this file puts you in an environment where all the
+# dependencies needed to work on `wallet-new` using `Cabal` are available.
+#
+# Running `nix-build` builds the `wallet-new` code.
+let
+  drv = (import ../. {}).cardano-sl-wallet-new;
+in
+  if ((import <nixpkgs> {}).stdenv.lib.inNixShell)
+    then drv.env
+    else drv


### PR DESCRIPTION
See `wallet-new/default.nix` documentation.