### PR TITLE
[DEVOPS-877] scripts/launch/connect-to-cluster: fix eval on macOS

### DIFF
--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -67,6 +67,13 @@ let
     "--configuration-file ${environments.${environment}.confFile or "${configFiles}/lib/configuration.yaml"}"
     "--configuration-key ${environments.${environment}.confKey}"
   ];
+  utf8LocaleSetting = ''
+    export LC_ALL=en_GB.UTF-8
+    export LANG=en_GB.UTF-8
+  '' + optionalString (pkgs.glibcLocales != null) ''
+    export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
+  '';
+
 in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   #!${pkgs.stdenv.shell} -e
 
@@ -81,15 +88,13 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   else
     RUNTIME_ARGS=""
   fi
-  export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
 
   echo "Keeping state in ${stateDir}"
   mkdir -p ${stateDir}/logs
 
   echo "Launching a node connected to '${environment}' ..."
   ${ifWallet ''
-  export LC_ALL=en_GB.UTF-8
-  export LANG=en_GB.UTF-8
+  ${utf8LocaleSetting}
   if [ ! -d ${stateDir}/tls ]; then
     mkdir -p ${stateDir}/tls/server && mkdir -p ${stateDir}/tls/client
     ${iohkPkgs.cardano-sl-tools}/bin/cardano-x509-certificates   \


### PR DESCRIPTION
## Description

macOS doesn't have a glibcLocales package. It was saying:

    in job 'mainnet.connectScripts.wallet.x86_64-darwin':
    cannot coerce null to a string, at /nix/store/6pvxqra7xrw29wdlrbpc8hbm1k5vhqvq-8a30d0e9b856466e4844a0da74b2b1c4818af5f647c3979d9f381e7eafadd107-8015a00/scripts/launch/connect-to-cluster/default.nix:70:63

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-877

## Type of change

- [x] Bug fix of scripts

## QA Steps

    nix-instantiate release.nix --argstr system x86_64-darwin -A mainnet.connectScripts.wallet.x86_64-darwin
    nix-build release.nix -A mainnet.connectScripts.wallet.x86_64-linux -o connect-mainnet.sh
    ./connect-mainnet.sh
