### PR TITLE
PostTransaction integration test failure

### DIFF
--- a/client/src/Pos/Client/Txp/Util.hs
+++ b/client/src/Pos/Client/Txp/Util.hs
@@ -662,8 +662,8 @@ computeTxFee pendingTx utxo outputs = do
 --       i.e. @ fee_{i+1} <= fee_{i} @.
 --
 --     * Number if input addresses decreased.
---       Is may occur when fee increases more than on current remainder.
---       Is this case fee on next iteration would indeed decrease, because
+--       It may occur when fee increases more than on current remainder.
+--       In this case fee on next iteration would indeed decrease, because
 --       size of single input is much greater than any fluctuations of
 --       remainder size (in bytes).
 --

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -11,7 +11,6 @@ import           Universum hiding (log)
 
 import           Data.Coerce (coerce)
 import           Data.List (delete, isInfixOf)
-import           Data.List.NonEmpty (fromList)
 
 import           Control.Lens (at, each, filtered, uses, (%=), (+=), (.=), (<>=), (?=))
 import           Test.Hspec
@@ -416,15 +415,17 @@ runAction wc action = do
 
             addressDestination <- pickRandomElement localAddresses
 
-            let paymentDistribution =
+            let paymentDestinations =
                     PaymentDistribution
                         { pdAddress = addrId addressDestination
                         , pdAmount  = V1 moneyAmount
-                        }
+                        } :| []
 
-            let newPayment =  createNewPayment
-                                  paymentSource
-                                  [paymentDistribution]
+            let newPayment = Payment
+                                 paymentSource
+                                 paymentDestinations
+                                 mzero
+                                 mzero
 
             -- Check the transaction fees.
             log $ "getTransactionFee: " <> show newPayment
@@ -436,27 +437,33 @@ runAction wc action = do
 
             -- Check the transaction.
             log $ "postTransaction: " <> show newPayment
-            result  <-  respToRes $ postTransaction wc newPayment
+            newTx  <-  respToRes $ postTransaction wc newPayment
 
-            let expectedAmount =
-                    V1 (mkCoin (getCoin moneyAmount - getCoin (unV1 (feeEstimatedAmount txFees))))
+            let sumCoins f =
+                    sum . map (getCoin . unV1 . pdAmount) . toList $ f newTx
+                inputSum = sumCoins txInputs
+                outputSum = sumCoins txOutputs
+
+            -- Transaction shouldn't produce any money
             checkInvariant
-                (txAmount result == expectedAmount)
-                (InvalidTransactionState result)
+                (inputSum >= outputSum)
+                (InvalidTransactionState newTx)
+
+            let actualFees = V1 . mkCoin $ inputSum - outputSum
+
+            -- Estimated fees should correspond to actual fees
+            -- TODO(akegalj): add custom error type
+            checkInvariant
+                (feeEstimatedAmount txFees == actualFees)
+                (InvalidTransactionState newTx)
+
+            -- TODO(akegalj): add invariant that checks is there paymentDestinations distributions in newTx
+            -- TODO(akegalj): add invariant that checks is paymentSource the only source of newTx
+            -- TODO(akegalj): add invariant that checks did accounts of all payment destinations increase by expected amount
+            -- TODO(akegalj): add invariant that checks did accounts of all payment sources decrease by expected amount
 
             -- Modify wallet state accordingly.
-            transactions  <>= [(accountSource, result)]
-
-          where
-            createNewPayment :: PaymentSource -> [PaymentDistribution] -> Payment
-            createNewPayment ps pd = Payment
-                { pmtSource           = ps
-                , pmtDestinations     = fromList pd
-                , pmtGroupingPolicy   = Nothing
-                -- ^ Simple for now.
-                , pmtSpendingPassword = Nothing
-                }
-
+            transactions  <>= [(accountSource, newTx)]
 
         GetTransaction  -> do
             ws <- get

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -237,20 +237,7 @@ instance ByteArray.ByteArrayAccess a => ByteArray.ByteArrayAccess (V1 a) where
 
 -- TODO(adinapoli) Rewrite it properly under CSL-2048.
 instance Arbitrary (V1 BackupPhrase) where
-    arbitrary = pure . V1 . BackupPhrase $ [
-          "shell"
-        , "also"
-        , "throw"
-        , "ramp"
-        , "grape"
-        , "chest"
-        , "setup"
-        , "mandate"
-        , "spare"
-        , "verb"
-        , "lemon"
-        , "test"
-        ]
+    arbitrary = V1 <$> arbitrary
 
 instance ToJSON (V1 BackupPhrase) where
     toJSON (V1 (BackupPhrase wrds)) = toJSON wrds

--- a/wallet/src/Pos/Util/BackupPhrase.hs
+++ b/wallet/src/Pos/Util/BackupPhrase.hs
@@ -12,8 +12,9 @@ import qualified Prelude
 import           Universum
 
 import           Crypto.Hash (Blake2b_256)
+import qualified Data.ByteString as BS
 import           Data.Text.Buildable (Buildable (..))
-import           Test.QuickCheck (Arbitrary (..), elements, genericShrink, vectorOf)
+import           Test.QuickCheck (Arbitrary (..), Gen, genericShrink, vectorOf)
 import           Test.QuickCheck.Instances ()
 
 import           Pos.Binary (Bi (..), serialize')
@@ -29,20 +30,17 @@ newtype BackupPhrase = BackupPhrase
     } deriving (Eq, Generic)
 
 instance Arbitrary BackupPhrase where
