### PR TITLE
Added endpoint for unspent transaction outputs

### DIFF
--- a/explorer/src/Pos/Explorer/Aeson/ClientTypes.hs
+++ b/explorer/src/Pos/Explorer/Aeson/ClientTypes.hs
@@ -17,9 +17,11 @@ import           Data.Fixed (showFixed)
 
 import           Pos.Explorer.Web.ClientTypes (CAda (..), CAddress,
                      CAddressSummary, CAddressType, CBlockEntry, CBlockSummary,
-                     CCoin, CGenesisAddressInfo, CGenesisSummary, CHash,
-                     CNetworkAddress, CTxBrief, CTxEntry, CTxId, CTxSummary)
+                     CByteString (..), CCoin, CGenesisAddressInfo,
+                     CGenesisSummary, CHash, CNetworkAddress, CTxBrief,
+                     CTxEntry, CTxId, CTxSummary, CUtxo)
 import           Pos.Explorer.Web.Error (ExplorerError)
+import           Pos.Txp ()
 
 deriveJSON defaultOptions ''CHash
 deriveJSON defaultOptions ''CAddress
@@ -37,6 +39,10 @@ deriveToJSON defaultOptions ''CNetworkAddress
 deriveToJSON defaultOptions ''CTxSummary
 deriveToJSON defaultOptions ''CGenesisSummary
 deriveToJSON defaultOptions ''CGenesisAddressInfo
+deriveToJSON defaultOptions ''CUtxo
+
+instance ToJSON CByteString where
+    toJSON (CByteString bs) = (toJSON.toString) bs
 
 instance ToJSON CAda where
     -- https://github.com/bos/aeson/issues/227#issuecomment-245400284

--- a/explorer/src/Pos/Explorer/Web/Api.hs
+++ b/explorer/src/Pos/Explorer/Web/Api.hs
@@ -15,7 +15,8 @@ import           Universum
 
 import           Control.Exception.Safe (try)
 import           Data.Proxy (Proxy (Proxy))
-import           Servant.API ((:>), Capture, Get, JSON, QueryParam, Summary)
+import           Servant.API ((:>), Capture, Get, JSON, Post, QueryParam,
+                     ReqBody, Summary)
 import           Servant.Generic ((:-), AsApi, ToServant)
 import           Servant.Server (ServantErr (..))
 
@@ -23,7 +24,7 @@ import           Pos.Core (EpochIndex)
 import           Pos.Explorer.Web.ClientTypes (Byte, CAda, CAddress,
                      CAddressSummary, CAddressesFilter, CBlockEntry,
                      CBlockSummary, CGenesisAddressInfo, CGenesisSummary,
-                     CHash, CTxBrief, CTxEntry, CTxId, CTxSummary)
+                     CHash, CTxBrief, CTxEntry, CTxId, CTxSummary, CUtxo)
 import           Pos.Explorer.Web.Error (ExplorerError)
 import           Pos.Util.Servant (DQueryParam, ModifiesApiRes (..), VerbMod)
 
@@ -113,6 +114,14 @@ data ExplorerApiRecord route = ExplorerApiRecord
         :> "summary"
         :> Capture "address" CAddress
         :> ExRes Get CAddressSummary
+
+  , _addressUtxoBulk :: route
+        :- Summary "Get summary information about multiple addresses."
+        :> "bulk"
+        :> "addresses"
+        :> "utxo"
+        :> ReqBody '[JSON] [CAddress]
+        :> ExRes Post [CUtxo]
 
   , _epochPages :: route
         :- Summary "Get epoch pages, all the paged slots in the epoch."

--- a/explorer/src/Pos/Explorer/Web/ClientTypes.hs
+++ b/explorer/src/Pos/Explorer/Web/ClientTypes.hs
@@ -17,6 +17,7 @@ module Pos.Explorer.Web.ClientTypes
        , CAddressType (..)
        , CAddressSummary (..)
        , CTxBrief (..)
+       , CUtxo  (..)
        , CNetworkAddress (..)
        , CTxSummary (..)
        , CGenesisSummary (..)
@@ -29,6 +30,7 @@ module Pos.Explorer.Web.ClientTypes
        , LocalSlotIndex (..)
        , StakeholderId
        , Byte
+       , CByteString (..)
        , mkCCoin
        , mkCCoinMB
        , toCHash
