### PR TITLE
[CDEC-371] Remove unnecessary `core-test` dependencies

### DIFF
--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -14,7 +14,6 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:
-                        Pos.Block.Base
                         Pos.Block.BHelpers
                         Pos.Block.BListener
                         Pos.Block.BlockWorkMode

--- a/block/src/Pos/Block/Logic/Creation.hs
+++ b/block/src/Pos/Block/Logic/Creation.hs
@@ -25,7 +25,6 @@ import           Serokell.Data.Memory.Units (Byte, memory)
 import           System.Wlog (WithLogger, logDebug)
 
 import           Pos.Binary.Class (biSize)
-import           Pos.Block.Base (mkGenesisBlock, mkMainBlock)
 import           Pos.Block.Logic.Internal (MonadBlockApply, applyBlocksUnsafe, normalizeMempool)
 import           Pos.Block.Logic.Util (calcChainQualityM)
 import           Pos.Block.Logic.VAR (verifyBlocksPrefix)
@@ -36,6 +35,7 @@ import           Pos.Core (Blockchain (..), EpochIndex, EpochOrSlot (..), HasPro
                            flattenSlotId, getEpochOrSlot, headerHash)
 import           Pos.Core.Block (BlockHeader (..), GenesisBlock, MainBlock, MainBlockchain)
 import qualified Pos.Core.Block as BC
+import           Pos.Core.Block.Constructors (mkGenesisBlock, mkMainBlock)
 import           Pos.Core.Context (HasPrimaryKey, getOurSecretKey)
 import           Pos.Core.Ssc (SscPayload)
 import           Pos.Core.Txp (TxAux (..), mkTxPayload)

--- a/block/test/Test/Pos/Block/Arbitrary.hs
+++ b/block/test/Test/Pos/Block/Arbitrary.hs
@@ -33,7 +33,6 @@ import           Pos.Arbitrary.Ssc (SscPayloadDependsOnSlot (..), genSscPayload,
                                     genSscPayloadForSlot)
 import           Pos.Arbitrary.Update (genUpdatePayload)
 import           Pos.Binary.Class (biSize)
-import qualified Pos.Block.Base as T
 import qualified Pos.Block.Logic.Integrity as T
 import           Pos.Block.Slog (SlogUndo)
 import           Pos.Block.Types (Undo (..))
@@ -41,6 +40,7 @@ import           Pos.Core (GenesisHash (..), HasGenesisHash, HasProtocolConstant
                            epochSlots, genesisHash)
 import qualified Pos.Core as Core
 import qualified Pos.Core.Block as T
+import qualified Pos.Core.Block.Constructors as T
 import           Pos.Crypto (ProtocolMagic, PublicKey, SecretKey, createPsk, hash, toPublic)
 import           Pos.Data.Attributes (areAttributesKnown)
 

--- a/client/src/Pos/Client/Txp/History.hs
+++ b/client/src/Pos/Client/Txp/History.hs
@@ -38,10 +38,10 @@ import           Mockable (CurrentTime, Mockable)
 import           Serokell.Util.Text (listJson)
 import           System.Wlog (WithLogger)
 
-import           Pos.Block.Base (genesisBlock0)
 import           Pos.Core (Address, ChainDifficulty, GenesisHash (..), HasConfiguration,
                            Timestamp (..), difficultyL, genesisHash, headerHash)
 import           Pos.Core.Block (Block, MainBlock, mainBlockSlot, mainBlockTxPayload)
+import           Pos.Core.Block.Constructors (genesisBlock0)
 import           Pos.Crypto (ProtocolMagic, WithHash (..), withHash)
 import           Pos.DB (MonadDBRead, MonadGState)
 import           Pos.DB.Block (getBlock)

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -41,6 +41,7 @@ library
                        Pos.Core.Block.Genesis
                        Pos.Core.Block.Main
                        Pos.Core.Block.Union
+                       Pos.Core.Block.Constructors
 
                        Pos.Core.Common
                        Pos.Core.Configuration
@@ -147,6 +148,7 @@ library
                        Pos.Core.Ssc.CommitmentsMap
                        Pos.Core.Ssc.Opening
                        Pos.Core.Ssc.OpeningsMap
+                       Pos.Core.Ssc.CommitmentAndOpening
                        Pos.Core.Ssc.Payload
                        Pos.Core.Ssc.Proof
                        Pos.Core.Ssc.SharesDistribution

