### PR TITLE
[CSL-2431] Change error in V1 when mnemonic phrase had already been used

### DIFF
--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -58,7 +58,8 @@ newWallet NewWallet{..} = do
                               <*> pure 0
     let walletInit = V0.CWalletInit initMeta backupPhrase
     single <$> do
-        v0wallet <- newWalletHandler newwalOperation spendingPassword walletInit `catch` rethrowDuplicateMnemonic
+        v0wallet <- newWalletHandler newwalOperation spendingPassword walletInit
+                        `catch` rethrowDuplicateMnemonic
         ss <- V0.askWalletSnapshot
         addWalletInfo ss v0wallet
   where

--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -19,6 +19,7 @@ import           Pos.Update.Configuration ()
 
 import           Pos.Util (HasLens (..))
 import qualified Pos.Wallet.WalletMode as V0
+import qualified Pos.Wallet.Web.Error.Types as V0
 import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogic, MonadWalletLogicRead)
 import           Pos.Wallet.Web.Tracking.Types (SyncQueue)
 import           Servant
@@ -57,9 +58,17 @@ newWallet NewWallet{..} = do
                               <*> pure 0
     let walletInit = V0.CWalletInit initMeta backupPhrase
     single <$> do
-        v0wallet <- newWalletHandler newwalOperation spendingPassword walletInit
+        v0wallet <- newWalletHandler newwalOperation spendingPassword walletInit `catch` rethrowDuplicateMnemonic
         ss <- V0.askWalletSnapshot
         addWalletInfo ss v0wallet