@@ -87,6 +89,8 @@ import           Pos.Explorer.Core (TxExtra (..))
 import           Pos.Explorer.ExplorerMode (ExplorerMode)
 import           Pos.Explorer.ExtraContext (HasExplorerCSLInterface (..))
 import           Pos.Explorer.TestUtil (secretKeyToAddress)
+
+
 -------------------------------------------------------------------------------------
 -- Hash types
 -------------------------------------------------------------------------------------
@@ -308,6 +312,18 @@ data CTxBrief = CTxBrief
     , ctbOutputSum  :: !CCoin
     } deriving (Show, Generic)
 
+data CUtxo = CUtxo
+    { cuId       :: !CTxId
+    , cuOutIndex :: !Int
+    , cuAddress  :: !CAddress
+    , cuCoins    :: !CCoin
+    }
+    | CUtxoUnknown
+    { cuTag  :: !Int
+      , cuBs :: !CByteString
+    }
+    deriving (Show, Generic)
+
 newtype CNetworkAddress = CNetworkAddress Text
     deriving (Show, Generic)
 
@@ -430,6 +446,12 @@ sumCoinOfInputsOutputs addressListMB
             addressCoinList = addressCoins <$> addressList
         mkCCoin $ mkCoin $ fromIntegral $ sum addressCoinList
     | otherwise = mkCCoinMB Nothing
+
+newtype CByteString = CByteString ByteString
+    deriving (Generic)
+
+instance Show CByteString where
+    show (CByteString bs) = (show . toString) bs
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/explorer/src/Pos/Explorer/Web/Server.hs
+++ b/explorer/src/Pos/Explorer/Web/Server.hs
@@ -44,7 +44,8 @@ import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
 
 import qualified Serokell.Util.Base64 as B64
 import           Servant.Generic (AsServerT, toServant)
-import           Servant.Server (Server, ServerT, serve)
+import           Servant.Server (Server, ServerT, err405, errReasonPhrase,
+                     serve)
 import           System.Wlog (logDebug)
 
 import           Pos.Crypto (WithHash (..), hash, redeemPkBuild, withHash)
