### PR TITLE
[DEVOPS-673] release.nix: add cardano-sl-explorer-frontend

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -31,6 +31,7 @@ let
     cardano-sl-wallet = supportedSystems;
     cardano-sl-wallet-new = supportedSystems;
     cardano-sl-explorer-static = [ "x86_64-linux" ];
+    cardano-sl-explorer-frontend = [ "x86_64-linux" ];
     cardano-report-server-static = [ "x86_64-linux" ];
     stack2nix = supportedSystems;
     purescript = supportedSystems;


### PR DESCRIPTION
I realised that I forgot to add a hydra job for the explorer frontend.