### PR TITLE
[CSL-2495] Create epoch boundary blocks in the wallet-new tests

### DIFF
--- a/lib/src/Pos/Launcher/Scenario.hs
+++ b/lib/src/Pos/Launcher/Scenario.hs
@@ -62,7 +62,7 @@ runNode' NodeResources {..} workers' plugins' = \diffusion -> do
     logInfo $ sformat
         ("Genesis stakeholders ("%int%" addresses, dust threshold "%build%"): "%build)
         (length $ getGenesisWStakeholders genesisStakeholders)
-        bootDustThreshold
+        (bootDustThreshold genesisStakeholders)
         genesisStakeholders
 
     let genesisDelegation = gdHeavyDelegation genesisData

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18844,6 +18844,7 @@ optparse-applicative
 QuickCheck
 quickcheck-instances
 random
+reflection
 safe-exceptions
 serokell-util
 servant

--- a/txp/src/Pos/Txp/Base.hs
+++ b/txp/src/Pos/Txp/Base.hs
@@ -17,12 +17,10 @@ import qualified Data.HashSet as HS
 import           Data.List (zipWith)
 import qualified Data.Map.Strict as M
 
-import           Pos.Core (AddrStakeDistribution (..), Address (..), Coin,
-                     CoinPortion, GenesisData (..), HasGenesisData,
-                     StakeholderId, StakesList, aaStakeDistribution,
-                     addrAttributesUnwrapped, applyCoinPortionDown,
-                     coinToInteger, genesisData, mkCoin, sumCoins,
-                     unsafeAddCoin, unsafeGetCoin, unsafeIntegerToCoin)
+import           Pos.Core (AddrStakeDistribution (..), Address (..), Coin, CoinPortion,
+                           StakeholderId, StakesList, aaStakeDistribution, addrAttributesUnwrapped,
+                           applyCoinPortionDown, coinToInteger, mkCoin, sumCoins, unsafeAddCoin,
+                           unsafeGetCoin, unsafeIntegerToCoin)
 import           Pos.Core.Genesis (GenesisWStakeholders (..))
 import           Pos.Core.Txp (TxAux (..), TxOut (..), TxOutAux (..),
                      TxPayload (..), mkTxPayload)
@@ -41,10 +39,10 @@ TxOutAux {..} `addrBelongsToSet` addrs = txOutAddress toaOut `HS.member` addrs
 
 -- | Use this function if you need to know how a 'TxOut' distributes stake
 -- (e.g. for the purpose of running follow-the-satoshi).
-txOutStake :: HasGenesisData => TxOut -> StakesList
-txOutStake TxOut {..} =
+txOutStake :: GenesisWStakeholders -> TxOut -> StakesList
+txOutStake genesisStakeholders (TxOut {..}) =
     case aaStakeDistribution (addrAttributesUnwrapped txOutAddress) of
-        BootstrapEraDistr            -> bootstrapEraDistr txOutValue
+        BootstrapEraDistr            -> (bootstrapEraDistr genesisStakeholders) txOutValue
         SingleKeyDistr sId           -> [(sId, txOutValue)]
         UnsafeMultiKeyDistr distrMap -> computeMultiKeyDistr (M.toList distrMap)
   where
@@ -80,14 +78,12 @@ emptyTxPayload = mkTxPayload []
 
 -- | If output has less coins than this value, 'BootstrapEraDistr'
 -- will use custom algorithm.
-bootDustThreshold :: HasGenesisData => Coin
-bootDustThreshold =
+bootDustThreshold :: GenesisWStakeholders -> Coin
+bootDustThreshold (GenesisWStakeholders bootHolders) =
     -- it's safe to use it here because weights are word16 and should
     -- be really low in production, so this sum is not going to be
     -- even more than 10-15 coins.
     unsafeIntegerToCoin . sum $ map fromIntegral $ toList bootHolders
-  where
-    GenesisWStakeholders bootHolders = gdBootStakeholders genesisData
 
 -- Compute bootstrap era distribution.
 --
@@ -99,14 +95,13 @@ bootDustThreshold =
 -- If coin is lower than 'bootDustThreshold' then this function
 -- distributes coins among first stakeholders in the list according to
 -- their weights. The list is ordered by 'StakeholderId's.
