### PR TITLE
[CBR-147] Rollback invariants

### DIFF
--- a/wallet-new/docs/spec.tex
+++ b/wallet-new/docs/spec.tex
@@ -68,12 +68,12 @@
 \begin{document}
 
 \title{Formal specification for a Cardano wallet \\
-       {\small (Version 1.0)} \\
+       {\small (Version 1.1)} \\
        {\large \sc An IOHK technical report}}
 \author{Duncan Coutts \\ {\small \texttt{duncan@well-typed.com}} \\
                          {\small \texttt{duncan.coutts@iohk.io}}
    \and Edsko de Vries \\ {\small \texttt{edsko@well-typed.com}}}
-\date{May 4, 2018}
+\date{May 15, 2018}
 
 \maketitle
 
@@ -202,6 +202,17 @@ The design clarifies that input selection and transaction signing can be
 handled asynchronously from the other wallet state changes. This is important
 since transaction signing in particular may need to be handled on a client
 device or special hardware and may require user confirmation.
+
+\subsection{Version history}
+
+\begin{description}
+\item[Version 1.0, May 4, 2018] First public release.
+
+\item[Version 1.1, May 15, 2018] Corrected definition of
+$\mathsf{updateExpected}$ (Figure~\ref{fig:model_with_expected_UTxO}), added
+missing value of $\mathit{txInfo}$ in $\mathsf{rollback}$
+(Figure~\ref{fig:tracking_metadata}), minor corrections to the text.
+\end{description}
 
 \pagebreak
 \tableofcontents
@@ -2927,7 +2938,7 @@ such as Bitcoin there are services known as ``laundry services'', ``mixers'' or
 third-parties that combine payments from various users into a single transaction, to
 break this assumption.}  that of all the transactions inputs belong to the same
 identity \citep{fergal}. On the output side, we may wish to take steps to ensure
-that attackers cannot easily identity which output is the change output
+that attackers cannot easily identify which output is the change output
 \citep{8260674}. For instance, for single payment transactions, we could try to
 ensure that the change output is roughly as large as the payment itself. Some
 systems give users the ability to override input selection on a per-transaction

--- a/wallet-new/docs/spec.tex
+++ b/wallet-new/docs/spec.tex
@@ -664,7 +664,7 @@ incorrect to use the definition
 \end{equation*}
 %
 The difference crops up when one considers transactions within the block $b$
