### PR TITLE
[DEVOPS-810] Fix nix-shell env

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -113,29 +113,7 @@ let
         # Provide a dummy installPhase for benchmark packages.
         installPhase = "mkdir -p $out";
       }) // optionalAttrs (args ? src) {
-        src = let
-           cleanSourceFilter = with pkgs.stdenv;
-             name: type: let baseName = baseNameOf (toString name); in ! (
-               # Filter out .git repo
-               (type == "directory" && baseName == ".git") ||
-               # Filter out editor backup / swap files.
-               lib.hasSuffix "~" baseName ||
-               builtins.match "^\\.sw[a-z]$" baseName != null ||
-               builtins.match "^\\..*\\.sw[a-z]$" baseName != null ||
-
-               # Filter out locally generated/downloaded things.
-               baseName == "dist" ||
-
-               # Filter out the files which I'm editing often.
-               lib.hasSuffix ".nix" baseName ||
-               # Filter out nix-build result symlinks
-               (type == "symlink" && lib.hasPrefix "result" baseName)
-             );
-
-          in
-            if (builtins.typeOf args.src) == "path"
-              then builtins.filterSource cleanSourceFilter args.src
-              else args.src or null;
+        src = localLib.cleanSourceTree args.src;
       } // optionalAttrs enableDebugging {
         # TODO: DEVOPS-355
         dontStrip = true;

--- a/default.nix
+++ b/default.nix
@@ -132,10 +132,12 @@ let
     walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev; };
     validateJson = pkgs.callPackage ./tools/src/validate-json {};
     demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev; };