-bootstrapEraDistr :: HasGenesisData => Coin -> [(StakeholderId, Coin)]
-bootstrapEraDistr c
-    | c < bootDustThreshold =
+bootstrapEraDistr :: GenesisWStakeholders -> Coin -> [(StakeholderId, Coin)]
+bootstrapEraDistr bs@(GenesisWStakeholders bootWHolders) c
+    | c < bootDustThreshold bs =
           snd $ foldr foldrFunc (0::Word64,[]) (M.toList bootWHolders)
     | otherwise =
           bootHolders `zip` stakeCoins
   where
-    GenesisWStakeholders bootWHolders = gdBootStakeholders genesisData
     foldrFunc (s,w) r@(totalSum, res) = case compare totalSum cval of
         EQ -> r
         GT -> error "bootstrapEraDistr: totalSum > cval can't happen"

--- a/txp/src/Pos/Txp/Base.hs
+++ b/txp/src/Pos/Txp/Base.hs
@@ -17,10 +17,11 @@ import qualified Data.HashSet as HS
 import           Data.List (zipWith)
 import qualified Data.Map.Strict as M
 
-import           Pos.Core (AddrStakeDistribution (..), Address (..), Coin, CoinPortion,
-                           StakeholderId, StakesList, aaStakeDistribution, addrAttributesUnwrapped,
-                           applyCoinPortionDown, coinToInteger, mkCoin, sumCoins, unsafeAddCoin,
-                           unsafeGetCoin, unsafeIntegerToCoin)
+import           Pos.Core (AddrStakeDistribution (..), Address (..), Coin,
+                     CoinPortion, StakeholderId, StakesList,
+                     aaStakeDistribution, addrAttributesUnwrapped,
+                     applyCoinPortionDown, coinToInteger, mkCoin, sumCoins,
+                     unsafeAddCoin, unsafeGetCoin, unsafeIntegerToCoin)
 import           Pos.Core.Genesis (GenesisWStakeholders (..))
 import           Pos.Core.Txp (TxAux (..), TxOut (..), TxOutAux (..),
                      TxPayload (..), mkTxPayload)

--- a/txp/src/Pos/Txp/DB/Utxo.hs
+++ b/txp/src/Pos/Txp/DB/Utxo.hs
@@ -42,8 +42,8 @@ import           Serokell.Util (Color (Red), colorize)
 import           System.Wlog (WithLogger, logError)
 import           UnliftIO (MonadUnliftIO)
 