--- a/core/src/Pos/Core/Block.hs
+++ b/core/src/Pos/Core/Block.hs
@@ -4,9 +4,11 @@ module Pos.Core.Block
        , module Pos.Core.Block.Main
        , module Pos.Core.Block.Genesis
        , module Pos.Core.Block.Blockchain
+       , module Pos.Core.Block.Constructors
        ) where
 
-import          Pos.Core.Block.Blockchain
-import          Pos.Core.Block.Genesis
-import          Pos.Core.Block.Main
-import          Pos.Core.Block.Union
+import           Pos.Core.Block.Blockchain
+import           Pos.Core.Block.Constructors
+import           Pos.Core.Block.Genesis
+import           Pos.Core.Block.Main
+import           Pos.Core.Block.Union

--- a/core/src/Pos/Core/Block/Constructors.hs
+++ b/core/src/Pos/Core/Block/Constructors.hs
@@ -131,35 +131,6 @@ mkMainBlockExplicit pm bv sv prevHash difficulty slotId sk pske body =
             (mkAttributes ())
             (hash extraB)
 
-
-{-
-
-# mhueschen: this is not used anywhere in the codebase
-
-# removed from exports
---        , emptyMainBody
-
-# removed from imports
--- import           Data.Default (Default (def))
--- import           Pos.Ssc.Base (defaultSscPayload)
--- import           Pos.Txp.Base (emptyTxPayload)
--- import           Pos.Core.Slotting (LocalSlotIndex)
--- import           Pos.Core.Configuration (HasProtocolConstants)
-
--- | Empty (i. e. no payload) body of main block for given local slot index.
-emptyMainBody
-    :: HasProtocolConstants
-    => LocalSlotIndex
-    -> MainBody
-emptyMainBody slot =
-    MainBody
-    { _mbTxPayload = emptyTxPayload
-    , _mbSscPayload = defaultSscPayload slot
-    , _mbDlgPayload = def
-    , _mbUpdatePayload = def
-    }
--}
-
 ----------------------------------------------------------------------------
 -- Genesis smart constructors
 ----------------------------------------------------------------------------

--- a/core/src/Pos/Core/Block/Constructors.hs
+++ b/core/src/Pos/Core/Block/Constructors.hs
@@ -1,11 +1,10 @@
 -- | Block constructors and basic functions.
 
-module Pos.Block.Base
+module Pos.Core.Block.Constructors
        ( mkMainBlockExplicit
        , mkMainBlock
        , mkMainHeaderExplicit
        , mkMainHeader
-       , emptyMainBody
 
        , mkGenesisHeader
        , mkGenesisBlock
@@ -14,24 +13,24 @@ module Pos.Block.Base
 
 import           Universum
 
-import           Data.Default (Default (def))
-
-import           Pos.Block.BHelpers ()
-import           Pos.Core (BlockVersion, ChainDifficulty, EpochIndex, GenesisHash (..),
-                           HasDifficulty (..), HasProtocolConstants, HeaderHash, LocalSlotIndex,
-                           SlotId, SlotLeaders, SoftwareVersion, headerHash)
-import           Pos.Core.Block (BlockHeader, BlockSignature (..), GenericBlock (..), GenesisBlock,
-                                 GenesisBlockHeader, GenesisBody (..), GenesisConsensusData (..),
-                                 GenesisExtraBodyData (..), GenesisExtraHeaderData (..), MainBlock,
-                                 MainBlockHeader, MainBody (..), MainConsensusData (..),
-                                 MainExtraBodyData (..), MainExtraHeaderData (..), MainToSign (..),
-                                 mkGenericHeader)
+import           Pos.Binary.Core.Blockchain () -- Bi instances
+import           Pos.Core.Block.Blockchain (GenericBlock (..), mkGenericHeader)
+import           Pos.Core.Block.Genesis (GenesisBody (..), GenesisConsensusData (..),
+                                         GenesisExtraBodyData (..), GenesisExtraHeaderData (..))
+import           Pos.Core.Block.Main (MainBody (..), MainExtraBodyData (..),
+                                      MainExtraHeaderData (..))
+import           Pos.Core.Block.Union (BlockHeader, BlockSignature (..), GenesisBlock,
+                                       GenesisBlockHeader, HeaderHash, MainBlock,
+                                       MainBlockHeader, MainConsensusData (..), MainToSign (..),
+                                       headerHash)
+import           Pos.Core.Common (ChainDifficulty, HasDifficulty (..), SlotLeaders)
+import           Pos.Core.Configuration (GenesisHash (..))
+import           Pos.Core.Delegation.HeavyDlgIndex (ProxySKBlockInfo)
+import           Pos.Core.Slotting (EpochIndex, SlotId)
+import           Pos.Core.Update (BlockVersion, SoftwareVersion)
 import           Pos.Crypto (ProtocolMagic, SecretKey, SignTag (..), hash, proxySign, sign,
                              toPublic)
 import           Pos.Data.Attributes (mkAttributes)
-import           Pos.Delegation.Types (ProxySKBlockInfo)
-import           Pos.Ssc.Base (defaultSscPayload)
-import           Pos.Txp.Base (emptyTxPayload)
 
 ----------------------------------------------------------------------------
 -- Main smart constructors
@@ -132,6 +131,21 @@ mkMainBlockExplicit pm bv sv prevHash difficulty slotId sk pske body =
             (mkAttributes ())
             (hash extraB)
 
+
+{-
+
+# mhueschen: this is not used anywhere in the codebase
+
+# removed from exports
+--        , emptyMainBody
+
+# removed from imports
+-- import           Data.Default (Default (def))
+-- import           Pos.Ssc.Base (defaultSscPayload)
+-- import           Pos.Txp.Base (emptyTxPayload)
+-- import           Pos.Core.Slotting (LocalSlotIndex)
+-- import           Pos.Core.Configuration (HasProtocolConstants)
+
 -- | Empty (i. e. no payload) body of main block for given local slot index.
 emptyMainBody
     :: HasProtocolConstants
@@ -144,6 +158,7 @@ emptyMainBody slot =
     , _mbDlgPayload = def
     , _mbUpdatePayload = def
     }
+-}
 
 ----------------------------------------------------------------------------
 -- Genesis smart constructors