@@ -65,10 +66,10 @@ import           Pos.Core (AddrType (..), Address (..), Coin, EpochIndex,
 import           Pos.Core.Block (Block, MainBlock, mainBlockSlot,
                      mainBlockTxPayload, mcdSlot)
 import           Pos.Core.Chrono (NewestFirst (..))
-import           Pos.Core.Txp (Tx (..), TxAux, TxId, TxOutAux (..), taTx,
-                     txOutValue, txpTxs, _txOutputs)
-import           Pos.DB.Txp (MonadTxpMem, getLocalTxs, getMemPool,
-                     withTxpLocalData)
+import           Pos.Core.Txp (Tx (..), TxAux, TxId, TxIn (..), TxOutAux (..),
+                     taTx, txOutAddress, txOutValue, txpTxs, _txOutputs)
+import           Pos.DB.Txp (MonadTxpMem, getFilteredUtxo, getLocalTxs,
+                     getMemPool, withTxpLocalData)
 import           Pos.Infra.Slotting (MonadSlots (..), getSlotStart)
 import           Pos.Txp (TxMap, mpLocalTxs, topsortTxs)
 import           Pos.Util (divRoundUp, maybeThrow)
@@ -87,15 +88,18 @@ import           Pos.Explorer.Web.Api (ExplorerApi, ExplorerApiRecord (..),
 import           Pos.Explorer.Web.ClientTypes (Byte, CAda (..), CAddress (..),
                      CAddressSummary (..), CAddressType (..),
                      CAddressesFilter (..), CBlockEntry (..),
-                     CBlockSummary (..), CGenesisAddressInfo (..),
-                     CGenesisSummary (..), CHash, CTxBrief (..), CTxEntry (..),
-                     CTxId (..), CTxSummary (..), TxInternal (..),
-                     convertTxOutputs, convertTxOutputsMB, fromCAddress,
-                     fromCHash, fromCTxId, getEpochIndex, getSlotIndex,
-                     mkCCoin, mkCCoinMB, tiToTxEntry, toBlockEntry,
-                     toBlockSummary, toCAddress, toCHash, toCTxId, toTxBrief)
+                     CBlockSummary (..), CByteString (..),
+                     CGenesisAddressInfo (..), CGenesisSummary (..), CHash,
+                     CTxBrief (..), CTxEntry (..), CTxId (..), CTxSummary (..),
+                     CUtxo (..), TxInternal (..), convertTxOutputs,
+                     convertTxOutputsMB, fromCAddress, fromCHash, fromCTxId,
+                     getEpochIndex, getSlotIndex, mkCCoin, mkCCoinMB,
+                     tiToTxEntry, toBlockEntry, toBlockSummary, toCAddress,
+                     toCHash, toCTxId, toTxBrief)
 import           Pos.Explorer.Web.Error (ExplorerError (..))
 
+import qualified Data.Map as M
+import           Pos.Configuration (explorerExtendedApi)
 
 
 ----------------------------------------------------------------
@@ -133,6 +137,7 @@ explorerHandlers _diffusion =
         , _txsLast            = getLastTxs
         , _txsSummary         = getTxSummary
         , _addressSummary     = getAddressSummary
+        , _addressUtxoBulk    = getAddressUtxoBulk
         , _epochPages         = getEpochPage
         , _epochSlots         = getEpochSlot
         , _genesisSummary     = getGenesisSummary
@@ -371,6 +376,42 @@ getAddressSummary cAddr = do
             ATScript     -> CScriptAddress
             ATRedeem     -> CRedeemAddress
             ATUnknown {} -> CUnknownAddress
+
+
+getAddressUtxoBulk
+    :: (ExplorerMode ctx m)
+    => [CAddress]
+    -> m [CUtxo]
+getAddressUtxoBulk cAddrs = do
+    unless explorerExtendedApi $
+        throwM err405
+        { errReasonPhrase = "Explorer extended API is disabled by configuration!"
+        }
+
+    let nAddrs = length cAddrs
+
+    when (nAddrs > 10) $
+        throwM err405
+        { errReasonPhrase = "Maximum number of addresses you can send to fetch Utxo in bulk is 10!"
+        }
+
+    addrs <- mapM cAddrToAddr cAddrs
+    utxo <- getFilteredUtxo addrs
+
+    pure . map futxoToCUtxo . M.toList $ utxo
+  where
+    futxoToCUtxo :: (TxIn, TxOutAux) -> CUtxo
+    futxoToCUtxo ((TxInUtxo txInHash txInIndex), txOutAux) = CUtxo {
+        cuId = toCTxId txInHash,
+        cuOutIndex = fromIntegral txInIndex,
+        cuAddress = toCAddress . txOutAddress . toaOut $ txOutAux,
+        cuCoins = mkCCoin . txOutValue . toaOut $ txOutAux
+    }
+    futxoToCUtxo ((TxInUnknown tag bs), _) = CUtxoUnknown {
+        cuTag = fromIntegral tag,
+        cuBs = CByteString bs
+    }
+
 
 -- | Get transaction summary from transaction id. Looks at both the database
 -- and the memory (mempool) for the transaction. What we have at the mempool

--- a/explorer/src/Pos/Explorer/Web/TestServer.hs
+++ b/explorer/src/Pos/Explorer/Web/TestServer.hs
@@ -24,9 +24,11 @@ import           Pos.Explorer.Web.ClientTypes (Byte, CAda (..), CAddress (..),
                      CAddressesFilter (..), CBlockEntry (..),
                      CBlockSummary (..), CGenesisAddressInfo (..),
                      CGenesisSummary (..), CHash (..), CTxBrief (..),
-                     CTxEntry (..), CTxId (..), CTxSummary (..), mkCCoin)
+                     CTxEntry (..), CTxId (..), CTxSummary (..), CUtxo (..),
+                     mkCCoin)
 import           Pos.Explorer.Web.Error (ExplorerError (..))
 import           Pos.Web ()
+
 
 ----------------------------------------------------------------
 -- Top level functionality
@@ -54,6 +56,7 @@ explorerHandlers =
         , _txsLast            = testTxsLast
         , _txsSummary         = testTxsSummary
         , _addressSummary     = testAddressSummary
+        , _addressUtxoBulk    = testAddressUtxoBulk
         , _epochPages         = testEpochPageSearch
         , _epochSlots         = testEpochSlotSearch
         , _genesisSummary     = testGenesisSummary
@@ -184,6 +187,16 @@ testAddressSummary
     :: CAddress
     -> Handler CAddressSummary
 testAddressSummary _  = pure sampleAddressSummary
