### PR TITLE
[CSL-2443] Fix PostTransaction test invariant

### DIFF
--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -11,7 +11,6 @@ import           Universum hiding (log)
 
 import           Data.Coerce (coerce)
 import           Data.List (delete, isInfixOf)
-import           Data.List.NonEmpty (fromList)
 
 import           Control.Lens (at, each, filtered, uses, (%=), (+=), (.=), (<>=), (?=))
 import           Test.Hspec
@@ -416,15 +415,17 @@ runAction wc action = do
 
             addressDestination <- pickRandomElement localAddresses
 
-            let paymentDistribution =
+            let paymentDestinations =
                     PaymentDistribution
                         { pdAddress = addrId addressDestination
                         , pdAmount  = V1 moneyAmount
-                        }
+                        } :| []
 
-            let newPayment =  createNewPayment
-                                  paymentSource
-                                  [paymentDistribution]
+            let newPayment = Payment
+                                 paymentSource
+                                 paymentDestinations
+                                 mzero
+                                 mzero
 
             -- Check the transaction fees.
             log $ "getTransactionFee: " <> show newPayment
@@ -436,27 +437,33 @@ runAction wc action = do
 
             -- Check the transaction.
             log $ "postTransaction: " <> show newPayment
-            result  <-  respToRes $ postTransaction wc newPayment
+            newTx  <-  respToRes $ postTransaction wc newPayment
 
-            let expectedAmount =
-                    V1 (mkCoin (getCoin moneyAmount - getCoin (unV1 (feeEstimatedAmount txFees))))
+            let sumCoins f =
+                    sum . map (getCoin . unV1 . pdAmount) . toList $ f newTx
+                inputSum = sumCoins txInputs
+                outputSum = sumCoins txOutputs
+
+            -- Transaction shouldn't produce any money
             checkInvariant
-                (txAmount result == expectedAmount)
-                (InvalidTransactionState result)
+                (inputSum >= outputSum)
+                (InvalidTransactionState newTx)
+
+            let actualFees = V1 . mkCoin $ inputSum - outputSum
+
+            -- Estimated fees should correspond to actual fees
+            -- TODO(akegalj): add custom error type
+            checkInvariant
+                (feeEstimatedAmount txFees == actualFees)
+                (InvalidTransactionState newTx)
+
+            -- TODO(akegalj): add invariant that checks is there paymentDestinations distributions in newTx
+            -- TODO(akegalj): add invariant that checks is paymentSource the only source of newTx
+            -- TODO(akegalj): add invariant that checks did accounts of all payment destinations increase by expected amount
+            -- TODO(akegalj): add invariant that checks did accounts of all payment sources decrease by expected amount
 
             -- Modify wallet state accordingly.
-            transactions  <>= [(accountSource, result)]
-
-          where
-            createNewPayment :: PaymentSource -> [PaymentDistribution] -> Payment
-            createNewPayment ps pd = Payment
-                { pmtSource           = ps
-                , pmtDestinations     = fromList pd
-                , pmtGroupingPolicy   = Nothing
-                -- ^ Simple for now.
-                , pmtSpendingPassword = Nothing
-                }
-
+            transactions  <>= [(accountSource, newTx)]
 
         GetTransaction  -> do
             ws <- get


### PR DESCRIPTION
The actual problem was because invariant:
```haskell
             checkInvariant
                (txAmount result == expectedAmount)
                (InvalidTransactionState result)
```
was assuming `txAmount` field in `Transaction` type will be equal to money we were planning to send - but actually `txAmount` will be sum of amounts in sources addresses. System is spending full amount from sources addresses and returning extra money to the sources (via outputs). In this case `txAmount` will match sources amount, not amount that we planned to send.

Example: We have account X with Y amount of money. We would like to send Z to Bob, from account X. In this example we assumed that `txAmount` will be equal to `Z`. But actually `txAmount` will be equal to Y. 

Invariant was changed so that now it calculates and checks is fee amount expected. There are few more TODO's added to make `PostTransaction` stronger but this will be handled in issue https://iohk.myjetbrains.com/youtrack/issue/CSL-2444 .

```
Starting the integration testing for wallet.
[TEST-LOG] Running: PostAddress
[TEST-LOG] Posting address: NewAddress {newaddrSpendingPassword = Nothing, newaddrAccountIndex = 2147483648, newaddrWalletId = WalletId "Ae2tdPwUPEZGwBoJZR6bA5ZDhAQ86E3CyLAHHvEWxqtaivVjgwvFYAkWm1t"}
[TEST-LOG] Success!
[TEST-LOG] Running: PostTransaction
[TEST-LOG] getTransactionFee: Payment {pmtSource = PaymentSource {psWalletId = WalletId "Ae2tdPwUPEZA3tszYyNZsCGXadb63QPgCEdR4ZSsYWTrwew9JenNhedr3Sf", psAccountIndex = 2147483648}, pmtDestinations = PaymentDistribution {pdAddress = Address {addrRoot = AbstractHash e5979cf6c9ae94f8d2172a3acac032f27a0439c0df666277cae977d7, addrAttributes = Attributes { data: AddrAttributes {aaPkDerivationPath = Just (HDAddressPayload {getHDAddressPayload = "*\200f\SYN\240\139\173\SUB\139U9\231\146!\215\130{\176S\DC1\SUB\214k\222\247#\160:"}), aaStakeDistribution = BootstrapEraDistr} }, addrType = ATPubKey}, pdAmount = Coin {getCoin = 10341875358355}} :| [], pmtGroupingPolicy = Nothing, pmtSpendingPassword = Nothing}
[TEST-LOG] postTransaction: Payment {pmtSource = PaymentSource {psWalletId = WalletId "Ae2tdPwUPEZA3tszYyNZsCGXadb63QPgCEdR4ZSsYWTrwew9JenNhedr3Sf", psAccountIndex = 2147483648}, pmtDestinations = PaymentDistribution {pdAddress = Address {addrRoot = AbstractHash e5979cf6c9ae94f8d2172a3acac032f27a0439c0df666277cae977d7, addrAttributes = Attributes { data: AddrAttributes {aaPkDerivationPath = Just (HDAddressPayload {getHDAddressPayload = "*\200f\SYN\240\139\173\SUB\139U9\231\146!\215\130{\176S\DC1\SUB\214k\222\247#\160:"}), aaStakeDistribution = BootstrapEraDistr} }, addrType = ATPubKey}, pdAmount = Coin {getCoin = 10341875358355}} :| [], pmtGroupingPolicy = Nothing, pmtSpendingPassword = Nothing}
[TEST-LOG] Success!

Addresses
  Creating an address makes it available
  Index returns real data

Finished in 1.5359 seconds
2 examples, 0 failures

```