--- a/core/src/Pos/Core/Delegation/HeavyDlgIndex.hs
+++ b/core/src/Pos/Core/Delegation/HeavyDlgIndex.hs
@@ -2,6 +2,7 @@ module Pos.Core.Delegation.HeavyDlgIndex
        ( HeavyDlgIndex (..)
        , ProxySigHeavy
        , ProxySKHeavy
+       , ProxySKBlockInfo
        ) where
 
 import           Universum
@@ -10,7 +11,7 @@ import qualified Data.Text.Buildable
 import           Formatting (bprint, build)
 
 import           Pos.Core.Slotting (EpochIndex)
-import           Pos.Crypto (ProxySecretKey (..), ProxySignature)
+import           Pos.Crypto (ProxySecretKey (..), ProxySignature, PublicKey)
 
 -- | Witness for heavy delegation signature -- epoch in which
 -- certificate starts being active. It is needed for replay attack
@@ -31,3 +32,8 @@ type ProxySigHeavy a = ProxySignature HeavyDlgIndex a
 
 -- | Heavy delegation PSK.
 type ProxySKHeavy = ProxySecretKey HeavyDlgIndex
+
+-- | Heavyweight PSK with real leader public key (because heavyweight
+-- psks have redelegation feature, so pskIssuerPk hPsk /= leader in
+-- general case). This is used to create a block header only.
+type ProxySKBlockInfo = Maybe (ProxySKHeavy, PublicKey)

--- a/core/src/Pos/Core/Ssc.hs
+++ b/core/src/Pos/Core/Ssc.hs
@@ -3,6 +3,7 @@ module Pos.Core.Ssc
        , module Pos.Core.Ssc.CommitmentsMap
        , module Pos.Core.Ssc.Opening
        , module Pos.Core.Ssc.OpeningsMap
+       , module Pos.Core.Ssc.CommitmentAndOpening
        , module Pos.Core.Ssc.Payload
        , module Pos.Core.Ssc.Proof
        , module Pos.Core.Ssc.SharesDistribution
@@ -15,6 +16,7 @@ import           Pos.Core.Ssc.Commitment
 import           Pos.Core.Ssc.CommitmentsMap
 import           Pos.Core.Ssc.Opening
 import           Pos.Core.Ssc.OpeningsMap
+import           Pos.Core.Ssc.CommitmentAndOpening
 import           Pos.Core.Ssc.Payload
 import           Pos.Core.Ssc.Proof
 import           Pos.Core.Ssc.SharesDistribution

