### PR TITLE
cardano-sl-infra: replace logging with cardano-sl-util (Pos_Util_Log)

### DIFF
--- a/infra/Pos/Network/Types.hs
+++ b/infra/Pos/Network/Types.hs
@@ -59,7 +59,8 @@ import qualified Network.Transport.TCP as TCP
 import           Node.Internal (NodeId (..))
 import qualified Prelude
 import qualified System.Metrics as Monitoring
-import           Pos.Util.Log (LoggerName (..))
+import           Pos.Util.Log (LoggerName)
+import qualified Data.Text as T
 
 import           Pos.Network.DnsDomains (DnsDomains (..), NodeAddr)
 import qualified Pos.Network.DnsDomains as DnsDomains
@@ -67,7 +68,7 @@ import qualified Pos.Network.Policy as Policy
 import           Pos.Reporting.Health.Types (HealthStatus (..))
 import           Pos.System.Metrics.Constants (cardanoNamespace)
 import           Pos.Util.TimeWarp (addressToNodeId)
-import           Pos.Util.Trace (wlogTrace)
+import           Pos.Util.Trace (logTrace)
 import           Pos.Util.Util (HasLens', lensOf)
 
 {-------------------------------------------------------------------------------
@@ -440,7 +441,7 @@ initQueue :: (MonadIO m, FormatMsg msg)
           -> m (OutboundQ msg NodeId Bucket)
 initQueue NetworkConfig{..} loggerName mStore = liftIO $ do
     let NodeName selfName = fromMaybe (NodeName "self") ncSelfName
-        oqTrace           = wlogTrace (loggerName <> LoggerName selfName)
+        oqTrace           = logTrace (loggerName `T.append` selfName)
     oq <- OQ.new oqTrace
                  ncEnqueuePolicy
                  ncDequeuePolicy

--- a/infra/Pos/Reporting/Methods.hs
+++ b/infra/Pos/Reporting/Methods.hs
@@ -19,7 +19,7 @@ module Pos.Reporting.Methods
        -- * Internals, exported for custom usages.
        -- E. g. to report crash from launcher.
        , sendReport
-       , retrieveLogFiles
+       --, retrieveLogFiles
        , compressLogs
        ) where
 
@@ -30,7 +30,7 @@ import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
 import           Control.Exception (ErrorCall (..))
 import           Control.Exception.Safe (Exception (..), try)
-import           Control.Lens (each, to)
+--import           Control.Lens (each, to)
 import           Data.Aeson (encode)
 import           Data.Bits (Bits (..))
 import qualified Data.ByteString as BS
@@ -38,7 +38,7 @@ import qualified Data.ByteString.Lazy as BSL
 import           Data.Conduit (runConduitRes, yield, (.|))
 import           Data.Conduit.List (consume)
 import qualified Data.Conduit.Lzma as Lzma
-import qualified Data.HashMap.Strict as HM
+--import qualified Data.HashMap.Strict as HM
 import           Data.List (isSuffixOf)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text.IO as TIO
@@ -56,10 +56,7 @@ import           System.Directory (canonicalizePath, doesFileExist, getTemporary
 import           System.FilePath (takeFileName)
 import           System.Info (arch, os)
 import           System.IO (IOMode (WriteMode), hClose, hFlush, withFile)
-import           Pos.Util.Log (LoggerConfig (..), Severity (..), WithLogger, hwFilePath, lcTree,
-                               logError, logInfo, logMessage, logWarning, ltFiles, ltSubloggers,
-                               retrieveLogContent)
-
+import qualified Pos.Util.Log as Log
 
 import           Paths_cardano_sl_infra (version)
 import           Pos.Crypto (ProtocolMagic (..), HasProtocolMagic, protocolMagic)
@@ -68,8 +65,7 @@ import           Pos.Exception (CardanoFatalError)
 import           Pos.KnownPeers (MonadFormatPeers (..))
 import           Pos.Network.Types (HasNodeType (..), NodeType (..))
 import           Pos.Reporting.Exceptions (ReportingError (..))
-import           Pos.Reporting.MemState (HasLoggerConfig (..), HasReportServers (..),
-                                         HasReportingContext (..))
+import           Pos.Reporting.MemState (HasLoggerConfig (..), reportServers, HasReportingContext (..))
 import           Pos.Util.CompileInfo (HasCompileInfo, compileInfo)
 import           Pos.Util.Filesystem (withSystemTempFile)
 import           Pos.Util.Util (maybeThrow, (<//>))
@@ -136,6 +132,7 @@ sendReport logFiles reportType appName reportServerUri = do
 -- | Given logger config, retrieves all (logger name, filepath) for
 -- every logger that has file handle. Filepath inside does __not__
 -- contain the common logger config prefix.
+{- TODO   this should not be here ..
 retrieveLogFiles :: LoggerConfig -> [([Text], FilePath)]
 retrieveLogFiles lconfig = fromLogTree $ lconfig ^. lcTree
   where
@@ -143,6 +140,7 @@ retrieveLogFiles lconfig = fromLogTree $ lconfig ^. lcTree
         let curElems = map ([],) (lt ^.. ltFiles . each . hwFilePath)
             iterNext (part, node) = map (first (part :)) $ fromLogTree node
         in curElems ++ concatMap iterNext (lt ^. ltSubloggers . to HM.toList)
+-}
 
 -- | Pass a list of absolute paths to log files. This function will
 -- archive and compress these files and put resulting file into log
@@ -204,7 +202,7 @@ type MonadReporting ctx m =
        , MonadFormatPeers m
        , HasReportingContext ctx
        , HasNodeType ctx
-       , WithLogger m
+       , Log.WithLogger m
        , HasProtocolMagic
        , HasCompileInfo
        )
@@ -233,7 +231,7 @@ sendReportNodeImpl rawLogs reportType = do
             whenNotNull errors $ throwSE . NE.head
   where
     onNoServers =
-        logInfo $ "sendReportNodeImpl: not sending report " <>
+        Log.logInfo $ "sendReportNodeImpl: not sending report " <>
                   "because no reporting servers are specified"
     throwSE (e :: SomeException) = throwM e
 
@@ -249,7 +247,7 @@ sendReportNode reportType = do
         then onNoServers
         else do
             logConfig <- view (reportingContext . loggerConfig)
-            let allFiles = map snd $ retrieveLogFiles logConfig
+            let allFiles = map snd $ Log.retrieveLogFiles logConfig
             logFile <-
                 maybeThrow
                     NoPubFiles
@@ -259,6 +257,8 @@ sendReportNode reportType = do
                 retrieveLogContent logFile (Just 5000)
             sendReportNodeImpl (Just $ unlines $ reverse logContent) reportType
   where
+    retrieveLogContent :: (MonadIO m) => FilePath -> Maybe Int -> m [Text]
+    retrieveLogContent _ _ = return []
     -- 2 megabytes, assuming we use chars which are ASCII mostly
     charsConst :: Int
     charsConst = 1024 * 1024 * 2
@@ -268,7 +268,7 @@ sendReportNode reportType = do
         let delta = curLimit - length t
         in bool [] (t : (takeGlobalSize delta xs)) (delta > 0)
     onNoServers =
-        logInfo $
+        Log.logInfo $
         "sendReportNode: not sending report " <>
         "because no reporting servers are specified"
 
@@ -295,7 +295,7 @@ reportNode sendLogs extendWithNodeInfo reportType =
            else send' reportType
     handler :: SomeException -> m ()
     handler e =
-        logError $
+        Log.logError $
         sformat ("Didn't manage to report "%shown%
                  " because of exception '"%string%"' raised while sending")
         reportType (displayException e)
@@ -306,18 +306,18 @@ reportNode sendLogs extendWithNodeInfo reportType =
     extendRTDesc text' (RInfo text)                    = RInfo $ text <> text'
     extendRTDesc _ x                                   = x
 
-    logReportType :: WithLogger m => ReportType -> m ()
-    logReportType (RCrash i) = logError $ "Reporting crash with code " <> show i
+    logReportType :: Log.WithLogger m => ReportType -> m ()
+    logReportType (RCrash i) = Log.logError $ "Reporting crash with code " <> show i
     logReportType (RError reason) =
-        logError $ "Reporting error with reason \"" <> reason <> "\""
+        Log.logError $ "Reporting error with reason \"" <> reason <> "\""
     logReportType (RMisbehavior True reason) =
-        logError $ "Reporting critical misbehavior with reason \"" <> reason <> "\""
+        Log.logError $ "Reporting critical misbehavior with reason \"" <> reason <> "\""
     logReportType (RMisbehavior False reason) =
-        logWarning $ "Reporting non-critical misbehavior with reason \"" <> reason <> "\""
+        Log.logWarning $ "Reporting non-critical misbehavior with reason \"" <> reason <> "\""
     logReportType (RInfo text) =
-        logInfo $ "Reporting info with text \"" <> text <> "\""
+        Log.logInfo $ "Reporting info with text \"" <> text <> "\""
     logReportType (RCustomReport{}) =
-        logInfo $ "Reporting custom report"
+        Log.logInfo $ "Reporting custom report"
 
     -- Retrieves node info that we would like to know when analyzing
     -- malicious behavior of node.
@@ -386,11 +386,11 @@ reportError = reportNode True True . RError
 -- you can rethrow it by yourself.
 reportOrLog
     :: forall ctx m . (MonadReporting ctx m)
-    => Severity -> Text -> SomeException -> m ()
+    => Log.Severity -> Text -> SomeException -> m ()
 reportOrLog severity prefix exc =
     case tryCast @CardanoFatalError <|> tryCast @ErrorCall <|> tryCast @DBError of
         Just msg -> reportError $ prefix <> msg
-        Nothing  -> logMessage severity $ prefix <> pretty exc
+        Nothing  -> Log.logMessage severity $ prefix <> pretty exc
   where
     tryCast ::
            forall e. Exception e
@@ -401,10 +401,10 @@ reportOrLog severity prefix exc =
 reportOrLogE
     :: forall ctx m . (MonadReporting ctx m)
     => Text -> SomeException -> m ()
-reportOrLogE = reportOrLog Error
+reportOrLogE = reportOrLog Log.Error
 
 -- | A version of 'reportOrLog' which uses 'Warning' severity.
 reportOrLogW
     :: forall ctx m . (MonadReporting ctx m)
     => Text -> SomeException -> m ()
-reportOrLogW = reportOrLog Warning
+reportOrLogW = reportOrLog Log.Warning

--- a/infra/Pos/Util/TimeLimit.hs
+++ b/infra/Pos/Util/TimeLimit.hs
@@ -23,7 +23,7 @@ import           Mockable (Async, Delay, Mockable, delay, withAsyncWithUnmask)
 import           Pos.Util.Log (WithLogger, logWarning)
 
 import           Pos.Crypto.Random (randomNumber)
-import           Pos.Util.LogSafe (logWarningS)
+--import           Pos.Util.LogSafe (logWarningS)
 
 -- | Data type to represent waiting strategy for printing warnings
 -- if action take too much time.
@@ -45,7 +45,7 @@ logWarningLongAction
     :: forall m a.
        CanLogInParallel m
     => Bool -> WaitingDelta -> Text -> m a -> m a
-logWarningLongAction secure delta actionTag action =
+logWarningLongAction {- secure -} _ delta actionTag action =
     -- Previous implementation was
     --
     --   bracket (fork $ waitAndWarn delta) killThread (const action)
@@ -62,9 +62,9 @@ logWarningLongAction secure delta actionTag action =
     -- this function is going to be called under 'mask'.
     withAsyncWithUnmask (\unmask -> unmask $ waitAndWarn delta) (const action)
   where
-    logFunc :: Text -> m ()
-    logFunc = bool logWarning logWarningS secure
-    printWarning t = logFunc $ sformat ("Action `"%stext%"` took more than "%shown)
+    --logFunc :: Text -> m ()
+    --logFunc = bool logWarning logWarningS secure
+    printWarning t = logWarning $ sformat ("Action `"%stext%"` took more than "%shown)
                                        actionTag t
 
     -- [LW-4]: avoid code duplication somehow (during refactoring)

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -119,7 +119,7 @@ library
 
                         -- Pos.Util
                         Pos.Util.JsonLog.Events
-                        Pos.Util.LogSafe
+                        --Pos.Util.LogSafe
                         Pos.Util.Monitor
                         Pos.Util.TimeLimit
                         Pos.Util.TimeWarp

--- a/node-ipc/node-ipc.cabal
+++ b/node-ipc/node-ipc.cabal
@@ -16,8 +16,8 @@ library
                      , binary
                      , bytestring
                      , cardano-sl-infra
+                     , cardano-sl-util
                      , Cabal
-                     , log-warper
                      , mtl
                      , universum
                      , unordered-containers

--- a/node-ipc/src/Cardano/NodeIPC.hs
+++ b/node-ipc/src/Cardano/NodeIPC.hs
@@ -24,8 +24,8 @@ import           Pos.Shutdown.Types        (ShutdownContext)
 import           System.Environment        (lookupEnv)
 import           System.IO.Error           (IOError, isEOFError)
 import           System.IO                 (hFlush, hGetLine, hSetNewlineMode, noNewlineTranslation)
-import           System.Wlog               (WithLogger, logInfo, logError)
-import           System.Wlog.LoggerNameBox (usingLoggerName)
+import           Pos.Util.Log              (WithLogger, logInfo, logError, usingLoggerName, Severity(..))
+--import           System.Wlog.LoggerNameBox (usingLoggerName)
 import           Universum
 
 data Packet = Started | QueryPort | ReplyPort Word16 | Ping | Pong | ParseError Text deriving (Show, Eq, Generic)
@@ -52,7 +52,7 @@ startNodeJsIPC port = void $ runMaybeT $ do
         void $ forkIO $ startIpcListener ctx handle port
 
 startIpcListener :: ShutdownContext -> Handle -> Word16 -> IO ()
-startIpcListener ctx handle port = usingLoggerName "NodeIPC" $ flip runReaderT ctx (ipcListener handle port)
+startIpcListener ctx handle port = usingLoggerName Debug "NodeIPC" $ flip runReaderT ctx (ipcListener handle port)
 
 readInt64 :: Handle -> IO Word64
 readInt64 hnd = do

--- a/txp/Pos/Txp/MemState/Metrics.hs
+++ b/txp/Pos/Txp/MemState/Metrics.hs
@@ -10,7 +10,7 @@ import           Data.Aeson.Types (ToJSON (..))
 import           Formatting (sformat, shown, (%))
 import qualified System.Metrics as Metrics
 import qualified System.Metrics.Gauge as Metrics.Gauge
-import           System.Wlog (logDebug)
+import           Pos.Util.Log (logDebug)
 
 import           Pos.StateLock (StateLockMetrics (..))
 import           Pos.System.Metrics.Constants (withCardanoNamespace)

--- a/util/Pos/Util/Log.hs
+++ b/util/Pos/Util/Log.hs
@@ -12,6 +12,7 @@ module Pos.Util.Log
        ---
        , LoggerConfig(..)
        , loadLogConfig
+       , retrieveLogFiles
        ---
        , loggerBracket
        ---
@@ -33,7 +34,7 @@ import           Control.Monad.Base (MonadBase)
 import           Control.Monad.Morph (MFunctor(..))
 import           Control.Monad.Writer (WriterT (..))
 
-import           Pos.Util.LoggerConfig (LoggerConfig(..), loadLogConfig)
+import           Pos.Util.LoggerConfig (LoggerConfig(..), loadLogConfig, retrieveLogFiles)
 import           Pos.Util.LogSeverity (Severity(..))
 import           Pos.Util.LogStdoutScribe (mkStdoutScribe)
 
@@ -84,6 +85,8 @@ instance (MonadReader r m, CanLog m) => MonadReader r (LoggerNameBox m) where
     reader = lift . reader
     local f (LoggerNameBox m) = askLoggerName >>= lift . local f . runReaderT m
 -}
+instance CanLog (LogContextT IO)
+instance HasLoggerName (LogContextT IO)
 
 -- | log a Text with severity
 logMessage :: (LogContext m {-, HasCallStack -}) => Severity -> Text -> m ()

--- a/util/Pos/Util/LogSeverity.hs
+++ b/util/Pos/Util/LogSeverity.hs
@@ -4,6 +4,11 @@ module Pos.Util.LogSeverity
        ) where
 
 
+import           Universum
+
+
+
 -- | abstract libraries' severity
 data Severity = Debug | Info | Warning | Notice | Error
+                deriving (Show)
 

--- a/util/Pos/Util/LoggerConfig.hs
+++ b/util/Pos/Util/LoggerConfig.hs
@@ -3,6 +3,7 @@ module Pos.Util.LoggerConfig
        ( LoggerConfig(..)
        , RotationParameters(..)
        , loadLogConfig
+       , retrieveLogFiles
        ) where
 
 import           Universum
@@ -21,10 +22,30 @@ data LoggerConfig = LoggerConfig
     {
         _lcRotation     :: Maybe RotationParameters
     ,   _lcMinSeverity  :: Severity
-    }
+    } deriving (Generic, Show)
 
