### PR TITLE
WIP: [CSL-2105] acid state design

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7719,23 +7719,24 @@ inherit (pkgs) mesa;};
            license = stdenv.lib.licenses.mit;
          }) {};
       "cardano-sl-wallet-new" = callPackage
-        ({ mkDerivation, aeson, aeson-diff, aeson-pretty, base, bytestring
-         , cardano-sl, cardano-sl-block, cardano-sl-client, cardano-sl-core
-         , cardano-sl-crypto, cardano-sl-db, cardano-sl-delegation
-         , cardano-sl-infra, cardano-sl-networking, cardano-sl-ssc
-         , cardano-sl-txp, cardano-sl-update, cardano-sl-util
-         , cardano-sl-wallet, conduit, constraints, containers, data-default
-         , directory, exceptions, formatting, generics-sop, hspec
-         , http-api-data, http-client, http-types, insert-ordered-containers
-         , ixset-typed, json-sop, lens, log-warper, memory, mmorph, mtl
-         , neat-interpolation, network-transport, optparse-applicative
-         , pretty-show, process, QuickCheck, quickcheck-instances
-         , reflection, safe-exceptions, serokell-util, servant
-         , servant-client, servant-client-core, servant-quickcheck
-         , servant-server, servant-swagger, servant-swagger-ui, stdenv, stm
-         , string-conv, swagger2, text, text-format, time, time-units
-         , transformers, universum, unliftio, unliftio-core
-         , unordered-containers, vector, wai, wai-cors, wai-extra, warp
+        ({ mkDerivation, acid-state, aeson, aeson-diff, aeson-pretty, base
+         , bytestring, cardano-sl, cardano-sl-block, cardano-sl-client
+         , cardano-sl-core, cardano-sl-crypto, cardano-sl-db
+         , cardano-sl-delegation, cardano-sl-infra, cardano-sl-networking
+         , cardano-sl-ssc, cardano-sl-txp, cardano-sl-update
+         , cardano-sl-util, cardano-sl-wallet, conduit, constraints
+         , containers, data-default, directory, exceptions, formatting
+         , generics-sop, hspec, http-api-data, http-client, http-types
+         , insert-ordered-containers, ixset-typed, json-sop, lens
+         , log-warper, memory, mmorph, mtl, neat-interpolation
+         , network-transport, optparse-applicative, pretty-show, process
+         , QuickCheck, quickcheck-instances, reflection, safe-exceptions
+         , safecopy, serokell-util, servant, servant-client
+         , servant-client-core, servant-quickcheck, servant-server
+         , servant-swagger, servant-swagger-ui, stdenv, stm, string-conv
+         , swagger2, text, text-format, time, time-units, transformers
+         , universum, unliftio, unliftio-core, unordered-containers, vector
+         , wai, wai-cors, wai-extra, warp
          }:
          mkDerivation {
            pname = "cardano-sl-wallet-new";
@@ -7744,18 +7745,18 @@ inherit (pkgs) mesa;};
            isLibrary = true;
            isExecutable = true;
            libraryHaskellDepends = [
-             aeson aeson-pretty base bytestring cardano-sl cardano-sl-block
-             cardano-sl-client cardano-sl-core cardano-sl-crypto cardano-sl-db
-             cardano-sl-infra cardano-sl-networking cardano-sl-ssc
-             cardano-sl-txp cardano-sl-update cardano-sl-util cardano-sl-wallet
-             containers data-default exceptions formatting generics-sop
-             http-api-data http-client http-types ixset-typed json-sop lens
-             log-warper memory mtl network-transport QuickCheck reflection
-             safe-exceptions serokell-util servant servant-client
-             servant-client-core servant-quickcheck servant-server
-             servant-swagger-ui stm string-conv swagger2 text text-format time
-             time-units transformers universum unliftio-core
-             unordered-containers vector wai
+             acid-state aeson aeson-pretty base bytestring cardano-sl
+             cardano-sl-block cardano-sl-client cardano-sl-core
+             cardano-sl-crypto cardano-sl-db cardano-sl-infra
+             cardano-sl-networking cardano-sl-ssc cardano-sl-txp
+             cardano-sl-update cardano-sl-util cardano-sl-wallet containers
+             data-default exceptions formatting generics-sop http-api-data
+             http-client http-types ixset-typed json-sop lens log-warper memory
+             mtl network-transport QuickCheck reflection safe-exceptions
+             safecopy serokell-util servant servant-client servant-client-core
+             servant-quickcheck servant-server servant-swagger-ui stm
+             string-conv swagger2 text text-format time time-units transformers
+             universum unliftio-core unordered-containers vector wai
            ];
            executableHaskellDepends = [
              aeson aeson-diff aeson-pretty base bytestring cardano-sl

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -17,6 +17,19 @@ library
   hs-source-dirs:      src
   exposed-modules:     Cardano.Wallet.TypeLits
                        Cardano.Wallet.Kernel
+                       Cardano.Wallet.Kernel.DB.AcidState
+                       Cardano.Wallet.Kernel.DB.AcidStateUtil
+                       Cardano.Wallet.Kernel.DB.BlockMeta
+                       Cardano.Wallet.Kernel.DB.HdWallet
+                       Cardano.Wallet.Kernel.DB.HdWallet.Create
+                       Cardano.Wallet.Kernel.DB.HdWallet.Delete
+                       Cardano.Wallet.Kernel.DB.HdWallet.Read
+                       Cardano.Wallet.Kernel.DB.HdWallet.Update
+                       Cardano.Wallet.Kernel.DB.InDb
+                       Cardano.Wallet.Kernel.DB.Resolved
+                       Cardano.Wallet.Kernel.DB.Spec
+                       Cardano.Wallet.Kernel.DB.Spec.Update
+                       Cardano.Wallet.Kernel.DB.TxMeta
                        Cardano.Wallet.Kernel.Diffusion
                        Cardano.Wallet.Kernel.Mode
                        Cardano.Wallet.Kernel.Types
@@ -72,6 +85,7 @@ library
   ghc-options:         -Wall
   build-depends:       base
                      , QuickCheck
+                     , acid-state
                      , aeson
                      , aeson-pretty
                      , bytestring
@@ -91,6 +105,7 @@ library
                      , mtl
                      , network-transport
                      , unliftio-core
+                     , safecopy
                      , safe-exceptions
                      , servant
                      , servant-client

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -18,7 +18,6 @@ library
   exposed-modules:     Cardano.Wallet.TypeLits
                        Cardano.Wallet.Kernel
                        Cardano.Wallet.Kernel.DB.AcidState
-                       Cardano.Wallet.Kernel.DB.AcidStateUtil
                        Cardano.Wallet.Kernel.DB.BlockMeta
                        Cardano.Wallet.Kernel.DB.HdWallet
                        Cardano.Wallet.Kernel.DB.HdWallet.Create
@@ -30,6 +29,8 @@ library
                        Cardano.Wallet.Kernel.DB.Spec
                        Cardano.Wallet.Kernel.DB.Spec.Update
                        Cardano.Wallet.Kernel.DB.TxMeta
+                       Cardano.Wallet.Kernel.DB.Util.AcidState
+                       Cardano.Wallet.Kernel.DB.Util.IxSet
                        Cardano.Wallet.Kernel.Diffusion
                        Cardano.Wallet.Kernel.Mode
                        Cardano.Wallet.Kernel.Types

--- a/wallet-new/src/Cardano/Wallet/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel.hs
@@ -33,24 +33,25 @@ module Cardano.Wallet.Kernel (
 import           Universum hiding (State)
 
 import           Control.Lens.TH
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
+import qualified Data.Set as Set
 
 import           System.Wlog (Severity (..))
 
+import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock)
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
-import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock(..), prefilterBlock, ourUtxo)
-import           Cardano.Wallet.Kernel.Types (ResolvedBlock(..), txUtxo)
+import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock (..), ourUtxo, prefilterBlock)
+import           Cardano.Wallet.Kernel.Types (txUtxo)
 
-import           Pos.Core (TxAux, HasConfiguration, sumCoins)
-import           Pos.Core.Txp (TxIn (..), Tx (..), TxAux (..), TxOutAux (..), TxOut (..), TxId)
-import           Pos.Txp (Utxo)
+import           Pos.Core (HasConfiguration, TxAux, sumCoins)
+import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (EncryptedSecretKey, hash)
-import           Pos.Util.Chrono (OldestFirst, NE)
+import           Pos.Txp (Utxo)
+import           Pos.Util.Chrono (NE, OldestFirst)
 
-import           Cardano.Wallet.Orphans()
+import           Cardano.Wallet.Orphans ()
 
 {-------------------------------------------------------------------------------
   Wallet with State
@@ -78,7 +79,7 @@ data Wallet = WalletHdRnd {
       -- TODO: We may need to rethink having this in-memory
       -- ESK should _not_ end up in the wallet's acid-state log
       -- (for some reason..)
-    _walletESK :: EncryptedSecretKey
+    _walletESK     :: EncryptedSecretKey
 
     -- | Wallet state
     --
@@ -124,7 +125,7 @@ makeLenses ''State
 data PassiveWallet = PassiveWallet {
       -- | Send log message
       _walletLogMessage :: Severity -> Text -> IO ()
-    , _wallets :: MVar Wallets
+    , _wallets          :: MVar Wallets
     }
 
 makeLenses ''PassiveWallet

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Acid-state database for the wallet kernel
+module Cardano.Wallet.Kernel.DB.AcidState (
+    -- * Top-level database
+    DB(..)
+  , hdRoots
+    -- * Acid-state operations
+    -- ** Snapshot
+  , Snapshot(..)
+    -- ** Spec mandated updates
+  , NewPending(..)
+  , ApplyBlock(..)
+  , SwitchToFork(..)
+    -- ** Updates on HD wallets
+    -- *** CREATE
+  , CreateHdRoot(..)
+  , CreateHdAccount(..)
+  , CreateHdAddress(..)
+    -- *** UPDATE
+  , UpdateHdRootAssurance
+  , UpdateHdRootName(..)
+  , UpdateHdAccountName(..)
+    -- *** DELETE
+  , DeleteHdRoot(..)
+  , DeleteHdAccount(..)
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+import           Data.Acid (Query, Update, makeAcidic)
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.BlockMeta
+import           Cardano.Wallet.Kernel.DB.HdWallet
+import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
+import qualified Cardano.Wallet.Kernel.DB.HdWallet.Delete as HD
+import qualified Cardano.Wallet.Kernel.DB.HdWallet.Update as HD
+import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.Resolved
+import           Cardano.Wallet.Kernel.DB.Spec
+import qualified Cardano.Wallet.Kernel.DB.Spec.Update as Spec
+
+{-------------------------------------------------------------------------------
+  Top-level database
+-------------------------------------------------------------------------------}
+
+-- | Full state of the wallet, with the exception of transaction metadata
+--
+-- We store the different kinds of wallets in different maps for increased
+-- type safety. Moreover, since we currently only have a single type of wallet,
+-- trying to factor our common parts would be premature at this point.
+--
+--  References:
+--
+--  * The acid-state DB for the legacy wallet is defined in module
+--    "Pos.Wallet.Web.State.Storage".
+--  * V1 API defined in "Cardano.Wallet.API.V1.*" (in @src/@)
+data DB = DB {
+      _hdRoots :: HdRoots
+    }
+
+makeLenses ''DB
+deriveSafeCopy 1 'base ''DB
+
+{-------------------------------------------------------------------------------
+  Specialized lenses
+-------------------------------------------------------------------------------}
+
+-- | All list of checkpoints across the entire DB
+dbCheckpoints :: Traversal' DB Checkpoints
+dbCheckpoints = hdRoots        . traverse
+              . hdRootAccounts . traverse
+              . hdAccountCheckpoints
+
+{-------------------------------------------------------------------------------
+  Wrap wallet spec
+-------------------------------------------------------------------------------}
+
+-- | Errors thrown by 'newPending'
+data NewPendingError =
+    -- | Unknown account
+    NewPendingUnknown UnknownHdAccount
+
+    -- | Some inputs are not in the wallet utxo
+  | NewPendingFailed Spec.NewPendingFailed
+
+deriveSafeCopy 1 'base ''NewPendingError
+
+newPending :: HdAccountId
+           -> InDb (Core.TxAux)
+           -> Update DB (Either NewPendingError ())
+newPending accountId tx = runUpdate' . zoom hdRoots $
+    zoomHdAccountId NewPendingUnknown accountId $
+    zoom hdAccountCheckpoints $
+      mapUpdateErrors NewPendingFailed $ Spec.newPending tx
+
+-- | Apply a block
+--
+-- The block should be prefiltered to contain only inputs and outputs relevant
+-- to /any/ of the wallets and accounts.
+--
+-- NOTE: Calls to 'applyBlock' must be sequentialized by the caller
+-- (although concurrent calls to 'applyBlock' cannot interfere with each
+-- other, 'applyBlock' must be called in the right order.)
+applyBlock :: (ResolvedBlock, BlockMeta) -> Update DB ()
+applyBlock block = runUpdateNoErrors . zoomAll dbCheckpoints $
+    Spec.applyBlock block
+
+switchToFork :: Int
+             -> [(ResolvedBlock, BlockMeta)]
+             -> Update DB ()
+switchToFork n blocks = runUpdateNoErrors . zoomAll dbCheckpoints $
+    Spec.switchToFork n blocks
+
+{-------------------------------------------------------------------------------
+  Wrap HD C(R)UD operations
+-------------------------------------------------------------------------------}
+
+createHdRoot :: HdRootId
+             -> WalletName
+             -> HasSpendingPassword
+             -> AssuranceLevel
+             -> InDb Core.Timestamp
+             -> Update DB (Either HD.CreateHdRootError ())
+createHdRoot rootId name hasPass assurance created = runUpdate' . zoom hdRoots $
+    HD.createHdRoot rootId name hasPass assurance created
+
+createHdAccount :: HdRootId
+                -> AccountName
+                -> Checkpoint
+                -> Update DB (Either HD.CreateHdAccountError AccountIx)
+createHdAccount rootId name checkpoint = runUpdate' . zoom hdRoots $
+    HD.createHdAccount rootId name checkpoint
+
+createHdAddress :: HdAddressId
+                -> InDb Core.Address
+                -> Update DB (Either HD.CreateHdAddressError ())
+createHdAddress addrId address = runUpdate' . zoom hdRoots $
+    HD.createHdAddress addrId address
+
+updateHdRootAssurance :: HdRootId
+                      -> AssuranceLevel
+                      -> Update DB (Either UnknownHdRoot ())
+updateHdRootAssurance rootId assurance = runUpdate' . zoom hdRoots $
+    HD.updateHdRootAssurance rootId assurance
+
+updateHdRootName :: HdRootId
+                 -> WalletName
+                 -> Update DB (Either UnknownHdRoot ())
+updateHdRootName rootId name = runUpdate' . zoom hdRoots $
+    HD.updateHdRootName rootId name
+
+updateHdAccountName :: HdAccountId
+                    -> AccountName
+                    -> Update DB (Either UnknownHdAccount ())
+updateHdAccountName accId name = runUpdate' . zoom hdRoots $
+    HD.updateHdAccountName accId name
+
+deleteHdRoot :: HdRootId -> Update DB ()
+deleteHdRoot rootId = runUpdateNoErrors . zoom hdRoots $
+    HD.deleteHdRoot rootId
+
+deleteHdAccount :: HdAccountId -> Update DB (Either UnknownHdRoot ())
+deleteHdAccount accId = runUpdate' . zoom hdRoots $
+    HD.deleteHdAccount accId
+
+{-------------------------------------------------------------------------------
+  Acid-state magic
+-------------------------------------------------------------------------------}
+
+snapshot :: Query DB DB
+snapshot = ask
+
+makeAcidic ''DB [
+      -- Database snapshot
+      'snapshot
+      -- Updates on the "spec state"
+    , 'newPending
+    , 'applyBlock
+    , 'switchToFork
+      -- Updates on HD wallets
+    , 'createHdRoot
+    , 'createHdAccount
+    , 'createHdAddress
+    , 'updateHdRootAssurance
+    , 'updateHdRootName
+    , 'updateHdAccountName
+    , 'deleteHdRoot
+    , 'deleteHdAccount
+    ]

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidStateUtil.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidStateUtil.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Some utilities for working with acid-state
+module Cardano.Wallet.Kernel.DB.AcidStateUtil (
+    -- * Acid-state updates with support for errors
+    Update'
+  , runUpdate'
+  , runUpdateNoErrors
+  , mapUpdateErrors
+    -- * Zooming
+  , zoom
+  , zoomTry
+  , zoomAll
+    -- ** Convenience re-exports
+  , throwError
+  ) where
+
+import           Universum
+
+import           Control.Monad.Except
+import           Data.Acid (Update)
+
+{-------------------------------------------------------------------------------
+  Acid-state updates with support for errors (and zooming, see below)
+-------------------------------------------------------------------------------}
+
+type Update' st e = StateT st (Except e)
+
+runUpdate' :: forall e st a. Update' st e a -> Update st (Either e a)
+runUpdate' upd = do
+    st <- get
+    case upd' st of
+      Left  e        -> return (Left e)
+      Right (a, st') -> put st' >> return (Right a)
+  where
+    upd' :: st -> Either e (a, st)
+    upd' = runExcept . runStateT upd
+
+runUpdateNoErrors :: Update' st Void a -> Update st a
+runUpdateNoErrors = fmap mustBeRight . runUpdate'
+
+mapUpdateErrors :: (e -> e') -> Update' st e a -> Update' st e' a
+mapUpdateErrors f upd = StateT $ withExcept f . runStateT upd
+
+{-------------------------------------------------------------------------------
+  Zooming
+-------------------------------------------------------------------------------}
+
+zoom :: Lens' st st' -> Update' st' e a -> Update' st e a
+zoom l upd = StateT $ \large -> do
+    let update small' = large & l .~ small'
+        small         = large ^. l
+    fmap update <$> runStateT upd small
+
+zoomTry :: e -> Lens' st (Maybe st') -> Update' st' e a -> Update' st e a
+zoomTry e l upd = StateT $ \large -> do
+    let update small' = large & l .~ Just small'
+        mSmall        = large ^. l
+    case mSmall of
+      Nothing    -> throwError e
+      Just small -> fmap update <$> runStateT upd small
+
+zoomAll :: Traversal' st st' -> Update' st' e () -> Update' st e ()
+zoomAll t upd = StateT $ \large -> do
+    let updateSmall = execStateT upd
+    ((),) <$> t updateSmall large
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+mustBeRight :: Either Void b -> b
+mustBeRight (Left  a) = absurd a
+mustBeRight (Right b) = b

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
@@ -1,0 +1,42 @@
+-- | Block metadata conform the wallet specification
+module Cardano.Wallet.Kernel.DB.BlockMeta (
+    -- * Block metadata
+    BlockMeta(..)
+    -- ** Lenses
+  , blockMetaSlotId
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+import qualified Data.Map.Strict as Map
+import           Data.SafeCopy (deriveSafeCopy, base)
+
+import qualified Pos.Core as Core
+
+import           Cardano.Wallet.Kernel.DB.InDb
+
+{-------------------------------------------------------------------------------
+  Block metadata
+-------------------------------------------------------------------------------}
+
+-- | Block metadata
+data BlockMeta = BlockMeta {
+      -- | Slot each transaction got confirmed in
+      _blockMetaSlotId :: InDb (Map Core.TxId Core.SlotId)
+    }
+
+makeLenses ''BlockMeta
+deriveSafeCopy 1 'base ''BlockMeta
+
+-- | Monoid instance to update 'BlockMeta' in 'applyBlock' (see wallet spec)
+instance Monoid BlockMeta where
+  mempty = BlockMeta {
+        _blockMetaSlotId = InDb Map.empty
+      }
+  a `mappend` b = BlockMeta {
+        _blockMetaSlotId = combineUsing (liftA2 Map.union) _blockMetaSlotId
+      }
+    where
+      combineUsing :: (a -> a -> a) -> (BlockMeta -> a) -> a
+      combineUsing op f = f a `op` f b

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -1,0 +1,275 @@
+-- | HD wallets
+module Cardano.Wallet.Kernel.DB.HdWallet (
+    -- * Supporting types
+    WalletName(..)
+  , AccountName(..)
+  , AccountIx(..)
+  , AddressIx(..)
+  , AssuranceLevel(..)
+  , HasSpendingPassword(..)
+    -- * HD proper
+  , HdRootId(..)
+  , HdAccountId(..)
+  , HdAddressId(..)
+  , HdRoot(..)
+  , HdAccount(..)
+  , HdAddress(..)
+    -- ** Lenses
+  , hdRootName
+  , hdRootHasPassword
+  , hdRootAssurance
+  , hdRootCreatedAt
+  , hdRootAccounts
+  , hdAccountName
+  , hdAccountAddresses
+  , hdAccountCheckpoints
+  , hdAddressAddress
+  , hdAddressIsUsed
+  , hdAddressIsChange
+    -- * Derived information
+  , hdRootBalance
+  , hdAccountBalance
+    -- * Unknown identifiers
+  , UnknownHdRoot(..)
+  , UnknownHdAccount(..)
+  , UnknownHdAddress(..)
+  , embedUnknownHdRoot
+  , embedUnknownHdAccount
+    -- * Zoom to parts of the HD wallet
+  , HdRoots
+  , zoomHdRootId
+  , zoomHdAccountId
+  , zoomHdAddressId
+  ) where
+
+import           Universum
+
+import           Control.Lens (at, toListOf)
+import           Control.Lens.TH (makeLenses)
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+import qualified Pos.Crypto as Core
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.Spec
+
+{-------------------------------------------------------------------------------
+  Supporting types
+-------------------------------------------------------------------------------}
+
+-- | Wallet name
+newtype WalletName = WalletName Text
+
+-- | Account name
+newtype AccountName = AccountName Text
+
+-- | Account index
+newtype AccountIx = AccountIx Word32
+  deriving (Eq, Ord)
+
+-- | Address index
+newtype AddressIx = AddressIx Word32
+  deriving (Eq, Ord)
+
+-- | Wallet assurance level
+--
+-- TODO: document what these levels mean (in particular, how it does translate
+-- to the depth required before a transaction is marked as Persisted?)
+data AssuranceLevel =
+    AssuranceLevelNormal
+  | AssuranceLevelStrict
+
+-- | Does this wallet have a spending password
+data HasSpendingPassword =
+    -- | No spending password set
+    NoSpendingPassword
+
+    -- | If there is a spending password, we record when it was last updated.
+  | HasSpendingPassword (InDb Core.Timestamp)
+
+deriveSafeCopy 1 'base ''WalletName
+deriveSafeCopy 1 'base ''AccountName
+deriveSafeCopy 1 'base ''AccountIx
+deriveSafeCopy 1 'base ''AddressIx
+deriveSafeCopy 1 'base ''AssuranceLevel
+deriveSafeCopy 1 'base ''HasSpendingPassword
+
+{-------------------------------------------------------------------------------
+  HD wallets
+-------------------------------------------------------------------------------}
+
+-- | HD wallet root ID
+data HdRootId = HdRootId (InDb (Core.AddressHash Core.PublicKey))
+  deriving (Eq, Ord)
+
+-- | HD wallet account ID
+data HdAccountId = HdAccountId HdRootId AccountIx
+  deriving (Eq, Ord)
+
+-- | HD wallet address ID
+data HdAddressId = HdAddressId HdAccountId AddressIx
+  deriving (Eq, Ord)
+
+-- | Root of a HD wallet
+--
+-- The wallet has sequentially assigned account indices and randomly assigned
+-- address indices.
+--
+-- NOTE: We do not store the encrypted key of the wallet.
+--
+-- TODO: synchronization state
+data HdRoot = HdRoot {
+      -- | Wallet name
+      _hdRootName        :: WalletName
+
+      -- | Does this wallet have a spending password?
+      --
+      -- NOTE: We do not store the spending password itself, but merely record
+      -- whether there is one. Updates to the spending password affect only the
+      -- external key storage, not the wallet DB proper.
+    , _hdRootHasPassword :: HasSpendingPassword
+
+      -- | Assurance level
+    , _hdRootAssurance   :: AssuranceLevel
+
+      -- | When was this wallet created?
+    , _hdRootCreatedAt   :: InDb Core.Timestamp
+
+      -- | Known derived accounts
+    , _hdRootAccounts    :: Map AccountIx HdAccount
+    }
+
+-- | Account in a HD wallet
+--
+-- Key derivation is cheap
+data HdAccount = HdAccount {
+      -- | Account name
+      _hdAccountName        :: AccountName
+
+      -- | Known derived addresses
+    , _hdAccountAddresses   :: Map AddressIx HdAddress
+
+      -- | State of the " wallet " as stipulated by the wallet specification
+    , _hdAccountCheckpoints :: NonEmpty Checkpoint
+    }
+
+-- | Address in an account of a HD wallet
+data HdAddress = HdAddress {
+      -- | The actual address
+      _hdAddressAddress  :: InDb Core.Address
+
+      -- | Has this address been involved in a transaction?
+      --
+      -- TODO: How is this determined? What is the definition? How is it set?
+    , _hdAddressIsUsed   :: Bool
+
+      -- | Was this address used as a change address?
+      --
+      -- TODO: How is this derived when we do wallet recovery?
+      -- TODO: Do we need this at all?
+    , _hdAddressIsChange :: Bool
+    }
+
+makeLenses ''HdRoot
+makeLenses ''HdAccount
+makeLenses ''HdAddress
+
+deriveSafeCopy 1 'base ''HdRootId
+deriveSafeCopy 1 'base ''HdAccountId
+deriveSafeCopy 1 'base ''HdAddressId
+
+deriveSafeCopy 1 'base ''HdRoot
+deriveSafeCopy 1 'base ''HdAccount
+deriveSafeCopy 1 'base ''HdAddress
+
+{-------------------------------------------------------------------------------
+  Derived information
+-------------------------------------------------------------------------------}
+
+-- | Total balance of a wallet
+--
+-- This returns an integer because we may otherwise run into overflow.
+hdRootBalance :: HdRoot -> Integer
+hdRootBalance = Core.sumCoins
+              . toListOf ( hdRootAccounts
+                         . traverse
+                         . hdAccountCheckpoints
+                         . currentUtxoBalance
+                         )
+
+-- | Current balance on an account
+hdAccountBalance :: HdAccount -> Core.Coin
+hdAccountBalance = view (hdAccountCheckpoints . currentUtxoBalance)
+
+{-------------------------------------------------------------------------------
+  Unknown identifiers
+-------------------------------------------------------------------------------}
+
+-- | Unknown root
+data UnknownHdRoot =
+    -- | Unknown root ID
+    UnknownHdRoot HdRootId
+
+-- | Unknown account
+data UnknownHdAccount =
+    -- | Unknown root ID
+    UnknownHdAccountRoot HdRootId
+
+    -- | Unknown account (implies the root is known)
+  | UnknownHdAccount HdAccountId
+
+-- | Unknown address
+data UnknownHdAddress =
+    -- | Unknown root ID
+    UnknownHdAddressRoot HdRootId
+
+    -- | Unknown account (implies the root is known)
+  | UnknownHdAddressAccount HdAccountId
+
+    -- | Unknown address (implies the account is known)
+  | UnknownHdAddress HdAddressId
+
+embedUnknownHdRoot :: UnknownHdRoot -> UnknownHdAccount
+embedUnknownHdRoot = go
+  where
+    go (UnknownHdRoot rootId) = UnknownHdAccountRoot rootId
+
+embedUnknownHdAccount :: UnknownHdAccount -> UnknownHdAddress
+embedUnknownHdAccount = go
+  where
+    go (UnknownHdAccountRoot rootId) = UnknownHdAddressRoot rootId
+    go (UnknownHdAccount accountId)  = UnknownHdAddressAccount accountId
+
+deriveSafeCopy 1 'base ''UnknownHdRoot
+deriveSafeCopy 1 'base ''UnknownHdAddress
+deriveSafeCopy 1 'base ''UnknownHdAccount
+
+{-------------------------------------------------------------------------------
+  Zoom to parts of a HD wallet
+-------------------------------------------------------------------------------}
+
+type HdRoots = Map HdRootId HdRoot
+
+zoomHdRootId :: (UnknownHdRoot -> e)
+             -> HdRootId
+             -> Update' HdRoot e a -> Update' HdRoots e a
+zoomHdRootId embedErr rootId =
+      zoomTry (embedErr $ UnknownHdRoot rootId) (at rootId)
+
+zoomHdAccountId :: (UnknownHdAccount -> e)
+                -> HdAccountId
+                -> Update' HdAccount e a -> Update' HdRoots e a
+zoomHdAccountId embedErr accId@(HdAccountId rootId accIx) =
+      zoomHdRootId (embedErr . embedUnknownHdRoot) rootId
+    . zoom hdRootAccounts
+    . zoomTry (embedErr $ UnknownHdAccount accId) (at accIx)
+
+zoomHdAddressId :: (UnknownHdAddress -> e)
+                -> HdAddressId
+                -> Update' HdAddress e a -> Update' HdRoots e a
+zoomHdAddressId embedErr addrId@(HdAddressId accId addrIx) =
+      zoomHdAccountId (embedErr . embedUnknownHdAccount) accId
+    . zoom hdAccountAddresses
+    . zoomTry (embedErr $ UnknownHdAddress addrId) (at addrIx)

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -1,0 +1,136 @@
+-- | CREATE operations on HD wallets
+module Cardano.Wallet.Kernel.DB.HdWallet.Create (
+    -- * Errors
+    CreateHdRootError(..)
+  , CreateHdAccountError(..)
+  , CreateHdAddressError(..)
+    -- * Functions
+  , createHdRoot
+  , createHdAccount
+  , createHdAddress
+  ) where
+
+import           Universum
+
+import           Control.Lens (at, (.=))
+import qualified Data.Map.Strict as Map
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.Spec
+import           Cardano.Wallet.Kernel.DB.HdWallet
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+-- | Errors thrown by 'createHdWallet'
+data CreateHdRootError =
+    -- | We already have a wallet with the specified ID
+    CreateHdRootExists HdRootId
+
+-- | Errors thrown by 'createHdAccount'
+data CreateHdAccountError =
+    -- | The specified wallet could not be found
+    CreateHdAccountUnknown UnknownHdRoot
+
+-- | Errors thrown by 'createHdAddress'
+data CreateHdAddressError =
+    -- | Account not found
+    CreateHdAddressUnknown UnknownHdAccount
+
+    -- | Address already used
+  | CreateHdAddressExists HdAddressId
+
+deriveSafeCopy 1 'base ''CreateHdRootError
+deriveSafeCopy 1 'base ''CreateHdAccountError
+deriveSafeCopy 1 'base ''CreateHdAddressError
+
+{-------------------------------------------------------------------------------
+  CREATE
+-------------------------------------------------------------------------------}
+
+-- | Create a new wallet
+--
+-- The encrypted secret key of the wallet is assumed to be stored elsewhere in
+-- some kind of secure key storage; here we ask for the hash of the public key
+-- only (i.e., a 'HdRootId'). It is the responsibility of the caller to use the
+-- 'BackupPhrase' and (optionally) the 'SpendingPassword' to create a new key
+-- add it to the key storage. This is important, beacuse these are secret
+-- bits of information that should never end up in the DB log.
+--
+-- NOTE: The wallet initially has no accounts (see 'createHdAccount').
+createHdRoot :: HdRootId
+             -> WalletName
+             -> HasSpendingPassword
+             -> AssuranceLevel
+             -> InDb Core.Timestamp
+             -> Update' HdRoots CreateHdRootError ()
+createHdRoot rootId name hasPass assurance created = do
+    exists <- gets $ Map.member rootId
+    when exists $ throwError $ CreateHdRootExists rootId
+    at rootId .= Just hdRoot
+  where
+    hdRoot :: HdRoot
+    hdRoot = HdRoot {
+          _hdRootName        = name
+        , _hdRootHasPassword = hasPass
+        , _hdRootAssurance   = assurance
+        , _hdRootCreatedAt   = created
+        , _hdRootAccounts    = Map.empty
+        }
+
+-- | Create a new account in the specified wallet
+--
+-- It is the responsibility of the caller to check the wallet's spending
+-- password.
+--
+-- TODO: If any key derivation is happening when creating accounts, should we
+-- store a public key or an address or something?
+createHdAccount :: HdRootId
+                -> AccountName
+                -> Checkpoint
+                -> Update' HdRoots CreateHdAccountError AccountIx
+createHdAccount rootId name checkpoint =
+    zoomHdRootId CreateHdAccountUnknown rootId $
+    zoom hdRootAccounts $ do
+      numAccounts <- gets Map.size
+      let accIx = AccountIx (fromIntegral numAccounts)
+      at accIx .= Just hdAccount
+      return accIx
+  where
+    hdAccount :: HdAccount
+    hdAccount = HdAccount {
+          _hdAccountName        = name
+        , _hdAccountAddresses   = Map.empty
+        , _hdAccountCheckpoints = checkpoint :| []
+        }
+
+-- | Create a new address in the specified account
+--
+-- Since the DB does not contain the private key of the wallet, we cannot
+-- do the actual address derivation here; this will be the responsibility of
+-- the caller (which will require the use of the spending password, if
+-- one exists).
+--
+-- Similarly, it will be the responsibility of the caller to pick a random
+-- address index, as we do not have access to a random number generator here.
+createHdAddress :: HdAddressId
+                -> InDb Core.Address
+                -> Update' HdRoots CreateHdAddressError ()
+createHdAddress addrId@(HdAddressId accId addrIx) address =
+    zoomHdAccountId CreateHdAddressUnknown accId $
+    zoom hdAccountAddresses $ do
+      exists <- gets $ Map.member addrIx
+      when exists $ throwError $ CreateHdAddressExists addrId
+      at addrIx .= Just hdAddress
+  where
+    hdAddress :: HdAddress
+    hdAddress = HdAddress {
+          _hdAddressAddress  = address
+        , _hdAddressIsUsed   = error "TODO"
+        , _hdAddressIsChange = error "TODO"
+        }

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -140,6 +140,6 @@ createHdAddress addrId address = do
     hdAddress = HdAddress {
           _hdAddressId       = addrId
         , _hdAddressAddress  = address
-        , _hdAddressIsUsed   = error "TODO"
-        , _hdAddressIsChange = error "TODO"
+        , _hdAddressIsUsed   = error "TODO: _hdAddressIsUsed"
+        , _hdAddressIsChange = error "TODO: _hdAddressIsChange"
         }

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
@@ -1,0 +1,31 @@
+-- | DELETE operatiosn on HD wallets
+module Cardano.Wallet.Kernel.DB.HdWallet.Delete (
+    deleteHdRoot
+  , deleteHdAccount
+  ) where
+
+import           Universum
+
+import           Control.Lens (at, (.=))
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.HdWallet
+
+{-------------------------------------------------------------------------------
+  DELETE
+
+  NOTE:
+
+  * There is no 'deleteAddress'.
+-------------------------------------------------------------------------------}
+
+-- | Delete a wallet
+deleteHdRoot :: HdRootId -> Update' HdRoots Void ()
+deleteHdRoot rootId = at rootId .= Nothing
+
+-- | Delete an account
+deleteHdAccount :: HdAccountId -> Update' HdRoots UnknownHdRoot ()
+deleteHdAccount (HdAccountId rootId accIx) =
+    zoomHdRootId identity rootId $
+    zoom hdRootAccounts $
+      at accIx .= Nothing

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
@@ -8,24 +8,17 @@ import           Universum
 
 import           Control.Lens (at, (.=))
 
-import           Cardano.Wallet.Kernel.DB.AcidStateUtil
 import           Cardano.Wallet.Kernel.DB.HdWallet
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
 
 {-------------------------------------------------------------------------------
   DELETE
-
-  NOTE:
-
-  * There is no 'deleteAddress'.
 -------------------------------------------------------------------------------}
 
 -- | Delete a wallet
-deleteHdRoot :: HdRootId -> Update' HdRoots Void ()
-deleteHdRoot rootId = at rootId .= Nothing
+deleteHdRoot :: HdRootId -> Update' HdWallets Void ()
+deleteHdRoot rootId = zoom hdWalletsRoots $ at rootId .= Nothing
 
 -- | Delete an account
-deleteHdAccount :: HdAccountId -> Update' HdRoots UnknownHdRoot ()
-deleteHdAccount (HdAccountId rootId accIx) =
-    zoomHdRootId identity rootId $
-    zoom hdRootAccounts $
-      at accIx .= Nothing
+deleteHdAccount :: HdAccountId -> Update' HdWallets UnknownHdRoot ()
+deleteHdAccount accId = zoom hdWalletsAccounts $ at accId .= Nothing

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Delete.hs
@@ -16,7 +16,7 @@ import           Cardano.Wallet.Kernel.DB.Util.AcidState
 -------------------------------------------------------------------------------}
 
 -- | Delete a wallet
-deleteHdRoot :: HdRootId -> Update' HdWallets Void ()
+deleteHdRoot :: HdRootId -> Update' HdWallets e ()
 deleteHdRoot rootId = zoom hdWalletsRoots $ at rootId .= Nothing
 
 -- | Delete an account

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
@@ -1,0 +1,150 @@
+-- | READ queries on the HD wallet
+--
+-- NOTE: These are pure functions, which are intended to work on a snapshot
+-- of the database. They are intended to support the V1 wallet API.
+--
+-- Filtering and sorting will be the responsibility of the next layer up.
+module Cardano.Wallet.Kernel.DB.HdWallet.Read (
+    -- | All wallets/accounts/addresses
+    readHdRoots
+  , readHdAccounts
+  , readHdAddresses
+    -- | Accumulate all accounts/addresses
+  , readAllHdAccounts
+  , readAllHdAddresses
+    -- | Single wallets/accounts/addresses
+  , readHdRoot
+  , readHdAccount
+  , readHdAddress
+  ) where
+
+import           Universum
+
+import qualified Data.Map as Map
+
+import           Pos.Core (Coin)
+
+import           Cardano.Wallet.Kernel.DB.HdWallet
+
+{-------------------------------------------------------------------------------
+  Infrastructure
+-------------------------------------------------------------------------------}
+
+-- | Query on a HD wallet
+type HdQuery a = HdRoots -> a
+
+-- | Like 'HdQuery', but with the possibility of errors
+type HdQueryErr e a = HdQuery (Either e a)
+
+{-------------------------------------------------------------------------------
+  Internal functions
+-------------------------------------------------------------------------------}
+
+hdRootsInfo :: HdRoots -> Map HdRootId (HdRoot, Integer)
+hdRootsInfo =
+    map aux
+  where
+    aux :: HdRoot -> (HdRoot, Integer)
+    aux hdRoot = (hdRoot, hdRootBalance hdRoot)
+
+hdAccountsInfo :: HdRootId -> HdRoot -> Map HdAccountId (HdAccount, Coin)
+hdAccountsInfo rootId =
+    mapKeysVals onKeys onVals . view hdRootAccounts
+  where
+    onKeys :: AccountIx -> HdAccountId
+    onKeys = HdAccountId rootId
+
+    onVals :: HdAccount -> (HdAccount, Coin)
+    onVals hdAccount = (hdAccount, hdAccountBalance hdAccount)
+
+hdAddressesInfo :: HdAccountId -> HdAccount -> Map HdAddressId HdAddress
+hdAddressesInfo accId =
+    Map.mapKeysMonotonic onKeys . view hdAccountAddresses
+  where
+    onKeys :: AddressIx -> HdAddressId
+    onKeys = HdAddressId accId
+
+{-------------------------------------------------------------------------------
+  Information about all wallets/accounts/addresses
+-------------------------------------------------------------------------------}
+
+-- | Meta information and total balance of all wallets
+readHdRoots :: HdQuery (Map HdRootId (HdRoot, Integer))
+readHdRoots = hdRootsInfo
+
+-- | Meta-information and total balance of all accounts in the given wallet
+readHdAccounts :: HdRootId
+               -> HdQueryErr UnknownHdRoot (Map HdAccountId (HdAccount, Coin))
+readHdAccounts rootId =
+      fmap (hdAccountsInfo rootId . fst)
+    . readHdRoot rootId
+
+-- | Meta-information about the addresses in an account
+readHdAddresses :: HdAccountId
+                -> HdQueryErr UnknownHdAccount (Map HdAddressId HdAddress)
+readHdAddresses accId =
+      fmap (hdAddressesInfo accId . fst)
+    . readHdAccount accId
+
+{-------------------------------------------------------------------------------
+  Accumulate across wallets/accounts
+-------------------------------------------------------------------------------}
+
+-- | Meta-information and total balance of /all/ accounts
+readAllHdAccounts :: HdQuery (Map HdAccountId (HdAccount, Coin))
+readAllHdAccounts =
+      Map.unions
+    . map (uncurry hdAccountsInfo)
+    . Map.toList . map fst
+    . readHdRoots
+
+-- | Meta-information and total balance of /all/ addresses
+readAllHdAddresses :: HdQuery (Map HdAddressId HdAddress)
+readAllHdAddresses =
+      Map.unions
+    . map (uncurry hdAddressesInfo)
+    . Map.toList . map fst
+    . readAllHdAccounts
+
+{-------------------------------------------------------------------------------
+  Information about a single wallet/address/account
+-------------------------------------------------------------------------------}
+
+-- | Meta information and total balance of the given wallet
+readHdRoot :: HdRootId -> HdQueryErr UnknownHdRoot (HdRoot, Integer)
+readHdRoot rootId =
+      aux . Map.lookup rootId
+    . readHdRoots
+  where
+    aux :: Maybe a -> Either UnknownHdRoot a
+    aux = maybe (Left (UnknownHdRoot rootId)) Right
+
+-- | Meta-information and balance of the given account
+readHdAccount :: HdAccountId -> HdQueryErr UnknownHdAccount (HdAccount, Coin)
+readHdAccount accId@(HdAccountId rootId _) =
+      either (Left . embedUnknownHdRoot) (aux . Map.lookup accId)
+    . readHdAccounts rootId
+  where
+    aux :: Maybe a -> Either UnknownHdAccount a
+    aux = maybe (Left (UnknownHdAccount accId)) Right
+
+-- | Meta-information about an address
+--
+-- We do NOT compute or cache a per-address balance.
+readHdAddress :: HdAddressId -> HdQueryErr UnknownHdAddress HdAddress
+readHdAddress addrId@(HdAddressId accId _) =
+      either (Left . embedUnknownHdAccount) (aux . Map.lookup addrId)
+    . readHdAddresses accId
+  where
+    aux :: Maybe a -> Either UnknownHdAddress a
+    aux = maybe (Left (UnknownHdAddress addrId)) Right
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+-- | Map both the keys and the values of a map
+--
+-- NOTE: Uses 'mapKeysMonotonic'; see side conditions.
+mapKeysVals :: (k1 -> k2) -> (a -> b) -> Map k1 a -> Map k2 b
+mapKeysVals onKeys onVals = map onVals . Map.mapKeysMonotonic onKeys

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
@@ -9,8 +9,8 @@ import           Universum
 
 import           Control.Lens ((.=))
 
-import           Cardano.Wallet.Kernel.DB.AcidStateUtil
 import           Cardano.Wallet.Kernel.DB.HdWallet
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
 
 {-------------------------------------------------------------------------------
   UPDATE
@@ -18,21 +18,21 @@ import           Cardano.Wallet.Kernel.DB.HdWallet
 
 updateHdRootAssurance :: HdRootId
                       -> AssuranceLevel
-                      -> Update' HdRoots UnknownHdRoot ()
+                      -> Update' HdWallets UnknownHdRoot ()
 updateHdRootAssurance rootId assurance =
     zoomHdRootId identity rootId $
       hdRootAssurance .= assurance
 
 updateHdRootName :: HdRootId
                  -> WalletName
-                 -> Update' HdRoots UnknownHdRoot ()
+                 -> Update' HdWallets UnknownHdRoot ()
 updateHdRootName rootId name =
     zoomHdRootId identity rootId $
       hdRootName .= name
 
 updateHdAccountName :: HdAccountId
                     -> AccountName
-                    -> Update' HdRoots UnknownHdAccount ()
+                    -> Update' HdWallets UnknownHdAccount ()
 updateHdAccountName accId name =
     zoomHdAccountId identity accId $
       hdAccountName .= name

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Update.hs
@@ -1,0 +1,38 @@
+-- | UPDATE operations on HD wallets
+module Cardano.Wallet.Kernel.DB.HdWallet.Update (
+    updateHdRootAssurance
+  , updateHdRootName
+  , updateHdAccountName
+  ) where
+
+import           Universum
+
+import           Control.Lens ((.=))
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.HdWallet
+
+{-------------------------------------------------------------------------------
+  UPDATE
+-------------------------------------------------------------------------------}
+
+updateHdRootAssurance :: HdRootId
+                      -> AssuranceLevel
+                      -> Update' HdRoots UnknownHdRoot ()
+updateHdRootAssurance rootId assurance =
+    zoomHdRootId identity rootId $
+      hdRootAssurance .= assurance
+
+updateHdRootName :: HdRootId
+                 -> WalletName
+                 -> Update' HdRoots UnknownHdRoot ()
+updateHdRootName rootId name =
+    zoomHdRootId identity rootId $
+      hdRootName .= name
+
+updateHdAccountName :: HdAccountId
+                    -> AccountName
+                    -> Update' HdRoots UnknownHdAccount ()
+updateHdAccountName accId name =
+    zoomHdAccountId identity accId $
+      hdAccountName .= name

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
@@ -34,42 +34,42 @@ makeLenses ''InDb
 -------------------------------------------------------------------------------}
 
 instance SafeCopy (InDb Core.Utxo) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.Utxo)"
+  putCopy = error "TODO: putCopy for (InDb Core.Utxo)"
 
 -- TODO: This is really a UTxO again..
 instance SafeCopy (InDb (NonEmpty (Core.TxIn, Core.TxOutAux))) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb (NonEmpty (Core.TxIn, Core.TxOutAux)))"
+  putCopy = error "TODO: putCopy for (InDb (NonEmpty (Core.TxIn, Core.TxOutAux)))"
 
 instance SafeCopy (InDb Core.Timestamp) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.Timestamp)"
+  putCopy = error "TODO: putCopy for (InDb Core.Timestamp)"
 
 instance SafeCopy (InDb Core.Address) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.Address)"
+  putCopy = error "TODO: putCopy for (InDb Core.Address)"
 
 instance SafeCopy (InDb (Core.AddressHash Core.PublicKey)) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb (Core.AddressHash Core.PublicKey))"
+  putCopy = error "TODO: putCopy for (InDb (Core.AddressHash Core.PublicKey))"
 
 instance SafeCopy (InDb Core.Coin) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.Coin)"