-    arbitrary = BackupPhrase <$> vectorOf 12 (elements englishWords)
+    arbitrary = do
+        em <- arbitraryMnemonic 16
+        case em of
+            Left _  -> arbitrary
+            Right a -> pure a
     shrink    = genericShrink
 
--- | (Some) valid English words as taken from <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki BIP-39>
-englishWords :: [Text]
-englishWords = [ "recycle" , "child" , "universe" , "extend" , "edge" , "tourist"
-               , "swamp" , "rare" , "enhance" , "rabbit" , "blast" , "plastic" , "attitude"
-               , "name" , "skull" , "merit" , "night" , "idle" , "bone" , "exact"
-               , "inflict" , "legal" , "predict" , "certain" , "napkin" , "blood"
-               , "color" , "screen" , "birth" , "detect" , "summer" , "palm"
-               , "entry" , "swing" , "fit" , "garden" , "trick" , "timber"
-               , "toss" , "atom" , "kitten" , "flush" , "master" , "transfer"
-               , "success" , "worry" , "rural" , "silver" , "invest" , "mean"
-               ]
+arbitraryMnemonic :: Int -> Gen (Either Text BackupPhrase)
+arbitraryMnemonic len = do
+    eitherMnemonic <- toMnemonic . BS.pack <$> vectorOf len arbitrary
+    pure . first toText $ BackupPhrase . words <$> eitherMnemonic
 
 -- | Number of words in backup phrase
 backupPhraseWordsNum :: Int


### PR DESCRIPTION
The actual problem was because invariant:
```haskell
             checkInvariant
                (txAmount result == expectedAmount)
                (InvalidTransactionState result)
```
was assuming `txAmount` field in `Transaction` type will be equal to money we were planning to send - but actually `txAmount` will be sum of amounts in sources addresses. System is spending full amount from sources addresses and returning extra money to the sources (via outputs). In this case `txAmount` will match sources amount, not amount that we planned to send.

Example: We have account X with Y amount of money. We would like to send Z to Bob, from account X. In this example we assumed that `txAmount` will be equal to `Z`. But actually `txAmount` will be equal to Y. 

Invariant was changed so that now it calculates and checks is fee amount expected. There are few more TODO's added to make `PostTransaction` stringer but this will be handled in issue https://iohk.myjetbrains.com/youtrack/issue/CSL-2444 .

```
Starting the integration testing for wallet.
[TEST-LOG] Running: PostAddress
[TEST-LOG] Posting address: NewAddress {newaddrSpendingPassword = Nothing, newaddrAccountIndex = 2147483648, newaddrWalletId = WalletId "Ae2tdPwUPEZGwBoJZR6bA5ZDhAQ86E3CyLAHHvEWxqtaivVjgwvFYAkWm1t"}
[TEST-LOG] Success!
[TEST-LOG] Running: PostTransaction
[TEST-LOG] getTransactionFee: Payment {pmtSource = PaymentSource {psWalletId = WalletId "Ae2tdPwUPEZA3tszYyNZsCGXadb63QPgCEdR4ZSsYWTrwew9JenNhedr3Sf", psAccountIndex = 2147483648}, pmtDestinations = PaymentDistribution {pdAddress = Address {addrRoot = AbstractHash e5979cf6c9ae94f8d2172a3acac032f27a0439c0df666277cae977d7, addrAttributes = Attributes { data: AddrAttributes {aaPkDerivationPath = Just (HDAddressPayload {getHDAddressPayload = "*\200f\SYN\240\139\173\SUB\139U9\231\146!\215\130{\176S\DC1\SUB\214k\222\247#\160:"}), aaStakeDistribution = BootstrapEraDistr} }, addrType = ATPubKey}, pdAmount = Coin {getCoin = 10341875358355}} :| [], pmtGroupingPolicy = Nothing, pmtSpendingPassword = Nothing}
[TEST-LOG] postTransaction: Payment {pmtSource = PaymentSource {psWalletId = WalletId "Ae2tdPwUPEZA3tszYyNZsCGXadb63QPgCEdR4ZSsYWTrwew9JenNhedr3Sf", psAccountIndex = 2147483648}, pmtDestinations = PaymentDistribution {pdAddress = Address {addrRoot = AbstractHash e5979cf6c9ae94f8d2172a3acac032f27a0439c0df666277cae977d7, addrAttributes = Attributes { data: AddrAttributes {aaPkDerivationPath = Just (HDAddressPayload {getHDAddressPayload = "*\200f\SYN\240\139\173\SUB\139U9\231\146!\215\130{\176S\DC1\SUB\214k\222\247#\160:"}), aaStakeDistribution = BootstrapEraDistr} }, addrType = ATPubKey}, pdAmount = Coin {getCoin = 10341875358355}} :| [], pmtGroupingPolicy = Nothing, pmtSpendingPassword = Nothing}
[TEST-LOG] Success!

Addresses
  Creating an address makes it available
  Index returns real data

Finished in 1.5359 seconds
2 examples, 0 failures

```

_For some reason there are 2 commits in this PR that are already in base branch - I guess github UI isn't updating correctly._