-import           Pos.Core (Address, Coin, HasCoreConfiguration, coinF, mkCoin,
-                     sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders), HasCoreConfiguration,
+                           coinF, genesisData, mkCoin, sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
 import           Pos.Core.Txp (TxIn (..), TxOutAux (toaOut))
 import           Pos.DB (DBError (..), DBIteratorClass (..), DBTag (GStateDB),
                      IterType, MonadDB, MonadDBRead, RocksBatchOp (..),
@@ -137,7 +137,8 @@ sanityCheckUtxo
     => Coin -> m ()
 sanityCheckUtxo expectedTotalStake = do
     let stakesSource =
-            mapOutput (map snd . txOutStake . toaOut . snd) utxoSource
+            mapOutput (map snd . txOutStake (gdBootStakeholders genesisData)
+                       . toaOut . snd) utxoSource
     calculatedTotalStake <-
         runConduitRes $ stakesSource .| CL.fold foldAdd (mkCoin 0)
     let fmt =

--- a/txp/src/Pos/Txp/DB/Utxo.hs
+++ b/txp/src/Pos/Txp/DB/Utxo.hs
@@ -42,8 +42,9 @@ import           Serokell.Util (Color (Red), colorize)
 import           System.Wlog (WithLogger, logError)
 import           UnliftIO (MonadUnliftIO)
 
-import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders), HasCoreConfiguration,
-                           coinF, genesisData, mkCoin, sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders),
+                     HasCoreConfiguration, coinF, genesisData, mkCoin,
+                     sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
 import           Pos.Core.Txp (TxIn (..), TxOutAux (toaOut))
 import           Pos.DB (DBError (..), DBIteratorClass (..), DBTag (GStateDB),
                      IterType, MonadDB, MonadDBRead, RocksBatchOp (..),

--- a/txp/src/Pos/Txp/Toil/Stakes.hs
+++ b/txp/src/Pos/Txp/Toil/Stakes.hs
@@ -16,8 +16,8 @@ import           Formatting (sformat, (%))
 import           Serokell.Util.Text (listJson)
 import           System.Wlog (logDebug)
 
-import           Pos.Core (HasGenesisData, StakesList, coinToInteger, mkCoin,
-                     sumCoins, unsafeIntegerToCoin)
+import           Pos.Core (GenesisData (gdBootStakeholders), HasGenesisData, StakesList,
+                           coinToInteger, genesisData, mkCoin, sumCoins, unsafeIntegerToCoin)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxOutAux (..), TxUndo)
 import           Pos.Txp.Base (txOutStake)
 import           Pos.Txp.Toil.Monad (GlobalToilM, getStake, getTotalStake,
@@ -90,6 +90,8 @@ concatStakes (unzip -> (txas, undo)) = (txasTxOutDistr, undoTxInDistr)
   where
     onlyKnownUndos = catMaybes . toList
     txasTxOutDistr = concatMap concatDistr txas
-    undoTxInDistr = concatMap (txOutStake . toaOut) (foldMap onlyKnownUndos undo)
+    undoTxInDistr = concatMap (txOutStake (gdBootStakeholders genesisData) . toaOut)
+                    (foldMap onlyKnownUndos undo)
     concatDistr (TxAux UnsafeTx {..} _) =
-        concatMap (txOutStake . toaOut) $ toList (map TxOutAux _txOutputs)
+        concatMap (txOutStake  (gdBootStakeholders genesisData) . toaOut)
+        $ toList (map TxOutAux _txOutputs)

--- a/txp/src/Pos/Txp/Toil/Stakes.hs
+++ b/txp/src/Pos/Txp/Toil/Stakes.hs
@@ -16,8 +16,9 @@ import           Formatting (sformat, (%))
 import           Serokell.Util.Text (listJson)
 import           System.Wlog (logDebug)
 
-import           Pos.Core (GenesisData (gdBootStakeholders), HasGenesisData, StakesList,
-                           coinToInteger, genesisData, mkCoin, sumCoins, unsafeIntegerToCoin)
+import           Pos.Core (GenesisData (gdBootStakeholders), HasGenesisData,
+                     StakesList, coinToInteger, genesisData, mkCoin, sumCoins,
+                     unsafeIntegerToCoin)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxOutAux (..), TxUndo)
 import           Pos.Txp.Base (txOutStake)
 import           Pos.Txp.Toil.Monad (GlobalToilM, getStake, getTotalStake,

--- a/txp/src/Pos/Txp/Toil/Utxo/Util.hs
+++ b/txp/src/Pos/Txp/Toil/Utxo/Util.hs
@@ -42,7 +42,8 @@ utxoToStakes :: HasGenesisData => Utxo -> StakesMap
 utxoToStakes = foldl' putDistr mempty . M.toList
   where
     plusAt hm (key, val) = HM.insertWith unsafeAddCoin key val hm
-    putDistr hm (_, TxOutAux txOut) = foldl' plusAt hm (txOutStake txOut)
+    putDistr hm (_, TxOutAux txOut) =
+        foldl' plusAt hm (txOutStake (gdBootStakeholders genesisData) txOut)
 
 utxoToAddressCoinPairs :: Utxo -> [(Address, Coin)]
 utxoToAddressCoinPairs utxo = combineWith unsafeAddCoin txOuts

--- a/txp/src/Pos/Txp/Toil/Utxo/Util.hs
+++ b/txp/src/Pos/Txp/Toil/Utxo/Util.hs
@@ -15,8 +15,8 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as M
 
-import           Pos.Core (Address, Coin, HasGenesisData, StakesMap, sumCoins,
-                     unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders), HasGenesisData,
+                           StakesMap, genesisData, sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
 import           Pos.Core.Txp (TxOut (txOutValue), TxOutAux (..), _TxOut)
 import           Pos.Txp.Base (addrBelongsTo, addrBelongsToSet, txOutStake)
 import           Pos.Txp.Toil.Types (Utxo)

--- a/txp/src/Pos/Txp/Toil/Utxo/Util.hs
+++ b/txp/src/Pos/Txp/Toil/Utxo/Util.hs
@@ -15,8 +15,9 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as M
 
-import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders), HasGenesisData,
-                           StakesMap, genesisData, sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core (Address, Coin, GenesisData (gdBootStakeholders),
+                     HasGenesisData, StakesMap, genesisData, sumCoins,
+                     unsafeAddCoin, unsafeIntegerToCoin)
 import           Pos.Core.Txp (TxOut (txOutValue), TxOutAux (..), _TxOut)
 import           Pos.Txp.Base (addrBelongsTo, addrBelongsToSet, txOutStake)
 import           Pos.Txp.Toil.Types (Utxo)

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -482,6 +482,7 @@ test-suite wallet-unit-tests
                     , QuickCheck
                     , quickcheck-instances
                     , safe-exceptions
