### PR TITLE
[DEVOPS-916] hydra: Fix cardano-sl-explorer-frontend eval

### DIFF
--- a/explorer/frontend/default.nix
+++ b/explorer/frontend/default.nix
@@ -62,6 +62,8 @@ let
     mkYarnPackage {
       name = "cardano-explorer-frontend";
       inherit src;
+      yarnLock = ./yarn.lock;
+      packageJSON = ./package.json;
       extraBuildInputs = [
         oldHaskellPackages.purescript-derive-lenses
         cardano-sl-explorer


### PR DESCRIPTION
## Description

Hydra is not happy with yarn2nix. For some reason `scripts/ci/check-hydra.sh` does not find the problem. This change passes `package.json` and `yarn.lock` directly to `mkYarnPackage`.

```
Errors occurred at 2018-06-27 01:49:32.
hydra-eval-jobs returned exit code 1: access to path '/nix/store/aq5cnwcaksc3j57zm3a80iv50ia8h3b4-frontend/package.json' is forbidden in restricted mode
(use '--show-trace' to show detailed location information)
```

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-916

## Type of change

 - [x] Build scripts

## QA Steps

 - [ ] PR build successfully evaluates in Hydra.
