### PR TITLE
[DEVOPS-632] ci: Build benchmarks in hydra and buildkite

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -22,20 +22,14 @@ fi
 
 # TODO: CSL-1133: Add test coverage to CI. To be reenabled when build times
 # become smaller and allow coverage report to be built.
-#projects="core db lrc infra update ssc godtossing txp"
-#to_build=''
-
-#for prj in $projects; do
-#  to_build="$to_build cardano-sl-$prj"
-#done
 
 for trgt in $targets; do
-  # echo "Prebuilding dependencies for $trgt, quietly.."
-  # nix-shell -A $trgt --run true --no-build-output --cores 0 --max-jobs 4 default.nix ||
-  #         echo "Prebuild failed!"
-
   echo "Building $trgt verbosely.."
-  nix-build -A "$trgt" -o "$trgt.root" --argstr gitrev "$BUILDKITE_COMMIT" --argstr buildId "$BUILDKITE_BUILD_NUMBER"
+  nix-build -A "$trgt" -o "$trgt.root" \
+      --argstr gitrev "$BUILDKITE_COMMIT" \
+      --argstr buildId "$BUILDKITE_BUILD_NUMBER" \
+      --arg enableBenchmarks true
+
 #    TODO: CSL-1133
 #    if [[ "$trgt" == "cardano-sl" ]]; then
 #      stack test --nix --fast --jobs=2 --coverage \
@@ -44,12 +38,3 @@ for trgt in $targets; do
 #    fi
 
 done
-
-#if [[ "$OS_NAME" == "linux" && "$BUILDKITE_BRANCH" == "master" && "$BUILDKITE_PULL_REQUEST" == "false" ]]; then
-  # XXX: DEVOPS-728 this won't work, unless `GITHUB_CARDANO_DOCS_ACCESS_2` and `GITHUB_CARDANO_DOCS_ACCESS` vars are supplied
-  #
-  #./update-wallet-web-api-docs.sh
-  #./update-explorer-web-api-docs.sh
-  #./update-cli-docs.sh
-  #./update-haddock.sh
-#fi


### PR DESCRIPTION
## Description

Benchmarks were not being built in CI and therefore were getting broken without anyone noticing.

This enables building (but not running) of benchmarks.

The CI for this PR should successfully fail because it doesn't include the merge of #3005.

I would like some feedback about the defaults in nix. Should the `enableBenchmarks` arg default to true or false? Should there be separate derivations with benchmarks enabled?

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-632

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI build scripts fix.

## Developer checklist

- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## QA Steps

    nix-build -A cardano-sl-wallet-new --arg enableBenchmarks true

## Screenshots

![bench](https://user-images.githubusercontent.com/1019641/40685419-23127102-638c-11e8-9da6-adf520aa4329.gif)
