### PR TITLE
[CSL-2433] Wrap actions with MaybeT to enable gaurds to exit gracefully

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7712,12 +7712,12 @@ inherit (pkgs) mesa;};
              cardano-sl-networking cardano-sl-ssc cardano-sl-txp
              cardano-sl-update cardano-sl-util cardano-sl-wallet conduit
              containers data-default exceptions formatting hspec http-api-data
-             http-types insert-ordered-containers ixset-typed lens log-warper
-             memory mtl neat-interpolation optparse-applicative QuickCheck
-             safe-exceptions serokell-util servant servant-server
-             servant-swagger servant-swagger-ui stm string-conv swagger2 text
-             text-format time-units universum unordered-containers wai wai-cors
-             wai-extra warp
+             http-client http-types insert-ordered-containers ixset-typed lens
+             log-warper memory mtl neat-interpolation optparse-applicative
+             QuickCheck safe-exceptions serokell-util servant servant-client
+             servant-server servant-swagger servant-swagger-ui stm string-conv
+             swagger2 text text-format time-units universum unordered-containers
+             wai wai-cors wai-extra warp
            ];
            testHaskellDepends = [
              aeson aeson-pretty base bytestring cardano-sl cardano-sl-block

--- a/scripts/test/wallet/integration.sh
+++ b/scripts/test/wallet/integration.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -Eeuo pipefail
 
@@ -38,7 +38,7 @@ tmux new-session -s $sessionName -d "WALLET_DEBUG=1 scripts/launch/demo-with-wal
 
 # wait until cluster is fully up and running
 echo "Waiting 140 seconds until local cluster is ready..."
-sleep 140s
+sleep 40s
 
 # import keys
 # TODO: we should import multiple keys for them to be useful as they contain little amount of money. Check does fakeavvm contains more money and if it does use that instead

--- a/scripts/test/wallet/integration.sh
+++ b/scripts/test/wallet/integration.sh
@@ -31,24 +31,20 @@ rm -rf $tmpSecrets
 stack exec -- cardano-keygen --system-start 0 generate-keys-by-spec --genesis-out-dir $tmpSecrets
 
 # run cluster
-# TODO (akegalj): move to integration/Main.hs
-# WALLET_DEBUG flag is needed so that wallet is launched without TLS. We could also use --no-tls, but this involves changes to the underlying script. See https://iohk.myjetbrains.com/youtrack/issue/CT-7#comment=93-17848
 echo "Starting local cardano cluster..."
 tmux new-session -s $sessionName -d "WALLET_DEBUG=1 scripts/launch/demo-with-wallet-api.sh"
 
 # wait until cluster is fully up and running
-echo "Waiting 140 seconds until local cluster is ready..."
+echo "Waiting 40 seconds until local cluster is ready..."
 sleep 40s
 
 # import keys
-# TODO: we should import multiple keys for them to be useful as they contain little amount of money. Check does fakeavvm contains more money and if it does use that instead
 echo "Importing poor HD key/wallet..."
  curl -X POST http://localhost:8090/api/wallets/keys -H 'cache-control: no-cache' -H 'content-type: application/json' -d "\"$tmpSecrets/generated-keys/poor/key0.sk\""
 
 FAILED=0
 
 # run integration tests
-# TODO (akegalj): add tls files to default integration options
 echo "Launching cardano integration tests..."
 stack exec -- cardano-integration-test --help
 stack exec -- cardano-integration-test || {
@@ -56,10 +52,8 @@ stack exec -- cardano-integration-test || {
     cleanState
     FAILED=1
 }
-# --tls-pub-cert scripts/tls-files/server.crt --tls-priv-key scripts/tls-files/server.key
 
 # kill cluster
-# TODO (akegalj): move to integration/Main.hs
 if [[ $FAILED == 0 ]]; then
     echo "Shutting down cardano cluster..."
     cleanState

--- a/wallet-new/integration/Error.hs
+++ b/wallet-new/integration/Error.hs
@@ -22,20 +22,20 @@ data WalletTestError
 
     | WalletBalanceNotZero Wallet
     | WalletPassMissing Wallet
-    | LocalWalletDiffers Wallet
-    | LocalWalletsDiffers [Wallet]
+    | LocalWalletDiffers Wallet Wallet
+    | LocalWalletsDiffers [Wallet] [Wallet]
 
     | AccountBalanceNotZero Account
-    | LocalAccountDiffers Account
-    | LocalAccountsDiffers [Account]
+    | LocalAccountDiffers Account Account
+    | LocalAccountsDiffers [Account] [Account]
 
     | AddressBalanceNotZero WalletAddress
     | LocalAddressesDiffer WalletAddress [WalletAddress]
-    | LocalAddressDiffer Address
+    | LocalAddressDiffer Address Address
 
     | InvalidTransactionState Transaction
     | InvalidTransactionFee EstimatedFees
-    | LocalTransactionsDiffer [Transaction]
+    | LocalTransactionsDiffer [Transaction] [Transaction]
     | LocalTransactionMissing Transaction [Transaction]
 
     deriving (Show, Eq, Generic)
@@ -48,19 +48,19 @@ instance Buildable WalletTestError where
     build (HttpClientError _        )     = bprint "Http client error"
     build (WalletBalanceNotZero    w)     = bprint ("Wallet balance is not zero - ("%stext%")") (show w)
     build (WalletPassMissing       w)     = bprint ("Missing wallet pass - ("%stext%")") (show w)
-    build (LocalWalletDiffers      w)     = bprint ("Local wallet differs - ("%stext%")") (show w)
-    build (LocalWalletsDiffers     w)     = bprint ("Local wallets differs - ("%stext%")") (show w)
+    build (LocalWalletDiffers      w w')     = bprint ("Local wallet differs - ("%stext%"), ("%stext%")") (show w) (show w')
+    build (LocalWalletsDiffers     w w')  = bprint ("Local wallets differs - ("%stext%"), ("%stext%")") (show w) (show w')
 
     build (AccountBalanceNotZero   a)     = bprint ("Acccount balance is not zero - ("%stext%")") (show a)
-    build (LocalAccountDiffers     a)     = bprint ("Local account differs - ("%stext%")") (show a)
-    build (LocalAccountsDiffers    a)     = bprint ("Local accounts differs - ("%stext%")") (show a)
+    build (LocalAccountDiffers     a a')  = bprint ("Local account differs - ("%stext%"), ("%stext%")") (show a) (show a')
+    build (LocalAccountsDiffers    a a')  = bprint ("Local accounts differs - ("%stext%"), ("%stext%")") (show a) (show a')
 
     build (AddressBalanceNotZero   a)     = bprint ("Address balance is not zero - ("%stext%")") (show a)
     build (LocalAddressesDiffer a as)     = bprint ("Local address ("%stext%") missing from addresses ("%stext%")") (show a) (show as)
-    build (LocalAddressDiffer      a)     = bprint ("Local address differs - ("%stext%")") (show a)
+    build (LocalAddressDiffer      a a')  = bprint ("Local address differs - ("%stext%"), ("%stext%")") (show a) (show a')
 
     build (InvalidTransactionState t)     = bprint ("Transaction state is invalid. Transaction - ("%stext%")") (show t)
     build (InvalidTransactionFee   f)     = bprint ("Transaction fees are invalid - ("%stext%")") (show f)
-    build (LocalTransactionsDiffer t)     = bprint ("Local transactions differs - ("%stext%")") (show t)
+    build (LocalTransactionsDiffer t t')  = bprint ("Local transactions differs - ("%stext%"), ("%stext%")") (show t) (show t')
     build (LocalTransactionMissing t ts)  = bprint ("Local transaction ("%stext%") missing from txs history ("%stext%")") (show t) (show ts)
 

--- a/wallet-new/integration/Error.hs
+++ b/wallet-new/integration/Error.hs
@@ -2,7 +2,6 @@
 
 -- | Types describing runtime errors related to
 -- wallet integration tests.
-
 module Error
     ( WalletTestError (..)
     ) where
@@ -20,8 +19,6 @@ import           Cardano.Wallet.Client (ClientError)
 
 data WalletTestError
     = HttpClientError ClientError
-
-    | InvalidProbabilityDistr
 
     | WalletBalanceNotZero Wallet
     | WalletPassMissing Wallet
@@ -49,8 +46,6 @@ instance Exception WalletTestError
 
 instance Buildable WalletTestError where
     build (HttpClientError _        )     = bprint "Http client error"
-    -- ^ TODO (ks): A proper instance
-    build InvalidProbabilityDistr         = bprint "The probability distribution should be between 1 - 100."
     build (WalletBalanceNotZero    w)     = bprint ("Wallet balance is not zero - ("%stext%")") (show w)
     build (WalletPassMissing       w)     = bprint ("Missing wallet pass - ("%stext%")") (show w)
     build (LocalWalletDiffers      w)     = bprint ("Local wallet differs - ("%stext%")") (show w)

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -115,9 +115,6 @@ runAction wc action = do
 
             let localWallets = ws ^. wallets
 
-            -- The precondition is that we need to have wallets.
-            guard (not (null localWallets))
-
             -- We choose from the existing wallets.
             wal@Wallet{ walId }  <-  pickRandomElement localWallets
 
@@ -132,9 +129,6 @@ runAction wc action = do
 
         DeleteWallet -> do
             localWallets <- use wallets
-
-            -- The precondition is that we need to have wallets.
-            guard (not (null localWallets))
 
             -- We choose from the existing wallets.
             wallet  <-  pickRandomElement localWallets
@@ -157,9 +151,6 @@ runAction wc action = do
 
             localWallets <- use wallets
 
-            -- The precondition is that we need to have wallets.
-            guard (not (null localWallets))
-
             -- We choose from the existing wallets.
             wallet  <-  pickRandomElement localWallets
 
@@ -180,9 +171,6 @@ runAction wc action = do
         UpdateWalletPass -> do
 
             localWallets <- use wallets
-
-            -- The precondition is that we need to have wallets.
-            guard (not (null localWallets))
 
             -- We choose from the existing wallets.
             wallet  <-  pickRandomElement localWallets
@@ -213,10 +201,6 @@ runAction wc action = do
         PostAccount -> do
 
             localWallets <- use wallets
-
-            -- Precondition, we need to have wallet in order
-            -- to create an account.
-            guard (not (null localWallets))
 
             wallet     <- pickRandomElement localWallets
             newAcc  <-  liftIO $ generate generateNewAccount
@@ -266,9 +250,6 @@ runAction wc action = do
         DeleteAccount -> do
             localAccounts <- use accounts
 
-            -- The precondition is that we need to have accounts.
-            guard (not (null localAccounts))
-
             -- We choose from the existing wallets AND existing accounts.
             account <-  pickRandomElement localAccounts
             let walletId = accWalletId account
@@ -288,9 +269,6 @@ runAction wc action = do
 
         UpdateAccount -> do
             localAccounts <- use accounts
-
-            -- The precondition is that we need to have accounts.
-            guard (not (null localAccounts))
 
             -- We choose from the existing wallets.
             account <-  pickRandomElement localAccounts
@@ -315,8 +293,6 @@ runAction wc action = do
             -- If we have accounts, that presupposes that we have wallets,
             -- which is the other thing we need here.
             localAccounts <- use accounts
-
-            guard (not (null localAccounts))
 
             -- We choose from the existing wallets AND existing accounts.
             account <-  pickRandomElement localAccounts
@@ -378,13 +354,6 @@ runAction wc action = do
             let minCoinForTxs = V1 . mkCoin $ 200000
             let localAccsWithMoney = filter ((> minCoinForTxs) . accAmount) localAccounts
 
-            -- | The preconditions we need to generate a transaction.
-            -- We need to have an account and an address.
-            -- We also need money to execute a transaction.
-            guard (not (null localAccounts))
-            guard (not (null localAddresses))
-            guard (not (null localAccsWithMoney))
-
             -- From which source to pay.
             accountSource <- pickRandomElement localAccsWithMoney
 
@@ -445,9 +414,6 @@ runAction wc action = do
         GetTransaction  -> do
             ws <- get
             let txs = ws ^. transactions
-
-            -- We need to have transactions in order to test this endpoint.
-            guard (not (null txs))
 
             -- We choose from the existing transactions.
             accTransaction  <- pickRandomElement txs

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -53,6 +53,15 @@ runActionCheck walletClient walletState actionProb = do
 
 -- | Attempt each action in the list. If an action fails, ignore the
 -- failure.
+--
+-- If this were implemented as:
+--
+-- @
+-- tryAll = foldr (\a b -> a *> b <|> b) empty
+-- @
+--
+-- Then it would always end up failing with the final `empty`. The explicit
+-- pattern matching allows us to potentially succeed.
 tryAll :: Alternative f => [f a] -> f a
 tryAll []     = empty
 tryAll (x:xs) = foldr (\act acc -> act *> acc <|> acc) x xs

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -4,8 +4,8 @@
 
 module Functions where
 
-import           Universum hiding (error)
 import           Prelude (error)
+import           Universum hiding (error)
 
 import           Data.Coerce (coerce)
 import           Data.List (delete)
@@ -94,8 +94,14 @@ runAction wc ws GetWallets   = do
         & actionsNum +~ 1
 
 runAction wc ws GetWallet    = do
+
+    let localWallets = ws ^. wallets
+
+    -- The precondition is that we need to have wallets.
+    guard (not (null localWallets))
+
     -- We choose from the existing wallets.
-    wallet  <-  pickRandomElement (ws ^. wallets)
+    wallet  <-  pickRandomElement localWallets
     result  <-  respToRes $ getWallet wc (walId wallet)
 
     checkInvariant

--- a/wallet-new/integration/Main.hs
+++ b/wallet-new/integration/Main.hs
@@ -7,11 +7,10 @@ import           Universum
 import           Cardano.Wallet.Client.Http
 import           Control.Lens hiding ((^..), (^?))
 import           System.IO (hSetEncoding, stdout, utf8)
-import           Test.QuickCheck (arbitrary, generate)
 import           Test.Hspec
+import           Test.QuickCheck (arbitrary, generate)
 
 import           CLI
-import           Error
 import           Functions
 import           Types
 
@@ -45,9 +44,6 @@ main = do
 
     let walletState = WalletState mempty mempty mempty mempty mempty 0
 
-    -- We throw exception if the value is invalid.
-    actionDistr <- either throwM pure actionDistribution
-
     -- some expected test cases
     hspec $ deterministicTests walletClient
 
@@ -55,18 +51,13 @@ main = do
     _ <- runActionCheck
         walletClient
         walletState
-        actionDistr
+        actionDistribution
 
     pure ()
   where
-    actionDistribution :: Either WalletTestError ActionProbabilities
+    actionDistribution :: ActionProbabilities
     actionDistribution = do
-        postWalletProb <- createProbability 50
-        getWalletProb  <- createProbability 50
-
-        pure $ (PostWallet, postWalletProb) :|
-             [ (GetWallet, getWalletProb)
-             ]
+        (PostWallet, Weight 1) :| fmap (\x -> (x, Weight 1)) [minBound .. maxBound]
 
 deterministicTests :: WalletClient IO -> Spec
 deterministicTests wc = do

--- a/wallet-new/integration/Main.hs
+++ b/wallet-new/integration/Main.hs
@@ -42,7 +42,7 @@ main = do
     let walletClient :: MonadIO m => WalletClient m
         walletClient = liftClient $ mkHttpClient baseUrl manager
 
-    let walletState = WalletState mempty mempty mempty mempty mempty 0
+    walletState <- initialWalletState walletClient
 
     -- some expected test cases
     hspec $ deterministicTests walletClient
@@ -58,6 +58,16 @@ main = do
     actionDistribution :: ActionProbabilities
     actionDistribution = do
         (PostWallet, Weight 1) :| fmap (\x -> (x, Weight 1)) [minBound .. maxBound]
+
+initialWalletState :: WalletClient IO -> IO  WalletState
+initialWalletState wc = do
+    _wallets <- either throwM (pure . wrData) =<< getWallets wc
+    let _walletsPass = mempty
+        _accounts = mempty
+        _addresses = mempty
+        _transactions = mempty
+        _actionsNum = 0
+    pure $ WalletState {..}
 
 deterministicTests :: WalletClient IO -> Spec
 deterministicTests wc = do

--- a/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
+++ b/wallet-new/server/Cardano/Wallet/Server/Plugins.hs
@@ -115,9 +115,9 @@ legacyWalletBackend WalletBackendParams {..} ntpStatus =
       return $ withMiddleware walletRunMode app
 
     exceptionHandler :: SomeException -> Response
-    exceptionHandler _ =
+    exceptionHandler exn =
         responseLBS badRequest400 [(hContentType, "application/json")] .
-            encode $ UnkownError "Something went wrong."
+            encode $ UnknownError $ "Something went wrong. " <> show exn
 
 -- | A 'Plugin' to start the wallet REST server
 --

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -53,7 +53,7 @@ data WalletError =
     | SomeOtherError { weFoo :: !Text, weBar :: !Int }
     | MigrationFailed { weDescription :: !Text }
     | JSONValidationFailed { weValidationError :: !Text }
-    | UnkownError { weMsg :: !Text }
+    | UnknownError { weMsg :: !Text }
     | InvalidAddressFormat { weMsg :: !Text }
     | WalletNotFound
     | AddressNotFound
@@ -95,7 +95,7 @@ sample =
   , SomeOtherError "foo" 14
   , MigrationFailed "migration"
   , JSONValidationFailed "Expected String, found Null."
-  , UnkownError "unknown"
+  , UnknownError "unknown"
   , WalletNotFound
   ]
 
@@ -109,7 +109,7 @@ toServantError err =
     SomeOtherError{}       -> err418
     MigrationFailed{}      -> err422
     JSONValidationFailed{} -> err400
-    UnkownError{}          -> err400
+    UnknownError{}          -> err400
     WalletNotFound{}       -> err404
     InvalidAddressFormat{} -> err401
     AddressNotFound{}      -> err404

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -208,7 +208,7 @@ data ClientError
     -- might return.
     | ClientHttpError ServantError
     -- ^ We directly expose the 'ServantError' type as part of this
-    | UnknownError SomeException
+    | UnknownClientError SomeException
     -- ^ This constructor is used when the API client reports an error that
     -- isn't represented in either the 'ServantError' HTTP errors or the
     -- 'WalletError' for API errors.
@@ -216,14 +216,14 @@ data ClientError
 
 -- | General (and naive) equality instance.
 instance Eq ClientError where
-    (==) (ClientWalletError e1) (ClientWalletError e2) = e1 == e2
-    (==) (ClientHttpError   e1) (ClientHttpError   e2) = e1 == e2
-    (==) (UnknownError      _ ) (UnknownError      _ ) = True
-    (==) _                      _                      = False
+    ClientWalletError  e1 == ClientWalletError  e2 = e1 == e2
+    ClientHttpError    e1 == ClientHttpError    e2 = e1 == e2
+    UnknownClientError _  == UnknownClientError _  = True
+    _ == _ = False
 
 -- | General exception instance.
 instance Exception ClientError where
-    toException   (ClientWalletError e) = toException e
-    toException   (ClientHttpError   e) = toException e
-    toException   (UnknownError      e) = toException e
+    toException (ClientWalletError  e) = toException e
+    toException (ClientHttpError    e) = toException e
+    toException (UnknownClientError e) = toException e
 


### PR DESCRIPTION
This PR fixes behaviour of `guard` in integration tests. Previously `guard` was using implementation of `Alternative IO` which would fail : 

```haskell
-- | @since 4.9.0.0
instance Alternative IO where
    empty = failIO "mzero"
    (<|>) = mplusIO
```

and now integration tests are wrapped with `MaybeT` which returns `Nothing` if `guard` fails and thus implements correct behaviour for our use case - which is: "Ignore actions which don't satisfy `guard`". We can simply achieve this with `catMaybes` or similar.

Issue: https://iohk.myjetbrains.com/youtrack/issue/CSL-2433

_Note that PR will be merged to `feature/csl2398-integration-ci` branch and the goal of this PR is to have isolated place to review yt issue and discuss things._