### PR TITLE
[DEVOPS-13] Linux wallet configuration key

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14752,6 +14752,16 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
       bvMinor: 1
       bvAlt: 0
 
+mainnet_wallet_linux: &mainnet_wallet_linux
+  <<: *mainnet_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
+
 ##############################################################################
 ##                                                                          ##
 ##   Mainnet dryrun config sample                                           ##
@@ -14782,6 +14792,16 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   update:
     applicationName: csl-daedalus
     applicationVersion: 6
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
+
+mainnet_dryrun_wallet_linux: &mainnet_dryrun_wallet_linux
+  <<: *mainnet_dryrun_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 0
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14822,6 +14842,16 @@ mainnet_staging_short_epoch_wallet_win64:
       bvAlt: 0
 
 mainnet_staging_short_epoch_wallet_macos64:
+  <<: *mainnet_staging_short_epoch_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 0
+      bvAlt: 0
+
+mainnet_staging_short_epoch_wallet_linux:
   <<: *mainnet_staging_short_epoch_full
   update:
     applicationName: csl-daedalus
@@ -14908,6 +14938,18 @@ devnet_macos64:
       bvAlt: 0
     systemTag: macos64
 
+devnet_linux:
+  <<: *devnet
+  update:
+    <<:
+    applicationName: csl-daedalus
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 0
+      bvAlt: 0
+    systemTag: linux
+
 ##############################################################################
 ##                                                                          ##
 ##   Internal staging configs                                               ##
@@ -14971,6 +15013,16 @@ internal_staging_wallet_win64:
       bvAlt: 0
 
 internal_staging_wallet_macos64:
+  <<: *internal_staging_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 0
+      bvAlt: 0
+
+internal_staging_wallet_linux:
   <<: *internal_staging_full
   update:
     applicationName: csl-daedalus


### PR DESCRIPTION
_Contents_

0. We now have a Linux wallet -- which needs its own configuration keys.  Add them.
0. ~Mainnet now runs with block minor version 1 -- set that as baseline.~