### PR TITLE
Bump tmux version in demo script

### DIFF
--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -10,7 +10,7 @@ fi
 # Make sure we're using proper version of tmux.
 tmux_actual_version=$(tmux -V | awk '{print $2}')
 # All tmux versions contain two numbers only.
-tmux_proper_versions=("2.3" "2.4" "2.5" "2.6" "master")
+tmux_proper_versions=("2.3" "2.4" "2.5" "2.6" "2.7" "master")
 checker=""
 for version in "${tmux_proper_versions[@]}"; do
     if [ "${version}" == "${tmux_actual_version}" ]; then


### PR DESCRIPTION
## Description

This issue relaxes tmux version constrain in `demo.sh` script and adds `2.7` as a valid `tmux` version (recently released https://github.com/tmux/tmux/releases)

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
launching demo script or integration tests (locally or within CI) should continue to work

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