--- a/core/src/Pos/Core/Ssc/CommitmentAndOpening.hs
+++ b/core/src/Pos/Core/Ssc/CommitmentAndOpening.hs
@@ -1,0 +1,37 @@
+module Pos.Core.Ssc.CommitmentAndOpening
+       ( randCommitmentAndOpening
+       ) where
+
+import           Universum
+
+import qualified Crypto.Random as Rand
+import qualified Data.HashMap.Strict as HM
+import qualified Data.List.NonEmpty as NE
+import           Formatting (build, sformat, (%))
+
+import           Pos.Binary.Class (asBinary)
+import           Pos.Core.Ssc.Commitment (Commitment (..))
+import           Pos.Core.Ssc.Opening (Opening (..))
+import           Pos.Crypto (Threshold, VssPublicKey, genSharedSecret)
+
+
+-- | Generate random SharedSeed.
+randCommitmentAndOpening
+    :: Rand.MonadRandom m
+    => Threshold -> NonEmpty VssPublicKey -> m (Commitment, Opening)
+randCommitmentAndOpening t pks
+    | t <= 1 = error $ sformat
+        ("randCommitmentAndOpening: threshold ("%build%") must be > 1") t
+    | t >= n - 1 = error $ sformat
+        ("randCommitmentAndOpening: threshold ("%build%") must be < n-1"%
+         " (n = "%build%")") t n
+    | otherwise = convertRes <$> genSharedSecret t pks
+  where
+    n = fromIntegral (length pks)
+    convertRes (secret, proof, shares) =
+        ( Commitment
+          { commProof = proof
+          , commShares = HM.fromList $ map toPair $ NE.groupWith fst shares
+          }
+        , Opening $ asBinary secret)
+    toPair ne@(x:|_) = (asBinary (fst x), NE.map (asBinary . snd) ne)

