### PR TITLE
[DEVOPS-59] nix: Add daedalus-bridge.version attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -119,12 +119,17 @@ let
       stagingWallet = mkDocker { environment = "mainnet-staging"; };
     };
 
-    daedalus-bridge = pkgs.runCommand "cardano-daedalus-bridge" {} ''
+    daedalus-bridge = let
+      inherit (cardanoPkgs.cardano-sl-node) version;
+    in pkgs.runCommand "cardano-daedalus-bridge-${version}" {
+      inherit version;
+    } ''
       # Generate daedalus-bridge
       mkdir -p $out/bin $out/config
       cd $out
       ${optionalString (buildId != null) "echo ${buildId} > build-id"}
       echo ${gitrev} > commit-id
+      echo ${version} > version
 
       cp ${./log-configs + "/daedalus.yaml"} config/log-config-prod.yaml
       cp ${./lib}/configuration.yaml config


### PR DESCRIPTION
## Description

This will allow the Daedalus installers build (both nix-build and make-installers) to easily get the cardano-sl version.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-59

## Type of change

New feature (non-breaking change which adds functionality).

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps

    nix build -f default.nix daedalus-bridge
    cat result/version