-    tests = {
-      shellcheck = pkgs.callPackage ./scripts/test/shellcheck.nix { src = ./.; };
-      hlint = pkgs.callPackage ./scripts/test/hlint.nix { src = ./.; };
-      stylishHaskell = pkgs.callPackage ./scripts/test/stylish.nix { src = ./.; stylish-haskell = cardanoPkgs.stylish-haskell; inherit localLib; };
+    tests = let
+      src = localLib.cleanSourceTree ./.;
+    in {
+      shellcheck = pkgs.callPackage ./scripts/test/shellcheck.nix { inherit src; };
+      hlint = pkgs.callPackage ./scripts/test/hlint.nix { inherit src; };
+      stylishHaskell = pkgs.callPackage ./scripts/test/stylish.nix { inherit (cardanoPkgs) stylish-haskell; inherit src localLib; };
       buildWalletIntegration = pkgs.callPackage ./scripts/test/wallet/integration/build-test.nix { inherit walletIntegrationTests pkgs; };
       swaggerSchemaValidation = pkgs.callPackage ./scripts/test/wallet/swaggerSchemaValidation.nix { inherit gitrev; };
     };

--- a/lib.nix
+++ b/lib.nix
@@ -12,10 +12,32 @@ let
        then result
        else default;
 
+  # Removes files within a Haskell source tree which won't change the
+  # result of building the package.
+  # This is so that cached build products can be used whenever possible.
+  # It also applies the lib.cleanSource filter from nixpkgs which
+  # removes VCS directories, emacs backup files, etc.
+  cleanSourceTree = src:
+    if (builtins.typeOf src) == "path"
+      then lib.cleanSourceWith {
+        filter = with pkgs.stdenv;
+          name: type: let baseName = baseNameOf (toString name); in ! (
+            # Filter out cabal build products.
+            baseName == "dist" || baseName == "dist-newstyle" ||
+            baseName == "cabal.project.local" ||
+            # Filter out stack build products.
+            lib.hasPrefix ".stack-work" baseName ||
+            # Filter out files which are commonly edited but don't
+            # affect the cabal build.
+            lib.hasSuffix ".nix" baseName
+          );
+        src = lib.cleanSource src;
+      } else src;
+
   pkgs = import fetchNixPkgs {};
   lib = pkgs.lib;
 in lib // (rec {
-  inherit fetchNixPkgs;
+  inherit fetchNixPkgs cleanSourceTree;
   isCardanoSL = lib.hasPrefix "cardano-sl";
   isBenchmark = args: !((args.isExecutable or false) || (args.isLibrary or true));
 

--- a/scripts/set-git-rev/default.nix
+++ b/scripts/set-git-rev/default.nix
@@ -20,7 +20,9 @@ let
   in
     pkgs.runCommand (staticName drvOut) {
       outputs  = drvOutOutputs;
-      passthru = drvOut.drvAttrs // { inherit gitrev; };
+      passthru = drvOut.drvAttrs
+        // (drvOut.passthru or {})
+        // { inherit gitrev; };
     }
     (concatMapStrings (output: ''
       cp -a "${drvOut.${output}}" "${"$"}${output}"

--- a/scripts/test/hlint.nix
+++ b/scripts/test/hlint.nix
@@ -1,13 +1,16 @@
 { runCommand, hlint, src, lib }:
 
 let
-  cleanSourceFilter = with lib;
+  # just haskell sources and the hlint config file
+  src' = lib.cleanSourceWith {
+   inherit src;
+   filter = with lib;
     name: type: let baseName = baseNameOf (toString name); in (
       (type == "regular" && hasSuffix ".hs" baseName) ||
       (type == "regular" && hasSuffix ".yaml" baseName) ||
       (type == "directory")
     );
-  src' = builtins.filterSource cleanSourceFilter src;
+  };
 in
 runCommand "cardano-hlint-check" { buildInputs = [ hlint ]; } ''
   set +e

--- a/scripts/test/shellcheck.nix
+++ b/scripts/test/shellcheck.nix
@@ -1,12 +1,15 @@
 { runCommand, shellcheck, src, lib }:
 
 let
-  cleanSourceFilter = with lib;
+  # just the shell scripts
+  src' = lib.cleanSourceWith {
+   inherit src;
+   filter = with lib;
     name: type: let baseName = baseNameOf (toString name); in (
       (type == "regular" && hasSuffix ".sh" baseName) ||
       (type == "directory")
     );
-  src' = builtins.filterSource cleanSourceFilter src;
+  };
 in
 runCommand "iohk-ops-shellcheck" { buildInputs = [ shellcheck ]; } ''
 EXIT_STATUS=0

--- a/scripts/test/stylish.nix
+++ b/scripts/test/stylish.nix
@@ -1,13 +1,16 @@
 { runCommand, stylish-haskell, src, lib, localLib, diffutils }:
 
 let
-  cleanSourceFilter = with lib;
+  # just haskell sources and the stylish-haskell config file
+  src' = lib.cleanSourceWith {
+   inherit src;
+   filter = with lib;
     name: type: let baseName = baseNameOf (toString name); in (
       (type == "regular" && hasSuffix ".hs" baseName) ||
       (type == "regular" && hasSuffix ".yaml" baseName) ||
       (type == "directory")
     );
-  src' = builtins.filterSource cleanSourceFilter src;
+  };
 in
 runCommand "cardano-stylish-check" {
   succeedOnFailure = true;
@@ -19,7 +22,7 @@ runCommand "cardano-stylish-check" {
   cp -a ${src'} stylish
   chmod -R +w stylish
   cd stylish
-  find . -type f -name "*hs" -not -path '.git' -not -path '*.stack-work*' -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
+  find . -type f -name "*hs" -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
   cd ..
   diff --brief --recursive orig stylish > /dev/null
   EXIT_CODE=$?


### PR DESCRIPTION
## Description

The change to `justStaticExecutablesGitRev` broke the `.env` attribute of haskell derivations.

Also there is a new nixpkgs lib function for filtering sources.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-810
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-937

## Type of change
- [x] Build scripts/dev environment bug fix
- [x] Build scripts refactor

## QA Steps

    nix-shell default.nix -A cardano-sl-wallet-new.env
    nix-build -A all-cardano-sl