--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -153,7 +153,6 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Pos.Binary.Class (asBinary, Bi, Raw (..))
-import           Pos.Block.Base (mkMainHeader, mkGenesisHeader)
 import           Pos.Core.Block (BlockBodyAttributes, BlockHeader (..),
                                  BlockHeaderAttributes, BlockSignature (..),
                                  GenesisBlockHeader, GenesisBody (..),
@@ -162,7 +161,7 @@ import           Pos.Core.Block (BlockBodyAttributes, BlockHeader (..),
                                  MainConsensusData (..),
                                  MainExtraBodyData (..),
                                  MainExtraHeaderData (..), MainProof (..),
-                                 MainToSign (..))
+                                 MainToSign (..), mkMainHeader, mkGenesisHeader)
 import           Pos.Core.Common (Address (..), AddrAttributes (..),
                                   AddrSpendingData (..),
                                   AddrStakeDistribution (..), AddrType (..),
@@ -176,7 +175,7 @@ import           Pos.Core.Configuration (CoreConfiguration (..),
                                          GenesisConfiguration (..),
                                          GenesisHash (..))
 import           Pos.Core.Delegation (HeavyDlgIndex (..), LightDlgIndices (..),
-                                      ProxySKHeavy)
+                                      ProxySKHeavy, DlgPayload (..), ProxySKBlockInfo)
 import           Pos.Core.Genesis (FakeAvvmOptions (..),
                                    GenesisAvvmBalances (..),
                                    GenesisDelegation (..),
@@ -195,7 +194,7 @@ import           Pos.Core.Ssc (Commitment, CommitmentSignature, CommitmentsMap,
                                InnerSharesMap, SharesDistribution, SharesMap,
                                SignedCommitment, SscPayload (..), SscProof,
                                VssCertificate (..), VssCertificatesHash,
-                               VssCertificatesMap (..))
+                               VssCertificatesMap (..), randCommitmentAndOpening)
 import           Pos.Core.Txp (Tx (..), TxAttributes, TxAux (..), TxId,
                                TxIn (..), TxInWitness (..), TxOut (..),
                                TxOutAux (..), TxPayload (..), TxProof (..),
@@ -211,10 +210,8 @@ import           Pos.Core.Update (ApplicationName (..), BlockVersion (..),
                                   UpId, VoteId)
 import           Pos.Crypto (deterministic, Hash, hash, safeCreatePsk, sign)
 import           Pos.Data.Attributes (Attributes (..), mkAttributes)
-import           Pos.Delegation.Types (DlgPayload (..), ProxySKBlockInfo)
 import           Pos.Merkle (mkMerkleTree, mtRoot, MerkleRoot(..),
                              MerkleTree (..))
-import           Pos.Ssc.Base (genCommitmentAndOpening)
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Test.Pos.Crypto.Gen (genAbstractHash, genDecShare,
@@ -589,7 +586,7 @@ genCommitmentOpening = do
     vssKeys <- replicateM numKeys genVssPublicKey
     pure
         $ deterministic "commitmentOpening"
-        $ genCommitmentAndOpening threshold (fromList vssKeys)
+        $ randCommitmentAndOpening threshold (fromList vssKeys)
 
 genCommitmentSignature :: Gen CommitmentSignature
 genCommitmentSignature = genSignature $ (,) <$> genEpochIndex <*> genCommitment

--- a/core/test/cardano-sl-core-test.cabal
+++ b/core/test/cardano-sl-core-test.cabal
@@ -21,12 +21,9 @@ library
                      , base
                      , bytestring
                      , cardano-sl-binary
-                     , cardano-sl-block
                      , cardano-sl-core
                      , cardano-sl-crypto
                      , cardano-sl-crypto-test
-                     , cardano-sl-delegation
-                     , cardano-sl-ssc
                      , cryptonite
                      , cryptonite-openssl >= 0.5
                      , hedgehog

--- a/delegation/src/Pos/Delegation/Types.hs
+++ b/delegation/src/Pos/Delegation/Types.hs
@@ -4,7 +4,6 @@ module Pos.Delegation.Types
        ( DlgPayload (..)
        , DlgUndo (..)
        , DlgMemPool
-       , ProxySKBlockInfo
        , module Pos.Core.Delegation
        , isRevokePsk
 
@@ -19,7 +18,7 @@ import           Formatting (bprint, (%))
 import           Serokell.Util.Text (listJson)
 
 import           Pos.Core (ComponentBlock (..), ProxySKHeavy, StakeholderId)
-import           Pos.Core.Delegation (DlgPayload (..), checkDlgPayload)
+import           Pos.Core.Delegation (DlgPayload (..), checkDlgPayload, ProxySKBlockInfo)
 import           Pos.Crypto (ProxySecretKey, PublicKey, isSelfSignedPsk)
 
 -- | Undo for the delegation component.
@@ -44,11 +43,6 @@ instance Buildable DlgUndo where
 
 -- | Map from issuer public keys to related heavy certs.
 type DlgMemPool = HashMap PublicKey ProxySKHeavy
-
--- | Heavyweight PSK with real leader public key (because heavyweight
--- psks have redelegation feature, so pskIssuerPk hPsk /= leader in
--- general case). This is used to create a block header only.
-type ProxySKBlockInfo = Maybe (ProxySKHeavy, PublicKey)
 
 -- | Checks if given PSK revokes delegation (issuer == delegate).
 isRevokePsk :: ProxySecretKey w -> Bool

--- a/explorer/src/Pos/Explorer/TestUtil.hs
+++ b/explorer/src/Pos/Explorer/TestUtil.hs
@@ -30,7 +30,6 @@ import           Serokell.Data.Memory.Units (Byte, Gigabyte, convertUnit)
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, Testable, choose, counterexample,
                                   forAll, generate, property, suchThat)
 
-import           Pos.Block.Base (mkGenesisBlock)
 import           Pos.Block.Logic (RawPayload (..), createMainBlockPure)
 import           Pos.Block.Types (Blund, SlogUndo (..), Undo (..))
 import qualified Pos.Communication ()
@@ -39,6 +38,7 @@ import           Pos.Core (Address, BlockCount (..), ChainDifficulty (..), Epoch
                            SlotId (..), SlotLeaders, StakeholderId, difficultyL, genesisHash,
                            headerHash, makePubKeyAddressBoot)
 import           Pos.Core.Block (Block, BlockHeader, GenesisBlock, MainBlock, getBlockHeader)
+import           Pos.Core.Block.Constructors (mkGenesisBlock)
 import           Pos.Core.Ssc (SscPayload)
 import           Pos.Core.Txp (TxAux)
 import           Pos.Core.Update (UpdatePayload (..))

--- a/generator/src/Pos/Generator/Block/Logic.hs
+++ b/generator/src/Pos/Generator/Block/Logic.hs
@@ -18,7 +18,6 @@ import           System.Random (RandomGen (..))
 import           System.Wlog (logWarning)
 
 import           Pos.AllSecrets (HasAllSecrets (..), unInvSecretsMap)
-import           Pos.Block.Base (mkGenesisBlock)
 import           Pos.Block.Logic (applyBlocksUnsafe, createMainBlockInternal, normalizeMempool,
                                   verifyBlocksPrefix)
 import           Pos.Block.Lrc (lrcSingleShot)
@@ -28,6 +27,7 @@ import           Pos.Communication.Message ()
 import           Pos.Core (EpochOrSlot (..), SlotId (..), addressHash, epochIndexL, getEpochOrSlot,
                            getSlotIndex)
 import           Pos.Core.Block (Block)
+import           Pos.Core.Block.Constructors (mkGenesisBlock)
 import           Pos.Crypto (ProtocolMagic, pskDelegatePk)
 import qualified Pos.DB.BlockIndex as DB
 import           Pos.Delegation.Logic (getDlgTransPsk)

--- a/lib/src/Pos/DB/DB.hs
+++ b/lib/src/Pos/DB/DB.hs
@@ -10,8 +10,8 @@ module Pos.DB.DB
 
 import           Universum
 
-import           Pos.Block.Base (genesisBlock0)
 import           Pos.Core (BlockVersionData, GenesisHash (..), genesisHash, headerHash)
+import           Pos.Core.Block.Constructors (genesisBlock0)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.DB.Block (prepareBlockDB)
 import           Pos.DB.Class (MonadDB, MonadDBRead (..))

--- a/lib/test/Test/Pos/Ssc/SeedSpec.hs
+++ b/lib/test/Test/Pos/Ssc/SeedSpec.hs
@@ -22,11 +22,10 @@ import           Test.QuickCheck.Property (failed, succeeded)
 import           Pos.Binary
 import           Pos.Core (AddressHash, SharedSeed (..), StakeholderId, addressHash, mkCoin)
 import           Pos.Core.Ssc (Commitment (..), CommitmentsMap, Opening (..), getCommShares,
-                               getCommitmentsMap, mkCommitmentsMap)
+                               getCommitmentsMap, mkCommitmentsMap, randCommitmentAndOpening)
 import           Pos.Crypto (DecShare, PublicKey, SecretKey, SignTag (SignCommitment), Threshold,
                              VssKeyPair, VssPublicKey, decryptShare, sign, toPublic, toVssPublicKey)
-import           Pos.Ssc (SscSeedError (..), calculateSeed, genCommitmentAndOpening,
-                          secretToSharedSeed, vssThreshold)
+import           Pos.Ssc (SscSeedError (..), calculateSeed, secretToSharedSeed, vssThreshold)
 
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Util.QuickCheck.Arbitrary (nonrepeating, sublistN)
@@ -208,7 +207,7 @@ generateKeysAndMpc threshold n = do
     vssKeys        <- sortWith toVssPublicKey <$> generate (nonrepeating n)
     let lvssPubKeys = NE.fromList $ map toVssPublicKey vssKeys
     (comms, opens) <-
-        unzip <$> replicateM n (genCommitmentAndOpening threshold lvssPubKeys)
+        unzip <$> replicateM n (randCommitmentAndOpening threshold lvssPubKeys)
     return (keys', NE.fromList vssKeys, comms, opens)
 
 mkCommitmentsMap' :: [SecretKey] -> [Commitment] -> CommitmentsMap

--- a/lib/test/Test/Pos/Types/BlockSpec.hs
+++ b/lib/test/Test/Pos/Types/BlockSpec.hs
@@ -14,7 +14,6 @@ import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Property, (===), (==>))
 
 import           Pos.Binary (Bi)
-import qualified Pos.Block.Base as T
 import qualified Pos.Block.Logic.Integrity as T
 import           Pos.Core (GenesisHash (..), HasConfiguration, genesisHash)
 import qualified Pos.Core as T

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15690,12 +15690,9 @@ license = stdenv.lib.licenses.mit;
 , base
 , bytestring
 , cardano-sl-binary
-, cardano-sl-block
 , cardano-sl-core
 , cardano-sl-crypto
 , cardano-sl-crypto-test
-, cardano-sl-delegation
-, cardano-sl-ssc
 , cpphs
 , cryptonite
 , cryptonite-openssl
@@ -15718,12 +15715,9 @@ libraryHaskellDepends = [
 base
 bytestring
 cardano-sl-binary
-cardano-sl-block
 cardano-sl-core
 cardano-sl-crypto
 cardano-sl-crypto-test
-cardano-sl-delegation
-cardano-sl-ssc
 cryptonite
 cryptonite-openssl
 hedgehog

--- a/ssc/Pos/Arbitrary/Ssc.hs
+++ b/ssc/Pos/Arbitrary/Ssc.hs
@@ -31,12 +31,13 @@ import           Pos.Core (EpochIndex, SlotId (..), VssCertificate (..), VssCert
 import           Pos.Core.Configuration (HasProtocolConstants, protocolConstants)
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..), VssMaxTTL (..), VssMinTTL (..))
 import           Pos.Core.Ssc (Commitment (..), CommitmentsMap, Opening (..), SignedCommitment,
-                               SscPayload (..), SscProof (..), mkCommitmentsMap)
+                               SscPayload (..), SscProof (..), mkCommitmentsMap,
+                               randCommitmentAndOpening)
 import           Pos.Crypto (ProtocolMagic, SecretKey, deterministic, randomNumberInRange,
                              toVssPublicKey, vssKeyGen)
 import           Pos.Infra.Communication.Types.Relay (DataMsg (..))