+                    , reflection
                     , serokell-util
                     , servant-server
                     , tabl

--- a/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
@@ -26,9 +26,9 @@ import qualified Data.Map.Strict as Map
 import           Data.Word (Word32)
 import           Formatting.Buildable (Buildable (..))
 
-import           Pos.Core (MainBlock, Tx, TxAux (..), TxId, TxIn (..), TxOut,
-                     TxOutAux (..), gbBody, mainBlockSlot, mbTxs, mbWitnesses,
-                     txInputs, txOutputs)
+import           Pos.Core (GenesisBlock, MainBlock, Tx, TxAux (..), TxId,
+                     TxIn (..), TxOut, TxOutAux (..), gbBody, mainBlockSlot,
+                     mbTxs, mbWitnesses, txInputs, txOutputs)
 import           Pos.Crypto.Hashing (hash)
 import           Pos.Txp (Utxo)
 import           Serokell.Util (enumerate)
@@ -117,10 +117,15 @@ mkRawResolvedTx txAux ins =
 
 -- | Signed block along with its resolved inputs
 --
+-- If this block sits directly after an epoch boundary, it might additionally
+-- have an attached epoch boundary block which should directly proceed it in the
+-- chain . This is becuase the DSL contains no notion of epoch boundaries.
+--
 -- Constructor is marked unsafe because the caller should make sure that
 -- invariant 'invRawResolvedBlock' holds.
 data RawResolvedBlock = UnsafeRawResolvedBlock {
       rawResolvedBlock       :: MainBlock
+    , rawResolvedBlockEBB    :: Maybe GenesisBlock
     , rawResolvedBlockInputs :: ResolvedBlockInputs
     }
 
@@ -138,10 +143,10 @@ invRawResolvedBlock block ins =
     txs = getBlockTxs block
 
 -- | Smart constructor for 'RawResolvedBlock' that checks the invariant
-mkRawResolvedBlock :: MainBlock -> ResolvedBlockInputs -> RawResolvedBlock
-mkRawResolvedBlock block ins =
+mkRawResolvedBlock :: MainBlock -> Maybe GenesisBlock -> ResolvedBlockInputs -> RawResolvedBlock
+mkRawResolvedBlock block mebb  ins =
     if invRawResolvedBlock block ins
