### PR TITLE
Devops 798 integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,8 @@ scripts/haskell/dependencies
 
 # 'pkgs/stack2nix' is a symlink into the nix store, it can safely be ignored
 pkgs/stack2nix
-nixpkgs # in case generate.sh clones nixpkgs in here
+# in case generate.sh clones nixpkgs in here
+nixpkgs
 pkgs/result
 
 # explorer
@@ -98,3 +99,4 @@ exchange-topology.yaml
 # launch scripts
 launch_*
 result*
+*.patch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,7 @@ before_test:
 
 test_script:
   - cd "%WORK_DIR%"
+  - stack exec -- ghc-pkg recache
   - stack --verbosity warn setup --no-reinstall > nul
   # Install happy separately: https://github.com/commercialhaskell/stack/issues/3151#issuecomment-310642487. Also install cpphs because it's a build-tool and Stack can't figure out by itself that it should be installed
   - scripts\ci\appveyor-retry call stack --verbosity warn install happy cpphs

--- a/default.nix
+++ b/default.nix
@@ -104,6 +104,9 @@ let
     in
       args: pkgs.callPackage ./scripts/launch/connect-to-cluster (args // { inherit gitrev; } // walletConfig );
   other = rec {
+    demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev; };
+    walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev; };
+    buildWalletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration/build-test.nix { inherit walletIntegrationTests pkgs; };
     cardano-sl-explorer-frontend = (import ./explorer/frontend {
       inherit system config gitrev pkgs;
       cardano-sl-explorer = cardanoPkgs.cardano-sl-explorer-static;
@@ -120,6 +123,7 @@ let
       mainnetWallet = connect {};
       mainnetExplorer = connect { executable = "explorer"; };
       stagingWallet = connect { environment = "mainnet-staging"; };
+      demoWallet = connect { environment = "demo"; };
       stagingExplorer = connect { executable = "explorer"; environment = "mainnet-staging"; };
     };
     dockerImages = {

--- a/release.nix
+++ b/release.nix
@@ -42,8 +42,9 @@ let
     daedalus-bridge = supportedSystems;
   };
   nixosTests = import ./nixos-tests;
+  walletIntegrationTests = iohkPkgs.buildWalletIntegrationTests;
 in (mapTestOn platforms) // {
-  inherit stagingWalletdockerImage nixosTests;
+  inherit stagingWalletdockerImage walletIntegrationTests;
   nixpkgs = let
     wrapped = pkgs.runCommand "nixpkgs" {} ''
       ln -sv ${fixedNixpkgs} $out

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -17,14 +17,24 @@ function find_build_binary {
 }
 
 function ensure_run {
-  run_dir="$base_common/../run"
+  if [[ $1 == "" ]]
+  then
+    local run_dir="$base_common/../run"
+  else
+    run_dir=$1
+  fi
   mkdir -p "$run_dir"
 }
 
 LOGS_TIME=`date '+%F_%H%M%S'`
 
 function ensure_logs {
-  logs_dir="$base_common/../logs/$LOGS_TIME"
+  if [[ $1 == "" ]]
+  then
+    logs_dir="$base_common/../logs/$LOGS_TIME"
+  else
+    logs_dir=$1
+  fi
   mkdir -p "$logs_dir"
 }
 
@@ -34,23 +44,24 @@ function dump_path {
 }
 
 function logs {
-  ensure_logs
+  local log_file=$2
+  ensure_logs $1
 
-  local log_file=$1
   local conf_dir="$logs_dir/conf"
   local template_name="../log-configs/template-demo.yaml"
   if [[ "$LOG_TEMPLATE" != "" ]]; then
-    template_name="$LOG_TEMPLATE"
+    local template="$LOG_TEMPLATE"
+  else
+    local template_name="../log-configs/template-demo.yaml"
+    local template="$base_common/$template_name"
   fi
-  local template="$base_common/$template_name"
 
   mkdir -p "$conf_dir"
   mkdir -p "$logs_dir/dump"
 
   local conf_file="$conf_dir/$log_file.yaml"
   cat "$template" \
-    | sed "s/{{file}}/$log_file/g" \
-    > "$conf_file"
+    | sed "s|{{file}}|$logs_dir/$log_file|g" > "$conf_file"
   echo -n " --json-log=$logs_dir/node$i.json "
   echo -n " --logs-prefix $logs_dir --log-config $conf_file "
 }
@@ -152,7 +163,7 @@ function gen_kademlia_topology {
       # add explorer (as relay node)
       if [[ $j -eq $npred ]]; then
         # count port
-        local exp=($n + 1)
+        local exp=($j + 1)
         # explorers routes
         local exr="["
         for k in $(seq 0 $npred); do
@@ -178,17 +189,18 @@ function gen_kademlia_topology {
 
 function node_cmd {
   local i=$1
-  local is_stat=$2
-  local wallet_args=$3
-  local system_start=$4
-  local config_dir=$5
-  local conf_file=$6
+  local wallet_args=$2
+  local system_start=$3
+  local config_dir=$4
+  local conf_file=$5
+  local log_dir=$6
+  local run_dir=$7
   local st=''
   local reb=''
   local web=''
   local configuration=''
 
-  ensure_run
+  ensure_run $run_dir
 
   keys_args="--genesis-secret $i"
   if [[ "$CSL_PRODUCTION" != "" ]]; then
@@ -197,9 +209,6 @@ function node_cmd {
 
   if [[ $NO_REBUILD == "" ]]; then
     reb=" --rebuild-db "
-  fi
-  if [[ $is_stat != "" ]]; then
-    stats=" --stats "
   fi
   if [[ "$REPORT_SERVER" != "" ]]; then
     report_server=" --report-server $REPORT_SERVER "
@@ -235,7 +244,7 @@ function node_cmd {
   if [[ "$configuration" != "" ]]; then
     echo -n " $configuration "
   fi
-  echo -n " $(logs node$i.log) $time_lord $stats"
+  echo -n " $(logs $log_dir node$i.log) $time_lord $stats"
   echo -n " $web "
   echo -n " $report_server "
   echo -n " $wallet_args "
@@ -270,7 +279,7 @@ function bench_cmd {
   echo -n "$(find_binary cardano-auxx)"
   # This assumes that the n-1 node is the relay
   echo -n " --peer 127.0.0.1:"`get_port $((i-1))`
-  echo -n " $(logs node_auxx.log)"
+  echo -n " $(logs "" node_auxx.log)"
   echo -n " --system-start $system_start"
   echo -n " cmd --commands \"send-to-all-genesis $time $conc $delay $sendmode ./tps-sent.csv\""
   echo -n " --configuration-key bench "

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -31,6 +31,9 @@ let
       relays = "relays.awstest.iohkdev.io";
       confKey = "mainnet_dryrun_full";
     };
+    demo = {
+      confKey = "dev";
+    };
     override = {
       inherit relays confKey;
     };
@@ -64,6 +67,11 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
     echo "Deleting ${stateDir} ... "
     rm -Rf ${stateDir}
   fi
+  if [[ "$2" == "--runtime-args" ]]; then
+    RUNTIME_ARGS=$3
+  else
+    RUNTIME_ARGS=""
+  fi
 
   echo "Keeping state in ${stateDir}"
   mkdir -p ${stateDir}/logs
@@ -94,5 +102,6 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
     ${ ifWallet "--wallet-address ${walletListen}" }               \
     --ekg-server ${ekgListen} --metrics                            \
     +RTS ${ghcRuntimeArgs} -RTS                                    \
-    ${additionalNodeArgs}
+    ${additionalNodeArgs}                                          \
+    $RUNTIME_ARGS
 ''

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -1,0 +1,137 @@
+{ localLib ? import ./../../../lib.nix
+, stateDir ? localLib.maybeEnv "CARDANO_STATE_DIR" "./state-demo"
+, config ? {}
+, runWallet ? true
+, runExplorer ? false
+, numCoreNodes ? 4
+, system ? builtins.currentSystem
+, pkgs ? import localLib.fetchNixPkgs { inherit system config; }
+, gitrev ? localLib.commitIdFromGitRepo ./../../../.git
+, ghcRuntimeArgs ? "-N2 -qg -A1m -I0 -T"
+, additionalNodeArgs ? ""
+, keepAlive ? true
+}:
+
+with localLib;
+
+let
+  executables =  {
+    corenode = "${iohkPkgs.cardano-sl-node-static}/bin/cardano-node-simple";
+    wallet = "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-node";
+    integration-test = "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-integration-test";
+    keygen = "${iohkPkgs.cardano-sl-tools}/bin/cardano-keygen";
+    explorer = "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
+  };
+  demoClusterDeps = with pkgs; (with iohkPkgs; [ jq coreutils pkgs.curl gnused openssl cardano-sl-tools cardano-sl-wallet-new cardano-sl-node-static ]);
+  ifWallet = localLib.optionalString (runWallet);
+  ifKeepAlive = localLib.optionalString (keepAlive);
+  iohkPkgs = import ./../../.. { inherit config system pkgs gitrev; };
+  src = ./../../..;
+  configFiles = pkgs.runCommand "cardano-config" {} ''
+    mkdir -pv $out
+    cd $out
+    cp -vi ${iohkPkgs.cardano-sl.src + "/configuration.yaml"} configuration.yaml
+    cp -vi ${iohkPkgs.cardano-sl.src + "/mainnet-genesis-dryrun-with-stakeholders.json"} mainnet-genesis-dryrun-with-stakeholders.json
+    cp -vi ${iohkPkgs.cardano-sl.src + "/mainnet-genesis.json"} mainnet-genesis.json
+  '';
+in pkgs.writeScript "demo-cluster" ''
+  #!${pkgs.stdenv.shell}
+  export PATH=${pkgs.lib.makeBinPath demoClusterDeps}
+  # Set to 0 (passing) by default. Tests using this cluster can set this variable
+  # to force the `stop_cardano` function to exit with a different code.
+  EXIT_STATUS=0
+  source ${src + "/scripts/common-functions.sh"}
+  LOG_TEMPLATE=${src + "/log-configs/template-demo.yaml"}
+  function stop_cardano {
+    trap "" INT TERM
+    echo "Received TERM!"
+    echo "Stopping Cardano core nodes"
+    for pid in ''${core_pid[@]}
+    do
+      echo killing pid $pid
+      kill $pid
+    done
+    ${ifWallet ''
+      echo killing wallet pid $wallet_pid
+    kill $wallet_pid
+    ''}
+    wait
+    echo "Stopped all Cardano processes, exiting with code $EXIT_STATUS!"
+    exit $EXIT_STATUS
+  }
+  system_start=$((`date +%s` + 15))
+  echo "Using system start time "$system_start
+
+
+
+  # Remove previous state
+  rm -rf ${stateDir}
+  mkdir -p ${stateDir}
+  echo "Creating genesis keys..."
+  cardano-keygen --system-start 0 generate-keys-by-spec --genesis-out-dir ${stateDir}/genesis-keys --configuration-file ${configFiles}/configuration.yaml
+
+  echo "Generating Topology"
+  gen_kademlia_topology ${builtins.toString (numCoreNodes + 1)} ${stateDir}
+
+  trap "stop_cardano" INT TERM
+  echo "Launching a demo cluster..."
+  for i in {0..${builtins.toString (numCoreNodes - 1)}}
+  do
+    node_args="$(node_cmd $i "" "$system_start" "${stateDir}" "" "${stateDir}/logs" "${stateDir}") --configuration-file ${configFiles}/configuration.yaml"
+    echo Launching core node $i with args: $node_args
+    cardano-node-simple $node_args &> /dev/null &
+    core_pid[$i]=$!
+
+  done
+  ${ifWallet ''
+    export LC_ALL=en_GB.UTF-8
+    if [ ! -d ${stateDir}/tls-files ]; then
+      mkdir -p ${stateDir}/tls-files
+      openssl req -x509 -newkey rsa:2048 -keyout ${stateDir}/tls-files/server.key -out ${stateDir}/tls-files/server.crt -days 30 -nodes -subj "/CN=localhost"
+    fi
+    echo Launching wallet node:
+    i=${builtins.toString numCoreNodes}
+    wallet_args=" --tlscert ${stateDir}/tls-files/server.crt --tlskey ${stateDir}/tls-files/server.key --tlsca ${stateDir}/tls-files/server.crt"
+    # TODO: remove wallet-debug and use TLS when the tests support it
+    wallet_args="$wallet_args --wallet-address 127.0.0.1:8090 --wallet-db-path ${stateDir}/wallet-db --wallet-debug"
+    node_args="$(node_cmd $i "$wallet_args" "$system_start" "${stateDir}" "" "${stateDir}/logs" "${stateDir}") --configuration-file ${configFiles}/configuration.yaml"
+    echo Running wallet with args: $node_args
+    cardano-node $node_args &> /dev/null &
+    wallet_pid=$!
+  ''}
+  # Query node info until synced
+  SYNCED=0
+  while [[ $SYNCED != 100 ]]
+  do
+    # TODO: switch to https when wallet-debug is removed
+    PERC=$(curl --silent -k http://localhost:8090/api/v1/node-info | jq .data.syncProgress.quantity)
+    if [[ $PERC == "100" ]]
+    then
+      echo Blockchain Synced: $PERC%
+      SYNCED=100
+    elif [[ $SYNCED -ge 10 ]]
+    then
+      echo Blockchain Syncing: $PERC%
+      echo "Sync Failed, Exiting!"
+      EXIT_STATUS=1
+      stop_cardano
+    else
+      echo Blockchain Syncing: $PERC%
+      SYNCED=$((SYNCED + 1))
+      sleep 5
+    fi
+  done
+  echo Blockchain Synced: $PERC%
+  # import keys
+  echo "Importing poor HD keys/wallet..."
+
+  for i in {0..11}
+  do
+      echo "Importing key$i.sk ..."
+      # TODO: switch to https when wallet-debug is removed
+      curl -k -X POST http://localhost:8090/api/wallets/keys -H 'cache-control: no-cache' -H 'content-type: application/json' -d "\"${stateDir}/genesis-keys/generated-keys/poor/key$i.sk\"" | jq .
+  done
+  ${ifKeepAlive ''
+    sleep infinity
+  ''}
+''

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -56,7 +56,7 @@ if [[ $config_dir == "" ]]; then
   echo $(pwd)
   gen_kademlia_topology $n
 fi
-
+run_dir=$config_dir
 
 # Stats are not mandatory either
 stats=$4
@@ -136,7 +136,7 @@ while [[ $i -lt $panesCnt ]]; do
       if [[ $WALLET_CONFIG != "" ]]; then
           conf_file=$WALLET_CONFIG
       fi
-      wallet_args=" --tlscert $base/../tls-files/server.crt --tlskey $base/../tls-files/server.key --tlsca $base/../tls-files/ca.crt $wallet_flush" # --wallet-rebuild-db'
+      wallet_args=" --tlscert $config_dir/tls-files/server.crt --tlskey $config_dir/tls-files/server.key --tlsca $config_dir/tls-files/ca.crt $wallet_flush" # --wallet-rebuild-db'
       wallet_args="$WALLET_EXTRA_ARGS $wallet_args --wallet-address 127.0.0.1:8090"
       exec_name="$WALLET_EXE_NAME"
       if [[ $WALLET_DEBUG != "" ]]; then
@@ -144,13 +144,13 @@ while [[ $i -lt $panesCnt ]]; do
       fi
   fi
   if [[ $i -lt $n ]]; then
-    node_args="$(node_cmd $i "$stats" "$wallet_args" "$system_start" "$config_dir" "$conf_file")"
+    node_args="$(node_cmd $i "$wallet_args" "$system_start" "$config_dir" "$conf_file" "$run_dir" "$run_dir/logs")"
     node_=$(find_binary $exec_name)
     if [[ $WALLET_TEST != "" ]] && [[ $i == $((n-1)) ]]; then
         updater_file="$config_dir/updater$i.sh"
         launcher_=$(find_binary cardano-launcher)
 
-        ensure_run
+        ensure_run $run_dir
 
         full_node_args="$node_args $reb $no_ntp $keys_args $rts_opts"
 

--- a/scripts/test/wallet/integration/build-test.nix
+++ b/scripts/test/wallet/integration/build-test.nix
@@ -1,0 +1,13 @@
+{pkgs, stdenv, walletIntegrationTests }:
+stdenv.mkDerivation rec {
+  name = "cardano-wallet-integration-tests";
+  buildInputs = with pkgs; [ jq curl ];
+  buildCommand = ''
+    ${walletIntegrationTests}
+    if [ $? == 0 ]
+    then
+      echo $? > $out
+    fi
+  '';
+
+}

--- a/scripts/test/wallet/integration/default.nix
+++ b/scripts/test/wallet/integration/default.nix
@@ -1,0 +1,30 @@
+{ localLib ? import ./../../../../lib.nix
+, config ? {}
+, numCoreNodes ? 4
+, stateDir ? localLib.maybeEnv "CARDANO_STATE_DIR" "./state-demo"
+, system ? builtins.currentSystem
+, pkgs ? import localLib.fetchNixPkgs { inherit system config; }
+, gitrev ? "123456" # Dummy git revision to prevent mass rebuilds
+, ghcRuntimeArgs ? "-N2 -qg -A1m -I0 -T"
+, additionalNodeArgs ? ""
+}:
+
+with localLib;
+
+let
+  demo-cluster = iohkPkgs.demoCluster.override {
+    inherit gitrev numCoreNodes stateDir;
+    keepAlive = false;
+  };
+  executables =  {
+    integration-test = "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-integration-test";
+  };
+  iohkPkgs = import ./../../../.. { inherit config system pkgs gitrev; };
+in pkgs.writeScript "integration-tests" ''
+  source ${demo-cluster}
+  mkdir -p scripts
+  cp -r ${stateDir}/tls-files scripts/tls-files
+  ${executables.integration-test}
+  EXIT_STATUS=$?
+  stop_cardano
+''


### PR DESCRIPTION
## Description

Adds nix framework for launching demo cluster and running integration tests.

Remaining issues:
* derivation in release.nix that hydra can build for any code changes that could affect tests.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-798

## Type of change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
`nix-shell --pure --run $(nix-build -A walletIntegrationTests)` runs the script exiting with status code of integration tests script

`nix-shell --pure --run $(nix-build -A demoCluster)` launches cluster and keeps running until you hit `ctrl-c`

`nix-build -A buildWalletIntegrationTests` runs tests in build environment isolated from network. Builds are cached so it will just return the derivation if it doesn't need to rebuild.

Note: it's expected to fail the tests because of a broken test case that @parsonsmatt is working on.

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
