### PR TITLE
Feature/csl2444 posttransaction invariants

### DIFF
--- a/wallet-new/integration/Error.hs
+++ b/wallet-new/integration/Error.hs
@@ -13,10 +13,11 @@ import           Universum
 import qualified Data.Text.Buildable
 import           Formatting (bprint, stext, (%))
 
-import           Cardano.Wallet.API.V1.Types (Account, Address, EstimatedFees, Transaction, Wallet,
-                                              WalletAddress)
+import           Cardano.Wallet.API.V1.Types (Account, Address, EstimatedFees, Transaction, V1,
+                                              Wallet, WalletAddress)
 
 import           Cardano.Wallet.Client (ClientError)
+import qualified Pos.Core as Core
 
 
 data WalletTestError
@@ -37,6 +38,8 @@ data WalletTestError
 
     | InvalidTransactionState Transaction
     | InvalidTransactionFee EstimatedFees
+    | UnexpectedAddressBalance WalletAddress WalletAddress
+    | CantFindAddress (V1 Core.Address)
     | LocalTransactionsDiffer [Transaction] [Transaction]
     | LocalTransactionMissing Transaction [Transaction]
 
@@ -57,6 +60,8 @@ showConstr = \case
     LocalAddressDiffer {} -> "LocalAddressDiffer"
     InvalidTransactionState {} -> "InvalidTransactionState"
     InvalidTransactionFee {} -> "InvalidTransactionFee"
+    UnexpectedAddressBalance {} -> "UnexpectedAddressBalance"
+    CantFindAddress {} -> "CantFindAddress"
     LocalTransactionsDiffer {} -> "LocalTransactionsDiffer"
     LocalTransactionMissing {} -> "LocalTransactionMissing"
 
@@ -80,6 +85,8 @@ instance Buildable WalletTestError where
 
     build (InvalidTransactionState t)     = bprint ("Transaction state is invalid. Transaction - ("%stext%")") (show t)
     build (InvalidTransactionFee   f)     = bprint ("Transaction fees are invalid - ("%stext%")") (show f)
+    build (UnexpectedAddressBalance b a)  = bprint ("Unexpected address balance before ("%stext%") and after ("%stext%")") (show b) (show a)
+    build (CantFindAddress a)  = bprint ("Can't find address ("%stext%") before and/or after transaction") (show a)
     build (LocalTransactionsDiffer t t')  = bprint ("Local transactions differs - ("%stext%"), ("%stext%")") (show t) (show t')
     build (LocalTransactionMissing t ts)  = bprint ("Local transaction ("%stext%") missing from txs history ("%stext%")") (show t) (show ts)
 

--- a/wallet-new/integration/Error.hs
+++ b/wallet-new/integration/Error.hs
@@ -38,6 +38,7 @@ data WalletTestError
 
     | InvalidTransactionState Transaction
     | InvalidTransactionFee EstimatedFees
+    | UnexpectedChangeAddress [WalletAddress]
     | UnexpectedAddressBalance WalletAddress WalletAddress
     | CantFindAddress (V1 Core.Address)
     | LocalTransactionsDiffer [Transaction] [Transaction]
@@ -60,6 +61,7 @@ showConstr = \case
     LocalAddressDiffer {} -> "LocalAddressDiffer"
     InvalidTransactionState {} -> "InvalidTransactionState"
     InvalidTransactionFee {} -> "InvalidTransactionFee"
+    UnexpectedChangeAddress {} -> "UnexpectedChangeAddress"
     UnexpectedAddressBalance {} -> "UnexpectedAddressBalance"
     CantFindAddress {} -> "CantFindAddress"
     LocalTransactionsDiffer {} -> "LocalTransactionsDiffer"
@@ -85,6 +87,7 @@ instance Buildable WalletTestError where
 
     build (InvalidTransactionState t)     = bprint ("Transaction state is invalid. Transaction - ("%stext%")") (show t)
     build (InvalidTransactionFee   f)     = bprint ("Transaction fees are invalid - ("%stext%")") (show f)
+    build (UnexpectedChangeAddress a)  = bprint ("Unexpected change address after transaction ("%stext%")") (show a)
     build (UnexpectedAddressBalance b a)  = bprint ("Unexpected address balance before ("%stext%") and after ("%stext%")") (show b) (show a)
     build (CantFindAddress a)  = bprint ("Can't find address ("%stext%") before and/or after transaction") (show a)
     build (LocalTransactionsDiffer t t')  = bprint ("Local transactions differs - ("%stext%"), ("%stext%")") (show t) (show t')

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -35,7 +35,7 @@ import           Cardano.Wallet.Client (ClientError (..), Response (..), Servant
                                         WalletClient (..), getAccounts, getAddressIndex,
                                         getTransactionIndex, getWallets, hoistClient)
 
-import           Pos.Core (getCoin, mkCoin)
+import           Pos.Core (getCoin, mkCoin, unsafeAddCoin, unsafeSubCoin)
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 
 import           Error
@@ -512,7 +512,9 @@ runAction wc action = do
 
             -- Check the transaction.
             log $ "postTransaction: " <> ppShowT newPayment
+            addressesBeforeTransaction <- respToRes $ getAddressIndex wc
             newTx  <-  respToRes $ postTransaction wc newPayment
+            addressesAfterTransaction <- respToRes $ getAddressIndex wc
 
             let sumCoins f =
                     sum . map (getCoin . unV1 . pdAmount) . toList $ f newTx
@@ -527,25 +529,39 @@ runAction wc action = do
             let actualFees = V1 . mkCoin $ inputSum - outputSum
 
             -- Estimated fees should correspond to actual fees
