### PR TITLE
[CBR-314] Kernel Keystore

### DIFF
--- a/block/src/Pos/Block/Error.hs
+++ b/block/src/Pos/Block/Error.hs
@@ -9,8 +9,8 @@ module Pos.Block.Error
 
 import           Universum
 
-import           Control.Exception.Safe (Exception (..))
 import           Control.DeepSeq (NFData)
+import           Control.Exception.Safe (Exception (..))
 import           Data.Text.Buildable (Buildable (..))
 import           Data.Text.Lazy.Builder (Builder, fromText)
 import           Formatting (bprint, stext, (%))

--- a/client/src/Pos/Client/KeyStorage.hs
+++ b/client/src/Pos/Client/KeyStorage.hs
@@ -19,7 +19,6 @@ module Pos.Client.KeyStorage
        , KeyData
        , KeyError (..)
        , AllUserSecrets (..)
-       , keyDataFromFile
        ) where
 
 import           Universum
@@ -27,12 +26,11 @@ import           Universum
 import qualified Control.Concurrent.STM as STM
 import           Control.Lens ((<%=), (<>~))
 import           Serokell.Util (modifyTVarS)
-import           System.Wlog (WithLogger)
 
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, SecretKey, hash,
                      runSecureRandom, safeKeyGen)
-import           Pos.Util.UserSecret (HasUserSecret (..), UserSecret,
-                     peekUserSecret, usKeys, usPrimKey, writeUserSecret)
+import           Pos.Util.UserSecret (HasUserSecret (..), UserSecret, usKeys,
+                     usPrimKey, writeUserSecret)
 
 type KeyData = TVar UserSecret
 
@@ -108,9 +106,6 @@ newSecretKey pp = do
 
 containsKey :: [EncryptedSecretKey] -> EncryptedSecretKey -> Bool
 containsKey ls k = hash k `elem` map hash ls
-
-keyDataFromFile :: (MonadIO m, WithLogger m) => FilePath -> m KeyData
-keyDataFromFile fp = peekUserSecret fp >>= liftIO . STM.newTVarIO
 
 data KeyError =
     PrimaryKey !Text -- ^ Failed attempt to delete primary key

--- a/lib/src/Pos/Util/UserSecret.hs
+++ b/lib/src/Pos/Util/UserSecret.hs
@@ -18,6 +18,7 @@ module Pos.Util.UserSecret
        , mkGenesisWalletUserSecret
 
        , UserSecret
+       , isEmptyUserSecret
        , usKeys
        , usVss
        , usWallet
@@ -135,6 +136,9 @@ data UserSecret = UserSecret
     } deriving (Generic)
 
 deriving instance Eq EncryptedSecretKey => Eq UserSecret
+
+isEmptyUserSecret :: UserSecret -> Bool
+isEmptyUserSecret us = null (_usKeys us)
 
 instance Arbitrary (Maybe FileLock) => Arbitrary UserSecret where
     arbitrary = genericArbitrary

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18639,6 +18639,7 @@ containers
 cryptonite
 data-default
 data-default-class
+directory
 exceptions
 formatting
 generics-sop

--- a/update/src/Pos/Update/Poll/Modifier.hs
+++ b/update/src/Pos/Update/Poll/Modifier.hs
@@ -17,8 +17,8 @@ module Pos.Update.Poll.Modifier
 
 import           Universum
 
-import           Control.Lens (makeLensesFor)
 import           Control.DeepSeq (NFData)
+import           Control.Lens (makeLensesFor)
 import           Data.Default (Default (def))
 import           Data.Semigroup (Semigroup)
 

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -89,6 +89,7 @@ library
                        Cardano.Wallet.Kernel.DB.Util.AcidState
                        Cardano.Wallet.Kernel.DB.Util.IxSet
                        Cardano.Wallet.Kernel.Diffusion
+                       Cardano.Wallet.Kernel.Keystore
                        Cardano.Wallet.Kernel.Mode
                        Cardano.Wallet.Kernel.PrefilterTx
                        Cardano.Wallet.Kernel.Submission

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -152,6 +152,7 @@ library
                      , cryptonite
                      , data-default
                      , data-default-class
+                     , directory
                      , exceptions
                      , formatting
                      , generics-sop
@@ -383,6 +384,7 @@ test-suite wallet-unit-tests
                       Test.Spec.CoinSelection
                       Test.Spec.CoinSelection.Generators
                       Test.Spec.Kernel
