### PR TITLE
[CBR-119] Ugly fix to avoid some OOM problems on Explorer

### DIFF
--- a/explorer/src/Pos/Explorer/Web/Server.hs
+++ b/explorer/src/Pos/Explorer/Web/Server.hs
@@ -340,9 +340,10 @@ getAddressSummary cAddr = do
 
     let nTxs = length txIds
 
-    -- FIXME Waiting for design discussion
+    -- FIXME [CBR-119] Waiting for design discussion
     when (nTxs > 1000) $
-        throwM $ Internal $ "Response too large: " <> show nTxs <> " transactions"
+        throwM $ Internal $ "Response too large: no more than 1000 transactions"
+            <> " can be returned at once. This issue is known and being worked on"
 
     transactions <- forM txIds $ \id -> do
         extra <- getTxExtraOrFail id

--- a/explorer/src/Pos/Explorer/Web/Server.hs
+++ b/explorer/src/Pos/Explorer/Web/Server.hs
@@ -337,6 +337,13 @@ getAddressSummary cAddr = do
 
     balance <- mkCCoin . fromMaybe minBound <$> getAddrBalance addr
     txIds <- getNewestFirst <$> getAddrHistory addr
+
+    let nTxs = length txIds
+
+    -- FIXME Waiting for design discussion
+    when (nTxs > 1000) $
+        throwM $ Internal $ "Response too large: " <> show nTxs <> " transactions"
+
     transactions <- forM txIds $ \id -> do
         extra <- getTxExtraOrFail id
         tx <- getTxMain id extra


### PR DESCRIPTION
While waiting for a better design / design revision, this will most likely fix CPU issues of
iterating over huge list of transactions for some addresses. The pagination of those addresses
happens client-side, in browser and forces the server to fetch and return all transactions
summaries on each page load; leading to really heavy load in some cases.