### PR TITLE
[CDEC-375] Move Arbitrary instances to test directory in explorer

### DIFF
--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -5,7 +5,7 @@ description:         Please see README.md
 license:             MIT
 license-file:        LICENSE
 author:              IOHK
-maintainer:          IOHK <hi@serokell.io>
+maintainer:          IOHK <support@iohk.io>
 copyright:           2017 IOHK
 category:            Currency
 build-type:          Simple
@@ -36,9 +36,6 @@ library
 
                         Pos.Explorer.TestUtil
 
-                        -- Needed for testing
-                        Pos.Arbitrary.Explorer
-
   other-modules:        Pos.Explorer.Aeson.ClientTypes
 
                         Pos.Binary.Explorer
@@ -65,7 +62,6 @@ library
                       , exceptions
                       , formatting
                       , free
-                      , generic-arbitrary
                       , lens
                       , log-warper
                       , memory
@@ -92,7 +88,6 @@ library
                       , cardano-sl-block
                       , cardano-sl-block-test
                       , cardano-sl-core
-                      , cardano-sl-core-test
                       , cardano-sl-crypto
                       , cardano-sl-crypto-test
                       , cardano-sl-db
@@ -103,7 +98,6 @@ library
                       , cardano-sl-networking
                       , cardano-sl-ssc
                       , cardano-sl-txp
-                      , cardano-sl-txp-test
                       , cardano-sl-update
                       , cardano-sl-util
 
@@ -334,6 +328,8 @@ test-suite cardano-explorer-test
   other-modules:
                        -- Standard module with some magic
                        Spec
+                       -- Arbitrary instances
+                       Test.Pos.Explorer.Arbitrary
                        -- Utils
                        Test.Pos.Explorer.MockFactory
                        -- Tests
@@ -355,6 +351,7 @@ test-suite cardano-explorer-test
                      , cardano-sl-block
                      , cardano-sl-block-test
                      , cardano-sl-core
+                     , cardano-sl-core-test
                      , cardano-sl-crypto
                      , cardano-sl-explorer
                      , cardano-sl-txp
@@ -362,6 +359,7 @@ test-suite cardano-explorer-test
                      , containers
                      , cryptonite
                      , engine-io
+                     , generic-arbitrary
                      , hspec
                      , lens
                      , log-warper

--- a/explorer/test/Test/Pos/Explorer/Arbitrary.hs
+++ b/explorer/test/Test/Pos/Explorer/Arbitrary.hs
@@ -2,13 +2,13 @@
 
 -- | Arbitrary instances for Explorer types.
 
-module Pos.Arbitrary.Explorer () where
+module Test.Pos.Explorer.Arbitrary () where
 
 import           Test.QuickCheck (Arbitrary (..))
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
-import           Pos.Explorer.Core.Types (TxExtra (..))
+import           Pos.Explorer.Core (TxExtra (..))
 
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Core.Arbitrary.Txp ()

--- a/explorer/test/Test/Pos/Explorer/Identity/BinarySpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Identity/BinarySpec.hs
@@ -8,9 +8,10 @@ import           Universum
 
 import           Test.Hspec (Spec, describe)
 
-import           Pos.Arbitrary.Explorer ()
 import           Pos.Explorer.Core (TxExtra)
+
 import           Test.Pos.Binary.Helpers (binaryTest)
+import           Test.Pos.Explorer.Arbitrary ()
 
 spec :: Spec
 spec = describe "Explorer types" $ do

--- a/infra/src/Pos/Infra/Communication/Types/Relay.hs
+++ b/infra/src/Pos/Infra/Communication/Types/Relay.hs
@@ -22,9 +22,9 @@ import qualified Data.Text.Buildable as B
 import           Formatting (bprint, build, (%))
 
 import           Pos.Binary.Class (Bi (..))
+import           Pos.Core.Txp (TxMsgContents (..))
 import qualified Pos.Core.Update as U
 import           Pos.Crypto (hash)
-import           Pos.Core.Txp (TxMsgContents (..))
 import           Pos.Util.Util (cborError)
 
 -- | Inventory message. Can be used to announce the fact that you have

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16473,7 +16473,6 @@ cardano-sl-binary
 cardano-sl-block
 cardano-sl-block-test
 cardano-sl-core
-cardano-sl-core-test
 cardano-sl-crypto
 cardano-sl-crypto-test
 cardano-sl-db
@@ -16484,7 +16483,6 @@ cardano-sl-lrc
 cardano-sl-networking
 cardano-sl-ssc
 cardano-sl-txp
-cardano-sl-txp-test
 cardano-sl-update
 cardano-sl-util
 conduit
@@ -16496,7 +16494,6 @@ ether
 exceptions
 formatting
 free
-generic-arbitrary
 http-types
 lens
 log-warper
@@ -16563,12 +16560,14 @@ cardano-sl-binary-test
 cardano-sl-block
 cardano-sl-block-test
 cardano-sl-core
+cardano-sl-core-test
 cardano-sl-crypto
 cardano-sl-txp
 cardano-sl-util
 containers
 cryptonite
 engine-io
+generic-arbitrary
 hspec
 lens
 log-warper


### PR DESCRIPTION
## Description

As it stands, the `Arbitrary` instances for data types in `explorer` all exist in `explorer/src/Pos/Arbitrary` when they should actually be in `explorer/test/Test/Pos/Explorer/Arbitrary`. The PR appropriately moves the `Arbitrary` instances.

## Linked issue

[https://iohk.myjetbrains.com/youtrack/issue/CDEC-375](https://iohk.myjetbrains.com/youtrack/issue/CDEC-375)
## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
