### PR TITLE
[DEVOPS-908] BuildKite: speed up macOS builds

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -13,28 +13,21 @@ if [[ ("$OS_NAME" == "linux") && ("$BUILDKITE_BRANCH" == "master") ]];
 fi
 export with_haddock
 
-targets="all-cardano-sl daedalus-bridge"
-
-# There are no macOS explorer devs atm and it's only deployed on linux
+# Build everything on linux but only a limited set of packages and
+# tests on macos.
 if [[ "$OS_NAME" == "linux" ]]; then
-   targets="$targets cardano-sl-explorer-frontend"
+    targets="all-cardano-sl daedalus-bridge"
+else
+    targets="daedalus-bridge"
 fi
 
 # TODO: CSL-1133: Add test coverage to CI. To be reenabled when build times
 # become smaller and allow coverage report to be built.
 
 for trgt in $targets; do
-  echo "Building $trgt verbosely.."
+  echo "Building $trgt..."
   nix-build -A "$trgt" -o "$trgt.root" \
       --argstr gitrev "$BUILDKITE_COMMIT" \
       --argstr buildId "$BUILDKITE_BUILD_NUMBER" \
       --arg enableBenchmarks true
-
-#    TODO: CSL-1133
-#    if [[ "$trgt" == "cardano-sl" ]]; then
-#      stack test --nix --fast --jobs=2 --coverage \
-#      --ghc-options="-j +RTS -A128m -n2m -RTS";
-#      stack --nix hpc report $to_build
-#    fi
-
 done


### PR DESCRIPTION
## Description

The all-cardano-sl collection is taking 3 hours to build and test on our macOS build agents.

This change cuts the build down to just daedalus-bridge, which is the wallet and tools necessary to run Daedalus on macOS.

The relevant test suite packages will still be executed because they are added as cabal package dependencies.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-908

## Type of change

 - [x] CI pipeline and scripts.

## QA Steps

Examine Buildkite build of this branch and see if it takes less than 3 hours.

https://buildkite.com/input-output-hk/cardano-sl/builds?branch=devops-908-buildkite-faster
