### PR TITLE
[CSL-2473] wallet evalChange test fix

### DIFF
--- a/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
@@ -119,6 +119,10 @@ evalChangeDiffAccounts :: AddressesFromDiffAccounts -> Property
 evalChangeDiffAccounts (AddressesFromDiffAccounts InpOutUsedAddresses {..}) =
    changeAddrs === HS.fromList (evalChange usedAddrs inpAddrs outAddrs False)
 
+-- | newtype defined so that its Arbitrary instance can set the stage for
+-- 'evalChangeSameAccounts'. The 'changeAddrs' field will always be set so
+-- that it should equal
+-- 'HS.fromList (evalChange usedAddrs inpAddrs outAddrs True)'.
 newtype AddressesFromSameAccounts = AddressesFromSameAccounts InpOutChangeUsedAddresses
     deriving Show
 
@@ -126,17 +130,37 @@ instance Arbitrary AddressesFromSameAccounts where
     arbitrary = do
         wId <- arbitrary
         accIdx <- arbitrary
-        let genAddrs n = map (uncurry $ WS.WAddressMeta wId accIdx) <$> vectorOf n arbitrary
-        inpAddrs <- choose (1, 5) >>= genAddrs
-        outAddrs <- choose (1, 5) >>= genAddrs
-        usedBase <- (inpAddrs ++) <$> (choose (1, 10) >>= flip vectorOf arbitrary)
+        -- generate n WAddressMeta terms each with the same wallet and account
+        -- identifier ('wId' and 'accIdx' above) subject to a predicate.
+        -- That predicate allows us to ensure that the output address
+        -- ('outAddrs') are disjiont under 'WAddressMeta' equality from the
+        -- input addresses, which is essential for the test.
+        let genAddrs pred n = vectorOf n $
+                (uncurry (WS.WAddressMeta wId accIdx) <$> arbitrary)
+                `suchThat` pred
+        inpAddrs <- choose (1, 5) >>= genAddrs (const True)
+        outAddrs <- choose (1, 5) >>= genAddrs (not . flip elem inpAddrs)
+        -- Throw on a bunch of arbitrary extra used addresses, but make sure
+        -- they are not 'WAddressMeta'-equal to any existing ones!
+        usedBase <- (inpAddrs ++) <$> (do
+            n <- choose (1, 10)
+            let allAddrs = inpAddrs ++ outAddrs
+                condition = not . flip elem allAddrs
+            vectorOf n $ arbitrary `suchThat` condition)
         (changeAddrs, extraUsed) <- oneof [
             -- Case when all outputs addresses are fresh and
-            -- weren't mentioned in the blockchain
+            -- weren't mentioned in the blockchain.
+            -- Change addresses should be empty.
             pure (mempty, [])
+            -- Otherwise, there's at least one non-change address in the
+            -- outputs. Every address that we don't put into the second
+            -- component (which goes into the set of all used) should appear as
+            -- a change address.
             , do
-                if length outAddrs == 1 then pure (mempty, [])
+                if length outAddrs == 1
+                then pure (mempty, [])
                 else do
+                    -- Problem case is when ext is all of 'outAddrs'.
                     ext <- sublistOf outAddrs `suchThat` (not . null)
                     pure (HS.fromList $ map (view WS.wamAddress) (outAddrs \\ ext), ext)
             ]


### PR DESCRIPTION
## Description

This wallet test would fail when run with seed 624026529. Also see https://iohk.myjetbrains.com/youtrack/issue/CSL-2473

If an output `WAddressMeta` is generated which is `WAddressMeta`-equal to one of the inputs, then that input, by inclusion in the set of all used addresses, will knock that output address out of qualification as a change address (the second condition, see the comment on `evalChange`). That would cause the test case to fail: it's assumed, when computing the `changeAddrs`, that the second component (`extraUsed`) will be removed from `outAddrs` to give the `changeAddrs`, when in fact the `inputAddrs` will also be removed from `outAddrs`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2473

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
