### PR TITLE
[CDEC-320] Investigate Cbor serialisation failure in CI. 

### DIFF
--- a/lib/src/Test/Pos/Helpers.hs
+++ b/lib/src/Test/Pos/Helpers.hs
@@ -64,7 +64,10 @@ cborCanonicalRep a = property $ do
     pure $ case out of
         -- perturbCanonicity may have not changed anything. Decoding can
         -- succeed in this case.
-        Right a' -> counterexample (show a') (sa == sa')
+        Right a' ->
+          counterexample (show a') $ counterexample (show sa) $ counterexample
+              (show sa')
+              (sa == sa')
         -- It didn't decode. The error had better be a canonicity violation.
         Left err -> counterexample (show err) (isCanonicityViolation err)
   where


### PR DESCRIPTION
## Description

The CBOR serialisation tests in `Test.Pos.Cbor.CborSpec` were failing very occasionally running `binaryTests` on `Attributes X1`. One of the `binaryTests` is a canonicity test that uses `perturbCanonicity`. In this case it was duplicating the last element of the `Map` underlying `UnparsedFields`. Due to a small bug in `deserializeOrFail` that didn't return all leftover bytes from the input this was decoded fine, breaking canonicity. This has been fixed and tested against various previously failing seeds.

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

[CDEC-320](https://iohk.myjetbrains.com/youtrack/issue/CDEC-320)

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