-            -- TODO(akegalj): add custom error type
             checkInvariant
                 (feeEstimatedAmount txFees == actualFees)
-                (InvalidTransactionState newTx)
+                (InvalidTransactionFee txFees)
 
             let changeAddress = toList (txOutputs newTx) \\ toList paymentDestinations
                 -- NOTE: instead of this manual conversion we could filter WalletAddress from getAddressIndex
                 pdToChangeAddress PaymentDistribution{..} = WalletAddress pdAddress pdAmount True True
+                realChangeAddressId = map addrId addressesAfterTransaction \\ map addrId addressesBeforeTransaction
+                changeWalletAddresses = filter ((`elem` realChangeAddressId) . addrId) addressesAfterTransaction
 
-            -- We expect at most one extra PaymentDestination which should be a change address
-            -- TODO(akegalj): add custom error type
+            -- We expect at most one extra PaymentDestination which should be a change address. Also at most one address should be added after transaction - which should be the same change address
+            -- All change addresses should set up a flag addrChangeAddress
+            -- TODO(akegalj): create custom error type
             checkInvariant
-                (length changeAddress <= 1)
+                (length changeAddress <= 1 && map pdAddress changeAddress == realChangeAddressId && and (map addrChangeAddress changeWalletAddresses))
                 (InvalidTransactionState newTx)
 
-            -- TODO(akegalj): add invariant that checks is there paymentDestinations distributions in newTx
-            -- TODO(akegalj): add invariant that checks is paymentSource the only source of newTx
-            -- TODO(akegalj): add invariant that checks did accounts of all payment destinations increase by expected amount
-            -- TODO(akegalj): add invariant that checks did accounts of all payment sources decrease by expected amount
+            let checkWalletAddressAfter diffList expectedOperation =
+                    forM_ diffList $ \PaymentDistribution{..} -> do
+                        let beforePayment = find ((pdAddress ==) . addrId) addressesBeforeTransaction
+                            afterPayment = find ((pdAddress ==) . addrId) addressesAfterTransaction
+                            balanceBeforePaymentModified = V1 . expectedOperation (unV1 pdAmount) . unV1 . addrBalance <$> beforePayment
+                            balanceAfterPayment = addrBalance <$> afterPayment
+                        checkInvariant
+                            (isJust beforePayment && balanceBeforePaymentModified == balanceAfterPayment)
+                            (InvalidTransactionState newTx)
+
+            -- Check did addresses of all payment sources decrease by expected amount after transaction
+            checkWalletAddressAfter (txInputs newTx) $ flip unsafeSubCoin
+
+            -- Check did addresses of all payment destinations increase by expected amount after transaction
+            -- NOTE: we are using paymentDestinations instead of txOutputs to eliminate changeAddress
+            checkWalletAddressAfter paymentDestinations unsafeAddCoin
 
             -- Modify wallet state accordingly.
             transactions  <>= [(accountSource, newTx)]

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -541,13 +541,12 @@ runAction wc action = do
 
             -- We expect at most one extra PaymentDestination which should be a change address. Also at most one address should be added after transaction - which should be the same change address
             -- All change addresses should set up a flag addrChangeAddress
-            -- TODO(akegalj): create custom error type
             checkInvariant
                 ( length changeAddress <= 1
                   && map pdAddress changeAddress == realChangeAddressId
                   && and (map addrChangeAddress changeWalletAddresses)
                 )
-                (InvalidTransactionState newTx)
+                (UnexpectedChangeAddress changeWalletAddresses)
 
             let checkWalletAddressAfter diffList expectedOperation = do
                     log "checking expected addresses balances..."

--- a/wallet-new/integration/Functions.hs
+++ b/wallet-new/integration/Functions.hs
@@ -544,7 +544,7 @@ runAction wc action = do
             checkInvariant
                 ( length changeAddress <= 1
                   && map pdAddress changeAddress == realChangeAddressId
-                  && and (map addrChangeAddress changeWalletAddresses)
+                  && all addrChangeAddress changeWalletAddresses
                 )
                 (UnexpectedChangeAddress changeWalletAddresses)
 

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -1047,8 +1047,8 @@ instance BuildableSafeGen EstimatedFees where
 -- | Maps an 'Address' to some 'Coin's, and it's
 -- typically used to specify where to send money during a 'Payment'.
 data PaymentDistribution = PaymentDistribution {
-      pdAddress :: V1 (Core.Address)
-    , pdAmount  :: V1 (Core.Coin)
+      pdAddress :: !(V1 Core.Address)
+    , pdAmount  :: !(V1 Core.Coin)
     } deriving (Show, Ord, Eq, Generic)
 
 deriveJSON Serokell.defaultOptions ''PaymentDistribution


### PR DESCRIPTION
## Description

Add stronger invariants to `PostTransaction` integration test. Most significantly:
 * added invariant that checks did transaction input/output addresses after transaction change by expected amount
 * added stronger invariant for change address
 * increased error verbosity

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2444

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

running ` ./scripts/test/wallet/integration.sh` should show `PostTransaction` is executing without problems

## Screenshots (if available)
```
$ stack exec cardano-integration-test
...
[TEST-LOG] Successfully run 7 out of 11 actions
[TEST-LOG] Successful actions counts: [(GetAddresses,1),(GetAddress,1),(PostTransaction,4),(NoOp,1)]
[TEST-LOG] Skipped actions: [PostWallet,GetWallets,GetWallet,DeleteWallet,UpdateWallet,UpdateWalletPass,PostAccount,GetAccounts,GetAccount,DeleteAccount,UpdateAccount,PostAddress,GetTransaction]
...
```
Example above shows `PostTransaction` has been executed successfully 4 times.