+                      Test.Spec.Keystore
                       Test.Spec.Models
                       Test.Spec.Submission
                       Test.Spec.Translation

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -42,6 +42,7 @@ import           System.Wlog (LoggerName, Severity (..), logInfo, logMessage,
 import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 
 import           Cardano.Wallet.Kernel (PassiveWallet)
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import           Cardano.Wallet.Server.CLI (ChooseWalletBackend (..),
                      NewWalletBackendParams (..), WalletBackendParams (..),
                      WalletStartupOptions (..), getWalletNodeOptions,
@@ -126,7 +127,8 @@ actionWithNewWallet pm sscParams nodeParams params =
       -- 'NewWalletBackendParams' to construct or initialize the wallet
 
       -- TODO(ks): Currently using non-implemented layer for wallet layer.
-      bracketKernelPassiveWallet logMessage' $ \walletLayer passiveWallet -> do
+      keystore <- Keystore.legacyKeystore (nrContext nr)
+      bracketKernelPassiveWallet logMessage' keystore $ \walletLayer passiveWallet -> do
         liftIO $ logMessage' Info "Wallet kernel initialized"
         Kernel.Mode.runWalletMode pm
                                   nr

--- a/wallet-new/src/Cardano/Wallet/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel.hs
@@ -198,9 +198,8 @@ prefilterBlock' :: PassiveWallet
                 -> ResolvedBlock
                 -> IO (Map HdAccountId PrefilteredBlock)
 prefilterBlock' pw b =
-    withKeystore pw $ \keystore ->
-        Keystore.toList keystore >>= \l -> return . Map.unions
-                                                  . map prefilterBlock_ $ l
+    withKeystore pw $ \ks ->
+        (Map.unions . map prefilterBlock_) <$> Keystore.toList ks
     where
         prefilterBlock_ (wid,esk) = prefilterBlock wid esk b
 

--- a/wallet-new/src/Cardano/Wallet/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel.hs
@@ -69,10 +69,10 @@ import           Cardano.Wallet.Kernel.Submission.Worker (tickSubmissionLayer)
 
 import           Cardano.Wallet.Kernel.DB.Read as Getters
 
-import           Pos.Core (AddressHash, Timestamp (..), TxAux (..))
+import           Pos.Core (Timestamp (..), TxAux (..))
 
 import           Pos.Core.Chrono (OldestFirst)
-import           Pos.Crypto (EncryptedSecretKey, PublicKey, hash)
+import           Pos.Crypto (EncryptedSecretKey, hash)
 import           Pos.Txp (Utxo)
 
 {-------------------------------------------------------------------------------
@@ -165,10 +165,10 @@ createWalletHdRnd :: PassiveWallet
                   -> HD.WalletName
                   -> HasSpendingPassword
                   -> AssuranceLevel
-                  -> (AddressHash PublicKey, EncryptedSecretKey)
+                  -> EncryptedSecretKey
                   -> Utxo
                   -> IO (Either HD.CreateHdRootError [HdAccountId])
-createWalletHdRnd pw@PassiveWallet{..} name spendingPassword assuranceLevel (pk,esk) utxo = do
+createWalletHdRnd pw@PassiveWallet{..} name spendingPassword assuranceLevel esk utxo = do
     created <- InDb <$> getCurrentTimestamp
     let newRoot = HD.initHdRoot rootId name spendingPassword assuranceLevel created
 
@@ -178,7 +178,7 @@ createWalletHdRnd pw@PassiveWallet{..} name spendingPassword assuranceLevel (pk,
         utxoByAccount = prefilterUtxo rootId esk utxo
         accountIds    = Map.keys utxoByAccount
 
-        rootId        = HD.HdRootId . InDb $ pk
+        rootId        = eskToHdRootId esk
         walletId      = WalletIdHdRnd rootId
 
         insertESK _arg = insertWalletESK pw walletId esk >> return (Right accountIds)

--- a/wallet-new/src/Cardano/Wallet/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel.hs
@@ -32,7 +32,7 @@ module Cardano.Wallet.Kernel (
 import           Universum hiding (State, init)
 
 import           Control.Concurrent.Async (async, cancel)
-import           Control.Concurrent.MVar (modifyMVar, modifyMVar_, withMVar)
+import           Control.Concurrent.MVar (modifyMVar, modifyMVar_)
 import           Control.Lens.TH
 import qualified Data.Map.Strict as Map
 import           Data.Time.Clock.POSIX (getPOSIXTime)
@@ -44,9 +44,11 @@ import           Data.Acid.Advanced (query', update')
 import           Data.Acid.Memory (openMemoryState)
 
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
+import           Cardano.Wallet.Kernel.Keystore (Keystore)
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock (..),
                      prefilterBlock, prefilterUtxo)
-import           Cardano.Wallet.Kernel.Types (WalletESKs, WalletId (..))
+import           Cardano.Wallet.Kernel.Types (WalletId (..))
 
 import           Cardano.Wallet.Kernel.DB.AcidState (ApplyBlock (..),
                      CancelPending (..), CreateHdWallet (..), DB,
@@ -84,9 +86,12 @@ import           Pos.Txp (Utxo)
 --
 data PassiveWallet = PassiveWallet {
       -- | Send log message
-      _walletLogMessage :: Severity -> Text -> IO () -- ^ Logger
-    , _walletESKs       :: MVar WalletESKs           -- ^ ESKs indexed by WalletId
-    , _wallets          :: AcidState DB              -- ^ Database handle
+      _walletLogMessage :: Severity -> Text -> IO ()
+      -- ^ Logger
+    , _walletKeystore   :: Keystore
+      -- ^ An opaque handle to a place where we store the 'EncryptedSecretKey'.
+    , _wallets          :: AcidState DB
+      -- ^ Database handle
     }
 
 makeLenses ''PassiveWallet
@@ -101,13 +106,14 @@ makeLenses ''PassiveWallet
 -- it shouldn't be too specific.
 bracketPassiveWallet :: (MonadMask m, MonadIO m)
                      => (Severity -> Text -> IO ())
+                     -> Keystore
                      -> (PassiveWallet -> m a) -> m a
-bracketPassiveWallet _walletLogMessage f =
+bracketPassiveWallet _walletLogMessage keystore f =
     bracket (liftIO $ openMemoryState defDB)
             (\_ -> return ())
             (\db ->
                 bracket
-                  (liftIO $ initPassiveWallet _walletLogMessage db)
+                  (liftIO $ initPassiveWallet _walletLogMessage keystore db)
                   (\_ -> return ())
                   f)
 
@@ -115,14 +121,13 @@ bracketPassiveWallet _walletLogMessage f =
   Manage the WalletESKs Map
 -------------------------------------------------------------------------------}
 
--- | Insert an ESK, indexed by WalletId, to the WalletESK map
+-- | Insert an ESK, indexed by WalletId, to the Keystore.
 insertWalletESK :: PassiveWallet -> WalletId -> EncryptedSecretKey -> IO ()
 insertWalletESK pw wid esk
-    = modifyMVar_ (pw ^. walletESKs) (return . f)
-    where f = Map.insert wid esk
+    = Keystore.insert wid esk (pw ^. walletKeystore)
 
-withWalletESKs :: forall a. PassiveWallet -> (WalletESKs -> IO a) -> IO a
-withWalletESKs pw = withMVar (pw ^. walletESKs)
+withKeystore :: forall a. PassiveWallet -> (Keystore -> IO a) -> IO a
+withKeystore pw action = action (pw ^. walletKeystore)
 
 {-------------------------------------------------------------------------------
   Wallet Initialisers
@@ -130,11 +135,11 @@ withWalletESKs pw = withMVar (pw ^. walletESKs)
 
 -- | Initialise Passive Wallet with empty Wallets collection
 initPassiveWallet :: (Severity -> Text -> IO ())
+                  -> Keystore
                   -> AcidState DB
                   -> IO PassiveWallet
-initPassiveWallet logMessage db = do
-    esks <- Universum.newMVar Map.empty
-    return $ PassiveWallet logMessage esks db
+initPassiveWallet logMessage keystore db = do
+    return $ PassiveWallet logMessage keystore db
 
 -- | Initialize the Passive wallet (specified by the ESK) with the given Utxo
 --
@@ -193,11 +198,9 @@ prefilterBlock' :: PassiveWallet
                 -> ResolvedBlock
                 -> IO (Map HdAccountId PrefilteredBlock)
 prefilterBlock' pw b =
-    withWalletESKs pw $ \esks ->
-        return
-        $ Map.unions
-        $ map prefilterBlock_
-        $ Map.toList esks
+    withKeystore pw $ \keystore ->
+        Keystore.toList keystore >>= \l -> return . Map.unions
+                                                  . map prefilterBlock_ $ l
     where
         prefilterBlock_ (wid,esk) = prefilterBlock wid esk b
 

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -58,6 +58,8 @@ module Cardano.Wallet.Kernel.DB.HdWallet (
   , zoomOrCreateHdAddress
   , assumeHdRootExists
   , assumeHdAccountExists
+    -- * General-utility functions
+  , eskToHdRootId
   ) where
 
 import           Universum
@@ -430,6 +432,14 @@ assumeHdRootExists _id = return ()
 -- Helper function which can be used as an argument to 'zoomOrCreateHdAddress'
 assumeHdAccountExists :: HdAccountId -> Update' HdWallets e ()
 assumeHdAccountExists _id = return ()
+
+{-------------------------------------------------------------------------------
+  General-utility functions
+-------------------------------------------------------------------------------}
+
+-- | Computes the 'HdRootId' from the given 'EncryptedSecretKey'.
+eskToHdRootId :: Core.EncryptedSecretKey -> HdRootId
+eskToHdRootId = HdRootId . InDb . Core.addressHash . Core.encToPublic
 
 {-------------------------------------------------------------------------------
   Pretty printing

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -127,7 +127,7 @@ deriveSafeCopy 1 'base ''HasSpendingPassword
 
 -- | HD wallet root ID. Conceptually, this is just an 'Address' in the form
 -- of 'Ae2tdPwUPEZ18ZjTLnLVr9CEvUEUX4eW1LBHbxxxJgxdAYHrDeSCSbCxrvx', but is,
--- in a sense, a special breed as its derived from the 'PublicKey' (derived
+-- in a sense, a special breed as it's derived from the 'PublicKey' (derived
 -- from some BIP-39 mnemonics, typically) and which does not depend from any
 -- delegation scheme, as you cannot really pay into this 'Address'. This
 -- ensures that, given an 'EncryptedSecretKey' we can derive its 'PublicKey'
@@ -307,28 +307,24 @@ instance HasPrimKey HdAddress where
     type PrimKey HdAddress = HdAddressId
     primKey = _hdAddressId
 
--- | An 'HdRoot' can be accessed via its 'Core.Address', which is the
--- Cardano 'Address' derived by the PublicKey associated with it.
-type HdRootIxs    = '[Core.Address]
-type HdAccountIxs = '[HdRootId]
-type HdAddressIxs = '[HdRootId, HdAccountId, Core.Address]
+type SecondaryHdRootIxs    = '[]
+type SecondaryHdAccountIxs = '[HdRootId]
+type SecondaryHdAddressIxs = '[HdRootId, HdAccountId, Core.Address]
 
-type instance IndicesOf HdRoot    = HdRootIxs
-type instance IndicesOf HdAccount = HdAccountIxs
-type instance IndicesOf HdAddress = HdAddressIxs
+type instance IndicesOf HdRoot    = SecondaryHdRootIxs
+type instance IndicesOf HdAccount = SecondaryHdAccountIxs
+type instance IndicesOf HdAddress = SecondaryHdAddressIxs
 
-instance IxSet.Indexable (HdRootId ': HdRootIxs)
+instance IxSet.Indexable (HdRootId ': SecondaryHdRootIxs)
                          (OrdByPrimKey HdRoot) where
     indices = ixList
-                (ixFun (\hdRoot -> case view hdRootId hdRoot of
-                                        HdRootId (InDb addr) -> [addr]))
 
-instance IxSet.Indexable (HdAccountId ': HdAccountIxs)
+instance IxSet.Indexable (HdAccountId ': SecondaryHdAccountIxs)
                          (OrdByPrimKey HdAccount) where
     indices = ixList
                 (ixFun ((:[]) . view hdAccountRootId))
 
-instance IxSet.Indexable (HdAddressId ': HdAddressIxs)
+instance IxSet.Indexable (HdAddressId ': SecondaryHdAddressIxs)
                          (OrdByPrimKey HdAddress) where
     indices = ixList
                 (ixFun ((:[]) . view hdAddressRootId))
@@ -451,7 +447,9 @@ assumeHdAccountExists _id = return ()
   General-utility functions
 -------------------------------------------------------------------------------}
 
--- | Computes the 'HdRootId' from the given 'EncryptedSecretKey'.
+-- | Computes the 'HdRootId' from the given 'EncryptedSecretKey'. See the
+-- comment in the definition of 'makePubKeyAddressBoot' on why this is
+-- acceptable.
 eskToHdRootId :: Core.EncryptedSecretKey -> HdRootId
 eskToHdRootId = HdRootId . InDb . Core.makePubKeyAddressBoot . Core.encToPublic
 

--- a/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -1,0 +1,83 @@
+{-- | An opaque handle to a keystore, used to read and write 'EncryptedSecretKey'
+      from/to disk.
+--}
+
+{-# LANGUAGE BangPatterns #-}
+
+module Cardano.Wallet.Kernel.Keystore (
+      Keystore -- opaque
+    , newKeystore
+    , legacyKeystore
+    -- * Inserting values
+    , insert
+    -- * Queries on a keystore
+    , lookupKey
+    -- * Conversions
+    , toList
+    ) where
+
+import           Universum hiding (toList)
+
+import           Control.Concurrent (modifyMVar_, withMVar)
+import           Control.Lens (mapped)
+import qualified Data.List
+
+import           Pos.Context (NodeContext (ncUserSecret))
+import           Pos.Crypto (EncryptedSecretKey, hash)
+import           Pos.Util.UserSecret (UserSecret, peekUserSecret, usKeys)
+import           System.Wlog (WithLogger)
+
+import           Cardano.Wallet.Kernel.DB.HdWallet (eskToHdRootId)
+import           Cardano.Wallet.Kernel.Types (WalletId (..))
+
+-- Internal storage necessary to smooth out the legacy 'UserSecret' API.
+data InternalStorage = InternalStorage {
+      _storageSecret      :: !UserSecret
+    }
+
+data Keystore = Keystore (MVar InternalStorage)
+
+-- | Creates a new keystore.
+newKeystore :: (MonadIO m, WithLogger m) => FilePath -> m Keystore
+newKeystore fp = do
+    us <- peekUserSecret fp
+    Keystore <$> newMVar (InternalStorage us)
+
+-- | Creates a legacy 'Keystore' by reading the 'UserSecret' from a 'NodeContext'.
+-- Hopefully this function will go in the near future.
+legacyKeystore :: MonadIO m => NodeContext -> m Keystore
+legacyKeystore ctx = do
+     us <- atomically $ readTVar $ ncUserSecret ctx
+     Keystore <$> newMVar (InternalStorage us)
+
+-- | Insert a new 'EncryptedSecretKey' indexed by the input 'WalletId'.
+insert :: MonadIO m
+       => WalletId
+       -> EncryptedSecretKey
+       -> Keystore
+       -> m ()
+insert _walletId esk (Keystore ks) =
+    liftIO $ modifyMVar_ ks $ \(InternalStorage us) -> do
+        return $ if view usKeys us `contains` esk
+                     then InternalStorage us
+                     else InternalStorage (us & over usKeys (esk :))
+    where
+      -- Comparator taken from the old code which needs to hash
+      -- all the 'EncryptedSecretKey' in order to compare them.
+      contains :: [EncryptedSecretKey] -> EncryptedSecretKey -> Bool
+      contains ls k = hash k `elem` map hash ls
+
+-- | Lookup an 'EncryptedSecretKey' associated to the input 'HdRootId'.
+lookupKey :: MonadIO m
+          => WalletId
+          -> Keystore
+          -> m (Maybe EncryptedSecretKey)
+lookupKey (WalletIdHdRnd walletId) (Keystore ks) =
+    liftIO $ withMVar ks $ \(InternalStorage us) ->
+        return $ Data.List.find (\k -> eskToHdRootId k == walletId) (us ^. usKeys)
+
+-- | Returns all the 'EncryptedSecretKey' known to this 'Keystore'.
+toList :: MonadIO m => Keystore -> m [(WalletId, EncryptedSecretKey)]
+toList (Keystore ks) =
+    liftIO $ withMVar ks $ \(InternalStorage us) ->
+        return (over mapped (\k -> (WalletIdHdRnd (eskToHdRootId k), k)) (us ^. usKeys))

--- a/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -1,83 +1,242 @@
 {-- | An opaque handle to a keystore, used to read and write 'EncryptedSecretKey'
       from/to disk.
+
+    NOTE: This module aims to provide a stable interface with a concrete
+    implementation concealed by the user of this module. The internal operations
+    are currently quite inefficient, as they have to work around the legacy
+    'UserSecret' storage.
 --}
 
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Wallet.Kernel.Keystore (
       Keystore -- opaque
-    , newKeystore
-    , legacyKeystore
+      -- * Constructing a keystore
+    , bracketKeystore
+    , bracketLegacyKeystore
+    -- * Destroying a keystore (something you rarely should do)
+    , releaseAndDestroyKeystore
+    -- * Releasing a keystore and its associated resources
+    , releaseKeystore
     -- * Inserting values
     , insert
+    -- * Deleting values
+    , delete
     -- * Queries on a keystore
-    , lookupKey
+    , lookup
     -- * Conversions
     , toList
+    -- * Tests handy functions
+    , newTemporaryKeystore
+    -- * Internal and test-only exports.
+    , newKeystore
     ) where
 
 import           Universum hiding (toList)
 
 import           Control.Concurrent (modifyMVar_, withMVar)
-import           Control.Lens (mapped)
+import           Control.Monad.Trans.Identity (IdentityT (..), runIdentityT)
 import qualified Data.List
+import           System.Directory (getTemporaryDirectory, removeFile)
+import           System.IO (hClose, openTempFile)
 
-import           Pos.Context (NodeContext (ncUserSecret))
 import           Pos.Crypto (EncryptedSecretKey, hash)
-import           Pos.Util.UserSecret (UserSecret, peekUserSecret, usKeys)
-import           System.Wlog (WithLogger)
+import           Pos.Util.UserSecret (UserSecret, getUSPath, takeUserSecret,
+                     usKeys, writeUserSecretRelease)
+import           System.Wlog (CanLog (..), HasLoggerName (..), LoggerName (..),
+                     logMessage)
 
 import           Cardano.Wallet.Kernel.DB.HdWallet (eskToHdRootId)
 import           Cardano.Wallet.Kernel.Types (WalletId (..))
 
 -- Internal storage necessary to smooth out the legacy 'UserSecret' API.
-data InternalStorage = InternalStorage {
-      _storageSecret      :: !UserSecret
-    }
+data InternalStorage =
+      StorageInitialised !UserSecret
+    | StorageReleased
 
 data Keystore = Keystore (MVar InternalStorage)
 
+data KeystoreOperation =
+      KeystoreLookup
+    | KeystoreDelete
+    | KeystoreInsert
+    | KeystoreToList
+    | KeystoreRelease
+    deriving Show
+
+data KeystoreError =
+    KeystoreErrorAlreadyReleased KeystoreOperation
+    -- ^ The keystore was already released by the time the requested
+    -- operation was attempted.
+    deriving Show
+
+instance Exception KeystoreError
+
+-- | Internal monad used to smooth out the 'WithLogger' dependency imposed
+-- by 'Pos.Util.UserSecret', to not commit to any way of logging things just yet.
+newtype KeystoreM a = KeystoreM { fromKeystore :: IdentityT IO a }
+                    deriving (Functor, Applicative, Monad, MonadIO)
+
+instance HasLoggerName KeystoreM where
+    askLoggerName = return (LoggerName "Keystore")
+    modifyLoggerName _ action = action
+
+instance CanLog KeystoreM where
+    dispatchMessage _ln sev txt = logMessage sev txt
+
+{-------------------------------------------------------------------------------
+  Creating a keystore
+-------------------------------------------------------------------------------}
+
+-- | Creates a 'Keystore' using a 'bracket' pattern, where the
+-- initalisation and teardown of the resource are wrapped in 'bracket'.
+bracketKeystore :: FilePath -> (Keystore -> IO a) -> IO a
+bracketKeystore fp withKeystore =
+    bracket (newKeystore fp) releaseKeystore withKeystore
+
 -- | Creates a new keystore.
-newKeystore :: (MonadIO m, WithLogger m) => FilePath -> m Keystore
-newKeystore fp = do
-    us <- peekUserSecret fp
-    Keystore <$> newMVar (InternalStorage us)
+newKeystore :: FilePath -> IO Keystore
+newKeystore fp = runIdentityT $ fromKeystore $ do
+    us <- takeUserSecret fp
+    Keystore <$> newMVar (StorageInitialised us)
 
 -- | Creates a legacy 'Keystore' by reading the 'UserSecret' from a 'NodeContext'.
 -- Hopefully this function will go in the near future.
-legacyKeystore :: MonadIO m => NodeContext -> m Keystore
-legacyKeystore ctx = do
-     us <- atomically $ readTVar $ ncUserSecret ctx
-     Keystore <$> newMVar (InternalStorage us)
+newLegacyKeystore :: UserSecret -> IO Keystore
+newLegacyKeystore us = Keystore <$> newMVar (StorageInitialised us)
+
+-- | Creates a legacy 'Keystore' using a 'bracket' pattern, where the
+-- initalisation and teardown of the resource are wrapped in 'bracket'.
+bracketLegacyKeystore :: UserSecret -> (Keystore -> IO a) -> IO a
+bracketLegacyKeystore us withKeystore =
+    bracket (newLegacyKeystore us)
+            (\_ -> return ()) -- Leave teardown to the legacy wallet
+            withKeystore
+
+-- | Creates a 'Keystore' out of a randomly generated temporary file (i.e.
+-- inside your $TMPDIR of choice). Suitable for testing.
+-- We don't offer a 'bracket' style here as the teardown is irrelevant, as
+-- the file is disposed automatically from being created into the
+-- OS' temporary directory.
+newTemporaryKeystore :: IO Keystore
+newTemporaryKeystore = liftIO $ runIdentityT $ fromKeystore $ do
+    tempDir         <- liftIO getTemporaryDirectory
+    (tempFile, hdl) <- liftIO $ openTempFile tempDir "keystore.key"
+    liftIO $ hClose hdl
+    us <- takeUserSecret tempFile
+    Keystore <$> newMVar (StorageInitialised us)
+
+
+-- | Release the resources associated with this 'Keystore'.
+-- This function is idempotent and can be called multiple times.
+releaseKeystore :: Keystore -> IO ()
+releaseKeystore (Keystore ks) = modifyMVar_ ks (fmap fst . release)
+
+
+-- | Releases the underlying 'InternalStorage' and returns the updated
+-- 'InternalStorage' and the file on disk this storage lives in.
+-- 'FilePath'.
+release :: InternalStorage -> IO (InternalStorage, FilePath)
+release internalStorage =
+    case internalStorage of
+         StorageReleased -> throwM (KeystoreErrorAlreadyReleased KeystoreRelease)
+         StorageInitialised us -> do
+             let fp = getUSPath us
+             writeUserSecretRelease us
+             return (StorageReleased, fp)
+
+
+{-------------------------------------------------------------------------------
+  Destroying a keystore
+-------------------------------------------------------------------------------}
+
+-- | Destroys a 'Keystore'.
+-- Completely obliterate the keystore from disk, with all its secrets.
+-- This operation cannot be reverted.
+-- This is a very destructive option that most of the time you
+-- probably don't want.
+-- This has still its use in some teardowns or tests.
+-- Note that this operation will always succeed. Use with care.
+releaseAndDestroyKeystore :: Keystore -> IO ()
+releaseAndDestroyKeystore (Keystore ks) =
+    modifyMVar_ ks $ \internalStorage -> do
+        (newStorage, fp) <- release internalStorage
+        removeFile fp
+        return newStorage
+
+{-------------------------------------------------------------------------------
+  Inserting things inside a keystore
+-------------------------------------------------------------------------------}
 
 -- | Insert a new 'EncryptedSecretKey' indexed by the input 'WalletId'.
-insert :: MonadIO m
-       => WalletId
+insert :: WalletId
        -> EncryptedSecretKey
        -> Keystore
-       -> m ()
+       -> IO ()
 insert _walletId esk (Keystore ks) =
-    liftIO $ modifyMVar_ ks $ \(InternalStorage us) -> do
-        return $ if view usKeys us `contains` esk
-                     then InternalStorage us
-                     else InternalStorage (us & over usKeys (esk :))
+    modifyMVar_ ks $ \internalStorage ->
+        case internalStorage of
+             StorageInitialised us -> do
+                return . StorageInitialised $
+                    if view usKeys us `contains` esk
+                             then us
+                             else us & over usKeys (esk :)
+             StorageReleased ->
+                 throwM (KeystoreErrorAlreadyReleased KeystoreInsert)
     where
       -- Comparator taken from the old code which needs to hash
       -- all the 'EncryptedSecretKey' in order to compare them.
       contains :: [EncryptedSecretKey] -> EncryptedSecretKey -> Bool
       contains ls k = hash k `elem` map hash ls
 
+{-------------------------------------------------------------------------------
+  Looking up things inside a keystore
+-------------------------------------------------------------------------------}
+
 -- | Lookup an 'EncryptedSecretKey' associated to the input 'HdRootId'.
-lookupKey :: MonadIO m
-          => WalletId
-          -> Keystore
-          -> m (Maybe EncryptedSecretKey)
-lookupKey (WalletIdHdRnd walletId) (Keystore ks) =
-    liftIO $ withMVar ks $ \(InternalStorage us) ->
-        return $ Data.List.find (\k -> eskToHdRootId k == walletId) (us ^. usKeys)
+lookup :: WalletId
+       -> Keystore
+       -> IO (Maybe EncryptedSecretKey)
+lookup wId (Keystore ks) =
+    withMVar ks $ \internalStorage ->
+        case internalStorage of
+             StorageInitialised us -> return $ lookupKey us wId
+             StorageReleased ->
+                 throwM (KeystoreErrorAlreadyReleased KeystoreLookup)
+
+
+lookupKey :: UserSecret -> WalletId -> Maybe EncryptedSecretKey
+lookupKey us (WalletIdHdRnd walletId) =
+    Data.List.find (\k -> eskToHdRootId k == walletId) (us ^. usKeys)
+
+{-------------------------------------------------------------------------------
+  Deleting things from the keystore
+-------------------------------------------------------------------------------}
+delete :: WalletId
+       -> Keystore
+       -> IO ()
+delete walletId (Keystore ks) = do
+    modifyMVar_ ks $ \internalStorage ->
+        case internalStorage of
+             StorageReleased ->
+                 throwM (KeystoreErrorAlreadyReleased KeystoreDelete)
+             StorageInitialised us -> do
+                let mbEsk = lookupKey us walletId
+                let erase = Data.List.deleteBy (\a b -> hash a == hash b)
+                let us' = maybe us (\esk -> us & over usKeys (erase esk)) mbEsk
+                return (StorageInitialised us')
+
+{-------------------------------------------------------------------------------
+  Converting a Keystore into container types
+-------------------------------------------------------------------------------}
 
 -- | Returns all the 'EncryptedSecretKey' known to this 'Keystore'.
-toList :: MonadIO m => Keystore -> m [(WalletId, EncryptedSecretKey)]
+toList :: Keystore -> IO [(WalletId, EncryptedSecretKey)]
 toList (Keystore ks) =
-    liftIO $ withMVar ks $ \(InternalStorage us) ->
-        return (over mapped (\k -> (WalletIdHdRnd (eskToHdRootId k), k)) (us ^. usKeys))
+    withMVar ks $ \internalStorage ->
+        case internalStorage of
+             StorageReleased ->
+                 throwM (KeystoreErrorAlreadyReleased KeystoreToList)
+             StorageInitialised us -> do
+                let kss = us ^. usKeys
+                return $ map (\k -> (WalletIdHdRnd (eskToHdRootId k), k)) kss

--- a/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
@@ -22,6 +22,7 @@ import           Universum
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import           Data.Text.Buildable (Buildable (..))
 import           Data.Word (Word32)
 
 import           Pos.Core (MainBlock, Tx, TxAux (..), TxIn (..), TxOut,
@@ -30,6 +31,9 @@ import           Pos.Core (MainBlock, Tx, TxAux (..), TxIn (..), TxOut,
 import           Pos.Crypto.Hashing (hash)
 import           Pos.Txp (Utxo)
 import           Serokell.Util (enumerate)
+
+import           Formatting (bprint, (%))
+import qualified Formatting as F
 
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb
@@ -56,6 +60,10 @@ data WalletId =
     -}
 
     deriving (Eq, Ord)
+
+instance Buildable WalletId where
+    build (WalletIdHdRnd rootId) =
+        bprint ("WalletIdHdRnd " % F.build) rootId
 
 accountToWalletId :: HD.HdAccountId -> WalletId
 accountToWalletId accountId

--- a/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
@@ -11,7 +11,6 @@ module Cardano.Wallet.Kernel.Types (
   , mkRawResolvedBlock
   -- ** Abstract Wallet/AccountIds
   , WalletId (..)
-  , WalletESKs
   , accountToWalletId
     -- ** From raw to derived types
   , fromRawResolvedTx
@@ -28,7 +27,6 @@ import           Data.Word (Word32)
 import           Pos.Core (MainBlock, Tx, TxAux (..), TxIn (..), TxOut,
                      TxOutAux (..), gbBody, mbTxs, mbWitnesses, txInputs,
                      txOutputs)
-import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Crypto.Hashing (hash)
 import           Pos.Txp (Utxo)
 import           Serokell.Util (enumerate)
@@ -58,12 +56,6 @@ data WalletId =
     -}
 
     deriving (Eq, Ord)
-
--- | Map of Wallet Master keys indexed by WalletId
---
--- TODO: We may need to rethink having this in-memory
--- ESK should _not_ end up in the wallet's acid-state log
-type WalletESKs = Map WalletId EncryptedSecretKey
 
 accountToWalletId :: HD.HdAccountId -> WalletId
 accountToWalletId accountId

--- a/wallet-new/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer.hs
@@ -20,6 +20,7 @@ import           System.Wlog (Severity)
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
 
 import           Cardano.Wallet.Kernel (PassiveWallet)
+import           Cardano.Wallet.Kernel.Keystore (Keystore)
 import qualified Cardano.Wallet.WalletLayer.Kernel as Kernel
 import qualified Cardano.Wallet.WalletLayer.Legacy as Legacy
 import qualified Cardano.Wallet.WalletLayer.QuickCheck as QuickCheck
@@ -32,6 +33,7 @@ import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..),
 bracketKernelPassiveWallet
     :: forall m n a. (MonadIO m, MonadIO n, MonadMask n)
     => (Severity -> Text -> IO ())
+    -> Keystore
     -> (PassiveWalletLayer m -> PassiveWallet -> n a) -> n a
 bracketKernelPassiveWallet = Kernel.bracketPassiveWallet
 

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -52,9 +52,8 @@ bracketPassiveWallet logFunction keystore f =
 
       -- TODO (temporary): build a sample wallet from a backup phrase
       _ <- liftIO $ do
-        let pk = error "TODO: need `AddressHash PublicKey` along with ESK to create a wallet"
         let (_, esk) = safeDeterministicKeyGen (mnemonicToSeed $ def @(Mnemonic 12)) emptyPassphrase
-        Kernel.createWalletHdRnd w walletName spendingPassword assuranceLevel (pk, esk) Map.empty
+        Kernel.createWalletHdRnd w walletName spendingPassword assuranceLevel esk Map.empty
 
       f (passiveWalletLayer w invoke) w
 

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -17,6 +17,7 @@ import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock)
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
+import           Cardano.Wallet.Kernel.Keystore (Keystore)
 import           Cardano.Wallet.Kernel.Types (RawResolvedBlock (..),
                      fromRawResolvedBlock)
 import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..),
@@ -35,9 +36,10 @@ import           Pos.Crypto.Signing
 bracketPassiveWallet
     :: forall m n a. (MonadIO n, MonadIO m, MonadMask m)
     => (Severity -> Text -> IO ())
+    -> Keystore
     -> (PassiveWalletLayer n -> Kernel.PassiveWallet -> m a) -> m a
-bracketPassiveWallet logFunction f =
-    Kernel.bracketPassiveWallet logFunction $ \w -> do
+bracketPassiveWallet logFunction keystore f =
+    Kernel.bracketPassiveWallet logFunction keystore $ \w -> do
 
       -- Create the wallet worker and its communication endpoint `invoke`.
       invoke <- Actions.forkWalletWorker $ Actions.WalletActionInterp

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -69,7 +69,7 @@ spec =
 -- | Initialize passive wallet in a manner suitable for the unit tests
 bracketPassiveWallet :: (Kernel.PassiveWallet -> IO a) -> IO a
 bracketPassiveWallet postHook = do
-      keystore <- Keystore.newTemporaryKeystore
+      keystore <- Keystore.newTestKeystore
       Kernel.bracketPassiveWallet logMessage keystore postHook
   where
    -- TODO: Decide what to do with logging.

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -8,6 +8,7 @@ import qualified Data.Set as Set
 
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.Diffusion as Kernel
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import           Pos.Core (Coeff (..), TxSizeLinear (..))
 
 import           Test.Infrastructure.Generator
@@ -67,7 +68,9 @@ spec =
 
 -- | Initialize passive wallet in a manner suitable for the unit tests
 bracketPassiveWallet :: (Kernel.PassiveWallet -> IO a) -> IO a
-bracketPassiveWallet = Kernel.bracketPassiveWallet logMessage
+bracketPassiveWallet postHook = do
+      keystore <- Keystore.newTemporaryKeystore
+      Kernel.bracketPassiveWallet logMessage keystore postHook
   where
    -- TODO: Decide what to do with logging.
    -- For now we are not logging them to stdout to not alter the output of

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -52,7 +52,7 @@ spec =
                     -> Expectation
     checkEquivalent activeWallet ind = do
        shouldReturnValidated $ runTranslateT $ do
-         equivalentT activeWallet (encKpHash ekp, encKpEnc ekp) (mkWallet (== addr)) ind
+         equivalentT activeWallet (encKpEnc ekp) (mkWallet (== addr)) ind
       where
         [addr]       = Set.toList $ inductiveOurs ind
         AddrInfo{..} = resolveAddr addr transCtxt

--- a/wallet-new/test/unit/Test/Spec/Keystore.hs
+++ b/wallet-new/test/unit/Test/Spec/Keystore.hs
@@ -1,0 +1,92 @@
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
+{-# LANGUAGE ViewPatterns #-}
+module Test.Spec.Keystore (
+    spec
+  ) where
+
+import           Universum
+
+import           System.Directory (doesFileExist, removeFile)
+import           System.IO.Error (IOError)
+
+import           Test.Hspec (Spec, describe, it, shouldBe, shouldReturn)
+import           Test.Hspec.QuickCheck (prop)
+import           Test.QuickCheck (Gen, arbitrary)
+import           Test.QuickCheck.Monadic (forAllM, monadicIO, pick, run)
+
+import           Pos.Crypto (EncryptedSecretKey, hash, safeKeyGen)
+
+import           Cardano.Wallet.Kernel.DB.HdWallet (eskToHdRootId)
+import           Cardano.Wallet.Kernel.Keystore (Keystore)
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
+import           Cardano.Wallet.Kernel.Types (WalletId (..))
+
+import           Util.Buildable (ShowThroughBuild (..))
+
+-- | Creates, operate on a keystore and finally destroys it.
+withKeystore :: (Keystore -> IO a) -> IO a
+withKeystore action =
+    bracket Keystore.newTemporaryKeystore
+            Keystore.releaseAndDestroyKeystore
+            action
+
+genKeypair :: Gen ( ShowThroughBuild WalletId
+                  , ShowThroughBuild EncryptedSecretKey
+                  )
+genKeypair = do
+    (_, esk) <- arbitrary >>= safeKeyGen
+    return $ bimap STB STB (WalletIdHdRnd . eskToHdRootId  $ esk, esk)
+
+nukeKeystore :: FilePath -> IO ()
+nukeKeystore fp =
+    removeFile fp `catch` (\(_ :: IOError) -> return ())
+
+spec :: Spec
+spec =
+    describe "Keystore to store UserSecret(s)" $ do
+        it "creating a brand new one works" $ do
+            nukeKeystore "test_keystore.key"
+            Keystore.bracketKeystore "test_keystore.key" $ \_keystore ->
+                doesFileExist "test_keystore.key" `shouldReturn` True
+
+        it "destroying a keystore (completely) works" $ do
+            nukeKeystore "test_keystore.key"
+            keystore <- Keystore.newKeystore "test_keystore.key"
+            Keystore.releaseAndDestroyKeystore keystore
+            doesFileExist "test_keystore.key" `shouldReturn` False
+
+        prop "lookup of keys works" $ monadicIO $ do
+            forAllM genKeypair $ \(STB wid, STB esk) -> run $ do
+                withKeystore $ \ks -> do
+                    Keystore.insert wid esk ks
+                    mbKey <- Keystore.lookup wid ks
+                    (fmap hash mbKey) `shouldBe` (Just (hash esk))
+
+        prop "Inserts are persisted after releasing the keystore" $ monadicIO $ do
+            (STB wid, STB esk) <- pick genKeypair
+            run $ do
+                nukeKeystore "test_keystore.key"
+                Keystore.bracketKeystore "test_keystore.key" $ \keystore1 ->
+                    Keystore.insert wid esk keystore1
+                Keystore.bracketKeystore "test_keystore.key" $ \keystore2 -> do
+                    mbKey <- Keystore.lookup wid keystore2
+                    (fmap hash mbKey) `shouldBe` (Just (hash esk))
+
+        prop "deletion of keys works" $ monadicIO $ do
+            forAllM genKeypair $ \(STB wid, STB esk) -> run $ do
+                withKeystore $ \ks -> do
+                    Keystore.insert wid esk ks
+                    Keystore.delete wid ks
+                    mbKey <- Keystore.lookup wid ks
+                    (fmap hash mbKey) `shouldBe` Nothing
+
+        prop "Deletion of keys are persisted after releasing the keystore" $ monadicIO $ do
+            (STB wid, STB esk) <- pick genKeypair
+            run $ do
+                nukeKeystore "test_keystore.key"
+                Keystore.bracketKeystore "test_keystore.key" $ \keystore1 -> do
+                    Keystore.insert wid esk keystore1
+                    Keystore.delete wid keystore1
+                Keystore.bracketKeystore "test_keystore.key" $ \keystore2 -> do
+                    mbKey <- Keystore.lookup wid keystore2
+                    (fmap hash mbKey) `shouldBe` Nothing

--- a/wallet-new/test/unit/Test/Spec/Keystore.hs
+++ b/wallet-new/test/unit/Test/Spec/Keystore.hs
@@ -23,6 +23,8 @@ import           Cardano.Wallet.Kernel.Types (WalletId (..))
 
 import           Util.Buildable (ShowThroughBuild (..))
 
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+
 -- | Creates, operate on a keystore and finally destroys it.
 withKeystore :: (Keystore -> IO a) -> IO a
 withKeystore action =

--- a/wallet-new/test/unit/Test/Spec/Submission.hs
+++ b/wallet-new/test/unit/Test/Spec/Submission.hs
@@ -10,8 +10,8 @@ module Test.Spec.Submission (
 import           Universum hiding (elems)
 
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountId (..),
-                     HdAccountIx (..), HdRootId (..))
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
+                     HdAccountIx (..), HdRootId (..), eskToHdRootId)
+import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import           Cardano.Wallet.Kernel.DB.Spec (Pending (..), emptyPending,
                      pendingTransactions, removePending)
 import           Cardano.Wallet.Kernel.Submission
@@ -28,7 +28,7 @@ import           Formatting (bprint, (%))
 import qualified Formatting as F
 import qualified Pos.Core as Core
 import           Pos.Crypto.Hashing (hash)
-import           Pos.Crypto.Signing (deterministicKeyGen)
+import           Pos.Crypto.Signing.Safe (safeDeterministicKeyGen)
 import           Pos.Data.Attributes (Attributes (..), UnparsedFields (..))
 import           Serokell.Util.Text (listJsonIndent)
 import qualified Test.Pos.Core.Arbitrary.Txp as Core
@@ -65,10 +65,9 @@ myAccountId = HdAccountId {
     }
     where
         myHdRootId :: HdRootId
-        myHdRootId = HdRootId $ InDb (Core.unsafeAddressHash .
-                                      fst .
-                                      deterministicKeyGen $
-                                      BS.pack (replicate 32 0))
+        myHdRootId = eskToHdRootId .
+                               snd .
+                               safeDeterministicKeyGen (BS.pack (replicate 32 0)) $ mempty
 
 -- Generates a random schedule by picking a slot >= of the input one but
 -- within a 'slot + 10' range, as really generating schedulers which generates

--- a/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
@@ -20,9 +20,9 @@ import qualified Data.List as List
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, (%))
 
-import           Pos.Core (AddressHash, HasConfiguration)
+import           Pos.Core (HasConfiguration)
 import           Pos.Core.Chrono
-import           Pos.Crypto (EncryptedSecretKey, PublicKey)
+import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Txp (Utxo, formatUtxo)
 
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
@@ -144,11 +144,11 @@ interpretT mkWallet EventCallbacks{..} Inductive{..} =
 
 equivalentT :: forall h m. (Hash h Addr, MonadIO m)
             => Kernel.ActiveWallet
-            -> (AddressHash PublicKey, EncryptedSecretKey)
+            -> EncryptedSecretKey
             -> (DSL.Transaction h Addr -> Wallet h Addr)
             -> Inductive h Addr
             -> TranslateT IntException m (Validated (EquivalenceViolation h) ())
-equivalentT activeWallet (pk,esk) = \mkWallet w ->
+equivalentT activeWallet esk = \mkWallet w ->
       fmap (void . validatedFromEither)
           $ catchSomeTranslateErrors
           $ interpretT mkWallet EventCallbacks{..} w
@@ -161,7 +161,7 @@ equivalentT activeWallet (pk,esk) = \mkWallet w ->
     walletBootT ctxt utxo = do
         res <- liftIO $ Kernel.createWalletHdRnd passiveWallet walletName
                                                  spendingPassword assuranceLevel
-                                                 (pk,esk) utxo
+                                                 esk utxo
 
         either createWalletErr (checkWalletAccountState ctxt) res
 

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -17,6 +17,7 @@ import           UTxO.Translate (runTranslateNoErrors, withConfig)
 
 import qualified Test.Spec.CoinSelection
 import qualified Test.Spec.Kernel
+import qualified Test.Spec.Keystore
 import qualified Test.Spec.Models
 import qualified Test.Spec.Submission
 import qualified Test.Spec.Translation
@@ -68,3 +69,4 @@ tests = describe "Wallet unit tests" $ do
     Test.Spec.Submission.spec
     txMetaStorageSpecs
     Test.Spec.CoinSelection.spec
+    Test.Spec.Keystore.spec


### PR DESCRIPTION
## Description

This PR introduces an opaque `Keystore` abstraction and a set of APIs meant to be able to store and retrieve `EncryptedSecretKey` from disk "out-of-acid-state", in the sense that those delicate sensitive information shouldn't be stored inside `acid-state`, to not incur in the risk of accidentally leaking them in the transaction logs.

The presented API models the one for `Data.Map` and should be quite general thanks to the use of the `Kernel.WalletId` type which incapsulate the notion of different ids, being them coming from HD wallets or elsewhere.

The concrete implementation is quite inefficient and relies on the already-present `UserSecret`, as reinventing the wheel here would be detrimental as it makes sense to piggyback on what we have already instead of rewriting it from scratch.

This `Keystore` is now hooked into the `PassiveWallet` and this means we can also get rid of the artificial creation of a `HdWallet` inside the worker thread, but rather start using this abstraction (cc @matt-noonan).

Tests are provided.

Let me know what you think!

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-314

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [X] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
