### PR TITLE
[CO-298] Apply fix from haskoin on mnemonic checksum calculation

### DIFF
--- a/wallet/src/Pos/Util/Mnemonics.hs
+++ b/wallet/src/Pos/Util/Mnemonics.hs
@@ -106,7 +106,7 @@ numCS :: Int -> Entropy -> Integer
 numCS len = shiftCS . bsToInteger
   where
     shiftCS = case 8 - len `mod` 8 of
-        0 -> identity
+        8 -> identity
         x -> flip shiftR x
 
 -- | Obtain 'Int' bits from beginning of 'ByteString'. Resulting 'ByteString'


### PR DESCRIPTION
## Description

See haskoin@f00f09d392ca38bb4b68a65c8515ed70f8986841.

I've came to the conclusion that it is safe to apply this fix. The fix only touches the `numCS` which is used internally in the `fromMnemonic` function to compute a number from a checksum to compare the computed checksum from the generated entropy with the one that is part of the mnemonic words (words actually represent the entropy and its checksum). 

Beside, the patch affects a pattern-match result that solely depends on the length of the checksum, and only matters when the length is a multiple of `8`.

Hence:

#### Affected mnemonic phrases

```hs
-- We support mnemonic phrase where entropy can be of any length, multiple of 32, 
-- from 0 (alas :'( ) to 512 bits.
-- i.e. [0,32,64,96,128,160,192,224,256,288,320,352,384,416,448,480,512]
let acceptedLength = [ 32 * n | n <- [0..16] ]

-- We compute the checksum length (`cs`) and the number of words corresponding 
-- to a given entropy length `ent` as follows:
let computeCSMS ent = let cs = ent `div` 32 in (cs, (ent + cs) `div` 11)

-- Are affected, only checksum multiple of 8
let isAffected (cs, _) = cs `mod` 8 == 0

-- Which leaves us with the followings:
filter isAffected (map computeCSMS acceptedLength)
-- [(0,0),(8,24),(16,48)]
```

So, from this, we can see that only mnemonic phrases with 0, 24 or 48 words would be affected by the patch (still, that doesn't mean the patch has any impact) which I believe, already makes it safe to apply. As far as I know, we use phrases of length 9, 12 and 15 depending on the purpose but not of 24 or 48 words. We still have the `0` case that is a bit special anyway and would be rejected in future releases anyway.

#### The fix doesn't actually change the behavior

If we look at where this `numCS` function comes into play, we find as I said earlier, only one place in the `fromMnemonic` function:

```hs
        ms_cs_num = numCS cs_len ms_cs
        ent_cs_num = numCS cs_len $ calcCS cs_len ms_ent
    when (ent_cs_num /= ms_cs_num) $
        Left $ "fromMnemonic: checksum failed: " ++ sh ent_cs_num ms_cs_num
```

We use this `numCS` to compute numbers from checksums that we then compare (it's still not clear to me why we don't simply compare bytes array at this point). `ms_cs_num` would be the one obtained from the checksum that is embedded in the mnemonic words, and `ent_cs_num` the one we compute from the entropy we just converted. The function `numCS` is, at least, pure, so yields the same results for the same inputs. We give it a same checksum length `cs_len` in both cases. So we have two scenarios:

- Either the checksums are identical and yields the same result. Applying the patch won't change that. 
- Or checksums are different, and because, for a same checksum length, the function `numCS` is injective, then we would get different results. Applying the patch won't change that.


#### QuickCheck

So on the paper, it seems safe to apply the patch. To get truly convinced of that, I've written a small QuickCheck to verify that `fromMnemonic` and `fromMnemonic'` yield identical result for 5M+ inputs (where `fromMnemonic'` represent the patched function):

```hs
    modifyMaxSuccess (const 5000000) $ prop "fromMnemonic == fromMnemonic'" $
        \(MnemonicWords m) -> let
            Right e  = fromMnemonic m
            Right e' = fromMnemonic' m
          in e == e'
```

Also runs fine.

(╯°□°）╯︵ ┻━┻

## Linked issue

[[CO-298]](https://iohk.myjetbrains.com/youtrack/issue/CO-298)


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