-import           Pos.Ssc.Base (genCommitmentAndOpening, isCommitmentIdExplicit, isOpeningIdExplicit,
-                               isSharesIdExplicit, mkSignedCommitment)
+import           Pos.Ssc.Base (isCommitmentIdExplicit, isOpeningIdExplicit, isSharesIdExplicit,
+                               mkSignedCommitment)
 import           Pos.Ssc.Message (MCCommitment (..), MCOpening (..), MCShares (..),
                                   MCVssCertificate (..), SscTag (..))
 import           Pos.Ssc.Toss.Types (TossModifier (..))
@@ -100,7 +101,7 @@ commitmentsAndOpenings =
       t <- randomNumberInRange 3 10
       n <- randomNumberInRange (t*2-1) (t*2)
       vssKeys <- replicateM (fromInteger n) $ toVssPublicKey <$> vssKeyGen
-      genCommitmentAndOpening (fromIntegral t) (NE.fromList vssKeys)
+      randCommitmentAndOpening (fromIntegral t) (NE.fromList vssKeys)
 
 instance Arbitrary CommitmentOpening where
     arbitrary = elements commitmentsAndOpenings

--- a/ssc/Pos/Ssc/Base.hs
+++ b/ssc/Pos/Ssc/Base.hs
@@ -42,15 +42,12 @@ module Pos.Ssc.Base
 
 import           Universum hiding (id)
 
