### PR TITLE
[CDEC-427] Move Arbitrary instances from ssc to ssc-test

### DIFF
--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -154,6 +154,7 @@ test-suite test
                      , cardano-sl-crypto-test
                      , cardano-sl-delegation-test
                      , cardano-sl-ssc
+                     , cardano-sl-ssc-test
                      , cardano-sl-txp-test
                      , cardano-sl-update
                      , cardano-sl-update-test

--- a/block/test/Test/Pos/Block/Arbitrary.hs
+++ b/block/test/Test/Pos/Block/Arbitrary.hs
@@ -29,8 +29,6 @@ import           Test.QuickCheck (Arbitrary (..), Gen, choose, suchThat,
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
-import           Pos.Arbitrary.Ssc (SscPayloadDependsOnSlot (..), genSscPayload,
-                     genSscPayloadForSlot)
 import           Pos.Binary.Class (biSize)
 import qualified Pos.Block.Logic.Integrity as T
 import           Pos.Block.Slog (SlogUndo)
@@ -47,6 +45,8 @@ import           Test.Pos.Core.Arbitrary (genSlotId)
 import           Test.Pos.Core.Arbitrary.Txp (genTxPayload)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Delegation.Arbitrary (genDlgPayload)
+import           Test.Pos.Ssc.Arbitrary (SscPayloadDependsOnSlot (..),
+                     genSscPayload, genSscPayloadForSlot)
 import           Test.Pos.Update.Arbitrary (genUpdatePayload)
 
 newtype BodyDependsOnSlot b = BodyDependsOnSlot

--- a/block/test/Test/Pos/Block/Arbitrary/Message.hs
+++ b/block/test/Test/Pos/Block/Arbitrary/Message.hs
@@ -11,12 +11,12 @@ import           Test.QuickCheck (Arbitrary (..))
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
-import           Pos.Arbitrary.Ssc ()
 import qualified Pos.Block.Network.Types as T
 import           Pos.Core (HasGenesisHash, HasProtocolConstants)
 
 import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Core.Chrono ()
+import           Test.Pos.Ssc.Arbitrary ()
 import           Test.Pos.Update.Arbitrary ()
 
 ------------------------------------------------------------------------------------------

--- a/block/test/cardano-sl-block-test.cabal
+++ b/block/test/cardano-sl-block-test.cabal
@@ -34,7 +34,7 @@ library
                      , cardano-sl-lrc
                      , cardano-sl-lrc-test
                      , cardano-sl-networking
-                     , cardano-sl-ssc
+                     , cardano-sl-ssc-test
                      , cardano-sl-txp
                      , cardano-sl-txp-test
                      , cardano-sl-update-test

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -50,6 +50,7 @@ library
                      , cardano-sl-lrc
                      , cardano-sl-networking
                      , cardano-sl-ssc
+                     , cardano-sl-ssc-test
                      , cardano-sl-txp
                      , cardano-sl-update
                      , cardano-sl-util
@@ -139,6 +140,7 @@ test-suite cardano-generator-test
                      , cardano-sl-generator
                      , cardano-sl-lrc
                      , cardano-sl-ssc
+                     , cardano-sl-ssc-test
                      , cardano-sl-txp
                      , cardano-sl-txp-test
                      , cardano-sl-update

--- a/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
@@ -15,8 +15,7 @@ import           Test.QuickCheck (Gen, Property, Testable, arbitrary, choose,
                      counterexample, elements, forAll, generate, listOf,
                      listOf1, oneof, property)
 
-import           Pos.Arbitrary.Ssc (commitmentMapEpochGen,
-                     vssCertificateEpochGen)
+
 import           Pos.Binary.Class (biSize)
 import           Pos.Block.Logic (RawPayload (..), createMainBlockPure)
 import qualified Pos.Communication ()
@@ -39,6 +38,8 @@ import           Test.Pos.Configuration (withDefConfiguration,
 import           Test.Pos.Core.Arbitrary.Txp (GoodTx, goodTxToTxAux)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Delegation.Arbitrary (genDlgPayload)
+import           Test.Pos.Ssc.Arbitrary (commitmentMapEpochGen,
+                     vssCertificateEpochGen)
 import           Test.Pos.Util.QuickCheck (SmallGenerator (..), makeSmall)
 
 spec :: Spec

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -325,6 +325,7 @@ test-suite cardano-test
                      , cardano-sl-lrc-test
                      , cardano-sl-networking
                      , cardano-sl-ssc
+                     , cardano-sl-ssc-test
                      , cardano-sl-txp
                      , cardano-sl-txp-test
                      , cardano-sl-update

--- a/lib/src/Pos/Context/Context.hs
+++ b/lib/src/Pos/Context/Context.hs
@@ -66,7 +66,7 @@ data SscContextTag
 -- | NodeContext contains runtime context of node.
 data NodeContext = NodeContext
     { ncSscContext          :: !SscContext
-    -- @georgeee please add documentation when you see this comment
+    -- ^ Context needed for Shared Seed Computation (SSC).
     , ncUpdateContext       :: !UpdateContext
     -- ^ Context needed for the update system
     , ncLrcContext          :: !LrcContext

--- a/lib/src/Pos/Worker/Ssc.hs
+++ b/lib/src/Pos/Worker/Ssc.hs
@@ -246,7 +246,9 @@ onNewSlotOpening
     :: ( SscMode ctx m
        )
     => ProtocolMagic
-    -> SscOpeningParams
+    -> SscOpeningParams     -- ^ This parameter is part of the node's
+                            -- BehaviorConfig which defines how the node should
+                            -- behave when it's sending openings to other nodes
     -> SlotId
     -> (Opening -> m ())
     -> m ()
@@ -269,8 +271,12 @@ onNewSlotOpening pm params SlotId {..} sendOpening
         "We don't know our opening, maybe we started recently"
     sendOpeningDo ourId open = do
         mbOpen' <- case params of
+            -- The node doesn't send an 'Opening'.
             SscOpeningNone   -> pure Nothing
+            -- The node acts as normal and sends an 'Opening'.
             SscOpeningNormal -> pure (Just open)
+            -- The node sends rubbish (a random 'Opening'). This setting is
+            -- typically only specified for testing purposes.
             SscOpeningWrong  -> Just <$> liftIO randomOpening
         whenJust mbOpen' $ \open' -> do
             sscProcessOurMessage (sscProcessOpening pm ourId open')

--- a/lib/src/Pos/Worker/Ssc.hs
+++ b/lib/src/Pos/Worker/Ssc.hs
@@ -21,7 +21,6 @@ import qualified System.Metrics.Gauge as Metrics
 import qualified Crypto.Random as Rand
 import           System.Wlog (WithLogger)
 
-import           Pos.Arbitrary.Ssc ()
 import           Pos.Binary.Class (AsBinary, asBinary, fromBinary)
 import           Pos.Core (EpochIndex, HasPrimaryKey, SlotId (..),
                      StakeholderId, Timestamp (..), VssCertificate (..),
@@ -238,7 +237,7 @@ randomOpening = snd <$> secureRandCommitmentAndOpening
   where
     secureRandCommitmentAndOpening = runSecureRandom $ do
         t       <- randomNumberInRange 3 10
-        n       <- randomNumberInRange (t*2-1) (t*2)
+        n       <- randomNumberInRange (t*2-1) (t*2) -- This seems strange.
         vssKeys <- replicateM (fromInteger n) $ toVssPublicKey <$> vssKeyGen
         randCommitmentAndOpening (fromIntegral t) (NE.fromList vssKeys)
 

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -21,7 +21,6 @@ import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (..))
 
-import           Pos.Arbitrary.Ssc ()
 import           Pos.Binary.Communication ()
 import qualified Pos.Communication as C
 import           Pos.Communication.Limits (mlOpening, mlUpdateVote,
@@ -52,6 +51,7 @@ import           Test.Pos.Delegation.Arbitrary ()
 import           Test.Pos.Infra.Arbitrary ()
 import           Test.Pos.Infra.Arbitrary.Communication ()
 import           Test.Pos.Infra.Arbitrary.Slotting ()
+import           Test.Pos.Ssc.Arbitrary ()
 import           Test.Pos.Update.Arbitrary ()
 import           Test.Pos.Util.QuickCheck (SmallGenerator)
 

--- a/lib/test/Test/Pos/Ssc/Identity/SafeCopySpec.hs
+++ b/lib/test/Test/Pos/Ssc/Identity/SafeCopySpec.hs
@@ -7,10 +7,10 @@ module Test.Pos.Ssc.Identity.SafeCopySpec
 import           Test.Hspec (Spec, describe)
 import           Universum
 
-import           Pos.Arbitrary.Ssc ()
 import qualified Pos.Core.Ssc as Ssc
 
 import           Test.Pos.Binary.Helpers (safeCopyTest)
+import           Test.Pos.Ssc.Arbitrary ()
 
 spec :: Spec
 spec = describe "Ssc" $ do

--- a/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
+++ b/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
@@ -18,8 +18,6 @@ import           Test.QuickCheck (Arbitrary (..), Gen, NonEmptyList (..),
                      Property, elements, listOf, property, sublistOf, suchThat,
                      vector, (.&&.), (===), (==>))
 
-import           Pos.Arbitrary.Ssc (BadCommAndOpening (..),
-                     BadSignedCommitment (..), CommitmentOpening (..))
 import           Pos.Binary (AsBinary)
 import           Pos.Core (Coin, EpochIndex, EpochOrSlot (..), HasConfiguration,
                      StakeholderId, VssCertificate (..),
@@ -45,6 +43,8 @@ import           Test.Pos.Util.QuickCheck.Property (qcElem, qcFail, qcIsRight)
 
 import           Test.Pos.Configuration (withDefConfiguration)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Ssc.Arbitrary (BadCommAndOpening (..),
+                     BadSignedCommitment (..), CommitmentOpening (..))
 
 spec :: Spec
 spec = withDefConfiguration $ \_ -> describe "Ssc.Base" $ do

--- a/lib/test/Test/Pos/Ssc/Toss/PureSpec.hs
+++ b/lib/test/Test/Pos/Ssc/Toss/PureSpec.hs
@@ -15,7 +15,6 @@ import           Test.QuickCheck (Arbitrary (..), Gen, Property, forAll, listOf,
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
-import           Pos.Arbitrary.Ssc ()
 import           Pos.Core (EpochOrSlot, HasConfiguration, InnerSharesMap,
                      Opening, SignedCommitment, StakeholderId,
                      VssCertificate (..), addressHash)
@@ -25,6 +24,7 @@ import qualified Pos.Ssc.Types as Toss
 
 import           Test.Pos.Configuration (withDefConfiguration)
 import           Test.Pos.Core.Arbitrary ()
+import           Test.Pos.Ssc.Arbitrary ()
 
 spec :: Spec
 spec = withDefConfiguration $ \_ -> describe "Toss" $ do

--- a/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
+++ b/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
@@ -17,7 +17,6 @@ import           Test.QuickCheck (Arbitrary (..), Gen, Property, choose,
                      conjoin, counterexample, suchThat, vectorOf, (.&&.),
                      (==>))
 
-import           Pos.Arbitrary.Ssc ()
 import           Pos.Core (EpochIndex (..), EpochOrSlot (..), HasConfiguration,
                      SlotId (..), VssCertificate (..), getCertId,
                      getVssCertificatesMap, mkVssCertificate,
@@ -32,6 +31,7 @@ import           Pos.Ssc (SscGlobalState (..), VssCertData (..), delete, empty,
 import           Test.Pos.Configuration (withDefConfiguration)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Ssc.Arbitrary ()
 import           Test.Pos.Util.QuickCheck.Property (qcIsJust)
 
 spec :: Spec

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14695,6 +14695,7 @@ license = stdenv.lib.licenses.bsd3;
 , cardano-sl-lrc-test
 , cardano-sl-networking
 , cardano-sl-ssc
+, cardano-sl-ssc-test
 , cardano-sl-txp
 , cardano-sl-txp-test
 , cardano-sl-update
@@ -14909,6 +14910,7 @@ cardano-sl-lrc
 cardano-sl-lrc-test
 cardano-sl-networking
 cardano-sl-ssc
+cardano-sl-ssc-test
 cardano-sl-txp
 cardano-sl-txp-test
 cardano-sl-update
@@ -15400,6 +15402,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-networking
 , cardano-sl-sinbin
 , cardano-sl-ssc
+, cardano-sl-ssc-test
 , cardano-sl-txp
 , cardano-sl-txp-test
 , cardano-sl-update
@@ -15513,6 +15516,7 @@ cardano-sl-crypto
 cardano-sl-crypto-test
 cardano-sl-delegation-test
 cardano-sl-ssc
+cardano-sl-ssc-test
 cardano-sl-txp-test
 cardano-sl-update
 cardano-sl-update-test
@@ -15604,7 +15608,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-lrc
 , cardano-sl-lrc-test
 , cardano-sl-networking
-, cardano-sl-ssc
+, cardano-sl-ssc-test
 , cardano-sl-txp
 , cardano-sl-txp-test
 , cardano-sl-update-test
@@ -15646,7 +15650,7 @@ cardano-sl-infra
 cardano-sl-lrc
 cardano-sl-lrc-test
 cardano-sl-networking
-cardano-sl-ssc
+cardano-sl-ssc-test
 cardano-sl-txp
 cardano-sl-txp-test
 cardano-sl-update-test
@@ -16632,6 +16636,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-lrc
 , cardano-sl-networking
 , cardano-sl-ssc
+, cardano-sl-ssc-test
 , cardano-sl-txp
 , cardano-sl-txp-test
 , cardano-sl-update
@@ -16689,6 +16694,7 @@ cardano-sl-infra
 cardano-sl-lrc
 cardano-sl-networking
 cardano-sl-ssc
+cardano-sl-ssc-test
 cardano-sl-txp
 cardano-sl-update
 cardano-sl-util
@@ -16734,6 +16740,7 @@ cardano-sl-delegation
 cardano-sl-delegation-test
 cardano-sl-lrc
 cardano-sl-ssc
+cardano-sl-ssc-test
 cardano-sl-txp
 cardano-sl-txp-test
 cardano-sl-update
@@ -17477,16 +17484,13 @@ license = stdenv.lib.licenses.mit;
 , bytestring
 , cardano-sl-binary
 , cardano-sl-core
-, cardano-sl-core-test
 , cardano-sl-crypto
-, cardano-sl-crypto-test
 , cardano-sl-db
 , cardano-sl-infra
 , cardano-sl-lrc
 , cardano-sl-networking
 , cardano-sl-sinbin
 , cardano-sl-util
-, cardano-sl-util-test
 , containers
 , cpphs
 , cryptonite
@@ -17534,16 +17538,13 @@ base
 bytestring
 cardano-sl-binary
 cardano-sl-core
-cardano-sl-core-test
 cardano-sl-crypto
-cardano-sl-crypto-test
 cardano-sl-db
 cardano-sl-infra
 cardano-sl-lrc
 cardano-sl-networking
 cardano-sl-sinbin
 cardano-sl-util
-cardano-sl-util-test
 containers
 cryptonite
 data-default
@@ -17577,6 +17578,45 @@ cpphs
 ];
 doHaddock = false;
 description = "Cardano SL - shared seed computation";
+license = stdenv.lib.licenses.mit;
+
+}) {};
+"cardano-sl-ssc-test" = callPackage
+({
+  mkDerivation
+, base
+, cardano-sl-core
+, cardano-sl-core-test
+, cardano-sl-crypto
+, cardano-sl-crypto-test
+, cardano-sl-infra
+, cardano-sl-ssc
+, cardano-sl-util-test
+, generic-arbitrary
+, QuickCheck
+, stdenv
+, universum
+}:
+mkDerivation {
+
+pname = "cardano-sl-ssc-test";
+version = "1.3.0";
+src = ./../ssc/test;
+libraryHaskellDepends = [
+base
+cardano-sl-core
+cardano-sl-core-test
+cardano-sl-crypto
+cardano-sl-crypto-test
+cardano-sl-infra
+cardano-sl-ssc
+cardano-sl-util-test
+generic-arbitrary
+QuickCheck
+universum
+];
+doHaddock = false;
+description = "Cardano SL - shared seed computation (tests)";
 license = stdenv.lib.licenses.mit;
 
 }) {};

--- a/ssc/cardano-sl-ssc.cabal
+++ b/ssc/cardano-sl-ssc.cabal
@@ -52,8 +52,6 @@ library
     Pos.Ssc.Toss.Trans
     Pos.Ssc.Toss.Types
 
-    Pos.Arbitrary.Ssc
-
     Pos.Security.Params
     Pos.Security.Util
 
@@ -64,16 +62,13 @@ library
                      , bytestring
                      , cardano-sl-binary
                      , cardano-sl-core
-                     , cardano-sl-core-test
                      , cardano-sl-crypto
-                     , cardano-sl-crypto-test
                      , cardano-sl-db
                      , cardano-sl-infra
                      , cardano-sl-lrc
                      , cardano-sl-networking
                      , cardano-sl-sinbin
                      , cardano-sl-util
-                     , cardano-sl-util-test
                      , containers
                      , cryptonite
                      , data-default

--- a/ssc/src/Pos/Ssc/Behavior.hs
+++ b/ssc/src/Pos/Ssc/Behavior.hs
@@ -26,20 +26,24 @@ import           Pos.Util.Util (toAesonError)
 --     sendShares: Normal | None | Wrong
 -- @
 data SscBehavior = SscBehavior
-    { -- | Opening settings (e.g. whether to send the opening at all)
+    { -- | Opening settings (e.g. whether to send rubbish instead of openings)
       sbSendOpening :: !SscOpeningParams
       -- | Shares settings (e.g. whether to send rubbish instead of shares)
     , sbSendShares  :: !SscSharesParams
     }
     deriving (Eq, Show, Generic)
 
+-- | An SSC setting to define how the node should behave when sending openings.
 data SscOpeningParams
     = SscOpeningNormal    -- ^ Normal mode of operation
     | SscOpeningNone      -- ^ An opening is not sent to other nodes
     | SscOpeningWrong     -- ^ An opening is generated at random and doesn't
-                          --    correspond to the commitment
+                          --    correspond to the commitment. This setting is
+                          --    typically only specified for testing purposes
+                          --    as the node will only send rubbish openings.
     deriving (Eq, Show)
 
+-- | An SSC setting to define how the node should behave when sending shares.
 data SscSharesParams
     = SscSharesNormal     -- ^ Normal mode of operation
     | SscSharesNone       -- ^ Decrypted shares are not sent to other nodes

--- a/ssc/test/LICENSE
+++ b/ssc/test/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ssc/test/Setup.hs
+++ b/ssc/test/Setup.hs
@@ -1,0 +1,2 @@
+import           Distribution.Simple
+main = defaultMain

--- a/ssc/test/Test/Pos/Ssc/Arbitrary.hs
+++ b/ssc/test/Test/Pos/Ssc/Arbitrary.hs
@@ -1,8 +1,17 @@
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Arbitrary instances and generators for SSC types.
 
-module Pos.Arbitrary.Ssc
+module Test.Pos.Ssc.Arbitrary
        ( SscPayloadDependsOnSlot (..)
        , BadCommAndOpening (..)
        , BadSignedCommitment (..)

--- a/ssc/test/cardano-sl-ssc-test.cabal
+++ b/ssc/test/cardano-sl-ssc-test.cabal
@@ -1,0 +1,34 @@
+name:                cardano-sl-ssc-test
+version:             1.3.0
+synopsis:            Cardano SL - shared seed computation (tests)
+description:         QuickCheck Arbitrary instances for Cardano SL shared
+                     seed computation.
+license:             MIT
+license-file:        LICENSE
+author:              IOHK
+maintainer:          IOHK <support@iohk.io>
+copyright:           2018 IOHK
+category:            Currency
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:
+                       Test.Pos.Ssc.Arbitrary
+
+  build-depends:       QuickCheck
+                     , base
+                     , cardano-sl-core
+                     , cardano-sl-core-test
+                     , cardano-sl-crypto
+                     , cardano-sl-crypto-test
+                     , cardano-sl-infra
+                     , cardano-sl-ssc
+                     , cardano-sl-util-test
+                     , generic-arbitrary
+                     , universum
+
+  default-language:    Haskell2010
+
+  ghc-options:         -Wall
+                       -O2

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,6 +29,7 @@ packages:
 - infra
 - infra/test
 - ssc
+- ssc/test
 - txp
 - txp/test
 - update

--- a/wallet-new/src/Cardano/Wallet/Orphans/Arbitrary.hs
+++ b/wallet-new/src/Cardano/Wallet/Orphans/Arbitrary.hs
@@ -8,12 +8,14 @@ module Cardano.Wallet.Orphans.Arbitrary where
 import           Universum
 
 import           Data.Default (def)
+import           Servant
+import           Test.QuickCheck (Arbitrary (..))
+
 import           Pos.Wallet.Web.ClientTypes.Types
 import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 import           Pos.Wallet.Web.State.Storage (WalletStorage (..))
-import           Servant
+
 import           Test.Pos.Core.Arbitrary ()
-import           Test.QuickCheck (Arbitrary (..))
 
 instance Arbitrary NoContent where
     arbitrary = pure NoContent

--- a/wallet/src/Pos/Arbitrary/Wallet/Web/ClientTypes.hs
+++ b/wallet/src/Pos/Arbitrary/Wallet/Web/ClientTypes.hs
@@ -9,12 +9,14 @@ module Pos.Arbitrary.Wallet.Web.ClientTypes
 import           Universum
 
 import qualified Data.ByteString.Char8 as B8
+import qualified Serokell.Util.Base64 as B64
+import           Test.QuickCheck (Arbitrary (..), vectorOf)
+
 import           Pos.Wallet.Web.ClientTypes.Types (CHash (..), CId (..),
                      CWAddressMeta (..))
 import           Pos.Wallet.Web.State (WAddressMeta (..))
-import qualified Serokell.Util.Base64 as B64
+
 import           Test.Pos.Core.Arbitrary ()
-import           Test.QuickCheck (Arbitrary (..), vectorOf)
 
 instance Arbitrary CHash where
     arbitrary = CHash . B64.encode . B8.pack <$> vectorOf 64 arbitrary


### PR DESCRIPTION
## Description

As it stands, the Arbitrary instances for data types in `ssc` all exist in `ssc` when they should actually be exposed from a separate package, `ssc-test`.

In addition to this, `Pos.Arbitrary.Ssc` was actually used within `Pos.Ssc.Worker`. It was used to [generate a random Opening](https://github.com/input-output-hk/cardano-sl/blob/develop/ssc/src/Pos/Ssc/Worker.hs#L235) in the event that we call [`onNewSlotOpening`](https://github.com/input-output-hk/cardano-sl/blob/develop/ssc/src/Pos/Ssc/Worker.hs#L206) while passing an instance of [`SscOpeningParams`](https://github.com/input-output-hk/cardano-sl/blob/develop/ssc/src/Pos/Ssc/Behavior.hs#L36) constructed with [`SscOpeningWrong`](https://github.com/input-output-hk/cardano-sl/blob/develop/ssc/src/Pos/Ssc/Behavior.hs#L39). This was changed not only because the `Arbitrary` instance deterministically generated an `Opening` (does anyone know whether there was any kind of security risk in this?), but also because `ssc` can't depend on `ssc-test` (circular dependency).

## Linked issue

[https://iohk.myjetbrains.com/youtrack/issue/CDEC-427](https://iohk.myjetbrains.com/youtrack/issue/CDEC-427)
## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