+
+testAddressUtxoBulk
+    :: [CAddress]
+    -> Handler [CUtxo]
+testAddressUtxoBulk _  = pure [CUtxo
+    { cuId = CTxId $ CHash "8aac4a6b18fafa2783071c66519332157ce96c67e88fc0cc3cb04ba0342d12a1"
+    , cuOutIndex = 0
+    , cuAddress = CAddress "19F6U1Go5B4KakVoCZfzCtqNAWhUBprxVzL3JsGu74TEwQnXPvAKPUbvG8o4Qe5RaY8Z7WKLfxmNFwBqPV1NQ2hRpKkdEN"
+    , cuCoins = mkCCoin $ mkCoin 3
+    }]
 
 testEpochSlotSearch
     :: EpochIndex

--- a/explorer/src/documentation/Main.hs
+++ b/explorer/src/documentation/Main.hs
@@ -27,8 +27,9 @@ import           Control.Lens (mapped, (?~))
 import           Data.Aeson (encode)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import           Data.Fixed (Fixed (..), Micro)
-import           Data.Swagger (Swagger, ToParamSchema (..), ToSchema (..),
-                     declareNamedSchema, defaultSchemaOptions, description,
+import           Data.Swagger (NamedSchema (..), Swagger, ToParamSchema (..),
+                     ToSchema (..), binarySchema, declareNamedSchema,
+                     defaultSchemaOptions, description,
                      genericDeclareNamedSchema, host, info, name, title,
                      version)
 import           Data.Typeable (Typeable, typeRep)
@@ -85,6 +86,7 @@ instance ToParamSchema C.EpochIndex
 instance ToSchema      C.CTxSummary
 instance ToSchema      C.CTxEntry
 instance ToSchema      C.CTxBrief
+instance ToSchema      C.CUtxo
 instance ToSchema      C.CBlockSummary
 instance ToSchema      C.CBlockEntry
 instance ToSchema      C.CAddressType
@@ -99,6 +101,9 @@ instance ToSchema      ExplorerError
 instance ToParamSchema C.CAddressesFilter
 
 deriving instance Generic Micro
+
+instance ToSchema C.CByteString where
+  declareNamedSchema _ = return $ NamedSchema (Just "CByteString") binarySchema
 
 -- | Instance for Either-based types (types we return as 'Right') in responses.
 -- Due 'typeOf' these types must be 'Typeable'.

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -112,6 +112,7 @@ dev: &dev
     pendingTxResubmissionPeriod: 7 # seconds
     walletProductionApi: false
     walletTxCreationDisabled: false
+    explorerExtendedApi: false
 
   tls: &dev_tls
     ca:
@@ -311,6 +312,7 @@ mainnet_base: &mainnet_base
     pendingTxResubmissionPeriod: 7 # seconds
     walletProductionApi: true
     walletTxCreationDisabled: false
+    explorerExtendedApi: false
 
   tls: &mainnet_base_tls
     ca:

--- a/lib/src/Pos/Configuration.hs
+++ b/lib/src/Pos/Configuration.hs
@@ -17,6 +17,9 @@ module Pos.Configuration
        , pendingTxResubmitionPeriod
        , walletProductionApi
        , walletTxCreationDisabled
+
+       -- * Explorer constants
+       , explorerExtendedApi
        ) where
 
 import           Universum
@@ -52,6 +55,9 @@ data NodeConfiguration = NodeConfiguration
     , ccWalletTxCreationDisabled     :: !Bool
       -- ^ Disallow transaction creation or re-submission of
       -- pending transactions by the wallet
+    , ccExplorerExtendedApi          :: !Bool
+      -- ^ Enable explorer extended API for fetching more
+      -- info about addresses (like utxos) and bulk endpoints
     } deriving (Show, Generic)
 
 instance ToJSON NodeConfiguration where
@@ -91,3 +97,12 @@ walletProductionApi = ccWalletProductionApi $ nodeConfiguration
 -- existing pending transactions.
 walletTxCreationDisabled :: HasNodeConfiguration => Bool
 walletTxCreationDisabled = ccWalletTxCreationDisabled $ nodeConfiguration
+
+----------------------------------------------------------------------------
+-- Explorer parameters
+----------------------------------------------------------------------------
+
+-- | If 'True', explorer extended API, like fetching utxos for address is enabled.
+-- WARNING Those endpoints are potentially expensive!
+explorerExtendedApi :: HasNodeConfiguration => Bool
+explorerExtendedApi = ccExplorerExtendedApi $ nodeConfiguration

--- a/lib/src/Pos/Configuration.hs
+++ b/lib/src/Pos/Configuration.hs
@@ -106,3 +106,4 @@ walletTxCreationDisabled = ccWalletTxCreationDisabled $ nodeConfiguration
 -- WARNING Those endpoints are potentially expensive!
 explorerExtendedApi :: HasNodeConfiguration => Bool
 explorerExtendedApi = ccExplorerExtendedApi $ nodeConfiguration
