### PR TITLE
[DEVOPS-879] Introduce '--no-client-auth' flag 

### DIFF
--- a/lib/src/Pos/Web/Server.hs
+++ b/lib/src/Pos/Web/Server.hs
@@ -168,7 +168,7 @@ tlsWebServerMode _ _ TlsParams{..} = tlsSettings
 tlsWithClientCheck
     :: String -> Word16 -> TlsParams -> TLSSettings
 tlsWithClientCheck host port TlsParams{..} = tlsSettings
-    { tlsWantClientCert = True
+    { tlsWantClientCert = tpClientAuth
     , tlsServerHooks    = def
         { onClientCertificate = fmap certificateUsageFromValidations . validateCertificate }
     }

--- a/lib/src/Pos/Web/Types.hs
+++ b/lib/src/Pos/Web/Types.hs
@@ -23,9 +23,10 @@ data SscStage
 
 -- | TLS Transport Layer Security file paths.
 data TlsParams = TlsParams
-    { tpCertPath :: FilePath
-    , tpCaPath   :: FilePath
-    , tpKeyPath  :: FilePath
+    { tpCertPath   :: FilePath
+    , tpCaPath     :: FilePath
+    , tpKeyPath    :: FilePath
+    , tpClientAuth :: Bool
     } deriving (Show)
 
 newtype CConfirmedProposalState = CConfirmedProposalState Text

--- a/wallet-new/src/Cardano/Wallet/Server/CLI.hs
+++ b/wallet-new/src/Cardano/Wallet/Server/CLI.hs
@@ -158,9 +158,10 @@ tlsParamsParser :: Parser (Maybe TlsParams)
 tlsParamsParser = constructTlsParams <$> certPathParser
                                      <*> keyPathParser
                                      <*> caPathParser
+                                     <*> (not <$> noClientAuthParser)
                                      <*> disabledParser
   where
-    constructTlsParams tpCertPath tpKeyPath tpCaPath disabled =
+    constructTlsParams tpCertPath tpKeyPath tpCaPath tpClientAuth disabled =
         guard (not disabled) $> TlsParams{..}
 
     certPathParser :: Parser FilePath
@@ -186,6 +187,13 @@ tlsParamsParser = constructTlsParams <$> certPathParser
                               "Path to file with TLS certificate authority"
                               <> value "scripts/tls-files/ca.crt"
                              )
+
+    noClientAuthParser :: Parser Bool
+    noClientAuthParser = switch $
+                         long "no-client-auth" <>
+                         help "Disable TLS client verification. If turned on, \
+                              \no client certificate is required to talk to \
+                              \the API."
 
     disabledParser :: Parser Bool
     disabledParser = switch $


### PR DESCRIPTION
## Description

`--no-client-auth` to disable client certificate verification by the wallet backend.

This will re-enable the behavior in place before client certificate verification was introduced. By default, it is turned on (to be discussed).

> /!\ TODO /!\ ops remaining work in the installers to make use of this flag.

## Linked issue

[[DEVOPS-879]](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-879)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
