### PR TITLE
[CSL-2442] Prevent the backend from making payments whilst a wallet is restoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ GPATH
 TAGS
 
 # Vim
-tags
+tags*
 
 # Intellij Idea & intellij-haskell
 .idea

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7672,8 +7672,8 @@ inherit (pkgs) mesa;};
              cardano-sl-networking cardano-sl-ssc cardano-sl-txp
              cardano-sl-update cardano-sl-util containers data-default ether
              formatting hspec lens log-warper MonadRandom mtl QuickCheck
-             safecopy serokell-util stm text-format universum
-             unordered-containers
+             safe-exceptions safecopy serokell-util servant-server stm
+             text-format universum unordered-containers
            ];
            testToolDepends = [ cpphs ];
            doHaddock = false;

--- a/wallet-new/integration/Main.hs
+++ b/wallet-new/integration/Main.hs
@@ -7,8 +7,8 @@ import           Universum
 import           Cardano.Wallet.Client
 import           Control.Lens hiding ((^..), (^?))
 import           System.IO (hSetEncoding, stdout, utf8)
-import           Test.QuickCheck (arbitrary, generate)
 import           Test.Hspec
+import           Test.QuickCheck (arbitrary, generate)
 
 import           CLI
 import           Error
@@ -63,6 +63,8 @@ main = do
 
 deterministicTests :: WalletClient IO -> Spec
 deterministicTests wc = do
+    -- TODO(adn): Add proper "Transactions" deterministicTests as part of
+    -- https://iohk.myjetbrains.com/youtrack/issue/CBR-184
     describe "Addresses" $ do
         it "Creating an address makes it available" $ do
             -- create a wallet

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -58,6 +58,10 @@ data WalletError =
     | WalletNotFound
     | AddressNotFound
     | MissingRequiredParams { requiredParams :: NonEmpty (Text, Text) }
+    | WalletIsNotReadyToProcessPayments
+    -- ^ The @Wallet@ where a @Payment@ is being originated is not fully
+    -- synced (its 'WalletSyncState' indicates it's either syncing or
+    -- restoring) and thus cannot accept new @Payment@ requests.
     deriving (Show, Eq)
 
 --
@@ -97,6 +101,7 @@ sample =
   , JSONValidationFailed "Expected String, found Null."
   , UnkownError "unknown"
   , WalletNotFound
+  , WalletIsNotReadyToProcessPayments
   ]
 
 
@@ -104,16 +109,17 @@ sample =
 toServantError :: WalletError -> ServantErr
 toServantError err =
   mkServantErr $ case err of
-    NotEnoughMoney{}       -> err403
-    OutputIsRedeem{}       -> err403
-    SomeOtherError{}       -> err418
-    MigrationFailed{}      -> err422
-    JSONValidationFailed{} -> err400
-    UnkownError{}          -> err400
-    WalletNotFound{}       -> err404
-    InvalidAddressFormat{} -> err401
-    AddressNotFound{}      -> err404
-    MissingRequiredParams{} -> err400
+    NotEnoughMoney{}                    -> err403
+    OutputIsRedeem{}                    -> err403
+    SomeOtherError{}                    -> err418
+    MigrationFailed{}                   -> err422
+    JSONValidationFailed{}              -> err400
+    UnkownError{}                       -> err400
+    WalletNotFound{}                    -> err404
+    InvalidAddressFormat{}              -> err401
+    AddressNotFound{}                   -> err404
+    MissingRequiredParams{}             -> err400
+    WalletIsNotReadyToProcessPayments{} -> err403
   where
     mkServantErr serr@ServantErr{..} = serr
       { errBody    = encode err

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -261,7 +261,9 @@ test-suite cardano-wallet-test
                      , log-warper
                      , mtl
                      , safecopy
+                     , safe-exceptions
                      , serokell-util >= 0.1.3.4
+                     , servant-server
                      , stm
                      , text-format
                      , universum >= 0.1.11

--- a/wallet/src/Pos/Wallet/Web/State/State.hs
+++ b/wallet/src/Pos/Wallet/Web/State/State.hs
@@ -44,6 +44,7 @@ module Pos.Wallet.Web.State.State
        , getCustomAddresses
        , getCustomAddress
        , isCustomAddress
+       , isWalletRestoring
        , getWalletUtxo
        , getWalletBalancesAndUtxo
        , updateWalletBalancesAndUtxo
@@ -198,6 +199,9 @@ getWAddresses ws mode wid = queryValue ws (S.getWAddresses mode wid)
 doesWAddressExist
     :: WalletSnapshot -> AddressLookupMode -> S.WAddressMeta -> Bool
 doesWAddressExist ws mode addr = queryValue ws (S.doesWAddressExist mode addr)
+
+isWalletRestoring :: WalletSnapshot -> CId Wal -> Bool
+isWalletRestoring ws walletId = queryValue ws (S.isWalletRestoring walletId)
 
 getProfile :: WalletSnapshot -> CProfile
 getProfile ws = queryValue ws S.getProfile

--- a/wallet/src/Pos/Wallet/Web/State/Storage.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Storage.hs
@@ -44,6 +44,7 @@ module Pos.Wallet.Web.State.Storage
        , getAccountWAddresses
        , getWAddresses
        , doesWAddressExist
+       , isWalletRestoring
        , getTxMeta
        , getNextUpdate
        , getHistoryCache
@@ -515,6 +516,17 @@ getCustomAddress t addr = view $ customAddressL t . at addr
 -- | Get list of all pending transactions.
 getPendingTxs :: Query [PendingTx]
 getPendingTxs = asks $ toListOf (wsWalletInfos . traversed . wsPendingTxs . traversed)
+
+-- | Returns 'True' if the input @Wallet@ (as identified by its @CId Wal@) is
+-- being restored, i.e. it has its 'WalletSyncState' on @RestoringFrom@.
+isWalletRestoring :: WebTypes.CId WebTypes.Wal -> Query Bool
+isWalletRestoring walletId = do
+    syncState <- getWalletSyncState walletId
+    return $ case syncState of
+         Nothing                  -> False
+         Just (SyncedWith _)      -> False
+         Just NotSynced           -> False
+         Just (RestoringFrom _ _) -> True
 
 -- | Get list of pending transactions related to given wallet.
 getWalletPendingTxs :: WebTypes.CId WebTypes.Wal -> Query (Maybe [PendingTx])


### PR DESCRIPTION
## Description

This PR builds on top of the work I did as part of `feature/CBR-90` to disallow making new payments whilst the _source_ wallet is being restored. This extends what we have been doing already in the frontend to the backend, to prevent exchanges from shooting on their feets.

It doesn't assume prior knowledge over the work on CBR-90, thus is suitable for reviewing in a black-box fashion by chaps like @KtorZ and @parsonsmatt . 

You will notice how there are no tests worth their name for the V1 API. Reason is twofold:

- We need proper support in the `deterministicTests`, for which I have logged CBR-184.
- The implementation for the V1 piggybacks on V0 (for which we have tests), therefore it should be enough to assess by code audit that the V1 shim does the right thing, and in terms of testing we are covered in the actual logic by the V0 handler extension (I hope 😂 ).

If you have ideas on how to test this one without the integration tests, I'm all ear.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2442