-      then UnsafeRawResolvedBlock block ins
+      then UnsafeRawResolvedBlock block mebb ins
       else error "mkRawResolvedBlock: invariant violation"
 
 {-------------------------------------------------------------------------------

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -118,7 +118,7 @@ bracketPassiveWallet logFunction keystore f =
     blundToResolvedBlock (b,u)
         = rightToJust b <&> \mainBlock ->
             fromRawResolvedBlock
-            $ UnsafeRawResolvedBlock mainBlock spentOutputs'
+            $ UnsafeRawResolvedBlock mainBlock Nothing spentOutputs'
         where
             spentOutputs' = map (map fromJust) $ undoTx u
             rightToJust   = either (const Nothing) Just

--- a/wallet-new/test/unit/Test/Infrastructure/Genesis.hs
+++ b/wallet-new/test/unit/Test/Infrastructure/Genesis.hs
@@ -22,6 +22,9 @@ data GenesisValues h = GenesisValues {
       -- | Initial balance of rich actor 0
       initR0   :: Value
 
+      -- | Initial balance of rich actor 1
+    , initR1   :: Value
+
       -- | Address of rich actor 0
     , r0       :: Addr
 
@@ -43,6 +46,7 @@ genesisValues :: (Hash h Addr) => TxSizeLinear -> Transaction h Addr -> GenesisV
 genesisValues txSizeLinear boot@Transaction{..} = GenesisValues{..}
   where
     initR0 = unsafeHead [val | Output a val <- trOuts, a == r0]
+    initR1 = unsafeHead [val | Output a val <- trOuts, a == r1]
 
       --11137499999752500
 

--- a/wallet-new/test/unit/Test/Spec/Translation.hs
+++ b/wallet-new/test/unit/Test/Spec/Translation.hs
@@ -50,7 +50,7 @@ spec = do
 
       it "can construct and verify chain that spans epochs" $
         let epochSlots = runTranslateNoErrors $ asks (ccEpochSlots . tcCardano)
-        in intAndVerifyPure linearFeePolicy (spanEpochs epochSlots) `shouldSatisfy` expectInvalid
+        in intAndVerifyPure linearFeePolicy (spanEpochs epochSlots) `shouldSatisfy` expectValid
 
     describe "Translation QuickCheck tests" $ do
       prop "can translate randomly generated chains" $
@@ -184,7 +184,7 @@ spanEpochs epochSlots GenesisValues{..} = OldestFirst $
        -> Value         -- r1's current total balance
        -> Int           -- Number of cycles to go
        -> [Block h Addr]
-    go _ _ _ _ _ 0 = []
+    go _ _ _ _ _ 1 = []
     go freshHash r0utxo r1utxo r0balance r1balance n =
         let tPing = ping freshHash       r0utxo r0balance
             tPong = pong (freshHash + 1) r1utxo r1balance
@@ -270,7 +270,7 @@ intAndVerifyChain pc = runTranslateT $ do
       Right (chain', ctxt) -> do
         let chain'' = fromMaybe (error "intAndVerify: Nothing")
                     $ nonEmptyOldestFirst
-                    $ map Right chain'
+                    $ chain'
         isCardanoValid <- verifyBlocksPrefix chain''
         case (dslIsValid, isCardanoValid) of
           (Invalid _ e' , Invalid _ e) -> return $ ExpectedInvalid e' e

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -75,22 +75,25 @@ data CardanoContext = CardanoContext {
       --
       -- NOTE: Derived from 'ccBlock0', /not/ the same as 'genesisHash'.
     , ccHash0       :: HeaderHash
+
+      -- | Number of slots in an epoch
+    , ccEpochSlots  :: SlotCount
     }
 
 initCardanoContext :: HasConfiguration => ProtocolMagic -> CardanoContext
 initCardanoContext pm = CardanoContext{..}
   where
-    ccLeaders  = genesisLeaders epochSlots
-    ccStakes   = genesisStakes
-    ccBlock0   = genesisBlock0 pm (GenesisHash genesisHash) ccLeaders
-    ccData     = genesisData
-    ccUtxo     = unGenesisUtxo genesisUtxo
-    ccSecrets  = fromMaybe (error "initCardanoContext: secrets unavailable") $
-                 generatedSecrets
+    ccLeaders     = genesisLeaders epochSlots
+    ccStakes      = genesisStakes
+    ccBlock0      = genesisBlock0 pm (GenesisHash genesisHash) ccLeaders
+    ccData        = genesisData
+    ccUtxo        = unGenesisUtxo genesisUtxo
+    ccSecrets     = fromMaybe (error "initCardanoContext: secrets unavailable")
+                  $ generatedSecrets
     ccInitLeaders = ccLeaders
-
-    ccBalances = utxoToAddressCoinPairs ccUtxo
-    ccHash0    = (blockHeaderHash . BlockHeaderGenesis . _gbHeader) ccBlock0
+    ccBalances    = utxoToAddressCoinPairs ccUtxo
+    ccHash0       = (blockHeaderHash . BlockHeaderGenesis . _gbHeader) ccBlock0
+    ccEpochSlots  = epochSlots
 
 {-------------------------------------------------------------------------------
   More explicit representation of the various actors in the genesis block

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -57,12 +57,14 @@ import           UTxO.Crypto
 
 -- | The information returned by core
 data CardanoContext = CardanoContext {
-      ccLeaders  :: SlotLeaders
-    , ccStakes   :: StakesMap
+      ccStakes   :: StakesMap
     , ccBlock0   :: GenesisBlock
     , ccData     :: GenesisData
     , ccUtxo     :: Utxo
     , ccSecrets  :: GeneratedSecrets
+
+      -- | Initial stake distribution
+    , ccInitLeaders :: SlotLeaders
 
       -- | Initial balances
       --
@@ -501,14 +503,14 @@ resolveAddress addr TransCtxt{..} =
   where
     AddrMap{..} = tcAddrMap
 
-leaderForSlot :: SlotId -> TransCtxt -> Stakeholder
-leaderForSlot slotId TransCtxt{..} = actorsStake Map.! leader
+leaderForSlot :: SlotLeaders -> SlotId -> TransCtxt -> Stakeholder
+leaderForSlot leaders slotId TransCtxt{..} = actorsStake Map.! leader
   where
     Actors{..}         = tcActors
     CardanoContext{..} = tcCardano
 
     leader :: StakeholderId
-    leader = ccLeaders NE.!! slotIx
+    leader = leaders NE.!! slotIx
 
     slotIx :: Int
     slotIx = fromIntegral $ getSlotIndex (siSlot slotId)
@@ -535,8 +537,10 @@ blockSignInfo Stakeholder{..} = BlockSignInfo{..}
     bsiKey    = regKpSec richKey
     bsiPSK    = delPSK
 
-blockSignInfoForSlot :: SlotId -> TransCtxt -> BlockSignInfo
-blockSignInfoForSlot slotId = blockSignInfo . leaderForSlot slotId
+blockSignInfoForSlot :: SlotLeaders -> SlotId -> TransCtxt -> BlockSignInfo
+blockSignInfoForSlot leaders slotId =
+      blockSignInfo
+    . leaderForSlot leaders slotId
 
 {-------------------------------------------------------------------------------
   Pretty-printing
@@ -617,13 +621,13 @@ instance Buildable Addr where
 instance Buildable CardanoContext where
   build CardanoContext{..} = bprint
       ( "CardanoContext"
-      % "{ leaders:  " % listJson
-      % ", stakes:   " % listJson
-      % ", balances: " % listJson
-      % ", utxo:     " % mapJson
+      % "{ initLeaders:  " % listJson
+      % ", stakes:       " % listJson
+      % ", balances:     " % listJson
+      % ", utxo:         " % mapJson
       % "}"
       )
-      ccLeaders
+      ccInitLeaders
       (map (bprint pairF) (HM.toList ccStakes))
       (map (bprint pairF) ccBalances)
       ccUtxo

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -57,11 +57,11 @@ import           UTxO.Crypto
 
 -- | The information returned by core
 data CardanoContext = CardanoContext {
-      ccStakes   :: StakesMap
-    , ccBlock0   :: GenesisBlock
-    , ccData     :: GenesisData
-    , ccUtxo     :: Utxo
-    , ccSecrets  :: GeneratedSecrets
+      ccStakes      :: StakesMap
+    , ccBlock0      :: GenesisBlock
+    , ccData        :: GenesisData
+    , ccUtxo        :: Utxo
+    , ccSecrets     :: GeneratedSecrets
 
       -- | Initial stake distribution
     , ccInitLeaders :: SlotLeaders
@@ -69,12 +69,12 @@ data CardanoContext = CardanoContext {
       -- | Initial balances
       --
       -- Derived from 'ccUtxo'.
-    , ccBalances :: [(Address, Coin)]
+    , ccBalances    :: [(Address, Coin)]
 
       -- | Hash of block0
       --
       -- NOTE: Derived from 'ccBlock0', /not/ the same as 'genesisHash'.
-    , ccHash0    :: HeaderHash
+    , ccHash0       :: HeaderHash
     }
 
 initCardanoContext :: HasConfiguration => ProtocolMagic -> CardanoContext
@@ -87,6 +87,7 @@ initCardanoContext pm = CardanoContext{..}
     ccUtxo     = unGenesisUtxo genesisUtxo
     ccSecrets  = fromMaybe (error "initCardanoContext: secrets unavailable") $
                  generatedSecrets
+    ccInitLeaders = ccLeaders
 
     ccBalances = utxoToAddressCoinPairs ccUtxo
     ccHash0    = (blockHeaderHash . BlockHeaderGenesis . _gbHeader) ccBlock0

--- a/wallet-new/test/unit/UTxO/Interpreter.hs
+++ b/wallet-new/test/unit/UTxO/Interpreter.hs
@@ -30,7 +30,6 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Reflection (give)
 import qualified Data.Set as Set
-import qualified Data.Text.Buildable
 import           Formatting (bprint, shown)
 import qualified Formatting.Buildable
 import           Prelude (Show (..))

--- a/wallet-new/test/unit/UTxO/Translate.hs
+++ b/wallet-new/test/unit/UTxO/Translate.hs
@@ -200,19 +200,116 @@ verify ma = withConfig $ do
 -- genesis/epoch boundary block itself. In practice, however, the passed in set
 -- of leaders is verified 'slogVerifyBlocks', so we'd have to modify the
 -- verification code a bit.
+
+--   It is not required that all blocks are from the same epoch. This will
+--   split the chain into epochs and validate each epoch individually
 verifyBlocksPrefix
-  :: Monad m
+  :: forall e' m.  Monad m
   => OldestFirst NE Block
   -> TranslateT e' m (Validated VerifyBlocksException (OldestFirst NE Undo, Utxo))
-verifyBlocksPrefix blocks = do
-    CardanoContext{..} <- asks tcCardano
-    let tip         = ccHash0
-        currentSlot = Nothing
-    withProtocolMagic $ \pm ->
-      verify $ Verify.verifyBlocksPrefix
-          pm
-          tip
-          currentSlot
-          ccInitLeaders    -- TODO: May not be necessary to pass this if we start from genesis
-          (OldestFirst []) -- TODO: LastBlkSlots. Unsure about the required value or its effect
-          blocks
+verifyBlocksPrefix blocks =
+    case splitEpochs blocks of
+      ESREmptyEpoch _          ->
+        validatedFromExceptT . throwError $ VerifyBlocksError "Whoa! Empty epoch!"
+      ESRStartsOnBoundary _    ->
+        validatedFromExceptT . throwError $ VerifyBlocksError "No genesis epoch!"
+      ESRValid genEpoch (OldestFirst succEpochs) -> withProtocolMagic $ \pm -> do
+        CardanoContext{..} <- asks tcCardano
+        verify $ validateGenEpoch pm ccHash0 ccInitLeaders genEpoch >>= \genUndos -> do
+          epochUndos <- sequence $ validateSuccEpoch pm <$> succEpochs
+          return $ foldl' (\a b -> a <> b) genUndos epochUndos
+
+  where
+    validateGenEpoch :: ProtocolMagic
+                     -> HeaderHash
+                     -> SlotLeaders
+                     -> OldestFirst NE MainBlock
+                     -> ( HasConfiguration
+                          => Verify VerifyBlocksException (OldestFirst NE Undo))
+    validateGenEpoch pm ccHash0 ccInitLeaders geb = do
+      Verify.verifyBlocksPrefix
+        pm
+        ccHash0
+        Nothing
+        ccInitLeaders
+        (OldestFirst [])
+        (Right <$> geb ::  OldestFirst NE Block)
+    validateSuccEpoch :: ProtocolMagic
+                      -> EpochBlocks NE
+                      -> ( HasConfiguration
+                           => Verify VerifyBlocksException (OldestFirst NE Undo))
+    validateSuccEpoch pm (SuccEpochBlocks ebb emb) = do
+      Verify.verifyBlocksPrefix
+        pm
+        (ebb ^. headerHashG)
+        Nothing
+        (ebb ^. gbBody . gbLeaders)
+        (OldestFirst []) -- ^ TODO pass these?
+        (Right <$> emb)
+
+-- | Blocks inside an epoch
+data EpochBlocks a = SuccEpochBlocks !GenesisBlock !(OldestFirst a MainBlock)
+
+-- | Try to convert the epoch into a non-empty epoch
+neEpoch :: EpochBlocks [] -> Maybe (EpochBlocks NE)
+neEpoch (SuccEpochBlocks ebb (OldestFirst mbs)) = case nonEmpty mbs of
+  Nothing   -> Nothing
+  Just mbs' -> Just $ SuccEpochBlocks ebb (OldestFirst mbs')
+
+-- | Epoch splitting result. This validates that the chain follow the pattern
+--   `m(m*)(b(m+))*`, where `m` denotes a main block, and `b` a boundary block.
+--
+--   Either we have a valid splitting of the chain into epochs, or at some point
+--   we have an empty epoch, in which case we return the successive boundary
+--   blocks, or we have that the chain starts on a boundary block.
+--
+--   This does not catch the case where blocks are in the wrong epoch, which
+--   will be detected by slot leaders being incorrect.
+data EpochSplitResult
+  = ESRValid !(OldestFirst NE MainBlock) !(OldestFirst [] (EpochBlocks NE))
+  | ESREmptyEpoch !GenesisBlock
+  | ESRStartsOnBoundary !GenesisBlock
+
+-- | Split a non-empty set of blocks into the genesis epoch (which does not start with
+--   an epoch boundary block) and a set of successive epochs, starting with an EBB.
+splitEpochs :: OldestFirst NE Block
+            -> EpochSplitResult
+splitEpochs blocks = case spanEpoch blocks of
+  (Left (SuccEpochBlocks ebb _), _) -> ESRStartsOnBoundary ebb
+  (Right genEpoch, OldestFirst rem') -> go [] (OldestFirst <$> nonEmpty rem') where
+    go !acc Nothing = ESRValid genEpoch (OldestFirst $ reverse acc)
+    go !acc (Just neRem) = case spanEpoch neRem of
+      (Right _, _) -> error "Impossible!"
+      (Left ebs@(SuccEpochBlocks ebb _), OldestFirst newRem) -> case neEpoch ebs of
+        Nothing   -> ESREmptyEpoch ebb
+        Just ebs' -> go (ebs' :  acc) (OldestFirst <$> nonEmpty newRem)
+
+-- | Span the epoch until the next epoch boundary block.
+--
+--   - If the list of blocks starts with an EBB, this will return 'Left
+--     EpochBlocks' containing the EBB and the successive blocks.
+--   - If the list of blocks does not start with an EBB, this will return
+--     `Right (OldestFirst NE Block)` containg all blocks before the next
+--     EBB.
+--
+--   In either case, it will also return any remainng blocks, which will either be
+--   empty or start with an EBB.
+spanEpoch :: OldestFirst NE Block
+          -> (Either (EpochBlocks []) (OldestFirst NE MainBlock), OldestFirst [] Block)
+spanEpoch (OldestFirst (x:|xs)) = case x of
+  Left ebb -> over _1 (Left . SuccEpochBlocks ebb . OldestFirst)
+              . over _2 OldestFirst
+              $ spanMaybe rightToMaybe xs
+  -- Take until we find an EBB
+  Right mb -> over _1 (Right . OldestFirst . (mb :|))
+       . over _2 OldestFirst
+       $ spanMaybe rightToMaybe xs
+
+-- | Returns the maximal prefix of the input list mapped to `Just`, along with
+-- the remainder.
+spanMaybe :: (a -> Maybe b) -> [a] -> ([b], [a])
+spanMaybe = go [] where
+  go !acc _ [] = (reverse acc, [])
+  go !acc f (x:xs) = case f x of
+    Just x' -> go (x':acc) f xs
+    Nothing -> (reverse acc, x:xs)

--- a/wallet-new/test/unit/UTxO/Translate.hs
+++ b/wallet-new/test/unit/UTxO/Translate.hs
@@ -190,6 +190,16 @@ verify ma = withConfig $ do
     return $ validatedFromEither (Verify.verify utxo ma)
 
 -- | Wrapper around 'UTxO.Verify.verifyBlocksPrefix'
+--
+-- NOTE: This assumes right now that we verify starting from the genesis block.
+-- If that assumption is not valid, we need to pass in the slot leaders here.
+-- Probably easier is to always start from an epoch boundary block; in such a
+-- case in principle we don't need to pass in the set of leaders all, since the
+-- the core of the block verification code ('verifyBlocks' from module
+-- "Pos.Block.Logic.Integrity") will then take the set of leaders from the
+-- genesis/epoch boundary block itself. In practice, however, the passed in set
+-- of leaders is verified 'slogVerifyBlocks', so we'd have to modify the
+-- verification code a bit.
 verifyBlocksPrefix
   :: Monad m
   => OldestFirst NE Block
@@ -203,6 +213,6 @@ verifyBlocksPrefix blocks = do
           pm
           tip
           currentSlot
-          ccLeaders        -- TODO: May not be necessary to pass this if we start from genesis
+          ccInitLeaders    -- TODO: May not be necessary to pass this if we start from genesis
           (OldestFirst []) -- TODO: LastBlkSlots. Unsure about the required value or its effect
           blocks


### PR DESCRIPTION
## Description

This PR calculates the running stakes throughout translation of the DSL. These are used to run follow-the-satoshi and create an epoch boundary block when needed.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-253

## Type of change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

