### PR TITLE
[DEVOPS-822] pkgs/generate.sh: Work with nix 2.0

### DIFF
--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -12,15 +12,20 @@ function runInShell {
 set -xe
 set -v
 
+# Ensure that nix 1.11 (used by cabal2nix) works in multi-user mode.
+if [ ! -w /nix/store ]; then
+    export NIX_REMOTE=${NIX_REMOTE:-daemon}
+fi
+
 # Get relative path to script directory
 scriptDir="$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
 
 pushd "${scriptDir}"
   # https://github.com/NixOS/cabal2nix/issues/146
-  runInShell "nix cabal2nix glibcLocales" cabal2nix --system x86_64-darwin --revision 25a53d417d7c7a8fc3116b63e3ba14ca7c8f188f \
+  runInShell "cabal2nix glibcLocales" cabal2nix --system x86_64-darwin --revision 25a53d417d7c7a8fc3116b63e3ba14ca7c8f188f \
      https://github.com/luite/hfsevents.git > hfsevents.nix
 
   # Generate cardano-sl package set
-  runInShell "nix cabal2nix glibcLocales" $(nix-build -A stack2nix --no-out-link -Q ../)/bin/stack2nix --platform x86_64-linux --hackage-snapshot 2018-03-22T11:56:04Z -j8 --test ./.. > default.nix.new
+  runInShell "cabal2nix glibcLocales" $(nix-build -A stack2nix --no-out-link -Q ../)/bin/stack2nix --platform x86_64-linux --hackage-snapshot 2018-03-22T11:56:04Z -j8 --test ./.. > default.nix.new
   mv default.nix.new default.nix
 popd


### PR DESCRIPTION
Fixes this error:

    error: Nix database directory ‘/nix/var/nix/db’ is not writable: Permission denied

Nix 2.0 no longer needs or sets the `NIX_REMOTE` variable, but when using nix-build (1.11.15) inside a shell it requires the variable.

So this provides a default for `NIX_REMOTE=daemon`.

The `NIX_REMOTE` variable setting can be removed completely when we update our nixpkgs pin to something that includes Nix 2.0.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-822

## Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## QA Steps

    ./pkgs/generate.sh