+instance Monoid LoggerConfig where
+    mempty = LoggerConfig { _lcRotation = Nothing, _lcMinSeverity = Debug }
+    mappend = (<>)
+
+instance Semigroup LoggerConfig
 
 -- | load log config from file  TODO
 loadLogConfig :: MonadIO m => Maybe FilePath -> Maybe FilePath -> m ()
 loadLogConfig _ _ = return ()
+
+-- | Given logger config, retrieves all (logger name, filepath) for
+-- every logger that has file handle. Filepath inside does __not__
+-- contain the common logger config prefix.
+-- (this function was in infra/Pos/Reporting/Methods.hs)
+retrieveLogFiles :: LoggerConfig -> [([Text], FilePath)]
+{-
+retrieveLogFiles lconfig = fromLogTree $ lconfig ^. lcTree
+  where
+    fromLogTree lt =
+        let curElems = map ([],) (lt ^.. ltFiles . each . hwFilePath)
+            iterNext (part, node) = map (first (part :)) $ fromLogTree node
+        in curElems ++ concatMap iterNext (lt ^. ltSubloggers . to HM.toList)
+-}
+retrieveLogFiles _ = []
 


### PR DESCRIPTION
Signed-off-by: Alexander Diemand <codieplusplus@apax.net>

## Description
[WIP]: cardano-sl-infra moving to use abstract logging interface (Pos.Util.Log)

## Linked issue

task: CBR-207, user story: CBR-97

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ x ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ x ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ x ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ~ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ~ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.

## QA Steps
none yet.

## Screenshots (if available)
