### PR TITLE
Rework storage layer to store blocks and undos in the same file.

### DIFF
--- a/block/src/Pos/Block/Types.hs
+++ b/block/src/Pos/Block/Types.hs
@@ -4,7 +4,6 @@ module Pos.Block.Types
        ( SlogUndo (..)
        , Undo (..)
        , Blund
-       , SerializedBlund
 
        , LastKnownHeader
        , LastKnownHeaderTag
@@ -27,7 +26,6 @@ import           Pos.Communication.Protocol (NodeId)
 import           Pos.Core (HasConfiguration, HasDifficulty (..), HasHeaderHash (..))
 import           Pos.Core.Block (Block, BlockHeader)
 import           Pos.Core.Txp (TxpUndo)
-import           Pos.DB.Class (SerializedUndo)
 import           Pos.Delegation.Types (DlgUndo)
 import           Pos.Update.Poll.Types (USUndo)
 import           Pos.Util.Util (HasLens (..))
@@ -44,8 +42,6 @@ instance NFData Undo
 
 -- | Block and its Undo.
 type Blund = (Block, Undo)
-
-type SerializedBlund = (Block, SerializedUndo)
 
 instance HasConfiguration => Buildable Undo where
     build Undo{..} =

--- a/block/src/Pos/DB/Block.hs
+++ b/block/src/Pos/DB/Block.hs
@@ -39,23 +39,23 @@ import           Control.Lens (at)
 import qualified Data.ByteString as BS (hPut, readFile)
 import           Data.Default (Default (def))
 import           Formatting (formatToString)
-import           System.Directory (createDirectoryIfMissing, removeFile)
+import           System.Directory (createDirectoryIfMissing, doesFileExist, removeFile)
 import           System.FilePath ((</>))
 import           System.IO (IOMode (WriteMode), hClose, hFlush, openBinaryFile)
 import           System.IO.Error (IOError, isDoesNotExistError)
 
 import           Pos.Binary.Block.Types ()
-import           Pos.Binary.Class (Bi, decodeFull', serialize')
+import           Pos.Binary.Class (decodeFull', serialize')
 import           Pos.Binary.Core ()
 import           Pos.Block.BHelpers ()
-import           Pos.Block.Types (Blund, SerializedBlund, SlogUndo (..), Undo (..))
+import           Pos.Block.Types (Blund, SlogUndo (..), Undo (..))
 import           Pos.Core (HasConfiguration, HeaderHash, headerHash)
 import           Pos.Core.Block (Block, GenesisBlock)
 import qualified Pos.Core.Block as CB
 import           Pos.Crypto (hashHexF)
 import           Pos.DB.BlockIndex (deleteHeaderIndex, putHeadersIndex)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..), Serialized (..), SerializedBlock,
-                               SerializedUndo, getBlock, getDeserialized)
+                               SerializedUndo, SerializedBlund, getBlock, getDeserialized)
 import           Pos.DB.Error (DBError (..))
 import           Pos.DB.GState.Common (getTipSomething)
 import           Pos.DB.Pure (DBPureVar, MonadPureDB, atomicModifyIORefPure, pureBlocksStorage)
@@ -73,14 +73,23 @@ getUndo = getDeserialized dbGetSerUndo
 
 -- | Convenient wrapper which combines 'dbGetBlock' and 'dbGetUndo' to
 -- read 'Blund'.
+--
+-- TODO Rewrite to use a single call
 getBlund :: MonadDBRead m => HeaderHash -> m (Maybe (Block, Undo))
 getBlund x =
     runMaybeT $
     (,) <$> MaybeT (getBlock x)
         <*> MaybeT (getUndo x)
 
+-- | Store blunds into a single file.
+--
+--   Notice that this uses an unusual encoding, in order to be able to fetch
+--   either the block or the undo independently without re-encoding.
 putBlunds :: MonadDB m => NonEmpty Blund -> m ()