-import qualified Crypto.Random as Rand
 import qualified Data.HashMap.Strict as HM
 import           Data.Ix (inRange)
-import qualified Data.List.NonEmpty as NE
-import           Formatting (build, sformat, (%))
 import           Serokell.Data.Memory.Units (Byte)
 import           Serokell.Util (VerificationRes, verifyGeneric)
 
-import           Pos.Binary.Class (asBinary, biSize, fromBinary)
+import           Pos.Binary.Class (biSize, fromBinary)
 import           Pos.Binary.Core ()
 import           Pos.Core (EpochIndex (..), LocalSlotIndex, SharedSeed (..), SlotCount, SlotId (..),
                            StakeholderId, addressHash, unsafeMkLocalSlotIndexExplicit)
@@ -62,8 +59,7 @@ import           Pos.Core.Ssc (Commitment (..), CommitmentsMap (getCommitmentsMa
                                SignedCommitment, SscPayload (..), VssCertificate (vcExpiryEpoch),
                                VssCertificatesMap (..), mkCommitmentsMapUnsafe)
 import           Pos.Crypto (ProtocolMagic, Secret, SecretKey, SignTag (SignCommitment), Threshold,
-                             VssPublicKey, checkSig, genSharedSecret, getDhSecret, secretToDhSecret,
-                             sign, toPublic, verifySecret)
+                             checkSig, getDhSecret, secretToDhSecret, sign, toPublic, verifySecret)
 
 -- | Convert Secret to SharedSeed.
 secretToSharedSeed :: Secret -> SharedSeed

