### PR TITLE
stack.yaml: Re-enable building of haddocks

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -215,8 +215,3 @@ ghc-options:
   cardano-sl-explorer:   -Werror
   cardano-sl-node:       -Werror
   cardano-sl-wallet-new: -Werror
-
-# The 'swagger2' has a broken Haddock with GHC 8.0. We can remove this flag
-# when we have upgraded to GHC >= 8.2
-build:
-  haddock-hyperlink-source: false


### PR DESCRIPTION
These were disabled due to problems with the swager2 version that was
being pulled from github. Since we have now moved to a swagger2 version
that comes from Hackage we can re-enable Haddock generation.

The fact that haddocks were not being built was on the list of issues
mentioned by the external auditors.