+  where
+    -- NOTE: this is temporary solution until we get rid of V0 error handling and/or we lift error handling into types:
+    --   https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183469153
+    --   https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183472103
+    rethrowDuplicateMnemonic (e :: V0.WalletError) =
+        case e of
+            V0.RequestError "Wallet with that mnemonics already exists" -> throwM $ WalletAlreadyExists "Can't create a wallet. The wallet already exists."
+            _ -> throwM e
 
 -- | Returns the full (paginated) list of wallets.
 listWallets :: ( MonadThrow m

--- a/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/server/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -67,7 +67,7 @@ newWallet NewWallet{..} = do
     --   https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183472103
     rethrowDuplicateMnemonic (e :: V0.WalletError) =
         case e of
-            V0.RequestError "Wallet with that mnemonics already exists" -> throwM $ WalletAlreadyExists "Can't create a wallet. The wallet already exists."
+            V0.RequestError "Wallet with that mnemonics already exists" -> throwM WalletAlreadyExists
             _ -> throwM e
 
 -- | Returns the full (paginated) list of wallets.

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -59,7 +59,8 @@ data WalletError =
     | UnknownError { weMsg :: !Text }
     | InvalidAddressFormat { weMsg :: !Text }
     | WalletNotFound
-    | WalletAlreadyExists { weExists :: !Text }
+    -- FIXME(akegalj): https://iohk.myjetbrains.com/youtrack/issue/CSL-2496
+    | WalletAlreadyExists
     | AddressNotFound
     | MissingRequiredParams { requiredParams :: NonEmpty (Text, Text) }
     | WalletIsNotReadyToProcessPayments { weStillRestoring :: SyncProgress }
@@ -113,7 +114,7 @@ sample =
   , UnknownError "unknown"
   , InvalidAddressFormat "Invalid base58 representation."
   , WalletNotFound
-  , WalletAlreadyExists "Wallet with that mnemonics already exists"
+  , WalletAlreadyExists
   , AddressNotFound
   , MissingRequiredParams (("wallet_id", "walletId") :| [])
   , WalletIsNotReadyToProcessPayments sampleSyncProgress
@@ -130,7 +131,7 @@ describe = \case
   UnknownError        _                -> "Unexpected internal error."
   InvalidAddressFormat _              -> "Provided address format is not valid."
   WalletNotFound                      -> "Reference to an unexisting wallet was given."
-  WalletAlreadyExists _               -> "Can't create a wallet. The wallet already exists."
+  WalletAlreadyExists                 -> "Can't create or restore a wallet. The wallet already exists."
   AddressNotFound                     -> "Reference to an unexisting address was given."
   MissingRequiredParams _             -> "Missing required parameters in the request payload."
   WalletIsNotReadyToProcessPayments _ -> "This wallet is restoring, and it cannot send new transactions until restoration completes."

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -59,6 +59,7 @@ data WalletError =
     | UnknownError { weMsg :: !Text }
     | InvalidAddressFormat { weMsg :: !Text }
     | WalletNotFound
+    | WalletAlreadyExists { weExists :: !Text }
     | AddressNotFound
     | MissingRequiredParams { requiredParams :: NonEmpty (Text, Text) }
     | WalletIsNotReadyToProcessPayments { weStillRestoring :: SyncProgress }
@@ -112,6 +113,7 @@ sample =
   , UnknownError "unknown"
   , InvalidAddressFormat "Invalid base58 representation."
   , WalletNotFound
+  , WalletAlreadyExists "Wallet with that mnemonics already exists"
   , AddressNotFound
   , MissingRequiredParams (("wallet_id", "walletId") :| [])
   , WalletIsNotReadyToProcessPayments sampleSyncProgress
@@ -128,6 +130,7 @@ describe = \case
   UnknownError        _                -> "Unexpected internal error."
   InvalidAddressFormat _              -> "Provided address format is not valid."
   WalletNotFound                      -> "Reference to an unexisting wallet was given."
+  WalletAlreadyExists _               -> "Can't create a wallet. The wallet already exists."
   AddressNotFound                     -> "Reference to an unexisting address was given."
   MissingRequiredParams _             -> "Missing required parameters in the request payload."
   WalletIsNotReadyToProcessPayments _ -> "This wallet is restoring, and it cannot send new transactions until restoration completes."
@@ -143,6 +146,7 @@ toServantError err =
     JSONValidationFailed{}              -> err400
     UnknownError{}                      -> err500
     WalletNotFound{}                    -> err404
+    WalletAlreadyExists{}               -> err403
     InvalidAddressFormat{}              -> err401
     AddressNotFound{}                   -> err404
     MissingRequiredParams{}             -> err400

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
@@ -13,13 +13,15 @@ import           Universum
 import qualified Data.Text.Buildable
 import           Formatting (bprint, stext, (%))
 
-import           Cardano.Wallet.API.V1.Types (WalletId, AccountIndex)
+import           Cardano.Wallet.API.V1.Types (AccountIndex, WalletId)
 
 
 data WalletLayerError
     = WalletNotFound WalletId
     | AccountNotFound WalletId AccountIndex
     | AddressNotFound WalletId AccountIndex
+    -- NOTE: optionally show mnemonic of the wallet (adn thinks its a bad idea https://iohk.myjetbrains.com/youtrack/issue/CSL-2431#comment=93-19922 )
+    | WalletAlreadyExists
     deriving (Show, Eq, Generic)
 
 instance Exception WalletLayerError
@@ -28,4 +30,4 @@ instance Buildable WalletLayerError where
     build (WalletNotFound  wId      ) = bprint ("Wallet not found. Wallet id ("%stext%").") (show wId)
     build (AccountNotFound wId accIx) = bprint ("Account not found. Wallet id ("%stext%"), accound index ("%stext%").") (show wId) (show accIx)
     build (AddressNotFound wId accIx) = bprint ("Address not found. Wallet id ("%stext%"), accound index ("%stext%").") (show wId) (show accIx)
-
+    build WalletAlreadyExists         = "Can't create a wallet. The wallet already exists."

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
@@ -20,7 +20,7 @@ data WalletLayerError
     = WalletNotFound WalletId
     | AccountNotFound WalletId AccountIndex
     | AddressNotFound WalletId AccountIndex
-    -- NOTE: optionally show mnemonic of the wallet (adn thinks its a bad idea https://iohk.myjetbrains.com/youtrack/issue/CSL-2431#comment=93-19922 )
+    -- FIXME(akegalj): https://iohk.myjetbrains.com/youtrack/issue/CSL-2496
     | WalletAlreadyExists
     deriving (Show, Eq, Generic)
 
@@ -30,4 +30,4 @@ instance Buildable WalletLayerError where
     build (WalletNotFound  wId      ) = bprint ("Wallet not found. Wallet id ("%stext%").") (show wId)
     build (AccountNotFound wId accIx) = bprint ("Account not found. Wallet id ("%stext%"), accound index ("%stext%").") (show wId) (show accIx)
     build (AddressNotFound wId accIx) = bprint ("Address not found. Wallet id ("%stext%"), accound index ("%stext%").") (show wId) (show accIx)
-    build WalletAlreadyExists         = "Can't create a wallet. The wallet already exists."
+    build WalletAlreadyExists = bprint ("Can't create or restore a wallet. The wallet already exists.")

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
@@ -110,7 +110,8 @@ pwlCreateWallet NewWallet{..} = do
 
     let walletInit = CWalletInit initMeta backupPhrase
 
-    wallet      <- newWalletHandler newwalOperation spendingPassword walletInit `catch` rethrowDuplicateMnemonic
+    wallet      <- newWalletHandler newwalOperation spendingPassword walletInit
+                       `catch` rethrowDuplicateMnemonic
     wId         <- migrate $ cwId wallet
 
     -- Get wallet or throw if missing.

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
@@ -13,8 +13,8 @@ import           Control.Monad.Catch (catchAll)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
 import           Data.Coerce (coerce)
 
-import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..))
 import           Cardano.Wallet.WalletLayer.Error (WalletLayerError (..))
+import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..))
 
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 
@@ -25,19 +25,20 @@ import           Cardano.Wallet.API.V1.Types (Account, AccountIndex, AccountUpda
                                               WalletId, WalletOperation (..), WalletUpdate)
 
 import           Pos.Client.KeyStorage (MonadKeys)
