### PR TITLE
[CDEC-416] Sinbin `Test.Pos.Infra.Arbitrary.Slotting`

### DIFF
--- a/infra/test/Test/Pos/Infra/Arbitrary/Slotting.hs
+++ b/infra/test/Test/Pos/Infra/Arbitrary/Slotting.hs
@@ -1,27 +1,3 @@
-{-# LANGUAGE NoImplicitPrelude #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
--- | Arbitrary instances for Pos.Slotting types (infra package)
-
 module Test.Pos.Infra.Arbitrary.Slotting () where
 
-import           Universum
-
-import           Test.QuickCheck (Arbitrary (..), arbitrary, oneof)
-import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
-                     genericShrink)
-
-import           Pos.Infra.Slotting.Types (EpochSlottingData (..), SlottingData,
-                     createInitSlottingData)
-
-import           Test.Pos.Core.Arbitrary ()
-
-instance Arbitrary EpochSlottingData where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
-
-instance Arbitrary SlottingData where
-    -- Fixed instance since it's impossible to create and instance
-    -- where one creates @SlottingData@ without at least two parameters.
-    arbitrary = oneof [ createInitSlottingData <$> arbitrary <*> arbitrary ]
+import           Test.Pos.Sinbin.Arbitrary.Slotting ()

--- a/infra/test/cardano-sl-infra-test.cabal
+++ b/infra/test/cardano-sl-infra-test.cabal
@@ -26,6 +26,7 @@ library
                      , cardano-sl-core-test
                      , cardano-sl-crypto
                      , cardano-sl-infra
+                     , cardano-sl-sinbin-test
                      , cardano-sl-util-test
                      , containers
                      , generic-arbitrary

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16903,6 +16903,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-core-test
 , cardano-sl-crypto
 , cardano-sl-infra
+, cardano-sl-sinbin-test
 , cardano-sl-util-test
 , containers
 , generic-arbitrary
@@ -16925,6 +16926,7 @@ cardano-sl-core
 cardano-sl-core-test
 cardano-sl-crypto
 cardano-sl-infra
+cardano-sl-sinbin-test
 cardano-sl-util-test
 containers
 generic-arbitrary
@@ -17425,6 +17427,35 @@ cpphs
 ];
 doHaddock = false;
 description = "Cardano SL - sinbin";
+license = stdenv.lib.licenses.mit;
+
+}) {};
+"cardano-sl-sinbin-test" = callPackage
+({
+  mkDerivation
+, base
+, cardano-sl-core-test
+, cardano-sl-sinbin
+, generic-arbitrary
+, QuickCheck
+, stdenv
+, universum
+}:
+mkDerivation {
+
+pname = "cardano-sl-sinbin-test";
+version = "1.3.0";
+src = ./../sinbin/test;
+libraryHaskellDepends = [
+base
+cardano-sl-core-test
+cardano-sl-sinbin
+generic-arbitrary
+QuickCheck
+universum
+];
+doHaddock = false;
+description = "Cardano SL - generators for cardano-sl-sinbin";
 license = stdenv.lib.licenses.mit;
 
 }) {};
@@ -18041,7 +18072,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-crypto
 , cardano-sl-crypto-test
 , cardano-sl-infra
-, cardano-sl-infra-test
+, cardano-sl-sinbin-test
 , cardano-sl-update
 , cardano-sl-util-test
 , containers
@@ -18064,7 +18095,7 @@ cardano-sl-core-test
 cardano-sl-crypto
 cardano-sl-crypto-test
 cardano-sl-infra
-cardano-sl-infra-test
+cardano-sl-sinbin-test
 cardano-sl-update
 cardano-sl-util-test
 containers

--- a/sinbin/test/LICENSE
+++ b/sinbin/test/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sinbin/test/Setup.hs
+++ b/sinbin/test/Setup.hs
@@ -1,0 +1,2 @@
+import           Distribution.Simple
+main = defaultMain

--- a/sinbin/test/Test/Pos/Sinbin/Arbitrary/Slotting.hs
+++ b/sinbin/test/Test/Pos/Sinbin/Arbitrary/Slotting.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Arbitrary instances for Pos.Slotting types (sinbin package)
+
+module Test.Pos.Sinbin.Arbitrary.Slotting () where
+
+import           Universum
+
+import           Test.QuickCheck (Arbitrary (..), arbitrary, oneof)
+import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
+                     genericShrink)
+
+import           Pos.Sinbin.Slotting.Types (EpochSlottingData (..),
+                     SlottingData, createInitSlottingData)
+
+import           Test.Pos.Core.Arbitrary ()
+
+instance Arbitrary EpochSlottingData where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary SlottingData where
+    -- Fixed instance since it's impossible to create and instance
+    -- where one creates @SlottingData@ without at least two parameters.
+    arbitrary = oneof [ createInitSlottingData <$> arbitrary <*> arbitrary ]

--- a/sinbin/test/cardano-sl-sinbin-test.cabal
+++ b/sinbin/test/cardano-sl-sinbin-test.cabal
@@ -1,0 +1,30 @@
+name:                cardano-sl-sinbin-test
+version:             1.3.0
+synopsis:            Cardano SL - generators for cardano-sl-sinbin
+description:         This package contains generators for the data types temporarily held in sinbin.
+license:             MIT
+license-file:        LICENSE
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:
+                       Test.Pos.Sinbin.Arbitrary.Slotting
+
+  build-depends:       QuickCheck
+                     , base
+                     , cardano-sl-core-test
+                     , cardano-sl-sinbin
+                     , generic-arbitrary
+                     , universum
+
+  default-language:    Haskell2010
+
+  default-extensions:  NoImplicitPrelude
+
+  ghc-options:         -Wall
+                       -O2

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,6 +25,7 @@ packages:
 - lrc
 - lrc/test
 - sinbin
+- sinbin/test
 - infra
 - infra/test
 - ssc

--- a/update/test/Test/Pos/Update/Arbitrary/Core.hs
+++ b/update/test/Test/Pos/Update/Arbitrary/Core.hs
@@ -30,7 +30,7 @@ import           Pos.Update.Poll.Types (VoteState (..))
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Crypto.Arbitrary ()
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
-import           Test.Pos.Infra.Arbitrary.Slotting ()
+import           Test.Pos.Sinbin.Arbitrary.Slotting ()
 
 instance Arbitrary BlockVersionModifier where
     arbitrary = genericArbitrary

--- a/update/test/Test/Pos/Update/Arbitrary/Poll.hs
+++ b/update/test/Test/Pos/Update/Arbitrary/Poll.hs
@@ -25,7 +25,7 @@ import           Pos.Update.Poll.Types (BlockVersionState (..),
                      UndecidedProposalState (..), UpsExtra (..))
 
 import           Test.Pos.Core.Arbitrary ()
-import           Test.Pos.Infra.Arbitrary.Slotting ()
+import           Test.Pos.Sinbin.Arbitrary.Slotting ()
 import           Test.Pos.Update.Arbitrary.Core ()
 import           Test.Pos.Util.Modifier ()
 

--- a/update/test/cardano-sl-update-test.cabal
+++ b/update/test/cardano-sl-update-test.cabal
@@ -29,7 +29,7 @@ library
                      , cardano-sl-crypto
                      , cardano-sl-crypto-test
                      , cardano-sl-infra
-                     , cardano-sl-infra-test
+                     , cardano-sl-sinbin-test
                      , cardano-sl-update
                      , cardano-sl-util-test
                      , containers


### PR DESCRIPTION
## Description

Free up `infra-test` by moving `Test.Pos.Infra.Arbitrary.Slotting` to `sinbin-test`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-416

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.