### PR TITLE
[CSL-2477] Add 'protocolMagic' field to NodeSettings

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Settings.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Settings.hs
@@ -8,6 +8,7 @@ import qualified Cardano.Wallet.API.V1.Settings as Settings
 import           Cardano.Wallet.API.V1.Types as V1
 import qualified Data.Text as T
 import           Paths_cardano_sl_wallet_new (version)
+import           Pos.Crypto.Configuration (protocolMagic)
 
 import           Pos.Update.Configuration (curSoftwareVersion)
 import           Pos.Util.CompileInfo (compileInfo, ctiGitRevision)
@@ -30,4 +31,5 @@ getSettings = do
                              <*> pure (V1 curSoftwareVersion)
                              <*> pure version
                              <*> pure (T.replace "\n" mempty $ ctiGitRevision compileInfo)
+                             <*> pure (V1 protocolMagic)
     return $ single settings

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -9,6 +9,7 @@ import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Typeable (typeRep)
 import           Pos.Client.Txp.Util (InputSelectionPolicy)
 import qualified Pos.Crypto as Crypto
+import           Pos.Crypto.Configuration (ProtocolMagic)
 import qualified Pos.Txp.Toil.Types as V0
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 import           Test.Hspec
@@ -37,6 +38,7 @@ spec = parallel $ describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @Account Proxy
         aesonRoundtripProp @AssuranceLevel Proxy
         aesonRoundtripProp @(V1 Core.SoftwareVersion) Proxy
+        aesonRoundtripProp @(V1 ProtocolMagic) Proxy
         aesonRoundtripProp @NodeSettings Proxy
         aesonRoundtripProp @Payment Proxy
         aesonRoundtripProp @PaymentDistribution Proxy


### PR DESCRIPTION
## Description

This commit adds the 'protocolMagic' as a field of 'NodeSettings', so that Daedalus can exploit this information to distinguish whether or not this wallet backend is "talking" to mainnet or to something different.

## Linked issue

CSL-2477

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [X] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## QA Steps

None needed.

## Screenshots (if available)

<img width="1587" alt="screen shot 2018-04-13 at 16 37 28" src="https://user-images.githubusercontent.com/29383371/38743444-5f2f6ecc-3f3f-11e8-8894-c7bd95457999.png">