-import           Pos.Crypto (PassPhrase)
 import           Pos.Core (ChainDifficulty)
+import           Pos.Crypto (PassPhrase)
 
-import           Pos.Wallet.Web.Tracking.Types (SyncQueue)
+import           Pos.Util (HasLens', maybeThrow)
 import           Pos.Wallet.Web.Account (GenSeed (..))
 import           Pos.Wallet.Web.ClientTypes.Types (CWallet (..), CWalletInit (..), CWalletMeta (..))
+import qualified Pos.Wallet.Web.Error.Types as V0
 import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogicRead)
 import qualified Pos.Wallet.Web.Methods.Logic as V0
 import           Pos.Wallet.Web.Methods.Restore (newWallet, restoreWalletFromSeed)
 import           Pos.Wallet.Web.State.State (WalletDbReader, askWalletDB, askWalletSnapshot,
                                              getWalletAddresses, setWalletMeta)
 import           Pos.Wallet.Web.State.Storage (getWalletInfo)
-import           Pos.Util (HasLens', maybeThrow)
+import           Pos.Wallet.Web.Tracking.Types (SyncQueue)
 
 -- | Let's unify all the requirements for the legacy wallet.
 type MonadLegacyWallet ctx m =
@@ -109,7 +110,7 @@ pwlCreateWallet NewWallet{..} = do
 
     let walletInit = CWalletInit initMeta backupPhrase
 
-    wallet      <- newWalletHandler newwalOperation spendingPassword walletInit
+    wallet      <- newWalletHandler newwalOperation spendingPassword walletInit `catch` rethrowDuplicateMnemonic
     wId         <- migrate $ cwId wallet
 
     -- Get wallet or throw if missing.
@@ -119,6 +120,13 @@ pwlCreateWallet NewWallet{..} = do
     newWalletHandler :: WalletOperation -> PassPhrase -> CWalletInit -> m CWallet
     newWalletHandler CreateWallet  = newWallet
     newWalletHandler RestoreWallet = restoreWalletFromSeed
+    -- NOTE: this is temporary solution until we get rid of V0 error handling and/or we lift error handling into types:
+    --   https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183469153
+    --   https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183472103
+    rethrowDuplicateMnemonic (e :: V0.WalletError) =
+        case e of
+            V0.RequestError "Wallet with that mnemonics already exists" -> throwM WalletAlreadyExists
+            _ -> throwM e
 
 
 pwlGetWalletIds


### PR DESCRIPTION
## Description

This issue:
 * changes error when trying to create a wallet with already used mnemonic
 * hides information that mnemonic is duplicated (see comment here https://iohk.myjetbrains.com/youtrack/issue/CSL-2431#comment=93-19922 )
 * adds error type to `V1.WalletError` and `WalletLayerError` for this error

By code review we are certain old `Wallet with that mnemonics already exists` error is thrown only from `V0.newWallet` and `V0.restoreWalletFromSeed` and its caught at all places. Alternativelly, to be extra safe, we could catch and modify V0 errors here https://github.com/input-output-hk/cardano-sl/blob/feature/csl2431-newwallet-error/wallet-new/server/Cardano/Wallet/Server/Plugins.hs#L142 : 
```haskell
            . try
            . fmap (join . over _Left V0ToV1Error)
  ...
  where
    V0ToV1Error (e :: V0.WalletError) =
       case e of
          Request "Error A" -> V1.ErrorA
          Request "Error B" -> V1.ErrorB
          ...     
```
but I don't believe its necessary for this single error. If there will be more examples like in this issue then this pattern might be handy. It also depends on how are we going to handle errors in future:
  * https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183469153
  * https://github.com/input-output-hk/cardano-sl/pull/2811#discussion_r183472103

Depending on is Daedalus GUI already using wallet-new, we would need to ping them about error msg change - as they depend on parsing error from backend to inform the user (at least it was like this few months ago)

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2431

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
Trying to create wallet with the same mnemonic twice:
```
curl -v -X POST http://127.0.0.1:8090/api/v1/wallets -H 'cache-control: no-cache' -H 'content-type: application/json;charset=utf-8' -d '{ "operation": "restore", "backupPhrase": [ "shell", "also", "throw", "ramp", "grape", "chest", "setup", "mandate", "spare", "verb", "lemon", "test" ], "assuranceLevel": "strict", "name": "My Wallet", "spendingPassword": null }'
```

will now return changed error type:
```
{"status":"error","diagnostic":{},"message":"WalletAlreadyExists"}
```

## Screenshots (if available)
Running integration tests will mark test as successful:
```
...
[TEST-LOG] Successfully run 9 out of 12 actions
[TEST-LOG] Successful actions counts: [(PostWallet,1),(UpdateWalletPass,1),(PostAccount,2),(DeleteAccount,1),(PostTransaction,2),(GetTransaction,1),(NoOp,1)]
[TEST-LOG] Skipped actions: [GetWallets,GetWallet,DeleteWallet,UpdateWallet,GetAccounts,GetAccount,UpdateAccount,PostAddress,GetAddresses,GetAddress]

Addresses
  Creating an address makes it available
  Index returns real data
Wallets
  Creating a wallet makes it available.
  Updating a wallet persists the update
  Creating a wallet with same mnemonics rises WalletAlreadyExists error.
  Restoring a wallet with same mnemonics rises WalletAlreadyExists error.
Transactions
  posted transactions appear in the index
  estimate fees of a well-formed transaction FAILED [1]
  fails if you spend too much money

Failures:

  integration/Main.hs:320: 
  1) Transactions estimate fees of a well-formed transaction
       predicate failed on: Left (ClientHttpError (FailureResponse (Response {responseStatusCode = Status {statusCode = 400, statusMessage = "Bad Request"}, responseBody = "{\"status\":\"error\",\"diagnostic\":{\"msg\":\"Cannot compute transaction fee: Transaction creation error: not enough money, need 155423 coin(s) more\"},\"message\":\"BadRequest\"}", responseHeaders = fromList [("Transfer-Encoding","chunked"),("Date","Tue, 24 Apr 2018 13:12:49 GMT"),("Server","Warp/3.2.13"),("Content-Type","application/json")], responseHttpVersion = HTTP/1.1})))

Randomized with seed 449759242

Finished in 14.3522 seconds
9 examples, 1 failure
```

Note that estmated fees is a failure for another yt issue (we are not dealing with that here)