### PR TITLE
[CSL-2488] Implement WalletPassiveLayer for settings and info.

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -64,10 +64,16 @@ library
 
   other-modules:       Cardano.Wallet.WalletLayer.Types
                        Cardano.Wallet.WalletLayer.Kernel
+
                        Cardano.Wallet.WalletLayer.Legacy
                        Cardano.Wallet.WalletLayer.Legacy.Transactions
+                       Cardano.Wallet.WalletLayer.Legacy.Settings
+                       Cardano.Wallet.WalletLayer.Legacy.Info
+
                        Cardano.Wallet.WalletLayer.QuickCheck
                        Cardano.Wallet.WalletLayer.Error
+
+                       Paths_cardano_sl_wallet_new
   ghc-options:         -Wall
   build-depends:       base
                      , QuickCheck

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Error.hs
@@ -25,6 +25,10 @@ module Cardano.Wallet.WalletLayer.Error
     , CreateTxException (..)
     , GetTxException (..)
     , FeeEstimateException (..)
+    -- settings
+    , GetSettingsException (..)
+    -- info
+    , GetInfoException (..)
     ) where
 
 import           Universum
@@ -290,4 +294,33 @@ instance Buildable FeeEstimateException where
         FeeEstimateWalletNotFound wId       -> build $ WalletNotFound wId
         FeeEstimateAccountNotFound aId      -> build $ AccountNotFound aId
         FeeEstimateAddressNotFound wAddr    -> build $ AddressNotFound wAddr
+
+------------------------------------------------------------
+-- Specific settings error handlers
+------------------------------------------------------------
+
+data GetSettingsException
+    = GetSettingsUndefined UndefinedException
+    deriving (Show, Eq, Generic)
+
+instance Exception GetSettingsException
+
+instance Buildable GetSettingsException where
+    build = \case
+        GetSettingsUndefined ue             -> build ue
+
+------------------------------------------------------------
+-- Specific info error handlers
+------------------------------------------------------------
+
+data GetInfoException
+    = GetInfoUndefined UndefinedException
+    deriving (Show, Eq, Generic)
+
+instance Exception GetInfoException
+
+instance Buildable GetInfoException where
+    build = \case
+        GetInfoUndefined ue                 -> build ue
+
 

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -47,6 +47,10 @@ bracketPassiveWallet logFunction =
             , _pwlCreateTx          = error "Not implemented!"
             , _pwlGetTxs            = error "Not implemented!"
             , _pwlEstimateFees      = error "Not implemented!"
+
+            , _pwlGetSettings       = error "Not implemented!"
+
+            , _pwlGetInfo           = error "Not implemented!"
             }
 
 -- | Initialize the active wallet.

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy.hs
@@ -16,11 +16,14 @@ import           Data.Coerce (coerce)
 import           Cardano.Wallet.WalletLayer.Error
 import           Cardano.Wallet.WalletLayer.Legacy.Transactions (pwlCreateTx, pwlEstimateFees,
                                                                  pwlGetTxs)
+import           Cardano.Wallet.WalletLayer.Legacy.Settings (getSettings)
+import           Cardano.Wallet.WalletLayer.Legacy.Info (getInfo)
+
 import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..))
 
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 
-import           Cardano.Wallet.API.V1.Migration (migrate)
+import           Cardano.Wallet.API.V1.Migration (HasConfigurations, HasCompileInfo, migrate)
 import           Cardano.Wallet.API.V1.Migration.Types ()
 import           Cardano.Wallet.API.V1.Types (Account (..), AccountIndex, AccountUpdate,
                                               AddressValidity (..), NewAccount (..),
@@ -60,6 +63,8 @@ type MonadLegacyWallet ctx m =
     , MonadKeys m
     , MonadWalletTxFull ctx m
     , MonadWalletHistory ctx m
+    , HasConfigurations
+    , HasCompileInfo
     )
 
 
@@ -110,6 +115,10 @@ passiveWalletLayer = PassiveWalletLayer
     , _pwlCreateTx          = try ... pwlCreateTx
     , _pwlGetTxs            = try ... pwlGetTxs
     , _pwlEstimateFees      = try ... pwlEstimateFees
