### PR TITLE
[CSL-2487] Implement WalletPassiveLayer for transactions

### DIFF
--- a/crypto/Pos/Crypto/Hashing.hs
+++ b/crypto/Pos/Crypto/Hashing.hs
@@ -15,6 +15,7 @@ module Pos.Crypto.Hashing
        , AbstractHash (..)
        , decodeAbstractHash
        , decodeHash
+       , encodeHash
        , abstractHash
        , unsafeAbstractHash
        , unsafeMkAbstractHash
@@ -133,6 +134,13 @@ decodeAbstractHash prettyHash = do
 -- | Parses given hash in base16 form.
 decodeHash :: Bi (Hash a) => Text -> Either Text (Hash a)
 decodeHash = decodeAbstractHash @Blake2b_256
+
+-- | Encodes the hash in text.
+encodeHash
+    :: (HashAlgorithm algo, Bi a)
+    => AbstractHash algo a
+    -> Text
+encodeHash = B16.encode . ByteArray.convert
 
 -- | Encode thing as 'Binary' data and then wrap into constructor.
 abstractHash

--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
@@ -66,7 +66,8 @@ newTransaction submitTx Payment {..} = do
     cTx <- V0.newPaymentBatch submitTx spendingPw batchPayment
     single <$> migrate cTx
 
