### PR TITLE
Added `--nix` argument to ./scripts/launch/demo.sh

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -3,15 +3,19 @@
 base_common="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function find_binary {
+  local nix=""
+  [[ -z $2 ]] || nix="--nix"
   pushd "$base_common/.." > /dev/null || exit
-  binpath=$(stack path --local-install-root)/bin
+  binpath=$(stack ${nix} path --local-install-root)/bin
   popd > /dev/null || exit
   echo "$binpath/$1"
 }
 
 function find_build_binary {
+  local nix=""
+  [[ -z $2 ]] || nix="--nix"
   pushd "$base_common/.." > /dev/null || exit
-  binpath=$(stack path --dist-dir)/build
+  binpath=$(stack ${nix} path --dist-dir)/build
   popd > /dev/null || exit
   echo "$binpath/$1/$1"
 }

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -9,6 +9,13 @@ if ! [ -n "$TMUX" ]; then
   exit 1
 fi
 
+# Check the `--nix` option (must be first option)
+nix=""
+if [[ $1 == "--nix" ]]; then
+  shift
+  nix="--nix"
+fi
+
 # Make sure we're using proper version of tmux.
 tmux_actual_version=$(tmux -V | awk '{print $2}')
 # All tmux versions contain two numbers only.
@@ -171,10 +178,10 @@ while [[ $i -lt $panesCnt ]]; do
   fi
   if [[ $i -lt $n ]]; then
     node_args="$(node_cmd $i "$wallet_args" "$system_start" "$config_dir" "$conf_file" "$run_dir" "$run_dir/logs")"
-    node_=$(find_binary $exec_name)
+    node_=$(find_binary $exec_name $nix)
     if [[ $WALLET_TEST != "" ]] && [[ $i -ge $((n-2)) ]]; then
         updater_file="$config_dir/updater$i.sh"
-        launcher_=$(find_binary cardano-launcher)
+        launcher_=$(find_binary cardano-launcher $nix)
 
         ensure_run $run_dir
 


### PR DESCRIPTION
## Description

This adds `--nix` parameter to `./scripts/launch/demo.sh`

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