+
+    , _pwlGetSettings       = try ... getSettings
+
+    , _pwlGetInfo           = try ... getInfo
     }
 
 ------------------------------------------------------------

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy/Info.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy/Info.hs
@@ -1,0 +1,44 @@
+module Cardano.Wallet.WalletLayer.Legacy.Info
+    ( getInfo
+    ) where
+
+import           Universum
+
+import           System.Wlog (WithLogger)
+
+import           Cardano.Wallet.API.V1.Migration
+import           Cardano.Wallet.API.V1.Types as V1
+
+import           Mockable (MonadMockable)
+import           Ntp.Client (NtpStatus)
+import           Pos.Wallet.WalletMode (MonadBlockchainInfo)
+
+import qualified Pos.Core as Core
+import qualified Pos.Wallet.Web.ClientTypes.Types as V0
+import qualified Pos.Wallet.Web.Methods.Misc as V0
+
+-- | Returns the @dynamic@ settings for this wallet node,
+-- like the local time difference (the NTP drift), the sync progress,
+-- etc.
+getInfo :: ( HasConfigurations
+           , MonadIO m
+           , WithLogger m
+           , MonadMockable m
+           , MonadBlockchainInfo m
+           )
+        => TVar NtpStatus
+        -> m NodeInfo
+getInfo ntpStatus = do
+    spV0            <- V0.syncProgress
+    syncProgress    <- migrate spV0
+    timeDifference  <- V0.localTimeDifference ntpStatus
+    pure $ NodeInfo
+        { nfoSyncProgress           = syncProgress
+        , nfoBlockchainHeight       = V1.mkBlockchainHeight . Core.getChainDifficulty <$> V0._spNetworkCD spV0
+        , nfoLocalBlockchainHeight  = V1.mkBlockchainHeight . Core.getChainDifficulty . V0._spLocalCD $ spV0
+        , nfoLocalTimeInformation   =
+            TimeInfo
+                { timeDifferenceFromNtpServer =
+                    fmap V1.mkLocalTimeDifference timeDifference
+                }
+        }

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy/Settings.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Legacy/Settings.hs
@@ -1,0 +1,29 @@
+module Cardano.Wallet.WalletLayer.Legacy.Settings
+    ( getSettings
+    ) where
+
+import           Universum
+
+import           Cardano.Wallet.API.V1.Migration
+import           Cardano.Wallet.API.V1.Types as V1
+import qualified Data.Text as T
+import           Paths_cardano_sl_wallet_new (version)
+
+import           Pos.Update.Configuration (curSoftwareVersion)
+import           Pos.Util.CompileInfo (compileInfo, ctiGitRevision)
+import           Pos.Wallet.WalletMode (MonadBlockchainInfo, blockchainSlotDuration)
+
+
+-- Returns the @static@ settings for this wallet node,
+-- like the slot duration or the current 'SoftwareVersion'.
+getSettings
+    :: forall m. (HasConfigurations, HasCompileInfo, MonadBlockchainInfo m)
+    => m NodeSettings
+getSettings = do
+    settings <- NodeSettings <$> (V1.mkSlotDuration . fromIntegral <$> blockchainSlotDuration)
+                             <*> pure (V1 curSoftwareVersion)
+                             <*> pure version
+                             <*> pure (T.replace "\n" mempty $ ctiGitRevision compileInfo)
+
+    pure settings
+

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/QuickCheck.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/QuickCheck.hs
@@ -44,6 +44,10 @@ bracketPassiveWallet =
         , _pwlCreateTx          = \_ _   -> Right <$> liftedGen
         , _pwlGetTxs            = \_ _ _ -> Right <$> liftedGen
         , _pwlEstimateFees      = \_     -> Right <$> liftedGen
+
+        , _pwlGetSettings       =           Right <$> liftedGen
+
+        , _pwlGetInfo           = \_     -> Right <$> liftedGen
         }
 
     -- | A utility function.

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Types.hs
@@ -24,6 +24,10 @@ module Cardano.Wallet.WalletLayer.Types
     , getTxs
     , estimateFees
 
+    , getSettings
+
+    , getInfo
+
     ) where
 
 
@@ -33,9 +37,10 @@ import           Control.Lens (makeLenses)
 
 import           Cardano.Wallet.API.V1.Types (Account, AccountIndex, AccountUpdate, AddressValidity,
                                               EstimatedFees, NewAccount, NewAddress, NewWallet,
-                                              Payment, Transaction, V1, Wallet, WalletAddress,
-                                              WalletId, WalletUpdate)
+                                              NodeInfo, NodeSettings, Payment, Transaction, V1,
+                                              Wallet, WalletAddress, WalletId, WalletUpdate)
 import           Pos.Core (Address, TxAux)
+import           Ntp.Client (NtpStatus)
 
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 import           Cardano.Wallet.WalletLayer.Error
@@ -67,6 +72,10 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , _pwlCreateTx       :: (TxAux -> m Bool) -> Payment -> m (Either CreateTxException Transaction)
     , _pwlGetTxs         :: Maybe WalletId -> Maybe AccountIndex -> Maybe (V1 Address) -> m (Either GetTxException [Transaction])
     , _pwlEstimateFees   :: Payment -> m (Either FeeEstimateException EstimatedFees)
+    -- * settings
+    , _pwlGetSettings    :: m (Either GetSettingsException NodeSettings)
+    -- * info
+    , _pwlGetInfo        :: TVar NtpStatus -> m (Either GetInfoException NodeInfo)
     }
 
 makeLenses ''PassiveWalletLayer
@@ -125,6 +134,14 @@ getTxs pwl = pwl ^. pwlGetTxs
 
 estimateFees :: forall m. PassiveWalletLayer m -> Payment -> m (Either FeeEstimateException EstimatedFees)
 estimateFees pwl = pwl ^. pwlEstimateFees
+
+
+getSettings :: forall m. PassiveWalletLayer m -> m (Either GetSettingsException NodeSettings)
+getSettings pwl = pwl ^. pwlGetSettings
+
+
+getInfo :: forall m. PassiveWalletLayer m -> TVar NtpStatus -> m (Either GetInfoException NodeInfo)
+getInfo pwl = pwl ^. pwlGetInfo
 
 ------------------------------------------------------------
 -- Active wallet layer


### PR DESCRIPTION
## Description

Implement WalletPassiveLayer for settings and info

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2338

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [X] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps

Not applicable.

## Screenshots (if available)

Not applicable.
