### PR TITLE
Akegalj/co 319/swagger account index

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -39,8 +39,8 @@ library
                        Cardano.Wallet.API.V1
                        Cardano.Wallet.API.V1.Accounts
                        Cardano.Wallet.API.V1.Addresses
-                       Cardano.Wallet.API.V1.Errors
                        Cardano.Wallet.API.V1.Generic
+                       Cardano.Wallet.API.V1.Errors
                        Cardano.Wallet.API.V1.Handlers
                        Cardano.Wallet.API.V1.Headers
                        Cardano.Wallet.API.V1.Info

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -42,6 +42,7 @@ library
                        Cardano.Wallet.API.V1.Errors
                        Cardano.Wallet.API.V1.Generic
                        Cardano.Wallet.API.V1.Handlers
+                       Cardano.Wallet.API.V1.Headers
                        Cardano.Wallet.API.V1.Info
                        Cardano.Wallet.API.V1.LegacyHandlers
                        Cardano.Wallet.API.V1.LegacyHandlers.Accounts

--- a/wallet-new/integration/TransactionSpecs.hs
+++ b/wallet-new/integration/TransactionSpecs.hs
@@ -5,14 +5,14 @@ module TransactionSpecs (transactionSpecs) where
 
 import           Universum hiding (log)
 
-import           Cardano.Wallet.API.V1.Errors hiding (describe)
 import           Cardano.Wallet.Client.Http
-import           Control.Lens
-import qualified Pos.Core as Core
-import           Test.Hspec
-
 import           Control.Concurrent (threadDelay)
+import           Control.Lens
+import           Test.Hspec
 import           Text.Show.Pretty (ppShow)
+
+import qualified Pos.Core as Core
+
 import           Util
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}

--- a/wallet-new/integration/WalletSpecs.hs
+++ b/wallet-new/integration/WalletSpecs.hs
@@ -5,8 +5,8 @@ module WalletSpecs (walletSpecs) where
 
 import           Universum
 
+import           Cardano.Wallet.API.V1.Types (WalletError (WalletAlreadyExists))
 import           Cardano.Wallet.Client.Http
-import           Cardano.Wallet.API.V1.Errors (WalletError (WalletAlreadyExists))
 import           Control.Lens
 import           Test.Hspec
 

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -208,6 +208,11 @@ instance FromJSON JSONValidationError where
 
 instance Exception JSONValidationError
 
+instance Arbitrary JSONValidationError where
+    arbitrary = oneof
+        [ pure $ JSONValidationFailed "JSON validation failed."
+        ]
+
 instance Buildable JSONValidationError where
     build = \case
         JSONValidationFailed _ ->

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -174,8 +174,15 @@ data ValidJSON deriving Typeable
 
 instance FromJSON a => MimeUnrender ValidJSON a where
     mimeUnrender _ bs = case eitherDecode bs of
-        Left err -> Left $ decodeUtf8 $ encodePretty (JSONValidationFailed $ toText err)
+        Left err -> Left $ decodeUtf8 $ encodePretty (jsonValidationFailed err)
         Right v  -> return v
+      where
+        -- NOTE Cheating a bit with type params here, ideally, we would like
+        -- types we can render ToJSON, though we only use the JSONValidationFailed
+        -- which doesn't rely on the type-parameters.
+        jsonValidationFailed :: String -> WalletError () () ()
+        jsonValidationFailed =
+            JSONValidationFailed . toText
 
 instance Accept ValidJSON where
     contentType _ = contentType (Proxy @ JSON)

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.API.Response (
   ) where
 
 import           Prelude
-import           Universum (Buildable, Text, decodeUtf8, toText, (<>))
+import           Universum (Buildable, Exception, Text, decodeUtf8, toText, (<>))
 
 import           Cardano.Wallet.API.Indices (Indexable', IxSet')
 import           Cardano.Wallet.API.Request (RequestParams (..))

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -1,205 +1,27 @@
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-
 module Cardano.Wallet.API.V1.Errors where
 
 import           Universum
 
-import           Data.Aeson
-import           Generics.SOP.TH (deriveGeneric)
-import           Servant
-import           Test.QuickCheck (Arbitrary (arbitrary))
-import           Test.QuickCheck.Gen (oneof)
-
-import           Cardano.Wallet.API.Response.JSend (ResponseStatus (ErrorStatus))
-import           Cardano.Wallet.API.V1.Generic (gparseJsend, gtoJsend)
 import           Cardano.Wallet.API.V1.Headers (applicationJson)
-import           Cardano.Wallet.API.V1.Types (SyncPercentage, SyncProgress (..), V1 (..), WalletId,
-                                              exampleWalletId, mkEstimatedCompletionTime,
-                                              mkSyncPercentage, mkSyncThroughput)
+import           Data.Aeson (ToJSON, encode)
+import           Formatting (build, sformat)
+import           Servant (ServantErr (..))
 
 import qualified Network.HTTP.Types as HTTP
 
 
---
--- Error handling
---
+class (ToJSON e) => ToServantError e where
+    declareServantError :: e -> ServantErr
+    toServantError :: e -> ServantErr
+    toServantError err =
+        mkServantErr (declareServantError err)
+      where
+        mkServantErr serr@ServantErr{..} = serr
+            { errBody    = encode err
+            , errHeaders = applicationJson : errHeaders
+            }
 