+  putCopy = error "TODO: putCopy for (InDb Core.Coin)"
 
 instance SafeCopy (InDb (Map Core.TxId Core.TxAux)) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb (Map Core.TxId Core.TxAux))"
+  putCopy = error "TODO: putCopy for (InDb (Map Core.TxId Core.TxAux))"
 
 instance SafeCopy (InDb Core.TxAux) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.TxAux)"
+  putCopy = error "TODO: putCopy for (InDb Core.TxAux)"
 
 instance SafeCopy (InDb Core.TxIn) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb Core.TxIn)"
+  putCopy = error "TODO: putCopy for (InDb Core.TxIn)"
 
 instance SafeCopy (InDb (Map Core.TxId Core.SlotId)) where
-  getCopy = error "TODO"
-  putCopy = error "TODO"
+  getCopy = error "TODO: getCopy for (InDb (Map Core.TxId Core.SlotId))"
+  putCopy = error "TODO: putCopy for (InDb (Map Core.TxId Core.SlotId))"

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
@@ -1,0 +1,75 @@
+module Cardano.Wallet.Kernel.DB.InDb (
+    InDb(..)
+  , fromDb
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+import           Data.SafeCopy (SafeCopy (..))
+
+import qualified Pos.Core   as Core
+import qualified Pos.Crypto as Core
+import qualified Pos.Txp    as Core
+
+{-------------------------------------------------------------------------------
+  Wrap core types so that we can make independent serialization decisions
+-------------------------------------------------------------------------------}
+
+-- | Wrapped type (with potentially different 'SafeCopy' instance)
+newtype InDb a = InDb { _fromDb :: a }
+  deriving (Eq, Ord)
+
+instance Functor InDb where
+  fmap f = InDb . f . _fromDb
+
+instance Applicative InDb where
+  pure = InDb
+  InDb f <*> InDb x = InDb (f x)
+
+makeLenses ''InDb
+
+{-------------------------------------------------------------------------------
+  Specific SafeCopy instances
+-------------------------------------------------------------------------------}
+
+instance SafeCopy (InDb Core.Utxo) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+-- TODO: This is really a UTxO again..
+instance SafeCopy (InDb (NonEmpty (Core.TxIn, Core.TxOutAux))) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb Core.Timestamp) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb Core.Address) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb (Core.AddressHash Core.PublicKey)) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb Core.Coin) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb (Map Core.TxId Core.TxAux)) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb Core.TxAux) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb Core.TxIn) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+instance SafeCopy (InDb (Map Core.TxId Core.SlotId)) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Resolved.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Resolved.hs
@@ -1,0 +1,61 @@
+-- | Resolved blocks and transactions
+module Cardano.Wallet.Kernel.DB.Resolved (
+    -- * Resolved blocks and transactions
+    ResolvedInput
+  , ResolvedTx(..)
+  , ResolvedBlock(..)
+    -- ** Lenses
+  , rtxInputs
+  , rtxOutputs
+  , rbTxs
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+import qualified Pos.Txp as Core
+
+import           Cardano.Wallet.Kernel.DB.InDb
+
+{-------------------------------------------------------------------------------
+  Resolved blocks and transactions
+-------------------------------------------------------------------------------}
+
+-- | Resolved input
+--
+-- A transaction input @(h, i)@ points to the @i@th output of the transaction
+-- with hash @h@, which is not particularly informative. The corresponding
+-- 'ResolvedInput' is obtained by looking up what that output actually is.
+type ResolvedInput = Core.TxOutAux
+
+-- | (Unsigned) transaction with inputs resolved
+--
+-- NOTE: We cannot recover the original transaction from a 'ResolvedTx'.
+-- Any information needed inside the wallet kernel must be explicitly
+-- represented here.
+data ResolvedTx = ResolvedTx {
+      -- | Transaction inputs
+      _rtxInputs  :: InDb (NonEmpty (Core.TxIn, ResolvedInput))
+
+      -- | Transaction outputs
+    , _rtxOutputs :: InDb Core.Utxo
+    }
+
+-- | (Unsigned block) containing resolved transactions
+--
+-- NOTE: We cannot recover the original block from a 'ResolvedBlock'.
+-- Any information needed inside the wallet kernel must be explicitly
+-- represented here.
+data ResolvedBlock = ResolvedBlock {
+      -- | Transactions in the block
+      _rbTxs  :: [ResolvedTx]
+    }
+
+makeLenses ''ResolvedTx
+makeLenses ''ResolvedBlock
+
+deriveSafeCopy 1 'base ''ResolvedTx
+deriveSafeCopy 1 'base ''ResolvedBlock

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec.hs
@@ -1,0 +1,87 @@
+-- | Wallet state as mandated by the wallet specification
+module Cardano.Wallet.Kernel.DB.Spec (
+    -- * Wallet state as mandated by the spec
+    Pending(..)
+  , Checkpoint(..)
+  , Checkpoints
+    -- ** Lenses
+  , pendingTransactions
+  , checkpointUtxo
+  , checkpointUtxoBalance
+  , checkpointExpected
+  , checkpointPending
+  , checkpointBlockMeta
+    -- ** Lenses into the current checkpoint
+  , currentCheckpoint
+  , currentUtxo
+  , currentUtxoBalance
+  , currentExpected
+  , currentPending
+  , currentBlockMeta
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+import qualified Pos.Txp as Core
+
+import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.BlockMeta
+
+{-------------------------------------------------------------------------------
+  Wallet state as mandated by the spec
+-------------------------------------------------------------------------------}
+
+-- | Pending transactions
+data Pending = Pending {
+      _pendingTransactions :: InDb (Map Core.TxId Core.TxAux)
+    }
+
+-- | Per-wallet state
+--
+-- This is the same across all wallet types.
+data Checkpoint = Checkpoint {
+      _checkpointUtxo        :: InDb Core.Utxo
+    , _checkpointUtxoBalance :: InDb Core.Coin
+    , _checkpointExpected    :: InDb Core.Utxo
+    , _checkpointPending     :: Pending
+    , _checkpointBlockMeta   :: BlockMeta
+    }
+
+-- | List of checkpoints
+type Checkpoints = NonEmpty Checkpoint
+
+makeLenses ''Pending
+makeLenses ''Checkpoint
+
+deriveSafeCopy 1 'base ''Pending
+deriveSafeCopy 1 'base ''Checkpoint
+
+{-------------------------------------------------------------------------------
+  Lenses for accessing current checkpoint
+-------------------------------------------------------------------------------}
+
+currentCheckpoint :: Lens' Checkpoints Checkpoint
+currentCheckpoint = neHead
+
+currentUtxo        :: Lens' Checkpoints Core.Utxo
+currentUtxoBalance :: Lens' Checkpoints Core.Coin
+currentExpected    :: Lens' Checkpoints Core.Utxo
+currentPending     :: Lens' Checkpoints Pending
+currentBlockMeta   :: Lens' Checkpoints BlockMeta
+
+currentUtxo        = currentCheckpoint . checkpointUtxo        . fromDb
+currentUtxoBalance = currentCheckpoint . checkpointUtxoBalance . fromDb
+currentExpected    = currentCheckpoint . checkpointExpected    . fromDb
+currentPending     = currentCheckpoint . checkpointPending
+currentBlockMeta   = currentCheckpoint . checkpointBlockMeta
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+neHead :: Lens' (NonEmpty a) a
+neHead f (x :| xs) = (:| xs) <$> f x

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
@@ -1,0 +1,75 @@
+-- | UPDATE operations on the wallet-spec state
+module Cardano.Wallet.Kernel.DB.Spec.Update (
+    -- * Errors
+    NewPendingFailed(..)
+    -- * Updates
+  , newPending
+  , applyBlock
+  , switchToFork
+  ) where
+
+import           Universum
+
+import           Data.SafeCopy (base, deriveSafeCopy)
+
+import qualified Pos.Core as Core
+
+import           Cardano.Wallet.Kernel.DB.AcidStateUtil
+import           Cardano.Wallet.Kernel.DB.BlockMeta
+import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.Resolved
+import           Cardano.Wallet.Kernel.DB.Spec
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+-- | Errors thrown by 'newPending'
+data NewPendingFailed =
+    -- | Some inputs are not in the wallet utxo
+    NewPendingInputUnavailable (InDb (Core.TxIn))
+
+deriveSafeCopy 1 'base ''NewPendingFailed
+
+{-------------------------------------------------------------------------------
+  Wallet spec mandated updates
+-------------------------------------------------------------------------------}
+
+-- | Insert new pending transaction into the specified wallet
+--
+-- NOTE: Transactions to be inserted must be fully constructed and signed; we do
+-- not offer input selection at this layer. Instead, callers must get a snapshot
+-- of the database, construct a transaction asynchronously, and then finally
+-- submit the transaction. It is of course possible that the state of the
+-- database has changed at this point, possibly making the generated transaction
+-- invalid; 'newPending' therefore returns whether or not the transaction could
+-- be inserted. If this fails, the process must be started again. This is
+-- important for a number of reasons:
+--
+-- * Input selection may be an expensive computation, and we don't want to
+--   lock the database while input selection is ongoing.
+-- * Transactions may be signed off-site (on a different machine or on a
+--   a specialized hardware device).
+-- * We do not actually have access to the key storage inside the DB layer
+--   (and do not store private keys) so we cannot actually sign transactions.
+newPending :: InDb (Core.TxAux)
+           -> Update' Checkpoints NewPendingFailed ()
+newPending _tx = error "TODO"
+
+-- | Apply a block to /all/ wallets' UTxO.
+--
+-- Ideally the block is prefiltered (see 'prefilter').
+applyBlock :: (ResolvedBlock, BlockMeta) -> Update' Checkpoints Void ()
+applyBlock (_resolvedBlock, _blockMeta) = error "TODO"
+
+-- | Rollback
+--
+-- This is an internal function only, and not exported. See 'switchToFork'.
+rollback :: Update' Checkpoints Void ()
+rollback = error "TODO"
+
+-- | Switch to a fork
+switchToFork :: Int                           -- ^ Number of blocks to rollback
+             -> [(ResolvedBlock, BlockMeta)]  -- ^ Blocks to apply
+             -> Update' Checkpoints Void ()
+switchToFork n blocks = replicateM_ n rollback >> mapM_ applyBlock blocks

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
@@ -14,11 +14,11 @@ import           Data.SafeCopy (base, deriveSafeCopy)
 
 import qualified Pos.Core as Core
 
-import           Cardano.Wallet.Kernel.DB.AcidStateUtil
 import           Cardano.Wallet.Kernel.DB.BlockMeta
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Resolved
 import           Cardano.Wallet.Kernel.DB.Spec
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
 
 {-------------------------------------------------------------------------------
   Errors

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
@@ -1,0 +1,59 @@
+-- | Transaction metadata conform the wallet specification
+module Cardano.Wallet.Kernel.DB.TxMeta (
+    -- * Transaction metadata
+    TxMeta(..)
+    -- ** Lenses
+  , txMetaId
+  , txMetaAmount
+  , txMetaInputs
+  , txMetaOutputs
+  , txMetaCreationAt
+  , txMetaIsLocal
+  , txMetaIsOutgoing
+  ) where
+
+import           Universum
+
+import           Control.Lens.TH (makeLenses)
+
+import qualified Pos.Core as Core
+
+{-------------------------------------------------------------------------------
+  Transaction metadata
+-------------------------------------------------------------------------------}
+
+-- | Transaction metadata
+--
+-- NOTE: This does /not/ live in the acid-state database (and consequently
+-- does not need a 'SafeCopy' instance), because this will grow without bound.
+data TxMeta = TxMeta {
+      -- | Transaction ID
+      _txMetaId         :: Core.TxId
+
+      -- | Total amount
+      --
+      -- TODO: What does this mean?
+    , _txMetaAmount     :: Core.Coin
+
+      -- | Transaction inputs
+    , _txMetaInputs     :: NonEmpty (Core.Address, Core.Coin)
+
+      -- | Transaction outputs
+    , _txMetaOutputs    :: NonEmpty (Core.Address, Core.Coin)
+
+      -- | Transaction creation time
+    , _txMetaCreationAt :: Core.Timestamp
+
+      -- | Is this a local transaction?
+      --
+      -- A transaction is local when /all/ of its inputs and outputs are
+      -- to and from addresses owned by this wallet.
+    , _txMetaIsLocal    :: Bool
+
+      -- | Is this an outgoing transaction?
+      --
+      -- A transaction is outgoing when it decreases the wallet's balance.
+    , _txMetaIsOutgoing :: Bool
+    }
+
+makeLenses ''TxMeta

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/IxSet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/IxSet.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE RankNTypes      #-}
+
+-- | Infrastructure for working with indexed sets
+module Cardano.Wallet.Kernel.DB.Util.IxSet (
+    -- * Primary keys
+    HasPrimKey(..)
+  , OrdByPrimKey -- opaque
+    -- * Wrapper around IxSet
+  , IndicesOf
+  , IxSet
+  , Indexable
+    -- * Building 'Indexable' instances
+  , ixFun
+  , ixList
+    -- ** Queries
+  , getEQ
+  , member
+  , size
+    -- ** Construction
+  , fromList
+  , traverse
+  ) where
+
+import           Universum hiding (traverse)
+
+import qualified Control.Lens as Lens
+import           Data.Coerce (coerce)
+import qualified Data.Foldable
+import qualified Data.IxSet.Typed as IxSet
+import           Data.SafeCopy (SafeCopy (..))
+import qualified Data.Traversable
+
+{-------------------------------------------------------------------------------
+  Primary keys
+-------------------------------------------------------------------------------}
+
+-- | Type equipped with a primary key
+--
+-- The key assumption is that such types can be compared for equality and
+-- sorted using their primary key only.
+class Ord (PrimKey a) => HasPrimKey a where
+  type PrimKey a :: *
+  primKey :: a -> PrimKey a
+
+-- | Newtype wrapper around a type that uses the type's primary key for
+-- equality and ordering comparisons.
+--
+-- Unfortunately we cannot keep this type entirely internally, since we need
+-- it in 'Indexable' instances. TODO: Is that fixable?
+newtype OrdByPrimKey a = WrapOrdByPrimKey { unwrapOrdByPrimKey :: a }
+
+instance HasPrimKey a => Eq (OrdByPrimKey a) where
+  (==) = (==) `on` (primKey . unwrapOrdByPrimKey)
+
+instance HasPrimKey a => Ord (OrdByPrimKey a) where
+  compare = compare `on` (primKey . unwrapOrdByPrimKey)
+
+{-------------------------------------------------------------------------------
+  Wrap IxSet
+-------------------------------------------------------------------------------}
+
+-- | Static set of indices per type
+type family IndicesOf (a :: *) :: [*]
+
+-- | Wrapper around IxSet
+--
+-- This is an 'IxSet' with a fixed set of indices ('IndicesOf') as well as
+-- a primary key.
+--
+-- NOTE: This module is intended as a replacement for an import of "Data.IxSet",
+-- so we use the same names as "Data.IxSet" uses.
+newtype IxSet a = WrapIxSet {
+      unwrapIxSet :: IxSet.IxSet (PrimKey a ': IndicesOf a) (OrdByPrimKey a)
+    }
+
+-- | Evidence that the specified indices are in fact available
+type Indexable a = IxSet.Indexable (PrimKey a ': IndicesOf a) (OrdByPrimKey a)
+
+-- | Evidence that something is an index
+type IsIndexOf ix a = IxSet.IsIndexOf ix (PrimKey a ': IndicesOf a)
+
+{-------------------------------------------------------------------------------
+  Safecopy
+-------------------------------------------------------------------------------}
+
+instance SafeCopy a => SafeCopy (IxSet a) where
+  getCopy = error "TODO"
+  putCopy = error "TODO"
+
+{-------------------------------------------------------------------------------
+  Building 'Indexable' instances
+-------------------------------------------------------------------------------}
+
+ixFun :: Ord ix => (a -> [ix]) -> IxSet.Ix ix (OrdByPrimKey a)
+ixFun f = IxSet.ixFun (f . unwrapOrdByPrimKey)
+
+ixList :: ( HasPrimKey a
+          , IxSet.MkIxList ixs (PrimKey a : ixs) (OrdByPrimKey a) r
+          )
+       => r
+ixList = IxSet.ixList (ixFun ((:[]) . primKey))
+
+{-------------------------------------------------------------------------------
+  Lens instances for the primary key
+-------------------------------------------------------------------------------}
+
+type instance Lens.Index   (IxSet a) = PrimKey a
+type instance Lens.IxValue (IxSet a) = a
+
+instance (HasPrimKey a, Indexable a) => Lens.Ixed (IxSet a) where
+  ix pk f (WrapIxSet s) =
+      case IxSet.getOne (IxSet.getEQ pk s) of
+        Nothing -> pure $ WrapIxSet s
+        Just a  -> upd <$> f (unwrapOrdByPrimKey a)
+    where
+      upd :: a -> IxSet a
+      upd a = WrapIxSet $ IxSet.updateIx pk (WrapOrdByPrimKey a) s
+
+instance (HasPrimKey a, Indexable a) => Lens.At (IxSet a) where
+  at pk f (WrapIxSet s) =
+      upd <$> f (unwrapOrdByPrimKey <$> IxSet.getOne (IxSet.getEQ pk s))
+    where
+      upd :: Maybe a -> IxSet a
+      upd Nothing  = WrapIxSet $ IxSet.deleteIx pk                      s
+      upd (Just a) = WrapIxSet $ IxSet.updateIx pk (WrapOrdByPrimKey a) s
+
+{-------------------------------------------------------------------------------
+  Standard and @universum@ type class instances
+-------------------------------------------------------------------------------}
+
+type instance Element (IxSet a) = a
+
+instance ToList (IxSet a) where
+    toList = coerce . IxSet.toList . unwrapIxSet
+    null   = IxSet.null . unwrapIxSet
+
+instance Foldable IxSet where
+    foldr f e = foldr f e . toList
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+getEQ :: (Indexable a, IsIndexOf ix a) => ix -> IxSet a -> IxSet a
+getEQ ix = WrapIxSet . IxSet.getEQ ix . unwrapIxSet
+
+member :: (HasPrimKey a, Indexable a) => PrimKey a -> IxSet a -> Bool
+member pk = isJust . view (Lens.at pk)
+
+size :: IxSet a -> Int
+size = IxSet.size . unwrapIxSet
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | Construct set from a list
+fromList :: Indexable a => [a] -> IxSet a
+fromList = WrapIxSet . IxSet.fromList . coerce
+
+-- | Traverse over an 'IxSet'
+--
+-- TODO: We could assume that @f@ does not change the primary key of the
+-- elements. In such a case we can avoid the conversions.
+traverse :: (Applicative f, Indexable a)
+         => (a -> f a) -> IxSet a -> f (IxSet a)
+traverse f = fmap fromList . Data.Traversable.traverse f . toList

--- a/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
@@ -20,7 +20,9 @@ import           Pos.Txp.Toil.Types (Utxo)
 import           Pos.Wallet.Web.Tracking.Decrypt (WalletDecrCredentials, eskToWalletDecrCredentials,
                                                   selectOwnAddresses)
 
-import           Cardano.Wallet.Kernel.Types (ResolvedBlock(..), ResolvedTx(..))
+import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
+import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock, ResolvedTx, rbTxs, rtxInputs,
+                                                    rtxOutputs)
 
 {-------------------------------------------------------------------------------
  Pre-filter Tx Inputs and Outputs to those that belong to the given Wallet.
@@ -49,7 +51,7 @@ prefilterBlock esk block = PrefilteredBlock {
   where
     inpss :: [[(TxIn, TxOutAux)]]
     outss :: [Utxo]
-    (inpss, outss) = unzip $ map (prefilterTx wdc) (rbTxs block)
+    (inpss, outss) = unzip $ map (prefilterTx wdc) (block ^. rbTxs)
 
     wdc :: WalletDecrCredentials
     wdc = eskToWalletDecrCredentials esk
@@ -58,8 +60,8 @@ prefilterTx :: WalletDecrCredentials
             -> ResolvedTx
             -> ([(TxIn, TxOutAux)], Utxo)
 prefilterTx wdc tx = (
-      ourResolvedTxPairs wdc (toList (rtxInputs  tx))
-    , ourUtxo_           wdc         (rtxOutputs tx)
+      ourResolvedTxPairs wdc (toList (tx ^. rtxInputs  . fromDb))
+    , ourUtxo_           wdc         (tx ^. rtxOutputs . fromDb)
     )
 
 ourResolvedTxPairs :: WalletDecrCredentials

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -5,20 +5,20 @@ module Cardano.Wallet.WalletLayer.Kernel
     , bracketActiveWallet
     ) where
 
-import           Pos.Core (HasConfiguration)
-import           System.Wlog (Severity)
 import           Universum
 
-import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..))
+import           Data.Maybe (fromJust)
+import           System.Wlog (Severity)
 
-import qualified Cardano.Wallet.Kernel as Kernel
-import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 import           Pos.Block.Types (Blund, Undo (..))
+import           Pos.Core (HasConfiguration)
 import           Pos.Util.Chrono (NE, OldestFirst (..))
 
-import           Cardano.Wallet.Kernel.Types (RawResolvedBlock (..), ResolvedBlock (..),
-                                              fromRawResolvedBlock)
-import           Data.Maybe (fromJust)
+import qualified Cardano.Wallet.Kernel as Kernel
+import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock)
+import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
+import           Cardano.Wallet.Kernel.Types (RawResolvedBlock (..), fromRawResolvedBlock)
+import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..))
 
 -- | Initialize the passive wallet.
 -- The passive wallet cannot send new transactions.

--- a/wallet-new/test/unit/UTxO/Interpreter.hs
+++ b/wallet-new/test/unit/UTxO/Interpreter.hs
@@ -32,6 +32,7 @@ import           Formatting (bprint, shown)
 import           Prelude (Show (..))
 
 import           Cardano.Wallet.Kernel.Types
+import           Cardano.Wallet.Kernel.DB.Resolved
 
 import           Pos.Block.Logic
 import           Pos.Client.Txp


### PR DESCRIPTION
NOTE: This is really only a single commit, but it depends on https://github.com/input-output-hk/cardano-sl/pull/2779 .

This provides the design of the acid-state layer. There are still some holes in the implementation but the layer itself is spec'ed out and can be reviewed. This PR makes no changes to existing code (provides no integration), but provides a whole series of new modules under the `Cardano.Wallet.Kernel.DB.*` module prefix. 

Once this PR is merged, this closes https://iohk.myjetbrains.com/youtrack/issue/CSL-2105 , but also https://iohk.myjetbrains.com/youtrack/issue/CSL-2409 , https://iohk.myjetbrains.com/youtrack/issue/CSL-2408 and https://iohk.myjetbrains.com/youtrack/issue/CSL-2411 .