-that depend on each other: that is where the output of one transaction is used
+that depend on each other: that is, where the output of one transaction is used
 as the input of another within the same block. To make this intuition clearer,
 we can define a function that computes only the `new' outputs from a block
 (outputs that are not spent within that same block):
@@ -1527,7 +1527,10 @@ rollbacks. The extended model is shown in
 \cref{fig:model_with_expected_UTxO}. When the wallet rolls back, the
 unspent outputs that are removed from the $\mathit{utxo}$ get added to
 $\mathit{expected}$. Conversely, when the wallet applies a block, any confirmed
-outputs are removed from $\mathit{expected}$.
+outputs are removed from $\mathit{expected}$. Put another way, during rollback
+anything that is removed from the actual UTxO gets added to the expected UTxO,
+and when applying a block anything that is added to the actual UTxO gets
+removed from the expected UTxO.
 
 \begin{figure}
 %
@@ -1553,7 +1556,7 @@ outputs are removed from $\mathit{expected}$.
 \emph{Auxiliary}
 %
 \begin{equation*}
-\mathsf{updateExpected} ~ b ~ \mathit{expected} = \mathsf{txins} ~ b \subtractdom \mathit{expected}
+\mathsf{updateExpected} ~ b ~ \mathit{expected} = \dom (\mathsf{new} ~ b) \subtractdom \mathit{expected}
 \end{equation*}
 %
 \caption{\label{fig:model_with_expected_UTxO}Model with rollback and expected UTxO}
@@ -2293,7 +2296,7 @@ well as the actual UTxO.
 & \qquad \text{where}
    \begin{array}[t]{rl}
      \mathit{pending}'  & = \{ tx \mid tx \in \mathit{pending}, (\mathit{inputs}, \,\underline{\phantom{a}}\,) = \mathit{tx}, \mathit{inputs} \cap \mathit{txins}_b = \emptyset \} \\
-     \mathit{expected}' & = \mathit{txins}_b \subtractdom \mathit{expected} \\
+     \mathit{expected}' & = \dom \mathit{txouts}_b \subtractdom \mathit{expected} \\
      \mathit{utxo}^+    & = \mathit{txouts}_b \\
      \mathit{utxo}^-    & = \mathit{txins}_b \restrictdom (\mathit{utxo} \cup \mathit{utxo}^+) \\
      \mathit{utxo}'     & = \mathit{txins}_b \subtractdom (\mathit{utxo} \cup \mathit{utxo}^+) \\

--- a/wallet-new/docs/spec.tex
+++ b/wallet-new/docs/spec.tex
@@ -2373,8 +2373,8 @@ on rollback we simply revert to the previous value of the block metadata.
          ) \\
 & \mathsf{newPending} ~ tx ~ ((\mathit{utxo}, \mathit{pending}, \mathit{blockMeta}) : \mathit{checkpoints}, \mathit{txInfo}) = \\
 & \qquad (\mathit{utxo}, pending \cup \{ tx \}, \mathit{blockMeta}) : \mathit{checkpoints}, \mathit{txInfo} \cup \{ \mathsf{txid} ~ \mathit{tx} \mapsto \mathsf{txMeta} ~ \mathit{tx} \}) \\
-& \mathsf{rollback} ~ ((\mathit{utxo}, \mathit{pending}, \mathit{blockMeta}) :  (\mathit{utxo}^\prime, \mathit{pending}^\prime, \mathit{blockMeta}') : \mathit{checkpoints})) = \\
-& \qquad (\mathit{utxo}^\prime, \mathit{pending} \cup \mathit{pending}^\prime, \mathit{blockMeta}') : \mathit{checkpoints}
+& \mathsf{rollback} ~ ((\mathit{utxo}, \mathit{pending}, \mathit{blockMeta}) :  (\mathit{utxo}^\prime, \mathit{pending}^\prime, \mathit{blockMeta}') : \mathit{checkpoints}, \mathit{txInfo}) = \\
+& \qquad ((\mathit{utxo}^\prime, \mathit{pending} \cup \mathit{pending}^\prime, \mathit{blockMeta}') : \mathit{checkpoints}, \mathit{txInfo})
 \end{align*}
 %
 \caption{\label{fig:tracking_metadata}Tracking metadata}
@@ -2665,7 +2665,7 @@ of view of the wallet model this corresponds to a new function
 By the logic of \cref{sec:transaction_status}, such a transaction would
 be reported as $\mathtt{WontApply}$. Since we removed the transaction from the
 $\mathit{pending}$ set in all checkpoints\footnote{If the overhead of traversing
-all checkpoints is too large, an alternative implementation strategy would to be
+all checkpoints is too large, an alternative implementation strategy would be to
 maintain an explicit $\mathit{cancelled}$ set of transaction as part of the
 wallet's state.}, however, a rollback won't reintroduce it into
 $\mathit{pending}$; if the user wants to explicitly tell the wallet to try this
@@ -2884,7 +2884,7 @@ Input selection is a large topic which merits a detailed study in its own right.
 Moreover, since input selection has multiple mutually incompatible goals, there
 is no single one-size-fits-all input selection algorithm.  We will therefore
 defer a detailed and formal discussion of input selection to a separate study.
-Here we will merely list of of the goals of input selection, and list some
+Here we will merely list the goals of input selection, and list some
 properties that a good input selection algorithm will have. We will also
 briefly consider what kind of data structure can be used to make sure that
 the asymptotic complexity of input selection is acceptable.

--- a/wallet-new/test/unit/Test/Spec/Models.hs
+++ b/wallet-new/test/unit/Test/Spec/Models.hs
@@ -43,8 +43,7 @@ testPureWalletWith :: forall h a. (Hash h a, Ord a, Buildable a)
                    => Inductive h a -> Property
 testPureWalletWith indWithRoll = conjoin [
       -- sanity check on the test
-      uptoFirstRollback indDontRoll `shouldBe` indDontRoll
-    , shouldBeValidated (void (inductiveIsValid indWithRoll))
+      shouldBeValidated (void (inductiveIsValid indWithRoll))
 
       -- check that the invariants hold in each model
     , checkInvariants NoRollback    "base" indDontRoll baseEmpty

--- a/wallet-new/test/unit/Wallet/Basic.hs
+++ b/wallet-new/test/unit/Wallet/Basic.hs
@@ -19,7 +19,7 @@ module Wallet.Basic (
 import           Universum hiding (State)
 
 import           Control.Lens.TH
-import qualified Data.Set as Set
+import qualified Data.Map as Map
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 
@@ -40,7 +40,7 @@ makeLenses ''State
 initState :: State h a
 initState = State {
       _stateUtxo    = utxoEmpty
-    , _statePending = Set.empty
+    , _statePending = Map.empty
     }
 
 {-------------------------------------------------------------------------------

--- a/wallet-new/test/unit/Wallet/Incremental.hs
+++ b/wallet-new/test/unit/Wallet/Incremental.hs
@@ -22,7 +22,7 @@ module Wallet.Incremental (
 import           Universum hiding (State)
 
 import           Control.Lens.TH
-import qualified Data.Set as Set
+import qualified Data.Map as Map
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 
@@ -93,7 +93,7 @@ applyBlock' (ins, outs) State{..} = State{
     , _stateUtxoBalance = balance'
     }
   where
-    pending' = Set.filter (\t -> disjoint (trIns t) ins) _statePending
+    pending' = Map.filter (\t -> disjoint (trIns t) ins) _statePending
     utxoNew  = outs
     unionNew = _stateUtxo `utxoUnion` utxoNew
     utxoRem  = utxoRestrictToInputs ins unionNew

--- a/wallet-new/test/unit/Wallet/Inductive.hs
+++ b/wallet-new/test/unit/Wallet/Inductive.hs
@@ -32,7 +32,6 @@ data WalletEvent h a =
 
     -- | Roll back the last block added to the blockchain
   | Rollback
-  deriving Eq
 
 walletEventIsRollback :: WalletEvent h a -> Bool
 walletEventIsRollback Rollback = True
@@ -53,7 +52,6 @@ data Inductive h a = Inductive {
       -- | Wallet events
     , inductiveEvents :: OldestFirst [] (WalletEvent h a)
     }
-  deriving (Eq)
 
 -- | The prefix of the 'Inductive' that doesn't include any rollbacks
 uptoFirstRollback :: Inductive h a -> Inductive h a

--- a/wallet-new/test/unit/Wallet/Inductive/Interpreter.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Interpreter.hs
@@ -1,5 +1,12 @@
 module Wallet.Inductive.Interpreter (
-    interpret
+    -- * History
+    History(..)
+  , HistoryD
+  , fromHistoryD
+  , historyD
+  , snocHistoryD
+    -- * Interpreter proper
+  , interpret
   , InvalidInput(..)
   ) where
 
@@ -8,11 +15,43 @@ import           Universum
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 import           Pos.Util.Chrono
+import           Serokell.Util (listJson)
 
 import           Util.Validated
 import           UTxO.DSL
 import           Wallet.Abstract
 import           Wallet.Inductive
+
+{-------------------------------------------------------------------------------
+  History
+-------------------------------------------------------------------------------}
+
+-- | History of interpretation
+--
+-- This is very useful for debugging
+data History h a = History {
+      -- | Wallet internal states
+      historyState :: [Text]
+
+      -- | Continuation of the history (if any)
+    , historyStep :: Maybe (WalletEvent h a, History h a)
+    }
+
+-- | "Difference history"
+type HistoryD h a = Maybe (WalletEvent h a, History h a) -> History h a
+
+fromHistoryD :: HistoryD h a -> History h a
+fromHistoryD = ($ Nothing)
+
+historyD :: [Wallet h a] -> HistoryD h a
+historyD = History . map dumpState
+
+-- | Append an action to a history
+snocHistoryD :: HistoryD h a     -- ^ Previous history
+             -> WalletEvent h a  -- ^ Event to append
+             -> [Wallet h a]     -- ^ Wallet states after the event
+             -> HistoryD h a
+snocHistoryD k ev ws h = k $ Just (ev, historyD ws h)
 
 {-------------------------------------------------------------------------------
   Interpreter
@@ -27,12 +66,12 @@ import           Wallet.Inductive
 -- calls to 'newPending', etc.). This is meant to check properties of the
 -- /wallet/, not the wallet input. See 'isInductiveValid'.
 interpret :: forall h a err.
-             (OldestFirst [] (WalletEvent h a) -> InvalidInput h a -> err)
+             (History h a -> InvalidInput h a -> err)
           -- ^ Inject invalid input err.
           -- We provide the events that lead to the error.
           -> (Transaction h a -> [Wallet h a])
           -- ^ Wallet constructors
-          -> (OldestFirst [] (WalletEvent h a) -> [Wallet h a] -> Validated err ())
+          -> (History h a -> [Wallet h a] -> Validated err ())
           -- ^ Predicate to check. The predicate is passed the events leading
           -- to this point, for better error messages.
           -> Inductive h a
@@ -43,40 +82,44 @@ interpret invalidInput mkWallets p Inductive{..} =
   where
     goBoot :: Transaction h a -> Validated err [Wallet h a]
     goBoot boot = do
-        let history = []
-        ws <- verify history (mkWallets boot)
-        goEvents history ws (getOldestFirst inductiveEvents)
+        let acc'     = mkWallets boot
+            history' = historyD acc'
+        verify history' acc'
+        goEvents history' acc' (getOldestFirst inductiveEvents)
 
-    goEvents :: [WalletEvent h a]  -- history
+    goEvents :: HistoryD h a       -- history
              -> [Wallet h a]       -- accumulator
              -> [WalletEvent h a]  -- events to process
              -> Validated err [Wallet h a]
     goEvents _ acc [] =
         return acc
     goEvents history acc (ApplyBlock b:es) = do
-        let history' = ApplyBlock b : history
-        acc' <- verify history' $ map (`applyBlock` b) acc
+        let acc'     = map (`applyBlock` b) acc
+            history' = snocHistoryD history (ApplyBlock b) acc'
+        verify history' acc'
         goEvents history' acc' es
     goEvents history acc (NewPending t:es) = do
-        let history' = NewPending t : history
-        acc' <- verify history' =<< mapM (newPending' history t) acc
+        acc' <- mapM (newPending' history t) acc
+        let history' = snocHistoryD history (NewPending t) acc'
+        verify history' acc'
         goEvents history' acc' es
     goEvents history acc (Rollback:es) = do
-        let history' = Rollback : history
-        acc' <- verify history' $ map rollback acc
+        let acc'     = map rollback acc
+            history' = snocHistoryD history Rollback acc'
+        verify history' acc'
         goEvents history' acc' es
 
-    verify :: [WalletEvent h a]
-           -> [Wallet h a] -> Validated err [Wallet h a]
-    verify history ws = p (OldestFirst (reverse history)) ws >> return ws
+    verify :: HistoryD h a
+           -> [Wallet h a] -> Validated err ()
+    verify history ws = p (fromHistoryD history) ws
 
-    newPending' :: [WalletEvent h a]
+    newPending' :: HistoryD h a
                 -> Transaction h a
                 -> Wallet h a -> Validated err (Wallet h a)
     newPending' history tx w =
         case newPending w tx of
           Just w' -> return w'
-          Nothing -> throwError . invalidInput (OldestFirst (reverse history))
+          Nothing -> throwError . invalidInput (fromHistoryD history)
                    $ InvalidPending tx (utxo w) (pending w)
 
 -- | We were unable to check the invariant because the input was invalid
@@ -110,3 +153,11 @@ instance (Hash h a, Buildable a) => Buildable (InvalidInput h a) where
     invalidPendingTransaction
     invalidPendingWalletUtxo
     invalidPendingWalletPending
+
+instance (Hash h a, Buildable a) => Buildable (History h a) where
+  build = bprint ("{" % build) . go
+    where
+      go (History s n)  = bprint ("state: " % listJson % build) s (go' n)
+
+      go' Nothing       = "}"
+      go' (Just (e, h)) = bprint (", action: " % build % ", " % build) e (go h)

--- a/wallet-new/test/unit/Wallet/Inductive/Invariants.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Invariants.hs
@@ -191,7 +191,7 @@ walletInvariants applicableInvariants l e w = do
         ]
 
       FullRollback -> sequence_ [
---          utxoExpectedDisjoint l e w
+          utxoExpectedDisjoint l e w
         ]
 
 pendingInUtxo :: WalletInv h a
@@ -236,15 +236,12 @@ balanceChangeAvailable l e = invariant (l <> "/balanceChangeAvailable") e $ \w -
                ("balance (total w)",
                  balance (total w))
 
-{-
--- TODO: disabled until we fix the spec
 utxoExpectedDisjoint :: WalletInv h a
 utxoExpectedDisjoint l e = invariant (l <> "/utxoExpectedDisjoint") e $ \w ->
     checkDisjoint ("utxoDomain (utxo w)",
                     utxoDomain (utxo w))
                   ("utxoDomain (expectedUtxo w)",
                     utxoDomain (expectedUtxo w))
--}
 
 {-------------------------------------------------------------------------------
   Compare different wallet implementations

--- a/wallet-new/test/unit/Wallet/Rollback/Basic.hs
+++ b/wallet-new/test/unit/Wallet/Rollback/Basic.hs
@@ -15,7 +15,7 @@ module Wallet.Rollback.Basic (
 import           Universum hiding (State)
 
 import           Control.Lens.TH
-import qualified Data.Set as Set
+import qualified Data.Map as Map
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 import           Serokell.Util (listJson)
@@ -78,7 +78,7 @@ rollback' State{ _stateCheckpoints = prev : checkpoints'
                } = State{
       _stateCurrent = Basic.State{
           _stateUtxo    = prev ^. Basic.stateUtxo
-        , _statePending = (curr ^. Basic.statePending) `Set.union`
+        , _statePending = (curr ^. Basic.statePending) `Map.union`
                           (prev ^. Basic.statePending)
         }
     , _stateCheckpoints = checkpoints'

--- a/wallet-new/test/unit/Wallet/Rollback/Full.hs
+++ b/wallet-new/test/unit/Wallet/Rollback/Full.hs
@@ -22,6 +22,7 @@ module Wallet.Rollback.Full (
 import           Universum hiding (State)
 
 import           Control.Lens.TH
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
@@ -124,7 +125,7 @@ rollback' State{ _stateCheckpoints = prev : checkpoints'
           _checkpointIncr = Incr.State {
                _stateBasic = Basic.State {
                    _stateUtxo    = prev ^. checkpointUtxo
-                 , _statePending = (curr ^. checkpointPending) `Set.union`
+                 , _statePending = (curr ^. checkpointPending) `Map.union`
                                    (prev ^. checkpointPending)
                  }
              , _stateUtxoBalance = prev ^. checkpointUtxoBalance

--- a/wallet-new/test/unit/Wallet/Rollback/Full.hs
+++ b/wallet-new/test/unit/Wallet/Rollback/Full.hs
@@ -106,8 +106,8 @@ applyBlock' :: Hash h a
             -> State h a -> State h a
 applyBlock' (ins, outs) State{..} = State{
       _stateCurrent = Checkpoint {
-           _checkpointIncr     = Incr.applyBlock' (ins, outs) _checkpointIncr
-         , _checkpointExpected = utxoRemoveInputs ins _checkpointExpected
+           _checkpointIncr     = Incr.applyBlock' (ins, outs)       _checkpointIncr
+         , _checkpointExpected = utxoRemoveInputs (utxoDomain outs) _checkpointExpected
          }
     , _stateCheckpoints = _stateCurrent : _stateCheckpoints
     }


### PR DESCRIPTION
This adds the final rollback invariants. It relies on https://github.com/input-output-hk/cardano-sl/pull/2930 because without that fix the invariants are not true. It also extends the interpreter to give a more informative history when an invariant breaks.