--- | Type representing any error which might be thrown by wallet.
---
--- Errors are represented in JSON in the JSend format (<https://labs.omniti.com/labs/jsend>):
--- ```
--- {
---     "status": "error"
---     "message" : <constr_name>,
---     "diagnostic" : <data>
--- }
--- ```
--- where `<constr_name>` is a string containing name of error's constructor (e. g. `NotEnoughMoney`),
--- and `<data>` is an object containing additional error data.
--- Additional data contains constructor fields, field names are record field names without
--- a `we` prefix, e. g. for `OutputIsRedeem` error "diagnostic" field will be the following:
--- ```
--- {
---     "address" : <address>
--- }
--- ```
---
--- Additional data in constructor should be represented as record fields.
--- Otherwise TemplateHaskell will raise an error.
---
--- If constructor does not have additional data (like in case of `WalletNotFound` error),
--- then "diagnostic" field will be empty object.
---
--- TODO: change fields' types to actual Cardano core types, like `Coin` and `Address`
-data WalletError address syncProgress syncPercentage =
-      NotEnoughMoney { weNeedMore :: !Int }
-    | OutputIsRedeem { weAddress :: !address }
-    | MigrationFailed { weDescription :: !Text }
-    | JSONValidationFailed { weValidationError :: !Text }
-    | UnknownError { weMsg :: !Text }
-    | InvalidAddressFormat { weMsg :: !Text }
-    | WalletNotFound
-    -- FIXME(akegalj): https://iohk.myjetbrains.com/youtrack/issue/CSL-2496
-    | WalletAlreadyExists { weWalletId :: WalletId }
-    | AddressNotFound
-    | TxFailedToStabilize
-    | TxRedemptionDepleted
-    | TxSafeSignerNotFound { weAddress :: address }
-    | MissingRequiredParams { requiredParams :: NonEmpty (Text, Text) }
-    | WalletIsNotReadyToProcessPayments { weStillRestoring :: syncProgress }
-    -- ^ The @Wallet@ where a @Payment@ is being originated is not fully
-    -- synced (its 'WalletSyncState' indicates it's either syncing or
-    -- restoring) and thus cannot accept new @Payment@ requests.
-    | NodeIsStillSyncing { wenssStillSyncing :: syncPercentage }
-    -- ^ The backend couldn't process the incoming request as the underlying
-    -- node is still syncing with the blockchain.
-    deriving (Show, Eq)
-
-
---
--- Instances for `WalletError`
-
--- deriveWalletErrorJSON ''WalletError
-deriveGeneric ''WalletError
-
-instance (ToJSON a, ToJSON b, ToJSON c) => ToJSON (WalletError a b c) where
-    toJSON = gtoJsend ErrorStatus
-
-instance (FromJSON a, FromJSON b, FromJSON c) => FromJSON (WalletError a b c) where
-    parseJSON = gparseJsend
-
-instance (Typeable a, Show a, Typeable b, Show b, Typeable c, Show c) =>
-    Exception (WalletError a b c)
-
-instance (Arbitrary a, Arbitrary b, Arbitrary c) => Arbitrary (WalletError a b c) where
-    arbitrary = oneof
-        [ NotEnoughMoney <$> arbitrary
-        , OutputIsRedeem <$> arbitrary
-        , pure (MigrationFailed "Migration failed.")
-        , pure (JSONValidationFailed "Expected String, found Null.")
-        , pure (UnknownError "Unknown error.")
-        , pure (InvalidAddressFormat "Invalid Base58 representation.")
-        , pure WalletNotFound
-        , pure WalletAlreadyExists
-        , pure AddressNotFound
-        , pure TxFailedToStabilize
-        , pure TxRedemptionDepleted
-        , TxSafeSignerNotFound <$> arbitrary
-        , pure (MissingRequiredParams (("wallet_id", "walletId") :| []))
-        , WalletIsNotReadyToProcessPayments <$> arbitrary
-        , NodeIsStillSyncing <$> arbitrary
-        ]
-
-
---
--- Helpers
---
-
--- | Give a short description of an error
-describe :: forall a b c. WalletError a b c -> String
-describe = \case
-    NotEnoughMoney _ ->
-         "Not enough available coins to proceed."
-    OutputIsRedeem _ ->
-         "One of the TX outputs is a redemption address."
-    MigrationFailed _ ->
-         "Error while migrating a legacy type into the current version."
-    JSONValidationFailed _ ->
-         "Couldn't decode a JSON input."
-    UnknownError _ ->
-         "Unexpected internal error."
-    InvalidAddressFormat _ ->
-         "Provided address format is not valid."
-    WalletNotFound ->
-         "Reference to an unexisting wallet was given."
-    WalletAlreadyExists _ ->
-         "Can't create or restore a wallet. The wallet already exists."
-    AddressNotFound ->
-         "Reference to an unexisting address was given."
-    MissingRequiredParams _ ->
-         "Missing required parameters in the request payload."
-    WalletIsNotReadyToProcessPayments _ ->
-         "This wallet is restoring, and it cannot send new transactions until restoration completes."
-    NodeIsStillSyncing _ ->
-         "The node is still syncing with the blockchain, and cannot process the request yet."
-    TxRedemptionDepleted ->
-        "The redemption address was already used."
-    TxSafeSignerNotFound _ ->
-        "The safe signer at the specified address was not found."
-    TxFailedToStabilize ->
-        "We were unable to find a set of inputs to satisfy this transaction."
-
-
--- | Convert wallet errors to Servant errors
-toServantError
-    :: forall a b c. (ToJSON a, ToJSON b, ToJSON c)
-    => WalletError a b c
-    -> ServantErr
-toServantError err =
-    mkServantErr $ case err of
-        NotEnoughMoney{} ->
-            err403
-        OutputIsRedeem{} ->
-            err403
-        MigrationFailed{} ->
-            err422
-        JSONValidationFailed{} ->
-            err400
-        UnknownError{} ->
-            err500
-        WalletNotFound{} ->
-            err404
-        WalletAlreadyExists{} ->
-            err403
-        InvalidAddressFormat{} ->
-            err401
-        AddressNotFound{} ->
-            err404
-        MissingRequiredParams{} ->
-            err400
-        WalletIsNotReadyToProcessPayments{} ->
-            err403
-        NodeIsStillSyncing{} ->
-            err412 -- Precondition failed
-        TxFailedToStabilize{} ->
-            err500
-        TxRedemptionDepleted{} ->
-            err400
-        TxSafeSignerNotFound{} ->
-            err400
-  where
-    mkServantErr serr@ServantErr{..} = serr
-        { errBody    = encode err
-        , errHeaders = applicationJson : errHeaders
-        }
-
--- |
-toHttpStatus
-    :: forall a b c. (ToJSON a, ToJSON b, ToJSON c)
-    => WalletError a b c
-    -> HTTP.Status
-toHttpStatus err = HTTP.Status (errHTTPCode $ toServantError err)
-                               (encodeUtf8 $ describe err)
+class (ToServantError e, Buildable e) => ToHttpErrorStatus e where
+    toHttpErrorStatus :: e -> HTTP.Status
+    toHttpErrorStatus err =
+        HTTP.Status (errHTTPCode $ toServantError err) (encodeUtf8 $ sformat build err)

--- a/wallet-new/src/Cardano/Wallet/API/V1/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Generic.hs
@@ -14,8 +14,7 @@ import           Data.Aeson.Types (Parser)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import           Generics.SOP
-import           Generics.SOP.JSON (JsonInfo (..), JsonOptions (..), Tag (..), defaultJsonOptions,
-                                    jsonInfo)
+import           Generics.SOP.JSON (JsonInfo (..), JsonOptions (..), Tag (..), defaultJsonOptions)
 
 import           Cardano.Wallet.API.Response.JSend (ResponseStatus (..))
 import           Cardano.Wallet.Util (mkJsonKey)
@@ -42,24 +41,46 @@ allpf = Proxy
 -- JSON encoding/decoding
 --
 
--- | Returns `JsonInfo` for type (from `json-sop` package)
--- for representing a type in a JSend format.
-jsendInfo
-    :: forall a. (HasDatatypeInfo a, SListI (Code a))
-    => Proxy a -> NP JsonInfo (Code a)
-jsendInfo pa = jsonInfo pa $ defaultJsonOptions
-    { jsonFieldName = const mkJsonKey
-    }
-
 -- | Generic method which makes JSON `Value` from a Haskell value in
 -- JSend format.
 gtoJsend
     :: forall a. (Generic a, HasDatatypeInfo a, All2 ToJSON (Code a))
     => ResponseStatus -> a -> Value
-gtoJsend rs a = hcollapse $
-    hcliftA2 allpt (gtoJsend' rs)
-    (jsendInfo (Proxy :: Proxy a))
-    (unSOP $ from a)
+gtoJsend rs a =
+    hcollapse $
+        hcliftA2 allpt (gtoJsend' rs)
+        (jsendInfo (Proxy :: Proxy a) jsendOptions)
+        (unSOP $ from a)
+
+-- | Our custom naming options
+jsendOptions :: JsonOptions
+jsendOptions = defaultJsonOptions
+    { jsonFieldName = const mkJsonKey
+    }
+
+-- | Slightly modified version compared to Generics.SOP.JSON, we also tag
+-- single-constructor (ADT with one constructor and newtype) because we
+-- rely on that information to wrap the corresponding json in a jsend payload.
+jsendInfo :: forall a. (HasDatatypeInfo a, SListI (Code a))
+         => Proxy a -> JsonOptions -> NP JsonInfo (Code a)
+jsendInfo pa opts =
+  case datatypeInfo pa of
+    Newtype _ t _  -> JsonOne (Tag $ jsonTagName opts t) :* Nil
+    ADT     _ n cs -> hliftA (jsonInfoFor opts n (Tag . jsonTagName opts)) cs
+
+-- Extracted from Generics.SOP.JSON
+jsonInfoFor :: forall xs. JsonOptions -> DatatypeName -> (ConstructorName -> Tag) -> ConstructorInfo xs -> JsonInfo xs
+jsonInfoFor _    _ tag (Infix n _ _)   = JsonMultiple (tag n)
+jsonInfoFor _    _ tag (Constructor n) =
+  case shape :: Shape xs of
+    ShapeNil           -> JsonZero     n
+    ShapeCons ShapeNil -> JsonOne      (tag n)
+    _                  -> JsonMultiple (tag n)
+jsonInfoFor opts d tag (Record n fields) =
+    JsonRecord (tag n) (hliftA jfieldName fields)
+  where
+    jfieldName :: FieldInfo a -> K String a
+    jfieldName (FieldInfo name) = K (jsonFieldName opts d name)
 
 gtoJsend'
     :: All ToJSON xs
@@ -79,7 +100,7 @@ gtoJsend' rs (JsonRecord tag fields) cs =
 gparseJsend
     :: forall a. (Generic a, HasDatatypeInfo a, All2 FromJSON (Code a))
     => Value -> Parser a
-gparseJsend v = to <$> gparseJsend' v (jsendInfo (Proxy :: Proxy a))
+gparseJsend v = to <$> gparseJsend' v (jsendInfo (Proxy :: Proxy a) jsendOptions)
 
 gparseJsend'
     :: forall (xss :: [[*]]). All2 FromJSON xss

--- a/wallet-new/src/Cardano/Wallet/API/V1/Headers.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Headers.hs
@@ -1,0 +1,11 @@
+module Cardano.Wallet.API.V1.Headers
+    ( applicationJson
+    ) where
+
+import           Network.HTTP.Types (Header, hContentType)
+
+
+-- | Generates the @Content-Type: application/json@ 'HTTP.Header'.
+applicationJson :: Header
+applicationJson =
+    (hContentType, "application/json")

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Addresses.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Addresses.hs
@@ -94,7 +94,7 @@ getAddress
     -> m (WalletResponse WalletAddress)
 getAddress addrText = do
     addr <- either
-        (throwM . InvalidAddressFormat)
+        (throwM . (InvalidAddressFormat :: (Text -> WalletErrorV1)))
         pure
         (decodeTextAddress addrText)
 
@@ -120,7 +120,7 @@ getAddress addrText = do
 
     case minfo of
         Nothing ->
-            throwM AddressNotFound
+            throwM (AddressNotFound :: WalletErrorV1)
         Just (_walletMeta, V0.AddressInfo{..}) -> do
             let accId = adiWAddressMeta ^. V0.wamAccount
             mps <- V0.withTxpLocalData V0.getMempoolSnapshot

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Addresses.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Addresses.hs
@@ -32,7 +32,6 @@ import           Cardano.Wallet.API.Indices (IxSet')
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
 import qualified Cardano.Wallet.API.V1.Addresses as Addresses
-import           Cardano.Wallet.API.V1.Errors
 import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types
 
@@ -94,7 +93,7 @@ getAddress
     -> m (WalletResponse WalletAddress)
 getAddress addrText = do
     addr <- either
-        (throwM . (InvalidAddressFormat :: (Text -> WalletErrorV1)))
+        (throwM . InvalidAddressFormat)
         pure
         (decodeTextAddress addrText)
 
@@ -120,7 +119,7 @@ getAddress addrText = do
 
     case minfo of
         Nothing ->
-            throwM (AddressNotFound :: WalletErrorV1)
+            throwM AddressNotFound
         Just (_walletMeta, V0.AddressInfo{..}) -> do
             let accId = adiWAddressMeta ^. V0.wamAccount
             mps <- V0.withTxpLocalData V0.getMempoolSnapshot

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
@@ -28,7 +28,7 @@ import qualified Cardano.Wallet.API.V1.Transactions as Transactions
 import           Cardano.Wallet.API.V1.Types
 
 
-convertTxError :: V0.TxError -> WalletErrorV1
+convertTxError :: V0.TxError -> WalletError
 convertTxError err = case err of
     V0.NotEnoughMoney coin ->
         NotEnoughMoney . fromIntegral . Core.getCoin $ coin

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
@@ -23,7 +23,6 @@ import qualified Pos.Wallet.Web.Util as V0
 
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
-import           Cardano.Wallet.API.V1.Errors
 import           Cardano.Wallet.API.V1.Migration (HasConfigurations, MonadV1, migrate)
 import qualified Cardano.Wallet.API.V1.Transactions as Transactions
 import           Cardano.Wallet.API.V1.Types
@@ -81,7 +80,7 @@ newTransaction pm submitTx Payment {..} = do
                                                            (mkSyncThroughput (Core.BlockCount 0))
                                                            (mkSyncPercentage 0)
                         Just (s, h) -> migrate (s, Just h)
-        throwM $ (WalletIsNotReadyToProcessPayments progress :: WalletErrorV1)
+        throwM $ WalletIsNotReadyToProcessPayments progress
 
     let (V1 spendingPw) = fromMaybe (V1 mempty) pmtSpendingPassword
     cAccountId <- migrate pmtSource
@@ -129,9 +128,9 @@ allTransactions mwalletId mAccIdx mAddr requestParams fops sops  =
             -- TODO: should we use the 'FilterBy' machinery instead? that
             --       let us express RANGE, GT, etc. in addition to EQ. does
             --       that make sense for this dataset?
-            throwM (MissingRequiredParams
+            throwM MissingRequiredParams
                 { requiredParams = pure ("wallet_id", "WalletId")
-                } :: WalletErrorV1)
+                }
 
 estimateFees
     :: (MonadThrow m, V0.MonadFees ctx m)

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -76,7 +76,7 @@ newWallet NewWallet{..} = do
 
     -- Do not allow creation or restoration of wallets if the underlying node
     -- is still catching up.
-    unless (isNodeSufficientlySynced spV0) $ throwM (NodeIsStillSyncing syncPercentage)
+    unless (isNodeSufficientlySynced spV0) $ throwM (NodeIsStillSyncing syncPercentage :: WalletErrorV1)
 
     let newWalletHandler CreateWallet  = V0.newWalletNoThrow
         newWalletHandler RestoreWallet = V0.restoreWalletFromSeedNoThrow
@@ -151,10 +151,10 @@ addWalletInfo
     => V0.WalletSnapshot
     -> V0.CWallet
     -> m Wallet
-addWalletInfo snapshot wallet = do
+addWalletInfo snapshot wallet =
     case V0.getWalletInfo (V0.cwId wallet) snapshot of
         Nothing ->
-            throwM WalletNotFound
+            throwM (WalletNotFound :: WalletErrorV1)
         Just walletInfo -> do
             currentDepth <- V0.networkChainDifficulty
             migrate (wallet, walletInfo, currentDepth)
@@ -170,7 +170,7 @@ updateWallet wid WalletUpdate{..} = do
     ws <- V0.askWalletSnapshot
     wid' <- migrate wid
     assurance <- migrate uwalAssuranceLevel
-    walletMeta <- maybe (throwM WalletNotFound) pure $ V0.getWalletMeta wid' ws
+    walletMeta <- maybe (throwM (WalletNotFound :: WalletErrorV1)) pure $ V0.getWalletMeta wid' ws
     updated <- V0.updateWallet wid' walletMeta
         { V0.cwName = uwalName
         , V0.cwAssurance = assurance

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Wallets.hs
@@ -16,7 +16,6 @@ import qualified Pos.Wallet.Web.State.Storage as V0
 
 import           Cardano.Wallet.API.Request
 import           Cardano.Wallet.API.Response
-import           Cardano.Wallet.API.V1.Errors
 import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.API.V1.Wallets as Wallets
@@ -76,7 +75,7 @@ newWallet NewWallet{..} = do
 
     -- Do not allow creation or restoration of wallets if the underlying node
     -- is still catching up.
-    unless (isNodeSufficientlySynced spV0) $ throwM (NodeIsStillSyncing syncPercentage :: WalletErrorV1)
+    unless (isNodeSufficientlySynced spV0) $ throwM (NodeIsStillSyncing syncPercentage)
 
     let newWalletHandler CreateWallet  = V0.newWalletNoThrow
         newWalletHandler RestoreWallet = V0.restoreWalletFromSeedNoThrow
@@ -154,7 +153,7 @@ addWalletInfo
 addWalletInfo snapshot wallet =
     case V0.getWalletInfo (V0.cwId wallet) snapshot of
         Nothing ->
-            throwM (WalletNotFound :: WalletErrorV1)
+            throwM WalletNotFound
         Just walletInfo -> do
             currentDepth <- V0.networkChainDifficulty
             migrate (wallet, walletInfo, currentDepth)
@@ -170,7 +169,7 @@ updateWallet wid WalletUpdate{..} = do
     ws <- V0.askWalletSnapshot
     wid' <- migrate wid
     assurance <- migrate uwalAssuranceLevel
-    walletMeta <- maybe (throwM (WalletNotFound :: WalletErrorV1)) pure $ V0.getWalletMeta wid' ws
+    walletMeta <- maybe (throwM WalletNotFound) pure $ V0.getWalletMeta wid' ws
     updated <- V0.updateWallet wid' walletMeta
         { V0.cwName = uwalName
         , V0.cwAssurance = assurance

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -16,7 +16,7 @@ import           Data.Map (elems)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Time.Units (fromMicroseconds, toMicroseconds)
 import           Data.Typeable (typeRep)
-import           Formatting (sformat)
+import           Formatting (sformat, build)
 
 import           Cardano.Wallet.API.V1.Errors as Errors
 import           Cardano.Wallet.API.V1.Types (V1 (..))
@@ -195,7 +195,7 @@ instance Migrate V0.AccountId (V1.WalletId, V1.AccountIndex) where
         (,)
             <$> eitherMigrate (V0.aiWId accId)
             <*> first
-                    Errors.MigrationFailed
+                    (Errors.MigrationFailed . sformat build)
                     (V1.mkAccountIndex $ V0.aiIndex accId)
 
 instance Migrate V0.CAccountId V0.AccountId where

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -27,6 +27,8 @@ import           Pos.Crypto (decodeHash)
 import           Pos.Wallet.Web.ClientTypes.Instances ()
 import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
 import           Servant (err422)
+import           Test.QuickCheck (Arbitrary (..))
+import           Test.QuickCheck.Gen (oneof)
 
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Control.Lens as Lens
@@ -346,6 +348,11 @@ instance FromJSON MigrationError where
     parseJSON = gparseJsend
 
 instance Exception MigrationError
+
+instance Arbitrary MigrationError where
+    arbitrary = oneof
+        [ pure $ MigrationFailed "Migration failed."
+        ]
 
 instance Buildable MigrationError where
     build = \case

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -3,36 +3,43 @@
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module Cardano.Wallet.API.V1.Migration.Types (
-      Migrate(..)
+module Cardano.Wallet.API.V1.Migration.Types
+    ( Migrate(..)
+    , MigrationError(..)
     , migrate
     ) where
 
 import           Universum hiding (elems)
 
-import qualified Control.Lens as Lens
-import qualified Control.Monad.Catch as Catch
+import           Cardano.Wallet.API.Response.JSend (ResponseStatus (..))
+import           Cardano.Wallet.API.V1.Errors (ToServantError (..))
+import           Cardano.Wallet.API.V1.Generic (gparseJsend, gtoJsend)
+import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Data.Aeson (FromJSON (..), ToJSON (..))
 import           Data.Map (elems)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Time.Units (fromMicroseconds, toMicroseconds)
 import           Data.Typeable (typeRep)
-import           Formatting (build, sformat)
-
-import           Cardano.Wallet.API.V1.Errors as Errors
-import           Cardano.Wallet.API.V1.Types (V1 (..), WalletErrorV1)
-import qualified Cardano.Wallet.API.V1.Types as V1
-import qualified Pos.Client.Txp.Util as V0
+import           Formatting (bprint, build, sformat)
+import           Generics.SOP.TH (deriveGeneric)
 import           Pos.Core (addressF)
+import           Pos.Crypto (decodeHash)
+import           Pos.Wallet.Web.ClientTypes.Instances ()
+import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
+import           Servant (err422)
+
+import qualified Cardano.Wallet.API.V1.Types as V1
+import qualified Control.Lens as Lens
+import qualified Control.Monad.Catch as Catch
+import qualified Data.Text.Buildable
+import qualified Pos.Client.Txp.Util as V0
 import qualified Pos.Core.Common as Core
 import qualified Pos.Core.Slotting as Core
 import qualified Pos.Core.Txp as Core
-import           Pos.Crypto (decodeHash)
 import qualified Pos.Txp.Toil.Types as V0
 import qualified Pos.Util.Servant as V0
-import qualified Pos.Wallet.Web.ClientTypes.Instances ()
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 import qualified Pos.Wallet.Web.State.Storage as OldStorage
-import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
 
 -- | 'Migrate' encapsulates migration between types, when possible.
 -- NOTE: This has @nothing@ to do with database migrations (see `safecopy`),
@@ -40,7 +47,7 @@ import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
 -- will be completed and the V0 API removed, we will be able to remove this
 -- typeclass altogether.
 class Migrate from to where
-    eitherMigrate :: from -> Either WalletErrorV1 to
+    eitherMigrate :: from -> Either MigrationError to
 
 -- | "Run" the migration.
 migrate :: ( Migrate from to, Catch.MonadThrow m ) => from -> m to
@@ -92,14 +99,14 @@ instance Migrate (OldStorage.SyncStatistics, Maybe Core.ChainDifficulty) V1.Sync
                 Just nd | wspCurrentBlockchainDepth >= nd -> 100
                 Just nd -> (fromIntegral wspCurrentBlockchainDepth / max 1.0 (fromIntegral nd)) * 100.0
             toMs (Core.Timestamp microsecs) =
-              V1.mkEstimatedCompletionTime (round @Double $ (realToFrac (toMicroseconds microsecs) / 1000.0))
+              V1.mkEstimatedCompletionTime (round @Double (realToFrac (toMicroseconds microsecs) / 1000.0))
             tput (OldStorage.SyncThroughput blocks) = V1.mkSyncThroughput blocks
             remainingBlocks = fmap (\total -> total - wspCurrentBlockchainDepth) currentBlockchainHeight
         in V1.SyncProgress <$> pure (toMs (maybe unknownCompletionTime
                                                  (calculateEstimatedRemainingTime wspThroughput)
                                                  remainingBlocks))
                            <*> pure (tput wspThroughput)
-                           <*> pure (V1.mkSyncPercentage (floor @Double $ percentage))
+                           <*> pure (V1.mkSyncPercentage (floor @Double percentage))
 
 -- NOTE: Migrate V1.Wallet V0.CWallet unable to do - not idempotent
 
@@ -115,7 +122,7 @@ instance Migrate V1.AssuranceLevel V0.CWalletAssurance where
 --
 instance Migrate V0.CCoin (V1 Core.Coin) where
     eitherMigrate c =
-        let err = Left . Errors.MigrationFailed . mappend "error migrating V0.CCoin -> Core.Coin, mkCoin failed: "
+        let err = Left . MigrationFailed . mappend "error migrating V0.CCoin -> Core.Coin, mkCoin failed: "
         in either err (pure . V1) (V0.decodeCType c)
 
 instance Migrate (V1 Core.Coin) V0.CCoin where
@@ -154,7 +161,7 @@ instance Migrate V0.CAddress V1.WalletAddress where
 instance Migrate V0.SyncProgress V1.SyncPercentage where
     eitherMigrate V0.SyncProgress{..} =
         let percentage = case _spNetworkCD of
-                Nothing -> (0 :: Word8)
+                Nothing -> 0 :: Word8
                 Just nd | _spLocalCD >= nd -> 100
                 Just nd -> floor @Double $ (fromIntegral _spLocalCD / max 1.0 (fromIntegral nd)) * 100.0
         in pure $ V1.mkSyncPercentage (fromIntegral percentage)
@@ -195,11 +202,11 @@ instance Migrate V0.AccountId (V1.WalletId, V1.AccountIndex) where
         (,)
             <$> eitherMigrate (V0.aiWId accId)
             <*> first
-                    (Errors.MigrationFailed . sformat build)
+                    (MigrationFailed . sformat build)
                     (V1.mkAccountIndex $ V0.aiIndex accId)
 
 instance Migrate V0.CAccountId V0.AccountId where
-    eitherMigrate = first Errors.MigrationFailed . V0.decodeCType
+    eitherMigrate = first MigrationFailed . V0.decodeCType
 
 instance Migrate V0.CAccountId V1.AccountIndex where
     eitherMigrate cAccId = do
@@ -215,24 +222,24 @@ instance Migrate V0.CAccountId V1.WalletId where
 
 instance Migrate V0.CAddress (V1 Core.Address) where
        eitherMigrate V0.CAddress {..} =
-           let err = Left . Errors.MigrationFailed . mappend "Error migrating V0.CAddress -> Core.Address failed: "
+           let err = Left . MigrationFailed . mappend "Error migrating V0.CAddress -> Core.Address failed: "
            in either err (pure . V1) (V0.decodeCType cadId)
 
 instance Migrate (V0.CId V0.Addr) (V1 Core.Address) where
     eitherMigrate (V0.CId (V0.CHash h)) =
-        let err = Left . Errors.MigrationFailed . mappend "Error migrating (V0.CId V0.Addr) -> Core.Address failed."
+        let err = Left . MigrationFailed . mappend "Error migrating (V0.CId V0.Addr) -> Core.Address failed."
         in either err (pure . V1) (Core.decodeTextAddress h)
 
 instance Migrate (V1 Core.Address) (V0.CId V0.Addr) where
     eitherMigrate (V1 address) =
       let h = sformat addressF address in
-      pure $ (V0.CId (V0.CHash h))
+      pure (V0.CId (V0.CHash h))
 
 instance Migrate (V0.CId V0.Addr, V0.CCoin) V1.PaymentDistribution where
     eitherMigrate (cIdAddr, cCoin) = do
         pdAddress <- eitherMigrate cIdAddr
         pdAmount  <- eitherMigrate cCoin
-        pure $ V1.PaymentDistribution {..}
+        pure V1.PaymentDistribution {..}
 
 instance Migrate V1.PaymentDistribution (V0.CId V0.Addr, Core.Coin) where
     eitherMigrate V1.PaymentDistribution {..} =
@@ -247,7 +254,7 @@ instance Migrate (V0.CId V0.Addr, Core.Coin) V1.PaymentDistribution where
 
 instance Migrate V0.CTxId (V1 Core.TxId) where
     eitherMigrate (V0.CTxId (V0.CHash h)) =
-        let err = Left . Errors.MigrationFailed . mappend "Error migrating a TxId: "
+        let err = Left . MigrationFailed . mappend "Error migrating a TxId: "
         in either err (pure . V1) (decodeHash h)
 
 instance Migrate POSIXTime (V1 Core.Timestamp) where
@@ -308,7 +315,7 @@ instance Migrate V1.EstimatedFees V0.TxFee where
 instance Migrate V1.WalletUpdate V0.CWalletMeta where
     eitherMigrate V1.WalletUpdate{..} = do
         migratedAssurance <- eitherMigrate uwalAssuranceLevel
-        pure $ V0.CWalletMeta
+        pure V0.CWalletMeta
             { cwName      = uwalName
             , cwAssurance = migratedAssurance
             , cwUnit      = 0
@@ -317,7 +324,35 @@ instance Migrate V1.WalletUpdate V0.CWalletMeta where
 instance Migrate V0.CWalletMeta V1.WalletUpdate where
     eitherMigrate V0.CWalletMeta{..} = do
         migratedAssurance <- eitherMigrate cwAssurance
-        pure $ V1.WalletUpdate
+        pure V1.WalletUpdate
             { uwalName              = cwName
             , uwalAssuranceLevel    = migratedAssurance
             }
+
+--
+-- Migration Errors
+--
+
+newtype MigrationError
+    = MigrationFailed Text
+    deriving (Eq, Show)
+
+deriveGeneric ''MigrationError
+
+instance ToJSON MigrationError where
+    toJSON = gtoJsend ErrorStatus
+
+instance FromJSON MigrationError where
+    parseJSON = gparseJsend
+
+instance Exception MigrationError
+
+instance Buildable MigrationError where
+    build = \case
+        MigrationFailed _ ->
+             bprint "Error while migrating a legacy type into the current version."
+
+instance ToServantError MigrationError where
+    declareServantError = \case
+        MigrationFailed _ ->
+            err422

--- a/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Migration/Types.hs
@@ -16,10 +16,10 @@ import           Data.Map (elems)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Time.Units (fromMicroseconds, toMicroseconds)
 import           Data.Typeable (typeRep)
-import           Formatting (sformat, build)
+import           Formatting (build, sformat)
 
 import           Cardano.Wallet.API.V1.Errors as Errors
-import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Cardano.Wallet.API.V1.Types (V1 (..), WalletErrorV1)
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Pos.Client.Txp.Util as V0
 import           Pos.Core (addressF)
@@ -40,7 +40,7 @@ import           Pos.Wallet.Web.Tracking.Sync (calculateEstimatedRemainingTime)
 -- will be completed and the V0 API removed, we will be able to remove this
 -- typeclass altogether.
 class Migrate from to where
-    eitherMigrate :: from -> Either Errors.WalletError to
+    eitherMigrate :: from -> Either WalletErrorV1 to
 
 -- | "Run" the migration.
 migrate :: ( Migrate from to, Catch.MonadThrow m ) => from -> m to

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -186,6 +186,9 @@ instance (HasSwagger subApi) => HasSwagger (WalletRequestParams :> subApi) where
 
 instance ToParamSchema WalletId
 
+instance ToSchema Core.Address where
+    declareNamedSchema = pure . paramSchemaToNamedSchema defaultSchemaOptions
+
 instance ToParamSchema Core.Address where
   toParamSchema _ = mempty
     & type_ .~ SwaggerString

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -186,16 +186,12 @@ instance (HasSwagger subApi) => HasSwagger (WalletRequestParams :> subApi) where
 
 instance ToParamSchema WalletId
 
-instance ToSchema Core.Address where
-    declareNamedSchema = pure . paramSchemaToNamedSchema defaultSchemaOptions
-
 instance ToParamSchema Core.Address where
   toParamSchema _ = mempty
     & type_ .~ SwaggerString
 
 instance ToParamSchema (V1 Core.Address) where
   toParamSchema _ = toParamSchema (Proxy @Core.Address)
-
 
 --
 -- Descriptions

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -17,32 +17,28 @@ import           Cardano.Wallet.API.Request.Pagination
 import           Cardano.Wallet.API.Request.Sort
 import           Cardano.Wallet.API.Response
 import           Cardano.Wallet.API.Types
-import qualified Cardano.Wallet.API.V1.Errors as Errors
 import           Cardano.Wallet.API.V1.Generic (gconsName)
+import           Cardano.Wallet.API.V1.Migration.Types (MigrationError (..))
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Swagger.Example
 import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.TypeLits (KnownSymbols (..))
-import qualified Pos.Core as Core
+import           Control.Lens ((?~))
+import           Data.Aeson (ToJSON (..), encode)
+import           Data.Aeson.Encode.Pretty
+import           Data.Map (Map)
+import           Data.String.Conv
+import           Data.Swagger hiding (Example, Header, example)
+import           Data.Swagger.Declare
+import           Data.Typeable
+import           Formatting (build, sformat)
+import           NeatInterpolation
 import           Pos.Core.Update (SoftwareVersion)
+import           Pos.Util.BackupPhrase (BackupPhrase (bpToList))
 import           Pos.Util.CompileInfo (CompileTimeInfo, ctiGitRevision)
 import           Pos.Util.Mnemonic (Mnemonic)
 import           Pos.Util.Servant (LoggingApi)
 import           Pos.Wallet.Web.Swagger.Instances.Schema ()
-
-import           Control.Lens ((?~))
-import           Data.Aeson (ToJSON (..), encode)
-import           Data.Aeson.Encode.Pretty
-import qualified Data.ByteString.Lazy as BL
-import           Data.Map (Map)
-import qualified Data.Map.Strict as M
-import qualified Data.Set as Set
-import           Data.Swagger hiding (Example, Header, example)
-import           Data.Swagger.Declare
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import           Data.Typeable
-import           NeatInterpolation
 import           Servant (Handler, ServantErr (..), Server)
 import           Servant.API.Sub
 import           Servant.Swagger
@@ -51,6 +47,16 @@ import           Servant.Swagger.UI.Internal (mkRecursiveEmbedded)
 import           Test.QuickCheck
 import           Test.QuickCheck.Gen
 import           Test.QuickCheck.Random
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as M
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Pos.Core as Core
+import qualified Pos.Crypto.Hashing as Crypto
+import qualified Pos.Data.Attributes as Core
+
 
 --
 -- Helper functions
@@ -228,13 +234,44 @@ Error Name / Description | HTTP Error code | Example
 $errors
 |] where
   errors = T.intercalate "\n" rows
-  rows = map (mkRow errToDescription) sampleErrors
+  rows =
+    [ mkRow errToDescription $ NotEnoughMoney 1400
+    , mkRow errToDescription $ OutputIsRedeem sampleAddress
+    , mkRow errToDescription $ MigrationFailed "Migration failed."
+    , mkRow errToDescription $ JSONValidationFailed "Expected String, found Null."
+    , mkRow errToDescription $ UnknownError "Unknown error."
+    , mkRow errToDescription $ InvalidAddressFormat "Invalid Base58 representation."
+    , mkRow errToDescription WalletNotFound
+    , mkRow errToDescription $ WalletAlreadyExists sampleWalletId
+    , mkRow errToDescription AddressNotFound
+    , mkRow errToDescription $ MissingRequiredParams (("wallet_id", "walletId") :| [])
+    , mkRow errToDescription $ WalletIsNotReadyToProcessPayments sampleSyncProgress
+    , mkRow errToDescription $ NodeIsStillSyncing (mkSyncPercentage 42)
+    ]
   mkRow fmt err = T.intercalate "|" (fmt err)
   errToDescription err =
-    [ surroundedBy "`" (gconsName err) <> "<br/>" <> toText (Errors.describe err)
-    , show $ errHTTPCode $ Errors.toServantError err
+    [ surroundedBy "`" (gconsName err) <> "<br/>" <> toText (sformat build err)
+    , show $ errHTTPCode $ toServantError err
     , inlineCodeBlock (T.decodeUtf8 $ BL.toStrict $ encodePretty err)
     ]
+
+  sampleWalletId =
+    WalletId "J7rQqaLLHBFPrgJXwpktaMB1B1kQBXAyc2uRSfRPzNVGiv6TdxBzkPNBUWysZZZdhFG9gRy3sQFfX5wfpLbi4XTFGFxTg"
+
+  sampleAddress = V1 Core.Address
+      { Core.addrRoot =
+          Crypto.unsafeAbstractHash ("asdfasdf" :: String)
+      , Core.addrAttributes =
+          Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr
+      , Core.addrType =
+          Core.ATPubKey
+      }
+
+  sampleSyncProgress = SyncProgress
+      { spEstimatedCompletionTime = mkEstimatedCompletionTime 3000
+      , spThroughput              = mkSyncThroughput (Core.BlockCount 400)
+      , spPercentage              = mkSyncPercentage 80
+      }
 
 
 -- | Shorter version of the doc below, only for Dev & V0 documentations
@@ -843,7 +880,7 @@ api (compileInfo, curSoftwareVersion) walletAPI mkDescription = toSwagger wallet
   & info.version .~ fromString (show curSoftwareVersion)
   & host ?~ "127.0.0.1:8090"
   & info.description ?~ mkDescription $ DescriptionEnvironment
-    { deErrorExample          = decodeUtf8 $ encodePretty Errors.WalletNotFound
+    { deErrorExample          = decodeUtf8 $ encodePretty WalletNotFound
     , deMnemonicExample       = decodeUtf8 $ encode (genExample @(Mnemonic 12))
     , deDefaultPerPage        = fromString (show defaultPerPageEntries)
     , deWalletErrorTable      = errorsDescription

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -27,14 +27,12 @@ import           Control.Lens ((?~))
 import           Data.Aeson (ToJSON (..), encode)
 import           Data.Aeson.Encode.Pretty
 import           Data.Map (Map)
-import           Data.String.Conv
 import           Data.Swagger hiding (Example, Header, example)
 import           Data.Swagger.Declare
 import           Data.Typeable
 import           Formatting (build, sformat)
 import           NeatInterpolation
 import           Pos.Core.Update (SoftwareVersion)
-import           Pos.Util.BackupPhrase (BackupPhrase (bpToList))
 import           Pos.Util.CompileInfo (CompileTimeInfo, ctiGitRevision)
 import           Pos.Util.Mnemonic (Mnemonic)
 import           Pos.Util.Servant (LoggingApi)
@@ -879,7 +877,7 @@ api (compileInfo, curSoftwareVersion) walletAPI mkDescription = toSwagger wallet
   & info.title   .~ "Cardano Wallet API"
   & info.version .~ fromString (show curSoftwareVersion)
   & host ?~ "127.0.0.1:8090"
-  & info.description ?~ mkDescription $ DescriptionEnvironment
+  & info.description ?~ mkDescription DescriptionEnvironment
     { deErrorExample          = decodeUtf8 $ encodePretty WalletNotFound
     , deMnemonicExample       = decodeUtf8 $ encode (genExample @(Mnemonic 12))
     , deDefaultPerPage        = fromString (show defaultPerPageEntries)

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -58,7 +58,7 @@ import           Test.QuickCheck.Random
 
 -- | Generates an example for type `a` with a static seed.
 genExample :: Example a => a
-genExample = (unGen (resize 3 example)) (mkQCGen 42) 42
+genExample = unGen (resize 3 example) (mkQCGen 42) 42
 
 -- | Generates a `NamedSchema` exploiting the `ToJSON` instance in scope,
 -- by calling `sketchSchema` under the hood.
@@ -155,7 +155,7 @@ instance
         in swgr & over (operationsOf swgr . parameters) addSortOperation
           where
             addSortOperation :: [Referenced Param] -> [Referenced Param]
-            addSortOperation xs = (Inline newParam) : xs
+            addSortOperation xs = Inline newParam : xs
 
             newParam :: Param
             newParam =
@@ -228,7 +228,7 @@ Error Name / Description | HTTP Error code | Example
 $errors
 |] where
   errors = T.intercalate "\n" rows
-  rows = map (mkRow errToDescription) Errors.sample
+  rows = map (mkRow errToDescription) sampleErrors
   mkRow fmt err = T.intercalate "|" (fmt err)
   errToDescription err =
     [ surroundedBy "`" (gconsName err) <> "<br/>" <> toText (Errors.describe err)
@@ -842,12 +842,12 @@ api (compileInfo, curSoftwareVersion) walletAPI mkDescription = toSwagger wallet
   & info.title   .~ "Cardano Wallet API"
   & info.version .~ fromString (show curSoftwareVersion)
   & host ?~ "127.0.0.1:8090"
-  & info.description ?~ (mkDescription $ DescriptionEnvironment
+  & info.description ?~ mkDescription $ DescriptionEnvironment
     { deErrorExample          = decodeUtf8 $ encodePretty Errors.WalletNotFound
     , deMnemonicExample       = decodeUtf8 $ encode (genExample @(Mnemonic 12))
     , deDefaultPerPage        = fromString (show defaultPerPageEntries)
     , deWalletErrorTable      = errorsDescription
     , deGitRevision           = ctiGitRevision compileInfo
     , deSoftwareVersion       = fromString $ show curSoftwareVersion
-    })
+    }
   & info.license ?~ ("MIT" & url ?~ URL "https://raw.githubusercontent.com/input-output-hk/cardano-sl/develop/lib/LICENSE")

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -17,7 +17,9 @@ import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 
 import qualified Data.Map.Strict as Map
 import qualified Pos.Core.Common as Core
+import qualified Pos.Crypto.Hashing as Crypto
 import qualified Pos.Crypto.Signing as Core
+import qualified Pos.Data.Attributes as Core
 
 
 class Arbitrary a => Example a where
@@ -137,6 +139,39 @@ instance Example Payment where
                       <*> example
 
 instance Example WalletStateSnapshot
+
+sampleErrors :: [WalletErrorV1]
+sampleErrors =
+    [ NotEnoughMoney 1400
+    , OutputIsRedeem sampleAddress
+    , MigrationFailed "Migration failed."
+    , JSONValidationFailed "Expected String, found Null."
+    , UnknownError "Unknown error."
+    , InvalidAddressFormat "Invalid Base58 representation."
+    , WalletNotFound
+    , WalletAlreadyExists
+    , AddressNotFound
+    , MissingRequiredParams (("wallet_id", "walletId") :| [])
+    , WalletIsNotReadyToProcessPayments sampleSyncProgress
+    , NodeIsStillSyncing (mkSyncPercentage 42)
+    ]
+  where
+    sampleAddress :: V1 Core.Address
+    sampleAddress = V1 Core.Address
+        { Core.addrRoot =
+            Crypto.unsafeAbstractHash ("asdfasdf" :: String)
+        , Core.addrAttributes =
+            Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr
+        , Core.addrType =
+            Core.ATPubKey
+        }
+
+    sampleSyncProgress :: SyncProgress
+    sampleSyncProgress = SyncProgress
+        { spEstimatedCompletionTime = mkEstimatedCompletionTime 3000
+        , spThroughput              = mkSyncThroughput (Core.BlockCount 400)
+        , spPercentage              = mkSyncPercentage 80
+        }
 
 
 

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -2,8 +2,6 @@ module Cardano.Wallet.API.V1.Swagger.Example where
 
 import           Universum
 
-import           Test.QuickCheck (Arbitrary (..), Gen, listOf1, oneof)
-
 import           Cardano.Wallet.API.Response
 import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.Orphans.Arbitrary ()
@@ -14,12 +12,11 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
 import           Pos.Util.Mnemonic (Mnemonic)
 import           Pos.Wallet.Web.ClientTypes (CUpdateInfo)
 import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
+import           Test.QuickCheck (Arbitrary (..), Gen, listOf1, oneof)
 
 import qualified Data.Map.Strict as Map
 import qualified Pos.Core.Common as Core
-import qualified Pos.Crypto.Hashing as Crypto
 import qualified Pos.Crypto.Signing as Core
-import qualified Pos.Data.Attributes as Core
 
 
 class Arbitrary a => Example a where
@@ -139,40 +136,6 @@ instance Example Payment where
                       <*> example
 
 instance Example WalletStateSnapshot
-
-sampleErrors :: [WalletErrorV1]
-sampleErrors =
-    [ NotEnoughMoney 1400
-    , OutputIsRedeem sampleAddress
-    , MigrationFailed "Migration failed."
-    , JSONValidationFailed "Expected String, found Null."
-    , UnknownError "Unknown error."
-    , InvalidAddressFormat "Invalid Base58 representation."
-    , WalletNotFound
-    , WalletAlreadyExists
-    , AddressNotFound
-    , MissingRequiredParams (("wallet_id", "walletId") :| [])
-    , WalletIsNotReadyToProcessPayments sampleSyncProgress
-    , NodeIsStillSyncing (mkSyncPercentage 42)
-    ]
-  where
-    sampleAddress :: V1 Core.Address
-    sampleAddress = V1 Core.Address
-        { Core.addrRoot =
-            Crypto.unsafeAbstractHash ("asdfasdf" :: String)
-        , Core.addrAttributes =
-            Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr
-        , Core.addrType =
-            Core.ATPubKey
-        }
-
-    sampleSyncProgress :: SyncProgress
-    sampleSyncProgress = SyncProgress
-        { spEstimatedCompletionTime = mkEstimatedCompletionTime 3000
-        , spThroughput              = mkSyncThroughput (Core.BlockCount 400)
-        , spPercentage              = mkSyncPercentage 80
-        }
-
 
 
 -- IMPORTANT: if executing `grep "[]\|null" wallet-new/spec/swagger.json` returns any element - then we have to add Example instances for those objects because we don't want to see [] or null examples in our docs.

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -42,6 +42,8 @@ module Cardano.Wallet.API.V1.Types (
   , AccountIndex
   , getAccIndex
   , mkAccountIndex
+  , AccountIndexError(..)
+  , renderAccountIndexError
   -- * Addresses
   , WalletAddress (..)
   , NewAddress (..)
@@ -88,6 +90,7 @@ import           Control.Lens (At, Index, IxValue, at, ix, makePrisms, to, (?~))
 import           Data.Aeson
 import           Data.Aeson.TH as A
 import           Data.Aeson.Types (toJSONKeyText, typeMismatch)
+import           Data.Bifunctor (first)
 import qualified Data.Char as C
 import           Data.Swagger as S
 import           Data.Swagger.Declare (Declare, look)
@@ -884,19 +887,38 @@ instance Bounded AccountIndex where
     minBound = AccountIndex 2147483648
     maxBound = AccountIndex maxBound
 
-mkAccountIndex :: Word32 -> Either Text AccountIndex
-mkAccountIndex index | index >= getAccIndex minBound = Right $ AccountIndex index
-                     | otherwise = Left $ sformat
-                            ("mkAccountIndex: Account index should be in range ["%int%".."%int%"]")
-                            (getAccIndex minBound)
-                            (getAccIndex maxBound)
+data AccountIndexError = AccountIndexError Word32
+    deriving (Eq, Show)
+
+instance Buildable AccountIndexError where
+    build (AccountIndexError i) =
+        bprint
+            ("Account index should be in range ["%int%".."%int%"], but "%int%" was provided.")
+            (getAccIndex minBound)
+            (getAccIndex maxBound)
+            i
+
+mkAccountIndex :: Word32 -> Either AccountIndexError AccountIndex
+mkAccountIndex index
+    | index >= getAccIndex minBound = Right $ AccountIndex index
+    | otherwise = Left $ AccountIndexError index
+
+renderAccountIndexError :: AccountIndexError -> Text
+renderAccountIndexError (AccountIndexError i) =
+    sformat
+        ("Account index should be in range ["%int%".."%int%"], but "%int%" was provided.")
+        (getAccIndex minBound)
+        (getAccIndex maxBound)
+        i
 
 instance ToJSON AccountIndex where
     toJSON = toJSON . getAccIndex
 
 instance FromJSON AccountIndex where
     parseJSON =
-        either (fail . toString) pure . mkAccountIndex <=< parseJSON
+        either (fail . toString . sformat build) pure
+        . mkAccountIndex
+        <=< parseJSON
 
 instance Arbitrary AccountIndex where
     arbitrary = AccountIndex <$> choose (getAccIndex minBound, getAccIndex maxBound)
@@ -916,7 +938,7 @@ instance ToSchema AccountIndex where
     declareNamedSchema = pure . paramSchemaToNamedSchema defaultSchemaOptions
 
 instance FromHttpApiData AccountIndex where
-    parseQueryParam = mkAccountIndex <=< parseQueryParam
+    parseQueryParam = first (sformat build) . mkAccountIndex <=< parseQueryParam
 
 instance ToHttpApiData AccountIndex where
     toQueryParam = fromString . show . getAccIndex

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -863,11 +863,10 @@ instance Bounded AccountIndex where
 
 mkAccountIndex :: Word32 -> Either Text AccountIndex
 mkAccountIndex index | index >= getAccIndex minBound = Right $ AccountIndex index
-                     | otherwise = Left $ "mkAccountIndex: Account index should be in range ["
-                                        <> show (getAccIndex minBound)
-                                        <> ".."
-                                        <> show (getAccIndex maxBound)
-                                        <> "]"
+                     | otherwise = Left $ sformat
+                            ("mkAccountIndex: Account index should be in range ["%int%".."%int%"]")
+                            (getAccIndex minBound)
+                            (getAccIndex maxBound)
 
 instance ToJSON AccountIndex where
     toJSON = toJSON . getAccIndex

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -904,12 +904,8 @@ mkAccountIndex index
     | otherwise = Left $ AccountIndexError index
 
 renderAccountIndexError :: AccountIndexError -> Text
-renderAccountIndexError (AccountIndexError i) =
-    sformat
-        ("Account index should be in range ["%int%".."%int%"], but "%int%" was provided.")
-        (getAccIndex minBound)
-        (getAccIndex maxBound)
-        i
+renderAccountIndexError =
+    sformat build
 
 instance ToJSON AccountIndex where
     toJSON = toJSON . getAccIndex

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -82,6 +82,9 @@ module Cardano.Wallet.API.V1.Types (
   , CaptureAccountId
   -- * Core re-exports
   , Core.Address
+  -- * Wallet Errors
+  , WalletErrorV1
+  , WalletError(..)
   ) where
 
 import           Universum
@@ -122,6 +125,7 @@ import           Pos.Util.Mnemonic (Mnemonic)
 -- importing for orphan instances for Coin
 import           Pos.Wallet.Web.ClientTypes.Instances ()
 
+import           Cardano.Wallet.API.V1.Errors (WalletError (..))
 import           Cardano.Wallet.Util (showApiUtcTime)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
@@ -248,6 +252,7 @@ instance Buildable (SecureLog a) => Buildable (SecureLog (V1 a)) where
 
 instance (Buildable a, Buildable b) => Buildable (a, b) where
     build (a, b) = bprint ("("%build%", "%build%")") a b
+
 
 --
 -- Benign instances
@@ -1846,6 +1851,16 @@ instance BuildableSafeGen NodeInfo where
         nfoLocalBlockchainHeight
         nfoLocalTimeInformation
         (Map.toList nfoSubscriptionStatus)
+
+
+--
+-- Wallet Errors
+--
+
+type WalletErrorV1 = WalletError
+    (V1 Core.Address)
+    SyncProgress
+    SyncPercentage
 
 
 --

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -83,8 +83,9 @@ module Cardano.Wallet.API.V1.Types (
   -- * Core re-exports
   , Core.Address
   -- * Wallet Errors
-  , WalletErrorV1
   , WalletError(..)
+  , toServantError
+  , toHttpErrorStatus
   ) where
 
 import           Universum
@@ -94,55 +95,57 @@ import           Data.Aeson
 import           Data.Aeson.TH as A
 import           Data.Aeson.Types (toJSONKeyText, typeMismatch)
 import           Data.Bifunctor (first)
-import qualified Data.Char as C
 import           Data.Swagger as S
 import           Data.Swagger.Declare (Declare, look)
 import           Data.Swagger.Internal.Schema (GToSchema)
 import           Data.Swagger.Internal.TypeShape (GenericHasSimpleShape, GenericShape)
 import           Data.Text (Text, dropEnd, toLower)
-import qualified Data.Text as T
-import qualified Data.Text.Buildable
 import           Data.Version (Version)
 import           Formatting (bprint, build, fconst, int, sformat, (%))
+import           Generics.SOP.TH (deriveGeneric)
 import           GHC.Generics (Generic, Rep)
 import           Network.Transport (EndPointAddress (..))
 import           Node (NodeId (..))
-import qualified Prelude
-import qualified Serokell.Aeson.Options as Serokell
 import           Serokell.Util (listJson)
-import qualified Serokell.Util.Base16 as Base16
 import           Servant
+import           Test.Pos.Core.Arbitrary ()
 import           Test.QuickCheck
 import           Test.QuickCheck.Gen (Gen (..))
 import           Test.QuickCheck.Random (mkQCGen)
 
+import           Cardano.Wallet.API.Response.JSend (ResponseStatus (ErrorStatus))
 import           Cardano.Wallet.API.Types.UnitOfMeasure (MeasuredIn (..), UnitOfMeasure (..))
+import           Cardano.Wallet.API.V1.Errors (ToHttpErrorStatus (..), ToServantError (..),
+                                               WalletError (..))
+import           Cardano.Wallet.API.V1.Generic (gparseJsend, gtoJsend)
 import           Cardano.Wallet.Orphans.Aeson ()
-
--- V0 logic
-import           Pos.Util.Mnemonic (Mnemonic)
-
--- importing for orphan instances for Coin
-import           Pos.Wallet.Web.ClientTypes.Instances ()
-
-import           Cardano.Wallet.API.V1.Errors (WalletError (..))
 import           Cardano.Wallet.Util (showApiUtcTime)
-import qualified Data.ByteArray as ByteArray
-import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as Map
 import           Pos.Aeson.Core ()
-import qualified Pos.Client.Txp.Util as Core
+import           Pos.Arbitrary.Core ()
 import           Pos.Core (addressF)
-import qualified Pos.Core as Core
 import           Pos.Crypto (decodeHash, hashHexF)
-import qualified Pos.Crypto.Signing as Core
 import           Pos.Infra.Diffusion.Subscription.Status (SubscriptionStatus (..))
 import           Pos.Infra.Util.LogSafe (BuildableSafeGen (..), SecureLog (..), buildSafe,
                                          buildSafeList, buildSafeMaybe, deriveSafeBuildable,
                                          plainOrSecureF)
-import qualified Pos.Wallet.Web.State.Storage as OldStorage
+import           Pos.Util.BackupPhrase (BackupPhrase (..))
+import           Pos.Util.Mnemonic (Mnemonic)
+import           Pos.Wallet.Web.ClientTypes.Instances ()
 
-import           Test.Pos.Core.Arbitrary ()
+import qualified Data.ByteArray as ByteArray
+import qualified Data.ByteString as BS
+import qualified Data.Char as C
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import qualified Data.Text.Buildable
+import qualified Pos.Client.Txp.Util as Core
+import qualified Pos.Core as Core
+import qualified Pos.Crypto.Signing as Core
+import qualified Pos.Wallet.Web.State.Storage as OldStorage
+import qualified Prelude
+import qualified Serokell.Aeson.Options as Serokell
+import qualified Serokell.Util.Base16 as Base16
+
 
 -- | Declare generic schema, while documenting properties
 --   For instance:
@@ -190,7 +193,7 @@ genericSchemaDroppingPrefix prfx extraDoc proxy = do
       & schema . example ?~ toJSON (genExample :: a)
   where
     genExample =
-      (unGen (resize 3 arbitrary)) (mkQCGen 42) 42
+      unGen (resize 3 arbitrary) (mkQCGen 42) 42
 
     addFieldDescription defs field desc =
       over (at field) (addDescription defs field desc)
@@ -260,7 +263,7 @@ instance (Buildable a, Buildable b) => Buildable (a, b) where
 
 instance ByteArray.ByteArrayAccess a => ByteArray.ByteArrayAccess (V1 a) where
    length (V1 a) = ByteArray.length a
-   withByteArray (V1 a) callback = ByteArray.withByteArray a callback
+   withByteArray (V1 a) = ByteArray.withByteArray a
 
 instance Arbitrary (V1 (Mnemonic 12)) where
     arbitrary =
@@ -306,7 +309,7 @@ instance Arbitrary (V1 Core.PassPhrase) where
     arbitrary = fmap V1 arbitrary
 
 instance ToSchema (V1 Core.PassPhrase) where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "V1PassPhrase") $ mempty
             & type_ .~ SwaggerString
             & format ?~ "hex|base16"
@@ -419,7 +422,7 @@ deriveJSON Serokell.defaultOptions { A.constructorTagModifier = toString . toLow
                                    } ''AssuranceLevel
 
 instance ToSchema AssuranceLevel where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "AssuranceLevel") $ mempty
             & type_ .~ SwaggerString
             & enum_ ?~ ["normal", "strict"]
@@ -471,7 +474,7 @@ deriveJSON Serokell.defaultOptions  { A.constructorTagModifier = reverse . drop 
                                     } ''WalletOperation
 
 instance ToSchema WalletOperation where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "WalletOperation") $ mempty
             & type_ .~ SwaggerString
             & enum_ ?~ ["create", "restore"]
@@ -579,7 +582,7 @@ instance FromJSON SyncPercentage where
     parseJSON = withObject "SyncPercentage" $ \sl -> mkSyncPercentage <$> sl .: "quantity"
 
 instance ToSchema SyncPercentage where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "SyncPercentage") $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["quantity", "unit"]
@@ -632,7 +635,7 @@ instance FromJSON EstimatedCompletionTime where
     parseJSON = withObject "EstimatedCompletionTime" $ \sl -> mkEstimatedCompletionTime <$> sl .: "quantity"
 
 instance ToSchema EstimatedCompletionTime where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "EstimatedCompletionTime") $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["quantity", "unit"]
@@ -680,7 +683,7 @@ instance FromJSON SyncThroughput where
     parseJSON = withObject "SyncThroughput" $ \sl -> mkSyncThroughput . Core.BlockCount <$> sl .: "quantity"
 
 instance ToSchema SyncThroughput where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "SyncThroughput") $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["quantity", "unit"]
@@ -848,7 +851,7 @@ newtype AddressValidity = AddressValidity { isValid :: Bool }
 deriveJSON Serokell.defaultOptions ''AddressValidity
 
 instance ToSchema AddressValidity where
-    declareNamedSchema = genericSchemaDroppingPrefix "is" (\_ -> identity)
+    declareNamedSchema = genericSchemaDroppingPrefix "is" (const identity)
 
 instance Arbitrary AddressValidity where
   arbitrary = AddressValidity <$> arbitrary
@@ -1277,7 +1280,7 @@ instance ToJSON (V1 Core.TxId) where
   toJSON (V1 t) = String (sformat hashHexF t)
 
 instance FromJSON (V1 Core.TxId) where
-    parseJSON = withText "TxId" $ \t -> do
+    parseJSON = withText "TxId" $ \t ->
        case decodeHash t of
            Left err -> fail $ "Failed to parse transaction ID: " <> toString err
            Right a  -> pure (V1 a)
@@ -1672,7 +1675,7 @@ instance FromJSON LocalTimeDifference where
     parseJSON = withObject "LocalTimeDifference" $ \sl -> mkLocalTimeDifference <$> sl .: "quantity"
 
 instance ToSchema LocalTimeDifference where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "LocalTimeDifference") $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["quantity"]
@@ -1713,7 +1716,7 @@ instance FromJSON BlockchainHeight where
         mkBlockchainHeight . Core.BlockCount <$> sl .: "quantity"
 
 instance ToSchema BlockchainHeight where
-    declareNamedSchema _ = do
+    declareNamedSchema _ =
         pure $ NamedSchema (Just "BlockchainHeight") $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["quantity"]
@@ -1857,10 +1860,148 @@ instance BuildableSafeGen NodeInfo where
 -- Wallet Errors
 --
 
-type WalletErrorV1 = WalletError
-    (V1 Core.Address)
-    SyncProgress
-    SyncPercentage
+--
+-- Error handling
+--
+
+-- | Type representing any error which might be thrown by wallet.
+--
+-- Errors are represented in JSON in the JSend format (<https://labs.omniti.com/labs/jsend>):
+-- ```
+-- {
+--     "status": "error"
+--     "message" : <constr_name>,
+--     "diagnostic" : <data>
+-- }
+-- ```
+-- where `<constr_name>` is a string containing name of error's constructor (e. g. `NotEnoughMoney`),
+-- and `<data>` is an object containing additional error data.
+-- Additional data contains constructor fields, field names are record field names without
+-- a `we` prefix, e. g. for `OutputIsRedeem` error "diagnostic" field will be the following:
+-- ```
+-- {
+--     "address" : <address>
+-- }
+-- ```
+--
+-- Additional data in constructor should be represented as record fields.
+-- Otherwise TemplateHaskell will raise an error.
+--
+-- If constructor does not have additional data (like in case of `WalletNotFound` error),
+-- then "diagnostic" field will be empty object.
+--
+-- TODO: change fields' types to actual Cardano core types, like `Coin` and `Address`
+data WalletError =
+      NotEnoughMoney { weNeedMore :: !Int }
+    | OutputIsRedeem { weAddress :: !(V1 Core.Address) }
+    | UnknownError { weMsg :: !Text }
+    | InvalidAddressFormat { weMsg :: !Text }
+    | WalletNotFound
+    -- FIXME(akegalj): https://iohk.myjetbrains.com/youtrack/issue/CSL-2496
+    | WalletAlreadyExists { weWalletId :: WalletId }
+    | AddressNotFound
+    | TxFailedToStabilize
+    | TxRedemptionDepleted
+    | TxSafeSignerNotFound { weAddress :: V1 Core.Address }
+    | MissingRequiredParams { requiredParams :: NonEmpty (Text, Text) }
+    | WalletIsNotReadyToProcessPayments { weStillRestoring :: SyncProgress }
+    -- ^ The @Wallet@ where a @Payment@ is being originated is not fully
+    -- synced (its 'WalletSyncState' indicates it's either syncing or
+    -- restoring) and thus cannot accept new @Payment@ requests.
+    | NodeIsStillSyncing { wenssStillSyncing :: SyncPercentage }
+    -- ^ The backend couldn't process the incoming request as the underlying
+    -- node is still syncing with the blockchain.
+    deriving (Show, Eq)
+
+-- deriveWalletErrorJSON ''WalletError
+deriveGeneric ''WalletError
+
+instance ToJSON WalletError where
+    toJSON = gtoJsend ErrorStatus
+
+instance FromJSON WalletError where
+    parseJSON = gparseJsend
+
+instance Exception WalletError
+
+instance Arbitrary WalletError where
+    arbitrary = oneof
+        [ NotEnoughMoney <$> arbitrary
+        , OutputIsRedeem <$> arbitrary
+        , pure (UnknownError "Unknown error.")
+        , pure (InvalidAddressFormat "Invalid Base58 representation.")
+        , pure WalletNotFound
+        , WalletAlreadyExists <$> arbitrary
+        , pure AddressNotFound
+        , pure TxFailedToStabilize
+        , pure TxRedemptionDepleted
+        , TxSafeSignerNotFound <$> arbitrary
+        , pure (MissingRequiredParams (("wallet_id", "walletId") :| []))
+        , WalletIsNotReadyToProcessPayments <$> arbitrary
+        , NodeIsStillSyncing <$> arbitrary
+        ]
+
+-- | Give a short description of an error
+instance Buildable WalletError where
+    build = \case
+        NotEnoughMoney _ ->
+             bprint "Not enough available coins to proceed."
+        OutputIsRedeem _ ->
+             bprint "One of the TX outputs is a redemption address."
+        UnknownError _ ->
+             bprint "Unexpected internal error."
+        InvalidAddressFormat _ ->
+             bprint "Provided address format is not valid."
+        WalletNotFound ->
+             bprint "Reference to an unexisting wallet was given."
+        WalletAlreadyExists _ ->
+             bprint "Can't create or restore a wallet. The wallet already exists."
+        AddressNotFound ->
+             bprint "Reference to an unexisting address was given."
+        MissingRequiredParams _ ->
+             bprint "Missing required parameters in the request payload."
+        WalletIsNotReadyToProcessPayments _ ->
+             bprint "This wallet is restoring, and it cannot send new transactions until restoration completes."
+        NodeIsStillSyncing _ ->
+             bprint "The node is still syncing with the blockchain, and cannot process the request yet."
+        TxRedemptionDepleted ->
+            bprint "The redemption address was already used."
+        TxSafeSignerNotFound _ ->
+            bprint "The safe signer at the specified address was not found."
+        TxFailedToStabilize ->
+            bprint "We were unable to find a set of inputs to satisfy this transaction."
+
+-- | Convert wallet errors to Servant errors
+instance ToServantError WalletError where
+    declareServantError = \case
+        NotEnoughMoney{} ->
+            err403
+        OutputIsRedeem{} ->
+            err403
+        UnknownError{} ->
+            err500
+        WalletNotFound{} ->
+            err404
+        WalletAlreadyExists{} ->
+            err403
+        InvalidAddressFormat{} ->
+            err401
+        AddressNotFound{} ->
+            err404
+        MissingRequiredParams{} ->
+            err400
+        WalletIsNotReadyToProcessPayments{} ->
+            err403
+        NodeIsStillSyncing{} ->
+            err412 -- Precondition failed
+        TxFailedToStabilize{} ->
+            err500
+        TxRedemptionDepleted{} ->
+            err400
+        TxSafeSignerNotFound{} ->
+            err400
+
+instance ToHttpErrorStatus WalletError
 
 
 --

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -136,7 +136,7 @@ paginateAll request = fmap fixMetadata <$> paginatePage 1
   where
     fixMetadata WalletResponse{..} =
         WalletResponse
-            { wrMeta = Metadata $
+            { wrMeta = Metadata
                 PaginationMetadata
                     { metaTotalPages = 1
                     , metaPage = Page 1
@@ -237,7 +237,7 @@ type Resp m a = m (Either ClientError (WalletResponse a))
 
 -- | The type of errors that the wallet might return.
 data ClientError
-    = ClientWalletError WalletErrorV1
+    = ClientWalletError WalletError
     -- ^ The 'WalletError' type represents known failures that the API
     -- might return.
     | ClientHttpError ServantError

--- a/wallet-new/src/Cardano/Wallet/Client.hs
+++ b/wallet-new/src/Cardano/Wallet/Client.hs
@@ -16,7 +16,7 @@ module Cardano.Wallet.Client
     , liftClient
     -- * The type of errors that the client might return
     , ClientError(..)
-    , V1Errors.WalletError(..)
+    , WalletError(..)
     , ServantError(..)
     , Response
     , GenResponse(..)
@@ -34,13 +34,12 @@ module Cardano.Wallet.Client
 import           Universum
 
 import           Control.Exception (Exception (..))
-import           Servant.Client (Response, GenResponse (..), ServantError (..))
+import           Servant.Client (GenResponse (..), Response, ServantError (..))
 
 import           Cardano.Wallet.API.Request.Filter
 import           Cardano.Wallet.API.Request.Pagination
 import           Cardano.Wallet.API.Request.Sort
 import           Cardano.Wallet.API.Response
-import qualified Cardano.Wallet.API.V1.Errors as V1Errors
 import           Cardano.Wallet.API.V1.Parameters
 import           Cardano.Wallet.API.V1.Types
 import qualified Pos.Core as Core
@@ -238,7 +237,7 @@ type Resp m a = m (Either ClientError (WalletResponse a))
 
 -- | The type of errors that the wallet might return.
 data ClientError
-    = ClientWalletError V1Errors.WalletError
+    = ClientWalletError WalletErrorV1
     -- ^ The 'WalletError' type represents known failures that the API
     -- might return.
     | ClientHttpError ServantError

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -24,8 +24,8 @@ import qualified Pos.Core as Core
 
 import           Cardano.Wallet.API.Indices
 import           Cardano.Wallet.API.Request.Pagination (Page, PerPage)
-import           Cardano.Wallet.API.V1.Errors (WalletError)
-import           Cardano.Wallet.API.V1.Migration.Types (Migrate (..))
+import           Cardano.Wallet.API.Response (JSONValidationError)
+import           Cardano.Wallet.API.V1.Migration.Types (Migrate (..), MigrationError)
 import           Cardano.Wallet.API.V1.Types
 import           Cardano.Wallet.Orphans ()
 import qualified Cardano.Wallet.Util as Util
@@ -53,6 +53,8 @@ spec = parallel $ describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @TransactionType Proxy
         aesonRoundtripProp @TransactionStatus Proxy
         aesonRoundtripProp @WalletError Proxy
+        aesonRoundtripProp @JSONValidationError Proxy
+        aesonRoundtripProp @MigrationError Proxy
         aesonRoundtripProp @WalletId Proxy
         aesonRoundtripProp @Wallet Proxy
         aesonRoundtripProp @SlotDuration Proxy
@@ -145,7 +147,7 @@ migrateRoundtrip :: (Arbitrary from, Migrate from to, Migrate to from, Eq from, 
 migrateRoundtrip (_ :: proxy from) (_ :: proxy to) = forAll arbitrary $ \(arbitraryFrom :: from) -> do
     (eitherMigrate =<< migrateTo arbitraryFrom) === Right arbitraryFrom
   where
-    migrateTo x = eitherMigrate x :: Either WalletError to
+    migrateTo x = eitherMigrate x :: Either MigrationError to
 
 migrateRoundtripProp
     :: (Arbitrary from, Migrate from to, Migrate to from, Eq from, Show from, Typeable from, Typeable to)


### PR DESCRIPTION
## Description

The example accountId from the API doc isn't much relevant and reflects an invalid value

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-319

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
1) Run a cardano-node
2) Visit https://localhost:8091/docs/v1/index/ - you will see changes showed bellow
3) Roundtrip tests pass (the screenshot bellow)

## Screenshots (if available)
`accountIndex` in request body shows correct value range
![look](https://user-images.githubusercontent.com/2461951/41376755-76dc7a74-6f5a-11e8-9e0c-8e2bf54b7cff.png)


`accountIndex` on description on the right picks correct value (not bellow the minimum)
![look](https://user-images.githubusercontent.com/2461951/41376784-88421a08-6f5a-11e8-98c6-b324257eace6.png)


`accountId` (same thing as `accountIndex`) in request params shows correct value range
![look](https://user-images.githubusercontent.com/2461951/41376464-96e8cd6e-6f59-11e8-8a3e-f967d41ac076.png)

roundtrip tests
![look](https://user-images.githubusercontent.com/2461951/41376705-4a2977d4-6f5a-11e8-936d-309a09b92358.png)


@KtorZ I wonder why did we ended up with `accountId` and `accountIndex` json keys for the same thing. Is it still too late to unify it? (it would be a breaking change for exchanges)

