### PR TITLE
node-ipc: Remove ChangeLog.md entry from cabal file

### DIFF
--- a/node-ipc/node-ipc.cabal
+++ b/node-ipc/node-ipc.cabal
@@ -5,7 +5,6 @@ license-file:        LICENSE
 author:              Michael Bishop
 maintainer:          cleverca22@gmail.com
 build-type:          Simple
-extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 


### PR DESCRIPTION
Cabal was giving a warning on a `ChangeLog.md` file listed in the cabal file but not present in the repo.

Its a one line diff!

