### PR TITLE
[DEVOPS-831] Static linking fixes nix build on macOS Sierra

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -89,6 +89,11 @@ let
       mkDerivation = args: super.mkDerivation (args // {
         enableLibraryProfiling = enableProfiling;
         enableExecutableProfiling = enableProfiling;
+        # Static linking for everything to work around
+        # https://ghc.haskell.org/trac/ghc/ticket/14444
+        # This will be the default in nixpkgs since
+        # https://github.com/NixOS/nixpkgs/issues/29011
+        enableSharedExecutables = false;
       } // optionalAttrs enableDebugging {
         # TODO: DEVOPS-355
         dontStrip = true;


### PR DESCRIPTION
## Description

MacOS builds were failing on hydra, e.g.https://hydra.iohk.io/build/121437/nixlog/1

This was previously worked around by weeding out dependencies but disabling shared libraries also solves the problem.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-831

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)
