### PR TITLE
[DEVOPS-936] Fix tests.stylishHaskell output when files are utf-8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -157,11 +157,10 @@ let
     tests = {
       shellcheck = pkgs.callPackage ./scripts/test/shellcheck.nix { src = ./.; };
       hlint = pkgs.callPackage ./scripts/test/hlint.nix { src = ./.; };
-      stylishHaskell = pkgs.callPackage ./scripts/test/stylish.nix { src = ./.; stylish-haskell = cardanoPkgs.stylish-haskell; };
+      stylishHaskell = pkgs.callPackage ./scripts/test/stylish.nix { src = ./.; stylish-haskell = cardanoPkgs.stylish-haskell; inherit localLib; };
       buildWalletIntegration = pkgs.callPackage ./scripts/test/wallet/integration/build-test.nix { inherit walletIntegrationTests pkgs; };
       swaggerSchemaValidation = pkgs.callPackage ./scripts/test/wallet/swaggerSchemaValidation.nix { inherit gitrev; };
     };
-    fixStylishHaskell = pkgs.callPackage ./scripts/haskell/stylish.nix { stylish-haskell = cardanoPkgs.stylish-haskell; };
     cardano-sl-explorer-frontend = (import ./explorer/frontend {
       inherit system config gitrev pkgs;
       cardano-sl-explorer = cardanoPkgs.cardano-sl-explorer-static;

--- a/lib.nix
+++ b/lib.nix
@@ -18,4 +18,13 @@ in lib // (rec {
   inherit fetchNixPkgs;
   isCardanoSL = lib.hasPrefix "cardano-sl";
   isBenchmark = args: !((args.isExecutable or false) || (args.isLibrary or true));
+
+  # Insert this into builder scripts where programs require a UTF-8
+  # locale to work.
+  utf8LocaleSetting = ''
+    export LC_ALL=en_GB.UTF-8
+    export LANG=en_GB.UTF-8
+  '' + lib.optionalString (pkgs.glibcLocales != null) ''
+    export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
+  '';
 })

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -67,12 +67,6 @@ let
     "--configuration-file ${environments.${environment}.confFile or "${configFiles}/lib/configuration.yaml"}"
     "--configuration-key ${environments.${environment}.confKey}"
   ];
-  utf8LocaleSetting = ''
-    export LC_ALL=en_GB.UTF-8
-    export LANG=en_GB.UTF-8
-  '' + optionalString (pkgs.glibcLocales != null) ''
-    export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
-  '';
 
 in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   #!${pkgs.stdenv.shell} -e

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -109,7 +109,7 @@ in pkgs.writeScript "demo-cluster" ''
 
   done
   ${ifWallet ''
-    export LC_ALL=C.UTF-8
+    ${utf8LocaleSetting}
     echo Launching wallet node: ${demoWallet}
     ${demoWallet} --runtime-args "--system-start $system_start" &> /dev/null &
     wallet_pid=$!

--- a/scripts/test/stylish.nix
+++ b/scripts/test/stylish.nix
@@ -1,4 +1,4 @@
-{ runCommand, stylish-haskell, src, lib, git }:
+{ runCommand, stylish-haskell, src, lib, localLib, git }:
 
 let
   cleanSourceFilter = with lib;
@@ -11,6 +11,7 @@ let
 in
 runCommand "cardano-stylish-check" { succeedOnFailure = true; buildInputs = [ stylish-haskell git ]; } ''
   set +e
+  ${localLib.utf8LocaleSetting}
   cp -a ${src'} tmp-cardano
   chmod -R 0755 tmp-cardano
   cd tmp-cardano

--- a/scripts/test/stylish.nix
+++ b/scripts/test/stylish.nix
@@ -1,4 +1,4 @@
-{ runCommand, stylish-haskell, src, lib, localLib, git }:
+{ runCommand, stylish-haskell, src, lib, localLib, diffutils }:
 
 let
   cleanSourceFilter = with lib;
@@ -9,21 +9,24 @@ let
     );
   src' = builtins.filterSource cleanSourceFilter src;
 in
-runCommand "cardano-stylish-check" { succeedOnFailure = true; buildInputs = [ stylish-haskell git ]; } ''
+runCommand "cardano-stylish-check" {
+  succeedOnFailure = true;
+  buildInputs = [ stylish-haskell diffutils ];
+} ''
   set +e
   ${localLib.utf8LocaleSetting}
-  cp -a ${src'} tmp-cardano
-  chmod -R 0755 tmp-cardano
-  cd tmp-cardano
-  git init
-  git add -A
+  cp -a ${src'} orig
+  cp -a ${src'} stylish
+  chmod -R +w stylish
+  cd stylish
   find . -type f -name "*hs" -not -path '.git' -not -path '*.stack-work*' -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
-  git diff --exit-code
+  cd ..
+  diff --brief --recursive orig stylish > /dev/null
   EXIT_CODE=$?
   if [[ $EXIT_CODE != 0 ]]
   then
     mkdir -p $out/nix-support
-    git diff > $out/stylish.diff
+    diff -ur orig stylish > $out/stylish.diff
     echo "file none $out/stylish.diff" > $out/nix-support/hydra-build-products
     echo "*** Stylish-haskell found changes that need addressed first"
     echo "*** Please run \`nix-shell -A fixStylishHaskell\` and commit changes"


### PR DESCRIPTION
## Description

stylish-haskell needs to be run under a utf-8 locale. Otherwise it will crash leaving a partially written file.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-936

## Type of change

 - [x] CI scripts

## QA Steps

    cat $(nix-build release.nix -A tests.stylishHaskell)/stylish.diff