--- a/ssc/Pos/Ssc/Base.hs
+++ b/ssc/Pos/Ssc/Base.hs
@@ -5,8 +5,7 @@
 module Pos.Ssc.Base
        (
          -- * Helpers
-         genCommitmentAndOpening
-       , isCommitmentIdExplicit
+         isCommitmentIdExplicit
        , isCommitmentId
        , isCommitmentIdxExplicit
        , isCommitmentIdx
@@ -77,27 +76,6 @@ secretToSharedSeed = SharedSeed . getDhSecret . secretToDhSecret
 -- shares, when verifying shares, and when recovering the secret.
 vssThreshold :: Integral a => a -> Threshold
 vssThreshold len = fromIntegral $ len `div` 2 + len `mod` 2
-
--- | Generate random SharedSeed.
-genCommitmentAndOpening
-    :: Rand.MonadRandom m
-    => Threshold -> NonEmpty VssPublicKey -> m (Commitment, Opening)
-genCommitmentAndOpening t pks
-    | t <= 1 = error $ sformat
-        ("genCommitmentAndOpening: threshold ("%build%") must be > 1") t
-    | t >= n - 1 = error $ sformat
-        ("genCommitmentAndOpening: threshold ("%build%") must be < n-1"%
-         " (n = "%build%")") t n
-    | otherwise = convertRes <$> genSharedSecret t pks
-  where
-    n = fromIntegral (length pks)
-    convertRes (secret, proof, shares) =
-        ( Commitment
-          { commProof = proof
-          , commShares = HM.fromList $ map toPair $ NE.groupWith fst shares
-          }
-        , Opening $ asBinary secret)
-    toPair ne@(x:|_) = (asBinary (fst x), NE.map (asBinary . snd) ne)
 
 -- | Make signed commitment from commitment and epoch index using secret key.
 mkSignedCommitment

--- a/ssc/Pos/Ssc/Worker.hs
+++ b/ssc/Pos/Ssc/Worker.hs
@@ -27,7 +27,8 @@ import           Pos.Core (EpochIndex, SlotId (..), StakeholderId, Timestamp (..
                            bvdMpcThd, getOurSecretKey, getOurStakeholderId, getSlotIndex, lookupVss,
                            memberVss, mkLocalSlotIndex, mkVssCertificate, slotSecurityParam,
                            vssMaxTTL)
-import           Pos.Core.Ssc (InnerSharesMap, Opening, SignedCommitment, getCommitmentsMap)
+import           Pos.Core.Ssc (InnerSharesMap, Opening, SignedCommitment, getCommitmentsMap,
+                               randCommitmentAndOpening)
 import           Pos.Crypto (ProtocolMagic, SecretKey, VssKeyPair, VssPublicKey, randomNumber,
                              runSecureRandom)
 import           Pos.Crypto.SecretSharing (toVssPublicKey)
@@ -41,8 +42,7 @@ import           Pos.Infra.Slotting (defaultOnNewSlotParams, getCurrentSlot,
 import           Pos.Infra.Util.LogSafe (logDebugS, logErrorS, logInfoS, logWarningS)
 import           Pos.Lrc.Consumer.Ssc (getSscRichmen)
 import           Pos.Lrc.Types (RichmenStakes)
-import           Pos.Ssc.Base (genCommitmentAndOpening, isCommitmentIdx, isOpeningIdx, isSharesIdx,
-                               mkSignedCommitment)
+import           Pos.Ssc.Base (isCommitmentIdx, isOpeningIdx, isSharesIdx, mkSignedCommitment)
 import           Pos.Ssc.Behavior (SscBehavior (..), SscOpeningParams (..), SscSharesParams (..))
 import           Pos.Ssc.Configuration (mpcSendInterval)
 import           Pos.Ssc.Functions (hasCommitment, hasOpening, hasShares, vssThreshold)
@@ -347,7 +347,7 @@ generateAndSetNewSecret pm sk SlotId {..} = do
                         logErrorS (here ("Couldn't deserialize keys: " <> err))
                     Right keys -> do
                         (comm, open) <- liftIO $ runSecureRandom $
-                            genCommitmentAndOpening threshold keys
+                            randCommitmentAndOpening threshold keys
                         let signedComm = mkSignedCommitment pm sk siEpoch comm
                         SS.putOurSecret signedComm open siEpoch
                         pure (Just signedComm)

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -44,7 +44,6 @@ import           Serokell.Util (listJson, mapJson, pairF)
 import           Serokell.Util.Base16 (base16F)
 import           Universum
 
-import           Pos.Block.Base
 import           Pos.Core
 import           Pos.Crypto
 import           Pos.Lrc.Genesis


### PR DESCRIPTION
## Description

When `Test.Pos.Core.Gen` was added to `cardano-sl-core-test`, dependencies on `cardano-sl-delegation`, `cardano-sl-block`, and `cardano-sl-ssc` were introduced. This introduced potential dependency cycles.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-371

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
Since this PR just moves code around between packages / directories, it relies on existing tests.
- [~] I have added tests to cover my changes.
- [x] All ~~new and~~ existing tests passed.