+


### PR DESCRIPTION
## Description

I added an endpoint to the blockchain explorer API to be able to retrieve the unspent transaction outputs (utxos) for a set of addresses. I am aware that this call is currently quite expensive, but its time complexity seems to not depend on the number of addresses queried (it takes roughly the same time to fetch the utxos for one and a couple of addresses as far as I have tried). That's why I made it a bulk endpoint.

This endpoint is useful for light wallets (i.e. wallets that do not store the blockchain locally but interact with the blockchain explorer instead) that want to be aware of the unspent outputs of the addresses they are controlling. Currently there is no way to reliably determine the unspent outputs for the addresses since the address summary endpoint (api/addresses/summary/) does not provide the exact origin of the inputs used in the transactions, only the address of origin, which is not enough in most cases to determine the exact transaction output involved in the transaction. This problem is mentioned also in the github issue referenced below (https://github.com/input-output-hk/cardano-sl/issues/2792).

Since calling this endpoint is expensive, I made it an optional endpoint which can be enabled/disabled in the configuration ("explorerExtendedApi" flag in configuration.yaml). It is false, therefore disabled, by default.

I believe that in the future fetching of individual unspent outputs for an address from the blockchain DB will be vastly improved, therefore this call won't be so expensive anymore.

## Linked issue

https://github.com/input-output-hk/cardano-sl/issues/2792

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
I did not add tests for this endpoint yet, because I'm waiting for a general review of the idea of a separate optional endpoint for address utxos. As soon as you say you are OK with the idea, I will add tests.

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
How to try the endpoint locally:
In lib/configuration.yaml set the "explorerExtendedApi" parameter to true to enable the endpoint.
After building and running the explorer node make a POST request to the address: http://localhost:8100/api/addresses/summary_bulk with the body e.g. `[
	"DdzFFzCqrhsvY5wo8gZTtbZ9yxc6eumih1gNm2grkq8K4UXuenuZJpdwE1jxuCypt2xcdHxSnfCw4fa4U4j3os9Gz7EpRSqyXpsBkD2G",
	"DdzFFzCqrhsuf6TDWvsH6vmkpfSZFzs1GYY7ZbxRuwRJdKUGLxH2Esmd8jVPap9bbUCwzayyCP8dxTuyg3PWbQx7MbTwxXqmz9kvrqP7",
	"DdzFFzCqrhsk911VfjGGthTFH8PH1TDjzb8FYQhFWrvPTnMfqw76t6Zv5kAxppdiw52Rgwzymn9qNTzuT2jrZ1cfHVz2hS4XsEcs2qiT",
	"DdzFFzCqrhsk911VfjGGthTFH8PH1TDjzb8FYQhFWrvPTnMfqw76t6Zv5kAxppdiw52Rgwzymn9qNTzuT2jrZ1cfHVz2hS4XsEcs2qiT"
]`

If your node is synced with the mainnet, you should receive after a couple of seconds (~10s on my laptop with an SSD and core i5 7th gen CPU) something like this:
`{
    "Right": [
        {
            "cuId": "ea9a299210651fe1e4b097fed8ea6031683d0f09543fbe3a4c7f7723ca4fd478",
            "cuOutIndex": 8,
            "cuAddress": "DdzFFzCqrhsk911VfjGGthTFH8PH1TDjzb8FYQhFWrvPTnMfqw76t6Zv5kAxppdiw52Rgwzymn9qNTzuT2jrZ1cfHVz2hS4XsEcs2qiT",
            "cuCoins": {
                "getCoin": "63587850"
            }
        },
        {
            "cuId": "ee08752fbe0968980a6b2340ce156a411fc7e57b84a18693bda16fcfdd972d14",
            "cuOutIndex": 1,
            "cuAddress": "DdzFFzCqrhsuf6TDWvsH6vmkpfSZFzs1GYY7ZbxRuwRJdKUGLxH2Esmd8jVPap9bbUCwzayyCP8dxTuyg3PWbQx7MbTwxXqmz9kvrqP7",
            "cuCoins": {
                "getCoin": "9718666193"
            }
        }
    ]
}`

which is the list of unspent outputs for this addresses.

If you disable the endpoint in the config, you will get an error 405 with a message stating that the endpoint was disabled by the config.

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
