### PR TITLE
Fix develop build

### DIFF
--- a/explorer/src/Pos/Explorer/ExplorerMode.hs
+++ b/explorer/src/Pos/Explorer/ExplorerMode.hs
@@ -37,6 +37,7 @@ import qualified Pos.Slotting as Slot
 import           Pos.Txp (GenericTxpLocalData (..), MempoolExt, MonadTxpMem, TxpHolderTag,
                           mkTxpLocalData)
 import           Pos.Util (postfixLFields)
+import           Pos.Util.Mockable () -- need this for orphan instances :\
 import           Pos.Util.Util (HasLens (..))
 
 import           Pos.Explorer.ExtraContext (ExtraContext, ExtraContextT, HasExplorerCSLInterface,

--- a/networking/src/Mockable/Monad.hs
+++ b/networking/src/Mockable/Monad.hs
@@ -10,7 +10,7 @@ module Mockable.Monad
 import           Control.Exception.Safe (MonadMask)
 import           Mockable.Channel (Channel)
 import           Mockable.Class (Mockable)
-import           Mockable.Concurrent (Async, Concurrently, Delay, MyThreadId, ThreadId)
+import           Mockable.Concurrent (Async, Concurrently, Delay, MyThreadId)
 import           Mockable.CurrentTime (CurrentTime)
 import           Mockable.Metrics (Metrics)
 import           Mockable.SharedAtomic (SharedAtomic)
@@ -28,8 +28,8 @@ type MonadMockable m
       , Mockable Async m
       , Mockable Channel m
       , MonadMask m
-      , Ord (ThreadId m)
-      , Show (ThreadId m)
+      -- , Ord (ThreadId m)
+      -- , Show (ThreadId m)
       , Mockable SharedExclusive m
       , Mockable Metrics m
       )

--- a/networking/src/Mockable/Monad.hs
+++ b/networking/src/Mockable/Monad.hs
@@ -10,7 +10,7 @@ module Mockable.Monad
 import           Control.Exception.Safe (MonadMask)
 import           Mockable.Channel (Channel)
 import           Mockable.Class (Mockable)
-import           Mockable.Concurrent (Async, Concurrently, Delay, MyThreadId)
+import           Mockable.Concurrent (Async, Concurrently, Delay, MyThreadId, ThreadId)
 import           Mockable.CurrentTime (CurrentTime)
 import           Mockable.Metrics (Metrics)
 import           Mockable.SharedAtomic (SharedAtomic)
@@ -28,8 +28,8 @@ type MonadMockable m
       , Mockable Async m
       , Mockable Channel m
       , MonadMask m
-      -- , Ord (ThreadId m)
-      -- , Show (ThreadId m)
+      , Ord (ThreadId m)
+      , Show (ThreadId m)
       , Mockable SharedExclusive m
       , Mockable Metrics m
       )


### PR DESCRIPTION
## Description

There were some missing instances causing compilation failures. This PR fixes them.

## Linked issue

None

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

`stack build --fast --bench --no-run-benchmarks --test --no-run-test` before this PR will fail with `No instance Ord (ThreadId (.........))` error. After this PR they succeed.