### PR TITLE
[DEVOPS-934] connect script - remove LOCALE_ARCHIVE on OSX

### DIFF
--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -27,6 +27,7 @@ with localLib;
 
 let
   ifDebug = localLib.optionalString (debug);
+  ifNotDarwin = localLib.optionalString (!pkgs.stdenv.isDarwin);
   ifDisableClientAuth = localLib.optionalString (disableClientAuth);
   environments = {
     mainnet = {
@@ -81,7 +82,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   else
     RUNTIME_ARGS=""
   fi
-  export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
+  ${ifNotDarwin ''export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"''}
 
   echo "Keeping state in ${stateDir}"
   mkdir -p ${stateDir}/logs


### PR DESCRIPTION
## Description

Fixes hydra failing eval on OSX.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