-
+-- TODO(ks): Why do we have a @Maybe WalletId@?
+-- At least that shouldn't be optional.
 allTransactions
     :: forall ctx m. (V0.MonadWalletHistory ctx m)
     => Maybe WalletId

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -33,6 +33,7 @@ module Cardano.Wallet.API.V1.Types (
   , WalletId (..)
   , WalletOperation (..)
   , SpendingPassword
+  , WalletRestorationStatus (..)
   -- * Addresses
   , AddressValidity (..)
   -- * Accounts
@@ -790,6 +791,23 @@ instance BuildableSafeGen Wallet where
 
 instance Buildable [Wallet] where
     build = bprint listJson
+
+-- | This is something we could easily expose in the
+-- future since it seems to be an important information
+-- for the user.
+data WalletRestorationStatus
+    = WalletRestoring
+    | WalletNotRestoring
+    deriving (Show, Eq, Generic)
+
+instance Buildable WalletRestorationStatus where
+    build WalletRestoring       = "WalletRestoring"
+    build WalletNotRestoring    = "WalletNotRestoring"
+
+deriveJSON Serokell.defaultOptions ''WalletRestorationStatus
+
+instance Arbitrary WalletRestorationStatus where
+    arbitrary = oneof [pure WalletRestoring, pure WalletNotRestoring]
 
 --------------------------------------------------------------------------------
 -- Addresses

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -28,25 +28,32 @@ bracketPassiveWallet logFunction =
     -- | TODO(ks): Currently not implemented!
     passiveWalletLayer _wallet =
         pure $ PassiveWalletLayer
-            { _pwlCreateWallet      = error "Not implemented!"
-            , _pwlGetWalletIds      = error "Not implemented!"
-            , _pwlGetWallet         = error "Not implemented!"
-            , _pwlUpdateWallet      = error "Not implemented!"
-            , _pwlDeleteWallet      = error "Not implemented!"
+            { _pwlCreateWallet          = error "Not implemented!"
+            , _pwlGetWalletIds          = error "Not implemented!"
+            , _pwlGetWallet             = error "Not implemented!"
+            , _pwlUpdateWallet          = error "Not implemented!"
+            , _pwlDeleteWallet          = error "Not implemented!"
 
-            , _pwlCreateAccount     = error "Not implemented!"
-            , _pwlGetAccounts       = error "Not implemented!"
-            , _pwlGetAccount        = error "Not implemented!"
-            , _pwlUpdateAccount     = error "Not implemented!"
-            , _pwlDeleteAccount     = error "Not implemented!"
+            , _pwlCreateAccount         = error "Not implemented!"
+            , _pwlGetAccounts           = error "Not implemented!"
+            , _pwlGetAccount            = error "Not implemented!"
+            , _pwlUpdateAccount         = error "Not implemented!"
+            , _pwlDeleteAccount         = error "Not implemented!"
 
-            , _pwlCreateAddress     = error "Not implemented!"
-            , _pwlGetAddresses      = error "Not implemented!"
-            , _pwlIsAddressValid    = error "Not implemented!"
+            , _pwlCreateAddress         = error "Not implemented!"
+            , _pwlGetAddresses          = error "Not implemented!"
+            , _pwlIsAddressValid        = error "Not implemented!"
+
+            , _pwlAddTx                 = error "Not implemented!"
+            , _pwlGetTxs                = error "Not implemented!"
+
+            , _pwlSetWalletRestoring    = error "Not implemented!"
+            , _pwlUnsetWalletRestoring  = error "Not implemented!"
+            , _pwlIsWalletRestoring     = error "Not implemented!"
+
+            , _pwlGetSyncState          = error "Not implemented!"
             }
 
--- | Initialize the active wallet.
--- The active wallet is allowed all.
 bracketActiveWallet
     :: forall m n a. (MonadMask m, Monad n)
     => PassiveWalletLayer n

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/QuickCheck.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/QuickCheck.hs
@@ -25,21 +25,30 @@ bracketPassiveWallet =
   where
     passiveWalletLayer :: PassiveWalletLayer n
     passiveWalletLayer = PassiveWalletLayer
-        { _pwlCreateWallet      = \_     -> liftedGen
-        , _pwlGetWalletIds      =           liftedGen
-        , _pwlGetWallet         = \_     -> liftedGen
-        , _pwlUpdateWallet      = \_ _   -> liftedGen
-        , _pwlDeleteWallet      = \_     -> liftedGen
+        { _pwlCreateWallet          = \_     -> liftedGen
+        , _pwlGetWalletIds          =           liftedGen
+        , _pwlGetWallet             = \_     -> liftedGen
+        , _pwlUpdateWallet          = \_ _   -> liftedGen
+        , _pwlDeleteWallet          = \_     -> liftedGen
 
-        , _pwlCreateAccount     = \_ _   -> liftedGen
-        , _pwlGetAccounts       = \_     -> liftedGen
-        , _pwlGetAccount        = \_ _   -> liftedGen
-        , _pwlUpdateAccount     = \_ _ _ -> liftedGen
-        , _pwlDeleteAccount     = \_ _   -> liftedGen
+        , _pwlCreateAccount         = \_ _   -> liftedGen
+        , _pwlGetAccounts           = \_     -> liftedGen
+        , _pwlGetAccount            = \_ _   -> liftedGen
+        , _pwlUpdateAccount         = \_ _ _ -> liftedGen
+        , _pwlDeleteAccount         = \_ _   -> liftedGen
 
-        , _pwlCreateAddress     = \_     -> liftedGen
-        , _pwlGetAddresses      = \_ _   -> liftedGen
-        , _pwlIsAddressValid    = \_     -> liftedGen
+        , _pwlCreateAddress         = \_     -> liftedGen
+        , _pwlGetAddresses          = \_ _   -> liftedGen
+        , _pwlIsAddressValid        = \_     -> liftedGen
+
+        , _pwlAddTx                 = \_ _ _ -> liftedGen
+        , _pwlGetTxs                = \_ _   -> liftedGen
+
+        , _pwlSetWalletRestoring    = \_     -> liftedGen
+        , _pwlUnsetWalletRestoring  = \_     -> liftedGen
+        , _pwlIsWalletRestoring     = \_     -> liftedGen
+
+        , _pwlGetSyncState          = \_     -> liftedGen
         }
 
     -- | A utility function.


### PR DESCRIPTION
## Description

Implement WalletPassiveLayer for transactions.

## Linked issue
https://iohk.myjetbrains.com/youtrack/issue/CSL-2487

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [X] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps

Not currently available.

## Screenshots (if available)

Not currently available.