### PR TITLE
Revert "[CDEC-299] Remove field accessors for `GenesisConfiguration`"

### DIFF
--- a/core/src/Pos/Core/Configuration/Core.hs
+++ b/core/src/Pos/Core/Configuration/Core.hs
@@ -41,12 +41,12 @@ data GenesisConfiguration
       -- | Genesis from a 'GenesisSpec'.
     = GCSpec !GenesisSpec
       -- | 'GenesisData' is stored in a file.
-    | GCSrc !FilePath
+    | GCSrc { gcsFile :: !FilePath
             -- ^ Path to file where 'GenesisData' is stored. Must be
             -- in JSON, not necessary canonical.
-            !(Hash Raw)
+            , gcsHash :: !(Hash Raw)
             -- ^ Hash of canonically encoded 'GenesisData'.
-
+            }
     deriving (Show)
 
 data CoreConfiguration = CoreConfiguration


### PR DESCRIPTION
This reverts commit b258f926580387f113d746f7f897444c0dcfc570 from PR #3140.

The record fields are used for parsing of `lib/configuration.yaml`.
