### PR TITLE
cardano-sl-wallet-new.cabal: Fix cabal build warning

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -408,6 +408,7 @@ test-suite wallet-new-specs
                     MarshallingSpec
                     SwaggerSpec
                     RequestSpec
+                    WalletHandlersSpec
 
                     Cardano.Wallet.API.Development.Helpers
                     Cardano.Wallet.API.Development.LegacyHandlers


### PR DESCRIPTION
Fixes the following warning when building with stack
```
wallet-new/cardano-sl-wallet-new.cabal:
             - In wallet-new-specs component:
                 WalletHandlersSpec- In wallet-new-specs component:
                 WalletHandlersSpec- In wallet-new-specs component:
                 WalletHandlersSpec- In wallet-new-specs component:
                 WalletHandlersSpec- In wallet-new-specs component:
                 WalletHandlersSpec
         
         Missing modules in the cabal file are likely to cause undefined
         reference errors from the linker, along with other problems.
```