### PR TITLE
[DEVOPS-850] dead strip unused dylibs on macOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,6 +32,9 @@ let
     '';
   });
   cardanoPkgs = ((import ./pkgs { inherit pkgs; }).override {
+    ghc = overrideDerivation pkgs.haskell.compiler.ghc802 (drv: {
+      patches = drv.patches ++ [ ./ghc-8.0.2-darwin-rec-link.patch ];
+    });
     overrides = self: super: {
       cardano-sl-core = overrideCabal super.cardano-sl-core (drv: {
         configureFlags = (drv.configureFlags or []) ++ [

--- a/ghc-8.0.2-darwin-rec-link.patch
+++ b/ghc-8.0.2-darwin-rec-link.patch
@@ -1,0 +1,24 @@
+diff --git a/compiler/main/DriverPipeline.hs b/compiler/main/DriverPipeline.hs
+index acd0d61..3e83c15 100644
+--- a/compiler/main/DriverPipeline.hs
++++ b/compiler/main/DriverPipeline.hs
+@@ -1916,6 +1916,7 @@ linkBinary' staticLink dflags o_files dep_packages = do
+                       ++ pkg_framework_opts
+                       ++ debug_opts
+                       ++ thread_opts
++                      ++ (if (platformOS platform `elem` [OSDarwin, OSiOS]) then [ "-Wl,-dead_strip_dylibs", "-Wl,-dead_strip" ] else [])
+                     ))
+ 
+ exeFileName :: Bool -> DynFlags -> FilePath
+diff --git a/compiler/main/SysTools.hs b/compiler/main/SysTools.hs
+index 1ab5b13..2ebbf51 100644
+--- a/compiler/main/SysTools.hs
++++ b/compiler/main/SysTools.hs
+@@ -1737,6 +1737,7 @@ linkDynLib dflags0 o_files dep_packages
+                  ++ map Option pkg_lib_path_opts
+                  ++ map Option pkg_link_opts
+                  ++ map Option pkg_framework_opts
++                 ++ [ Option "-Wl,-dead_strip_dylibs" ]
+               )
+         OSiOS -> throwGhcExceptionIO (ProgramError "dynamic libraries are not supported on iOS target")
+         _ -> do


### PR DESCRIPTION
GHC links the full transitive closure over the dependencies when building dynamic libraries.

This quickly leads to a large number of referenced dynamic libraries, which all count towards the load command size limit on macOS. Which manifests in the linker refusing to load the library with: malformed mach-o: load commands size (32864) > 32768.

The macOS linker is capable of recursively linking dylibs, and as such only direct ones would be needed. However computing the direct dependencies in GHC at link time is rather complex, due to GHC's aggressive cross-library inlining.

We can however use the linker to dead strip dynamic lirbaries that are unused. As such we drop all dynamic lirbaries that are not referenced.

## Description

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-850

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
