### PR TITLE
[DEVOPS-916] nix: Fix slow eval of cardano-sl-explorer-frontend

### DIFF
--- a/explorer/frontend/default.nix
+++ b/explorer/frontend/default.nix
@@ -38,34 +38,6 @@ let
     inherit src;
   };
 
-  generatedSrc = pkgs.runCommand "cardano-sl-explorer-frontend-src" {
-    inherit src bowerComponents;
-    buildInputs = [
-      oldHaskellPackages.purescript-derive-lenses
-      cardano-sl-explorer
-    ];
-  } ''
-    cp -R --reflink=auto $src $out
-    chmod -R u+w $out
-    cd $out
-    rm -rf .psci_modules .pulp-cache bower_components output result
-
-    # Purescript code generation
-    cardano-explorer-hs2purs --bridge-path src/Generated/
-    scripts/generate-explorer-lenses.sh
-
-    # Frontend dependencies
-    ln -s $bowerComponents/bower_components .
-
-    # Patch the build recipe for nix
-    echo "patching webpack.config.babel.js"
-    sed -e "s/COMMIT_HASH.*/COMMIT_HASH': '\"@GITREV@\"',/" \
-        -e "s/import GitRevisionPlugin.*//" \
-        -e "s/path:.*/path: process.env.out,/" \
-        -e "/new ProgressPlugin/d" \
-        -i webpack.config.babel.js
-  '';
-
   # p-d-l does not build with our main version of nixpkgs.
   # Needs to use something off 17.03 branch.
   oldHaskellPackages = (import (pkgs.fetchzip {
@@ -89,8 +61,30 @@ let
   frontend = { stdenv, python, purescript, mkYarnPackage }:
     mkYarnPackage {
       name = "cardano-explorer-frontend";
-      src = generatedSrc;
-      extraBuildInputs = [ purescript ];
+      inherit src;
+      extraBuildInputs = [
+        oldHaskellPackages.purescript-derive-lenses
+        cardano-sl-explorer
+        purescript
+      ];
+      postConfigure = ''
+        rm -rf .psci_modules .pulp-cache bower_components output result
+
+        # Purescript code generation
+        cardano-explorer-hs2purs --bridge-path src/Generated/
+        scripts/generate-explorer-lenses.sh
+
+        # Frontend dependencies
+        ln -s ${bowerComponents}/bower_components .
+
+        # Patch the build recipe for nix
+        echo "patching webpack.config.babel.js"
+        sed -e "s/COMMIT_HASH.*/COMMIT_HASH': '\"@GITREV@\"',/" \
+            -e "s/import GitRevisionPlugin.*//" \
+            -e "s/path:.*/path: process.env.out,/" \
+            -e "/new ProgressPlugin/d" \
+            -i webpack.config.babel.js
+      '';
       installPhase = ''
         # run the build:prod script
         export PATH=$(pwd)/node_modules/.bin:$PATH


### PR DESCRIPTION
## Description

yarn2nix needs to have a `src` argument to generate its nix expression (at evaluation time). It's not good if building `src` depends on building cardano-sl.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-916

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps

    nix-instantiate -A cardano-sl-explorer-frontend
    # (verify that cardano-sl is not built or fetched)
    nix-build -A cardano-sl-explorer-frontend
    ls -l ./result
