### PR TITLE
[CSL-2430] Get wallet snapshot after inserting wallet into a db

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -3,15 +3,15 @@ module Cardano.Wallet.API.V1.LegacyHandlers.Wallets where
 import           Universum
 
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
-import qualified Pos.Wallet.Web.State.Storage as V0
 import qualified Pos.Wallet.Web.Methods as V0
-import qualified Pos.Wallet.Web.State as V0 (askWalletSnapshot, WalletSnapshot)
+import qualified Pos.Wallet.Web.State as V0 (WalletSnapshot, askWalletSnapshot)
+import qualified Pos.Wallet.Web.State.Storage as V0
 
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
+import           Cardano.Wallet.API.V1.Errors
 import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types as V1
-import           Cardano.Wallet.API.V1.Errors
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
 import qualified Data.IxSet.Typed as IxSet
 import           Pos.Update.Configuration ()
@@ -40,7 +40,6 @@ newWallet
     => NewWallet
     -> m (WalletResponse Wallet)
 newWallet NewWallet{..} = do
-    ss <- V0.askWalletSnapshot
     let newWalletHandler CreateWallet  = V0.newWallet
         newWalletHandler RestoreWallet = V0.restoreWallet
         (V1 spendingPassword) = fromMaybe (V1 mempty) newwalSpendingPassword
@@ -51,6 +50,7 @@ newWallet NewWallet{..} = do
     let walletInit = V0.CWalletInit initMeta backupPhrase
     single <$> do
         v0wallet <- newWalletHandler newwalOperation spendingPassword walletInit
+        ss <- V0.askWalletSnapshot
         addWalletInfo ss v0wallet
 
 -- | Returns the full (paginated) list of wallets.


### PR DESCRIPTION
## Problem
Creating a wallet in V1 throws an exception after wallet has been already created and inserted in db.

## Reason
Wallet snapshot was not up to date after wallet has been inserted, so wallet was non existing in the created snapshot.

## Fix
Wallet snapshot was read after wallet was created.

## QA steps
1) Launch local cluster:
```
[akegalj@notebook cardano-sl]$ git rev-parse HEAD
83b4a69212b8d628830148f24dd375242d7ee9ae

[akegalj@notebook cardano-sl]$ scripts/clean/db.sh 

[akegalj@notebook cardano-sl]$ WALLET_DEBUG=1 scripts/launch/demo-with-wallet-api.sh
```

2) Create a wallet with V1:
```
[akegalj@notebook cardano-sl]$ curl -v -X POST http://127.0.0.1:8090/api/v1/wallets -H 'cache-control: no-cache' -H 'content-type: application/json;charset=utf-8' -d '{ "operation": "restore", "backupPhrase": [ "shell", "also", "throw", "ramp", "grape", "chest", "setup", "mandate", "spare", "verb", "lemon", "test" ], "assuranceLevel": "strict", "name": "My Wallet", "spendingPassword": null }'

< HTTP/1.1 201 Created

{"data":{"id":"Ae2tdPwUPEYxZqYcW7MGhTcqoCymor93dTq3kqf59AdxBzMsjCgURkVCKcj","name":"My Wallet","balance":0,"hasSpendingPassword":false,"spendingPasswordLastUpdate":"2018-04-04T08:13:16.24104","createdAt":"2018-04-04T08:13:16.24104","assuranceLevel":"strict"},"status":"success","meta":{"pagination":{"totalPages":1,"p...
```

3) Check created wallet:
```
[akegalj@notebook cardano-sl]$ curl http://localhost:8090/api/wallets
{"Right":[{"cwId":"Ae2tdPwUPEYxZqYcW7MGhTcqoCymor93dTq3kqf59AdxBzMsjCgURkVCKcj","cwMeta":{"cwName":"My Wallet","cwAssurance":"CWAStrict","cwUnit":0},"cwAccountsNumber":1,"cwAmount":{"getCCoin":"0"},"cwHasPassphrase":false,"cwPassphraseLU":1.522829596241040327e9}]}
```

*Wallet will be created without an exception being thrown*