-putBlunds = dbPutSerBlunds . map (fmap (Serialized . serialize'))
+putBlunds = dbPutSerBlunds
+          . map (\bu@(b,_) -> ( CB.getBlockHeader b
+                              , Serialized . serialize' $ bimap serialize' serialize' bu)
+                )
 
 -- | Get 'Block' corresponding to tip.
 getTipBlock :: MonadDBRead m => m Block
@@ -94,38 +103,61 @@ getTipBlock = getTipSomething "block" getBlock
 getSerializedBlock
     :: forall ctx m. (HasConfiguration, MonadRealDB ctx m)
     => HeaderHash -> m (Maybe ByteString)
-getSerializedBlock = blockDataPath >=> getRawData
+getSerializedBlock hh = do
+    bsp <- flip getAllPaths hh . view blockDataDir <$> getNodeDBs
+    blundExists <- liftIO $ doesFileExist (bspBlund bsp)
+    if blundExists
+    then do
+      mbs <- getRawData $ bspBlund bsp
+      case mbs of
+        Nothing -> pure Nothing
+        Just ser -> eitherToThrow $ bimap DBMalformed (Just . fst)
+                    $ decodeFull' @(ByteString, ByteString) ser
+    else getRawData $ bspBlock bsp
 
 -- Get serialization of an undo data for block with given hash from Block DB.
 getSerializedUndo :: (HasConfiguration, MonadRealDB ctx m) => HeaderHash -> m (Maybe ByteString)
-getSerializedUndo = undoDataPath >=> getRawData
+getSerializedUndo  hh = do
+    bsp <- flip getAllPaths hh . view blockDataDir <$> getNodeDBs
+    blundExists <- liftIO $ doesFileExist (bspBlund bsp)
+    if blundExists
+    then do
+      mbs <- getRawData $ bspBlund bsp
+      case mbs of
+        Nothing -> pure Nothing
+        Just ser -> eitherToThrow $ bimap DBMalformed (Just . snd)
+                    $ decodeFull' @(ByteString, ByteString) ser
+    else getRawData $ bspUndo bsp
 
--- For every blund, put given block, its metadata and Undo data into
--- Block DB. This function uses 'MonadRealDB' constraint which is too
--- severe. Consider using 'dbPutBlund' instead.
+
+-- For every blund, put given block, its metadata and Undo data into Block DB.
+--
+-- TODO What does this comment mean? If the constraint isn't needed, why is it
+-- here? The referenced 'dbPutBlund' function doesn't even exist.
+--
+-- This function uses 'MonadRealDB' constraint which is too severe.
+-- Consider using 'dbPutBlund' instead.
 putSerializedBlunds
     :: (HasConfiguration, MonadRealDB ctx m, MonadDB m)
-    => NonEmpty SerializedBlund -> m ()
+    => NonEmpty (CB.BlockHeader, SerializedBlund) -> m ()
 putSerializedBlunds (toList -> bs) = do
     bdd <- view blockDataDir <$> getNodeDBs
-    let allData = map (\(b,u) -> let (dP, bP, uP) = getAllPaths bdd (headerHash b)
-                                 in (dP,(b,u,bP,uP))
+    let allData = map (\(bh,bu) -> let bsp = getAllPaths bdd (headerHash bh)
+                                    in (bspRoot bsp,(bu, bspBlund bsp))
                       )
                       bs
     forM_ (ordNub $ map fst allData) $ \dPath ->
         liftIO $ createDirectoryIfMissing False dPath
-    forM_ (map snd allData) $ \(blk,serUndo,bPath,uPath) -> do
-        putData bPath blk
-        putRawData uPath (unSerialized serUndo)
-    putHeadersIndex $ toList $ map (CB.getBlockHeader . fst) bs
+    forM_ (map snd allData) $ \(blund,buPath) -> do
+        putRawData buPath $ unSerialized blund
+    putHeadersIndex $ toList $ map fst bs
 
 deleteBlock :: (MonadRealDB ctx m, MonadDB m) => HeaderHash -> m ()
 deleteBlock hh = do
     deleteHeaderIndex hh
     bdd <- view blockDataDir <$> getNodeDBs
-    let (_, bPath, uPath) = getAllPaths bdd hh
-    deleteData bPath
-    deleteData uPath
+    let bsp = getAllPaths bdd hh
+    mapM_ deleteData [bspBlock bsp, bspUndo bsp, bspBlund bsp]
 
 ----------------------------------------------------------------------------
 -- Initialization
@@ -135,7 +167,9 @@ prepareBlockDB
     :: MonadDB m
     => GenesisBlock -> m ()
 prepareBlockDB blk =
-    dbPutSerBlunds $ one (Left blk, Serialized $ serialize' genesisUndo)
+    dbPutSerBlunds
+    $ one ( CB.getBlockHeader $ Left blk
+          , Serialized . serialize' $ bimap (serialize' @Block) serialize' (Left blk, genesisUndo))
   where
     genesisUndo =
         Undo
@@ -149,49 +183,40 @@ prepareBlockDB blk =
 -- Pure implementation
 ----------------------------------------------------------------------------
 
-decodeOrFailPureDB
-    :: HasConfiguration
-    => ByteString
-    -> Either Text (Block, Undo)
-decodeOrFailPureDB = decodeFull'
-
-dbGetBlundPureDefault ::
-       (HasConfiguration, MonadPureDB ctx m)
-    => HeaderHash
-    -> m (Maybe (Block, Undo))
-dbGetBlundPureDefault h = do
-    (blund :: Maybe ByteString) <-
-        view (pureBlocksStorage . at h) <$> (view (lensOf @DBPureVar) >>= readIORef)
-    case decodeOrFailPureDB <$> blund of
-        Nothing        -> pure Nothing
-        Just (Left e)  -> throwM (DBMalformed e)
-        Just (Right v) -> pure (Just v)
-
 dbGetSerBlockPureDefault
     :: (HasConfiguration, MonadPureDB ctx m)
     => HeaderHash
     -> m (Maybe SerializedBlock)
-dbGetSerBlockPureDefault h = (Serialized . serialize' . fst) <<$>> dbGetBlundPureDefault h
+dbGetSerBlockPureDefault h = do
+    (serblund :: Maybe ByteString) <-
+        view (pureBlocksStorage . at h) <$> (view (lensOf @DBPureVar) >>= readIORef)
+    case decodeFull' @(ByteString, ByteString) <$> serblund of
+        Nothing        -> pure Nothing
+        Just (Left e)  -> throwM (DBMalformed e)
+        Just (Right v) -> pure . Just . Serialized $ fst v
 
 dbGetSerUndoPureDefault
     :: forall ctx m. (HasConfiguration, MonadPureDB ctx m)
     => HeaderHash
     -> m (Maybe SerializedUndo)
-dbGetSerUndoPureDefault h = (Serialized . serialize' . snd) <<$>> dbGetBlundPureDefault h
+dbGetSerUndoPureDefault h =  do
+    (serblund :: Maybe ByteString) <-
+        view (pureBlocksStorage . at h) <$> (view (lensOf @DBPureVar) >>= readIORef)
+    case decodeFull' @(ByteString, ByteString) <$> serblund of
+        Nothing        -> pure Nothing
+        Just (Left e)  -> throwM (DBMalformed e)
+        Just (Right v) -> pure . Just . Serialized $ snd v
 
 dbPutSerBlundsPureDefault ::
        forall ctx m. (HasConfiguration, MonadPureDB ctx m, MonadDB m)
-    => NonEmpty SerializedBlund
+    => NonEmpty (CB.BlockHeader, SerializedBlund)
     -> m ()
 dbPutSerBlundsPureDefault (toList -> blunds) = do
-    forM_ blunds $ \(blk, serUndo) -> do
-        undo <- eitherToThrow $ first DBMalformed $ decodeFull' $ unSerialized serUndo
-        let blund :: Blund -- explicit signature is required
-            blund = (blk,undo)
+    forM_ blunds $ \(bh, serBlund) -> do
         (var :: DBPureVar) <- view (lensOf @DBPureVar)
         flip atomicModifyIORefPure var $
-            (pureBlocksStorage . at (headerHash blk) .~ Just (serialize' blund))
-    putHeadersIndex $ map (CB.getBlockHeader . fst) blunds
+            (pureBlocksStorage . at (headerHash bh) .~ Just (unSerialized serBlund))
+    putHeadersIndex $ map fst blunds
 
 ----------------------------------------------------------------------------
 -- Rocks implementation
@@ -219,7 +244,7 @@ dbGetSerUndoRealDefault x = Serialized <<$>> getSerializedUndo x
 
 dbPutSerBlundsRealDefault ::
        (HasConfiguration, MonadDB m, MonadRealDB ctx m)
-    => NonEmpty SerializedBlund
+    => NonEmpty (CB.BlockHeader, SerializedBlund)
     -> m ()
 dbPutSerBlundsRealDefault = putSerializedBlunds
 
@@ -246,7 +271,7 @@ dbGetSerUndoSumDefault hh =
 
 dbPutSerBlundsSumDefault
     :: forall ctx m. (DBSumEnv ctx m)
-    => NonEmpty SerializedBlund -> m ()
+    => NonEmpty (CB.BlockHeader, SerializedBlund) -> m ()
 dbPutSerBlundsSumDefault b =
     eitherDB (dbPutSerBlundsRealDefault b) (dbPutSerBlundsPureDefault b)
 
@@ -262,9 +287,6 @@ getRawData  = handle handler . fmap Just . liftIO . BS.readFile
         | isDoesNotExistError e = pure Nothing
         | otherwise = throwM e
 
-putData ::  (MonadIO m, Bi v) => FilePath -> v -> m ()
-putData fp = putRawData fp . serialize'
-
 putRawData ::  MonadIO m => FilePath -> ByteString -> m ()
 putRawData fp v = liftIO $
     bracket (openBinaryFile fp WriteMode) hClose $ \h ->
@@ -277,21 +299,24 @@ deleteData fp = (liftIO $ removeFile fp) `catch` handler
         | isDoesNotExistError e = pure ()
         | otherwise = throwM e
 
-blockDataPath :: MonadRealDB ctx m => HeaderHash -> m FilePath
-blockDataPath hh = do
-    bdd <- view blockDataDir <$> getNodeDBs
-    pure $ (view _2) $ getAllPaths bdd hh
-
-undoDataPath :: MonadRealDB ctx m => HeaderHash -> m FilePath
-undoDataPath hh = do
-    bdd <- view blockDataDir <$> getNodeDBs
-    pure $ (view _3) $ getAllPaths bdd hh
+-- | Paths at which we store the block data.
+data BlockStoragePaths = BlockStoragePaths
+  { bspRoot :: FilePath
+    -- | Block data itself.
+  , bspBlock :: FilePath
+    -- | Unfo information for a block.
+  , bspUndo :: FilePath
+    -- | Combined storage format. Either this or a combination of 'Block' and
+    -- 'Undo' files will be present.
+  , bspBlund :: FilePath
+  }
 
 -- | Pass blockDataDir path
-getAllPaths :: FilePath -> HeaderHash -> (FilePath, FilePath, FilePath)
-getAllPaths bdd hh = (dir,bl,un)
+getAllPaths :: FilePath -> HeaderHash -> BlockStoragePaths
+getAllPaths bdd hh = BlockStoragePaths dir bl un blund
   where
     (fn0, fn1) = splitAt 2 $ formatToString hashHexF hh
     dir = bdd </> fn0
     bl = dir </> (fn1 <> ".block")
     un = dir </> (fn1 <> ".undo")
+    blund = dir </> (fn1 <> ".blund")

--- a/db/Pos/DB/Class.hs
+++ b/db/Pos/DB/Class.hs
@@ -33,6 +33,7 @@ module Pos.DB.Class
        , Serialized (..)
        , SerializedBlock
        , SerializedUndo
+       , SerializedBlund
        , MonadBlockDBRead
        , getDeserialized
        , getBlock
@@ -58,8 +59,8 @@ import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class (Bi, decodeFull')
 import           Pos.Binary.Core ()
-import           Pos.Core (Block, BlockVersionData (..), EpochIndex, HasConfiguration, HeaderHash,
-                           isBootstrapEra)
+import           Pos.Core (Block, BlockHeader, BlockVersionData (..), EpochIndex, HasConfiguration,
+                           HeaderHash, isBootstrapEra)
 import           Pos.DB.Error (DBError (DBMalformed))
 import           Pos.Util.Util (eitherToThrow)
 
@@ -90,9 +91,11 @@ newtype Serialized a = Serialized
 
 data SerBlock
 data SerUndo
+data SerBlund
 
 type SerializedBlock = Serialized SerBlock
 type SerializedUndo = Serialized SerUndo
+type SerializedBlund = Serialized SerBlund
 
 -- | Pure read-only interface to the database.
 class (HasConfiguration, MonadThrow m) => MonadDBRead m where
@@ -162,7 +165,7 @@ class MonadDBRead m => MonadDB m where
     dbDelete :: DBTag -> ByteString -> m ()
 
     -- | Put given blunds into the Block DB.
-    dbPutSerBlunds :: NonEmpty (Block, SerializedUndo) -> m ()
+    dbPutSerBlunds :: NonEmpty (BlockHeader, SerializedBlund) -> m ()
 
 instance {-# OVERLAPPABLE #-}
     (MonadDB m, MonadTrans t, MonadThrow (t m)) =>


### PR DESCRIPTION
This is an attempt at "simplest possible change" which moves us in the
direction of using fewer files for the block storage. However, this also
tries to tidy up some of the way 'SerializedBlunds' were handled. It avoids
cases where we end up doing serialize/deserialize loops, and tries to remove
a bunch of unneeded functions.

I still don't like this way of handling things - in particular, the contract
on _how_ exactly a `Blund` is stored is completely implicit, yet not isolated
to this module.

## Description

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
Run against an existing node DB and verify that existing blocks load correctly.

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
