### PR TITLE
[DEVOPS-817] Fix appveyor build on release branch and bump cabal version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,7 @@ before_test:
 
 test_script:
   - cd "%WORK_DIR%"
+  - stack exec -- ghc-pkg recache
   - stack --verbosity warn setup --no-reinstall > nul
   # Install happy separately: https://github.com/commercialhaskell/stack/issues/3151#issuecomment-310642487. Also install cpphs because it's a build-tool and Stack can't figure out by itself that it should be installed
   - scripts\ci\appveyor-retry call stack --verbosity warn install happy cpphs

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-auxx
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - Auxx
 description:         Cardano SL - Auxx
 license:             MIT

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-binary
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - binary serialization
 description:         This package defines a type class for binary serialization,
                      helpers and instances.

--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-block
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - block processing
 description:         Cardano SL - block processing
 license:             MIT

--- a/client/cardano-sl-client.cabal
+++ b/client/cardano-sl-client.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-client
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL client modules
 description:         Cardano SL client modules
 license:             MIT

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-core
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - core
 description:         Cardano SL - core
 license:             MIT

--- a/crypto/cardano-sl-crypto.cabal
+++ b/crypto/cardano-sl-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-crypto
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - cryptography primitives
 description:         This package contains cryptography primitives used in Cardano SL.
 license:             MIT

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-db
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - basic DB interfaces
 description:         Cardano SL - basic DB interfaces
 license:             MIT

--- a/delegation/cardano-sl-delegation.cabal
+++ b/delegation/cardano-sl-delegation.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-delegation
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - delegation
 description:         Cardano SL - delegation
 license:             MIT

--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-explorer
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano explorer
 description:         Please see README.md
 license:             MIT

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-generator
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - arbitrary data generation
 description:         Cardano SL - arbitrary data generation
 license:             MIT

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-infra
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - infrastructural
 description:         Cardano SL - infrastructural
 license:             MIT

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL main implementation
 description:         Please see README.md
 license:             MIT

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-lrc
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - Leaders and Richmen computation
 description:         Cardano SL - Leaders and Richmen computation
 license:             MIT

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-networking
-version:             1.1.1
+version:             1.2.0
 license:             MIT
 license-file:        LICENSE
 category:            Network

--- a/node/cardano-sl-node.cabal
+++ b/node/cardano-sl-node.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-node
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL simple node executable
 description:         Please see README.md
 license:             MIT

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6952,7 +6952,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../lib;
            libraryHaskellDepends = [
              aeson ansi-terminal ansi-wl-pprint async base bytestring
@@ -7003,7 +7003,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-auxx";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../auxx;
            isLibrary = true;
            isExecutable = true;
@@ -7046,7 +7046,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-binary";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../binary;
            libraryHaskellDepends = [
              autoexporter base binary bytestring cborg containers digest
@@ -7074,7 +7074,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-block";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../block;
            libraryHaskellDepends = [
              aeson base bytestring cardano-sl-binary cardano-sl-core
@@ -7104,7 +7104,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-client";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../client;
            libraryHaskellDepends = [
              base cardano-sl cardano-sl-block cardano-sl-core cardano-sl-crypto
@@ -7141,7 +7141,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-core";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../core;
            libraryHaskellDepends = [
              aeson ansi-terminal autoexporter base base58-bytestring binary
@@ -7170,7 +7170,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-crypto";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../crypto;
            libraryHaskellDepends = [
              aeson autoexporter base binary bytestring cardano-crypto
@@ -7195,7 +7195,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-db";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../db;
            libraryHaskellDepends = [
              base bytestring cardano-sl-binary cardano-sl-core cardano-sl-crypto
@@ -7220,7 +7220,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-delegation";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../delegation;
            libraryHaskellDepends = [
              aeson base cardano-sl-binary cardano-sl-core cardano-sl-crypto
@@ -7255,7 +7255,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-explorer";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../explorer;
            isLibrary = true;
            isExecutable = true;
@@ -7308,7 +7308,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-generator";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../generator;
            libraryHaskellDepends = [
              base bytestring cardano-sl cardano-sl-block cardano-sl-client
@@ -7350,7 +7350,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-infra";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../infra;
            libraryHaskellDepends = [
              aeson base base64-bytestring bytestring cardano-report-server
@@ -7379,7 +7379,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-lrc";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../lrc;
            libraryHaskellDepends = [
              base bytestring cardano-sl-binary cardano-sl-core cardano-sl-crypto
@@ -7406,7 +7406,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-networking";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../networking;
            isLibrary = true;
            isExecutable = true;
@@ -7440,7 +7440,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-node";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../node;
            isLibrary = false;
            isExecutable = true;
@@ -7467,7 +7467,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-ssc";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../ssc;
            libraryHaskellDepends = [
              aeson array base bytestring cardano-sl-binary cardano-sl-core
@@ -7506,7 +7506,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-tools";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../tools;
            isLibrary = true;
            isExecutable = true;
@@ -7555,7 +7555,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-txp";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../txp;
            libraryHaskellDepends = [
              aeson base bytestring cardano-sl-binary cardano-sl-core
@@ -7587,7 +7587,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-update";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../update;
            libraryHaskellDepends = [
              aeson base bytestring Cabal cardano-sl-binary cardano-sl-core
@@ -7620,7 +7620,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-util";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../util;
            libraryHaskellDepends = [
              aeson autoexporter base bytestring cardano-sl-networking cborg
@@ -7657,7 +7657,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-wallet";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../wallet;
            libraryHaskellDepends = [
              acid-state aeson async base base58-bytestring bytestring cardano-sl
@@ -7710,7 +7710,7 @@ inherit (pkgs) mesa;};
          }:
          mkDerivation {
            pname = "cardano-sl-wallet-new";
-           version = "1.1.1";
+           version = "1.2.0";
            src = ./../wallet-new;
            isLibrary = true;
            isExecutable = true;

--- a/ssc/cardano-sl-ssc.cabal
+++ b/ssc/cardano-sl-ssc.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-ssc
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - shared seed computation
 description:         Cardano SL - shared seed computation
 license:             MIT

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-tools
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - Tools
 description:         Cardano SL - Tools
 license:             MIT

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-txp
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - transaction processing
 description:         Cardano SL - transaction processing
 license:             MIT

--- a/update/cardano-sl-update.cabal
+++ b/update/cardano-sl-update.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-update
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - update
 description:         Cardano SL - update
 license:             MIT

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-util
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - general utilities
 description:         This package contains utility functions not specific
                      to Cardano SL which extend 3rd party libraries or implement

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-wallet-new
-version:             1.1.1
+version:             1.2.0
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-sl/#readme

--- a/wallet/cardano-sl-wallet.cabal
+++ b/wallet/cardano-sl-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-wallet
-version:             1.1.1
+version:             1.2.0
 synopsis:            Cardano SL - wallet
 description:         Cardano SL - wallet
 license:             MIT


### PR DESCRIPTION
For the 1.2.0 release branch:

 - Applies a fix for AppVeyor builds (DEVOPS-817).
 - Bumps the cabal version so that tools report the correct version.
