### PR TITLE
Matt noonan/size estimates

### DIFF
--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -35,6 +35,8 @@ library
                      , formatting
                      , hashable
                      , lens
+                     , micro-recursion-schemes
+                     , mtl
                      , safecopy
                      , safe-exceptions
                      , serokell-util

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -89,6 +89,7 @@ test-suite test
   other-modules:
                        Spec
                        Test.Pos.Binary.BiSerialize
+                       Test.Pos.Binary.BiSizeBounds
                        Test.Pos.Binary.Cbor.CborSpec
                        Test.Pos.Binary.Helpers
                        Test.Pos.Binary.Helpers.GoldenRoundTrip

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -41,6 +41,7 @@ library
                      , tagged
                      , template-haskell
                      , text
+                     , text-format
                      , th-utilities
                      , time-units
                      , universum

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -124,6 +124,7 @@ test-suite test
                      , quickcheck-instances
                      , safecopy
                      , serokell-util >= 0.1.3.4
+                     , tagged
                      , template-haskell
                      , text
                      , formatting

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -939,6 +939,7 @@ szWithCtx ctx pxy = case M.lookup (typeRep pxy) ctx of
     Nothing       -> normal
     Just override -> case override of
         SizeConstant sz -> sz
+        SizeExpression f -> f (szWithCtx ctx)
         SelectCase name -> case normal of
             Fix (CasesF cs) -> matchCase name cs
             _               -> normal
@@ -954,6 +955,8 @@ szWithCtx ctx pxy = case M.lookup (typeRep pxy) ctx of
 -- | Override mechanisms to be used with 'szWithCtx'.
 data SizeOverride
     = SizeConstant Size    -- ^ Replace with a fixed @Size@.
+    | SizeExpression ((forall a. Bi a => Proxy a -> Size) -> Size)
+                           -- ^ Recursively compute the size.
     | SelectCase   String  -- ^ Select only a specific case from a @CasesF@.
 
 -- | Simplify the given @Size@, resulting in either the simplified @Size@ or,

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -573,6 +573,7 @@ instance (Bi a) => Bi (Vector.Vector a) where
   {-# INLINE encode #-}
   decode = decodeVector
   {-# INLINE decode #-}
+  encodedSizeExpr size _ = 2 + size (Proxy @(LengthOf (Vector.Vector a))) * size (Proxy @a)
 
 ----------------------------------------------------------------------------
 -- Other types

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -863,10 +863,6 @@ instance Num b => Num (Range b) where
 instance Buildable (Range Byte) where
     build r = bprint (shown % ".." % shown) (toInteger $ lo r) (toInteger $ hi r)
 
-instance Buildable (Either Size (Range Byte)) where
-    build (Right x) = bprint build x
-    build (Left x)  = bprint build x
-
 -- | Fully evaluate a size expression by applying the given function to any
 --   suspended computations. @szEval g@ effectively turns each "thunk"
 --   of the form @TodoF f x@ into @g x@, then evaluates the result.

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -72,7 +72,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import           Data.Tagged (Tagged (..))
 import qualified Data.Text as Text
-import qualified Data.Text.Buildable
+import qualified Formatting.Buildable
 import           Data.Time.Units (Microsecond, Millisecond)
 import           Data.Typeable (TypeRep, typeRep)
 import qualified Data.Vector as Vector

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -962,7 +962,7 @@ szSimplify = cata (simplify . normalize)
     simplify = \case
         TodoF f pxy -> Left (todo f pxy)
         ValueF x    -> Right (Range { lo = x, hi = x })
-        CasesF xs   -> case sequence (map caseValue xs) of
+        CasesF xs   -> case mapM caseValue xs of
             Right xs' -> Right (Range { lo = minimum (map lo xs')
                                       , hi = maximum (map hi xs') })
             Left _  -> Left (szCases $ map (fmap toSize) xs)

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -147,6 +147,11 @@ class Typeable a => Bi a where
     decodeList :: D.Decoder s [a]
     decodeList = defaultDecodeList
 
+    -- | Generate a symbolic expression representing the size bounds for
+    --   encoded values of this type. If the size depends on sizes of other types,
+    --   the first argument should be used to compute those sizes. This allows
+    --   the user to select between different evaluation strategies and to override
+    --   the size of specific types.
     encodedSizeExpr :: (forall t. Bi t => Proxy t -> Size) -> Proxy a -> Size
     encodedSizeExpr = todo
 

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -1009,5 +1009,3 @@ szForce = cata $ \case
 
 szBounds :: Bi a => a -> Either Size (Range Byte)
 szBounds = szSimplify . szGreedy . pure
-
---szBoundsWithLength :: Bi a => Size -> a -> Bool

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -50,7 +50,6 @@ module Pos.Binary.Class.Core
     , szBounds
     ) where
 
-import           Formatting (bprint, build, shown, string, (%))
 import           Universum
 
 import qualified Codec.CBOR.Decoding as D
@@ -74,6 +73,7 @@ import           Data.Typeable (TypeRep, typeRep)
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Generic as Vector.Generic
 import           Foreign.Storable (sizeOf)
+import           Formatting (bprint, build, shown, string, (%))
 import qualified Formatting.Buildable
 import qualified GHC.Generics as G
 import           Serokell.Data.Memory.Units (Byte, fromBytes, toBytes)

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -903,7 +903,7 @@ szLazy = todo (encodedSizeExpr szLazy)
     in their 'Bi' instance.
 
 > ghci> putStrLn $ pretty $ szGreedy (Proxy @TxAux)
-> (0 + { ok=(2 + ((0 + (((1 + (2 + ((_ :: LengthOf [TxIn]) * (2 + { TxInUtxo=(2 + ((1 + 34) + { minBound=1 maxBound=5 })) })))) + (2 + ((_ :: LengthOf [TxOut]) * (0 + { ok=(2 + ((0 + ((2 + ((2 + withWordSize((((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + (((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + { minBound=1 maxBound=5 })) + { minBound=1 maxBound=9 })) })))) + (_ :: Attributes ()))) + (_ :: Vector TxInWitness))) })
+> (0 + { TxAux=(2 + ((0 + (((1 + (2 + ((_ :: LengthOf [TxIn]) * (2 + { TxInUtxo=(2 + ((1 + 34) + { minBound=1 maxBound=5 })) })))) + (2 + ((_ :: LengthOf [TxOut]) * (0 + { TxOut=(2 + ((0 + ((2 + ((2 + withWordSize((((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + (((1 + 30) + (_ :: Attributes AddrAttributes)) + 1))) + { minBound=1 maxBound=5 })) + { minBound=1 maxBound=9 })) })))) + (_ :: Attributes ()))) + (_ :: Vector TxInWitness))) })
 
 -}
 szGreedy :: Bi a => (Proxy a -> Size)
@@ -999,7 +999,7 @@ szSimplify = cata $ \case
 -- | Force any thunks in the given @Size@ expression.
 --
 -- > ghci> putStrLn $ pretty $ szForce $ szLazy (Proxy @TxAux)
--- > (0 + { ok=(2 + ((0 + (_ :: Tx)) + (_ :: Vector TxInWitness))) })
+-- > (0 + { TxAux=(2 + ((0 + (_ :: Tx)) + (_ :: Vector TxInWitness))) })
 szForce :: Size -> Size
 szForce = cata $ \case
     AddF x y -> x + y

--- a/binary/src/Pos/Binary/Class/Core.hs
+++ b/binary/src/Pos/Binary/Class/Core.hs
@@ -111,12 +111,16 @@ matchSize requestedSize lbl actualSize =
 
 -- | Compute encoded size of an integer.
 withWordSize :: (Integral s, Integral a) => s -> a
-withWordSize s =
-  if | s <= 0x17       -> 1
-     | s <= 0xff       -> 2
-     | s <= 0xffff     -> 3
-     | s <= 0xffffffff -> 5
-     | otherwise      -> 9
+withWordSize x = let s = fromIntegral x :: Integer in
+  if | s <= 0x17 &&
+       s >= (-0x18)        -> 1
+     | s <= 0xff &&
+       s >= (-0x100)       -> 2
+     | s <= 0xffff &&
+       s >= (-0x10000)     -> 3
+     | s <= 0xffffffff &&
+       s >= (-0x100000000) -> 5
+     | otherwise           -> 9
 
 ----------------------------------------
 
@@ -208,7 +212,7 @@ instance Bi Integer where
     decode = D.decodeIntegerCanonical
 
 encodedSizeRange :: forall a. (Integral a, Bounded a) => Proxy a -> Size
-encodedSizeRange _ = szCases [ mkCase "minBound" minBound
+encodedSizeRange _ = szCases [ mkCase "minBound" 0 -- min, in absolute value
                              , mkCase "maxBound" maxBound ]
   where mkCase n x = Case n (fromIntegral $ (withWordSize :: a -> Integer) x)
 

--- a/binary/src/Pos/Binary/Class/Primitive.hs
+++ b/binary/src/Pos/Binary/Class/Primitive.hs
@@ -1,5 +1,7 @@
 -- | Useful functions for serialization/deserialization.
 
+{-# LANGUAGE RankNTypes #-}
+
 module Pos.Binary.Class.Primitive
        ( serialize
        , serializeWith
@@ -27,10 +29,13 @@ module Pos.Binary.Class.Primitive
        -- * CBOR in CBOR
        , encodeKnownCborDataItem
        , encodeUnknownCborDataItem
+       , knownCborDataItemSizeExpr
+       , unknownCborDataItemSizeExpr
        , decodeKnownCborDataItem
        , decodeUnknownCborDataItem
        -- * Cyclic redundancy check
        , encodeCrcProtected
+       , encodedCrcProtectedSizeExpr
        , decodeCrcProtected
        ) where
 
@@ -54,7 +59,7 @@ import           Formatting (sformat, shown, (%))
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class.Core (Bi (..), cborError, enforceSize,
-                     toCborError)
+                     toCborError, Size, apMono, withWordSize, szCases)
 
 -- | Serialize a Haskell value to an external binary representation.
 --
@@ -221,6 +226,12 @@ encodeKnownCborDataItem = encodeUnknownCborDataItem . serialize
 encodeUnknownCborDataItem :: BSL.ByteString -> E.Encoding
 encodeUnknownCborDataItem x = E.encodeTag 24 <> encode x
 
+knownCborDataItemSizeExpr :: Size -> Size
+knownCborDataItemSizeExpr x = 2 + apMono "withWordSize" withWordSize x + x
+
+unknownCborDataItemSizeExpr :: Size -> Size
+unknownCborDataItemSizeExpr x = 2 + apMono "withWordSize" withWordSize x + x
+
 -- | Remove the the semantic tag 24 from the enclosed CBOR data item,
 -- failing if the tag cannot be found.
 decodeCborDataItemTag :: D.Decoder s ()
@@ -256,6 +267,11 @@ encodeCrcProtected x =
     E.encodeListLen 2 <> encodeUnknownCborDataItem body <> encode (crc32 body)
   where
     body = serialize x
+
+encodedCrcProtectedSizeExpr :: forall a. Bi a => (forall t. Bi t => Proxy t -> Size) -> Proxy a -> Size
+encodedCrcProtectedSizeExpr size pxy =
+    2 + unknownCborDataItemSizeExpr (size pxy)
+      + size (pure $ crc32 (serialize (error "unused" :: a)))  
 
 -- | Decodes a CBOR blob into a type `a`, checking the serialised CRC corresponds to the computed one.
 decodeCrcProtected :: forall s a. Bi a => D.Decoder s a

--- a/binary/src/Pos/Binary/Class/Primitive.hs
+++ b/binary/src/Pos/Binary/Class/Primitive.hs
@@ -59,7 +59,7 @@ import           Formatting (sformat, shown, (%))
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class.Core (Bi (..), cborError, enforceSize,
-                     toCborError, Size, apMono, withWordSize, szCases)
+                     toCborError, Size, apMono, withWordSize)
 
 -- | Serialize a Haskell value to an external binary representation.
 --

--- a/binary/src/Pos/Binary/Class/Primitive.hs
+++ b/binary/src/Pos/Binary/Class/Primitive.hs
@@ -59,7 +59,7 @@ import           Formatting (sformat, shown, (%))
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class.Core (Bi (..), Size, apMono, cborError,
-                                        enforceSize, toCborError, withWordSize)
+                     enforceSize, toCborError, withWordSize)
 
 -- | Serialize a Haskell value to an external binary representation.
 --

--- a/binary/src/Pos/Binary/Class/Primitive.hs
+++ b/binary/src/Pos/Binary/Class/Primitive.hs
@@ -58,8 +58,8 @@ import           Data.Typeable (typeOf)
 import           Formatting (sformat, shown, (%))
 import           Serokell.Data.Memory.Units (Byte)
 
-import           Pos.Binary.Class.Core (Bi (..), cborError, enforceSize,
-                     toCborError, Size, apMono, withWordSize)
+import           Pos.Binary.Class.Core (Bi (..), Size, apMono, cborError,
+                                        enforceSize, toCborError, withWordSize)
 
 -- | Serialize a Haskell value to an external binary representation.
 --
@@ -271,7 +271,7 @@ encodeCrcProtected x =
 encodedCrcProtectedSizeExpr :: forall a. Bi a => (forall t. Bi t => Proxy t -> Size) -> Proxy a -> Size
 encodedCrcProtectedSizeExpr size pxy =
     2 + unknownCborDataItemSizeExpr (size pxy)
-      + size (pure $ crc32 (serialize (error "unused" :: a)))  
+      + size (pure $ crc32 (serialize (error "unused" :: a)))
 
 -- | Decodes a CBOR blob into a type `a`, checking the serialised CRC corresponds to the computed one.
 decodeCrcProtected :: forall s a. Bi a => D.Decoder s a

--- a/binary/src/Pos/Binary/Class/TH.hs
+++ b/binary/src/Pos/Binary/Class/TH.hs
@@ -497,7 +497,10 @@ deriveSimpleBiInternal predsMB headTy constrs = do
         lam1E (varP size) $
             lam1E (varP pxy) $ do
                 [| $(return $ LitE $ IntegerL $ if length filteredConstrs > 1 then 1 else 0)
-                   + Bi.szCases $(fmap ListE (sequence $ imap encodedSizeExprConstr filteredConstrs)) |]
+                   + Bi.szCases $(
+                    fmap ListE (sequence $
+                                imap (\idx ctor -> [| Bi.Case "ok" $(encodedSizeExprConstr idx ctor) |])
+                                filteredConstrs)) |]
 
     encodedSizeExprConstr :: Int -> Cons -> Q Exp
     encodedSizeExprConstr _ (Cons _ cFields) = do

--- a/binary/src/Pos/Binary/Class/TH.hs
+++ b/binary/src/Pos/Binary/Class/TH.hs
@@ -508,7 +508,7 @@ deriveSimpleBiInternal predsMB headTy constrs = do
           --count = length cFields + (if length filteredConstrs > 1 then 1 else 0)
           extraBytes = 2 -- error "MN TODO"
       [| $((pure . LitE . IntegerL) extraBytes) + sum $(ListE <$> fields) |] -- MN TODO: also add length and, when needed, Word8 tag
-      
+
     encodedSizeExprField :: Field -> Q Exp
     encodedSizeExprField Field{..} = do
         (_, fTy) <- expToNameAndType fFieldAndType

--- a/binary/src/Pos/Binary/Class/TH.hs
+++ b/binary/src/Pos/Binary/Class/TH.hs
@@ -505,9 +505,8 @@ deriveSimpleBiInternal predsMB headTy constrs = do
     encodedSizeExprConstr :: Int -> Cons -> Q Exp
     encodedSizeExprConstr _ (Cons _ cFields) = do
       let fields = mapM encodedSizeExprField cFields
-          --count = length cFields + (if length filteredConstrs > 1 then 1 else 0)
-          extraBytes = 2 -- error "MN TODO"
-      [| $((pure . LitE . IntegerL) extraBytes) + sum $(ListE <$> fields) |] -- MN TODO: also add length and, when needed, Word8 tag
+          extraBytes = 2
+      [| $((pure . LitE . IntegerL) extraBytes) + sum $(ListE <$> fields) |]
 
     encodedSizeExprField :: Field -> Q Exp
     encodedSizeExprField Field{..} = do

--- a/binary/src/Pos/Binary/Class/TH.hs
+++ b/binary/src/Pos/Binary/Class/TH.hs
@@ -499,7 +499,8 @@ deriveSimpleBiInternal predsMB headTy constrs = do
                 [| $(return $ LitE $ IntegerL $ if length filteredConstrs > 1 then 1 else 0)
                    + Bi.szCases $(
                     fmap ListE (sequence $
-                                imap (\idx ctor -> [| Bi.Case "ok" $(encodedSizeExprConstr idx ctor) |])
+                                imap (\idx ctor -> [| Bi.Case $(pure $ LitE $ StringL $ show (cName ctor))
+                                                             $(encodedSizeExprConstr idx ctor) |])
                                 filteredConstrs)) |]
 
     encodedSizeExprConstr :: Int -> Cons -> Q Exp

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -1,165 +1,80 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Test.Pos.Binary.BiSizeBounds
     ( tests
     ) where
 
-import           Formatting (bprint, build)
 import           Pos.Binary.Class
 import           Universum
 
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
-import           Data.Map (Map)
-import qualified Data.Map as M
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Tagged (Tagged (..))
-import           Data.Text.Lazy (unpack)
-import           Data.Text.Lazy.Builder (toLazyText)
-import           Data.Typeable (TypeRep, typeRep)
-import           Hedgehog (Gen, Group (..), Property, annotate, failure,
-                           forAllWith, property, success)
-import qualified Hedgehog as H
+import           Data.Typeable (typeRep)
+import           Hedgehog (Group (..), checkParallel)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Serokell.Data.Memory.Units (Byte)
-
-bshow :: Buildable a => a -> String
-bshow = unpack . toLazyText . bprint build
-
--- | Configuration for a single test case.
-data TestConfig a = TestConfig
-    { debug    :: a -> String      -- ^ Pretty-print values
-    , lengthOf :: Maybe (a -> Int) -- ^ Compute the length of a value
-    , lengthTy :: TypeRep         -- ^ TypeRep used to represent the length.
-    , gen      :: Gen a           -- ^ Generator
-    , precise  :: Bool            -- ^ Must estimates be exact?
-    }
-
--- | Default configuration, for @Buildable@ types.
-cfg :: forall a. (Typeable a, Buildable a) => TestConfig a
-cfg = TestConfig { debug    = bshow
-                 , lengthOf = Nothing
-                 , lengthTy = typeRep (Proxy @(LengthOf a))
-                 , gen      = Gen.discard
-                 , precise  = False
-                 }
-
--- | Default configuration, for @Show@able types.
-scfg :: forall a. (Typeable a, Show a) => TestConfig a
-scfg = TestConfig { debug    = show
-                  , lengthOf = Nothing
-                  , lengthTy = typeRep (Proxy @(LengthOf a))
-                  , gen      = Gen.discard
-                  , precise  = False
-                  }
-
-runTest :: forall a. Bi a => TestConfig a -> Property
-runTest TestConfig{..} = property $ do
-    x <- forAllWith debug gen
-
-    let ctx = case lengthOf of
-            Nothing  -> []
-            Just len -> [ (lengthTy, SizeConstant $ fromIntegral (len x)) ]
-
-        badBounds sz bounds = do
-            annotate ("Computed bounds: " <> bshow bounds)
-            annotate ("Actual size:     " <> show sz)
-            annotate ("Value: " <> debug x)
-            failure
-
-    case szVerify (M.fromList ctx) x of
-        Exact -> success
-        WithinBounds _ _  | not precise -> success
-        WithinBounds sz bounds -> badBounds sz bounds
-        BoundsAreSymbolic bounds -> do
-            annotate ("Bounds are symbolic: " <> bshow bounds)
-            failure
-        OutOfBounds sz bounds -> badBounds sz bounds
-
--- | The possible results from @szVerify@, describing various ways
---   a size can or cannot be found within a certain range.
-data ComparisonResult
-    = Exact                          -- ^ Size matched the bounds, and the bounds were exact.
-    | WithinBounds Byte (Range Byte) -- ^ Size matched the bounds, but the bounds are not exact.
-    | BoundsAreSymbolic Size         -- ^ The bounds could not be reduced to a numerical range.
-    | OutOfBounds Byte (Range Byte)  -- ^ The size fell outside of the bounds.
-
--- | For a given value @x :: a@ with @Bi a@, check that the encoded size
---   of @x@ falls within the statically-computed size range for @a@.
-szVerify :: Bi a => Map TypeRep SizeOverride -> a -> ComparisonResult
-szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
-    Left bounds -> BoundsAreSymbolic bounds
-    Right range | lo range <= sz && sz <= hi range ->
-                      if lo range == hi range
-                      then Exact
-                      else WithinBounds sz range
-    Right range | otherwise -> OutOfBounds sz range
-  where
-    sz = fromIntegral $ BSL.length $ toLazyByteString $ encode x
+import           Test.Pos.Binary.Helpers
 
 tests :: IO Bool
 tests =
     let listOf = Gen.list (Range.linear 0 300)
         wordGen = Gen.word Range.exponentialBounded
-    in H.checkParallel $ Group "Encoded size bounds for core types."
-       $ [ ("()"     , runTest $ scfg { gen = pure (), precise = True })
-         , ("Bool"   , runTest $ cfg { gen = Gen.bool, precise = True })
-         , ("Char"   , runTest $ cfg { gen = Gen.unicode })
-         , ("Char 2" , runTest $ cfg { gen = Gen.latin1 })
-         , ("String"   , runTest $ cfg { gen = listOf Gen.unicode
+    in checkParallel $ Group "Encoded size bounds for core types."
+       $ [ ("()"     , sizeTest $ scfg { gen = pure (), precise = True })
+         , ("Bool"   , sizeTest $ cfg { gen = Gen.bool, precise = True })
+         , ("Char"   , sizeTest $ cfg { gen = Gen.unicode })
+         , ("Char 2" , sizeTest $ cfg { gen = Gen.latin1 })
+         , ("String"   , sizeTest $ cfg { gen = listOf Gen.unicode
                                               , lengthOf = Just length
                                               , lengthTy = typeRep (Proxy @(LengthOf [Char])) })
-         , ("String 2" , runTest $ cfg { gen = listOf Gen.latin1
+         , ("String 2" , sizeTest $ cfg { gen = listOf Gen.latin1
                                               , lengthOf = Just length
                                               , lengthTy = typeRep (Proxy @(LengthOf [Char])) })
-         , ("Word"   , runTest $ cfg { gen = Gen.word   Range.exponentialBounded })
-         , ("Word8"  , runTest $ cfg { gen = Gen.word8  Range.exponentialBounded })
-         , ("Word16" , runTest $ cfg { gen = Gen.word16 Range.exponentialBounded })
-         , ("Word32" , runTest $ cfg { gen = Gen.word32 Range.exponentialBounded })
-         , ("Word64" , runTest $ cfg { gen = Gen.word64 Range.exponentialBounded })
-         , ("Int"    , runTest $ cfg { gen = Gen.int    Range.exponentialBounded })
-         , ("Float"  , runTest $ cfg { gen = Gen.float (Range.exponentialFloat (-1000000) 1000000) })
-         , ("Int32"  , runTest $ cfg { gen = Gen.int32  Range.exponentialBounded })
-         , ("Int64"  , runTest $ cfg { gen = Gen.int64  Range.exponentialBounded })
-         , ("Tagged () Word32", runTest $ (scfg :: TestConfig (Tagged () Word32))
+         , ("Word"   , sizeTest $ cfg { gen = Gen.word   Range.exponentialBounded })
+         , ("Word8"  , sizeTest $ cfg { gen = Gen.word8  Range.exponentialBounded })
+         , ("Word16" , sizeTest $ cfg { gen = Gen.word16 Range.exponentialBounded })
+         , ("Word32" , sizeTest $ cfg { gen = Gen.word32 Range.exponentialBounded })
+         , ("Word64" , sizeTest $ cfg { gen = Gen.word64 Range.exponentialBounded })
+         , ("Int"    , sizeTest $ cfg { gen = Gen.int    Range.exponentialBounded })
+         , ("Float"  , sizeTest $ cfg { gen = Gen.float (Range.exponentialFloat (-1000000) 1000000) })
+         , ("Int32"  , sizeTest $ cfg { gen = Gen.int32  Range.exponentialBounded })
+         , ("Int64"  , sizeTest $ cfg { gen = Gen.int64  Range.exponentialBounded })
+         , ("Tagged () Word32", sizeTest $ (scfg @(Tagged () Word32))
                { gen = Tagged <$> Gen.word32 Range.exponentialBounded })
          , ("(Char, Bool)",
-               runTest $ scfg { gen = (,) <$> Gen.unicode <*> Gen.bool })
+               sizeTest $ scfg { gen = (,) <$> Gen.unicode <*> Gen.bool })
          , ("(Char, Char, Bool)",
-               runTest $ scfg { gen = ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool) })
+               sizeTest $ scfg { gen = ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool) })
          , ("(Char, Char, Bool, Bool)",
-               runTest $ scfg { gen = ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool) })
-         , ("ByteString"     , runTest $ (scfg :: TestConfig BS.ByteString)
+               sizeTest $ scfg { gen = ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool) })
+         , ("ByteString"     , sizeTest $ (scfg @BS.ByteString)
                { debug = show . (BS.unpack :: BS.ByteString -> [Word8])
                , lengthOf = Just (fromIntegral . BS.length)
                , gen = Gen.bytes (Range.linear 0 1000) })
-         , ("Lazy.ByteString", runTest $ (scfg :: TestConfig BSL.ByteString)
-               { debug = show . (BSL.unpack :: BSL.ByteString -> [Word8])
-               , lengthOf = Just (fromIntegral . BSL.length)
-               , gen = BSL.fromStrict <$> Gen.bytes (Range.linear 0 1000) })
-         , ("Text", runTest $ cfg
+         , ("Lazy.ByteString", sizeTest $ (scfg @LBS.ByteString)
+               { debug = show . (LBS.unpack :: LBS.ByteString -> [Word8])
+               , lengthOf = Just (fromIntegral . LBS.length)
+               , gen = LBS.fromStrict <$> Gen.bytes (Range.linear 0 1000) })
+         , ("Text", sizeTest $ cfg
                { lengthOf = Just length
                , lengthTy = typeRep (Proxy @(LengthOf [Char]))
                , gen = Gen.text (Range.linear 0 1000) Gen.latin1 })
-         , ("Text 2", runTest $ cfg
+         , ("Text 2", sizeTest $ cfg
                { lengthOf = Just length
                , lengthTy = typeRep (Proxy @(LengthOf [Char]))
                , gen = Gen.text (Range.linear 0 1000) Gen.unicode })
-         , ("[Bool]"       , runTest $ scfg
+         , ("[Bool]"       , sizeTest $ scfg
                { gen = listOf Gen.bool
                , lengthOf = Just length
                , precise = True})
-         , ("NonEmpty Bool", runTest $ scfg
+         , ("NonEmpty Bool", sizeTest $ scfg
                { gen = listOf Gen.bool
                , lengthOf = Just length
                , precise = True })
-         , ("Either Bool Word", runTest $ (scfg :: TestConfig (Either Bool Word))
+         , ("Either Bool Word", sizeTest $ (scfg @(Either Bool Word))
                { gen = Left  <$> Gen.bool })
-         , ("Either Bool Word", runTest $ (scfg :: TestConfig (Either Bool Word))
+         , ("Either Bool Word", sizeTest $ (scfg @(Either Bool Word))
                { gen = Right <$> wordGen })
-         , ("Maybe Word"      , runTest $ cfg { gen = wordGen })
+         , ("Maybe Word"      , sizeTest $ cfg { gen = wordGen })
          ]
 

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Pos.Binary.BiSizeBounds
+    ( tests
+    ) where
+
+import           Formatting (bprint, build)
+import           Pos.Binary.Class
+import           Universum
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Map (Map)
+import qualified Data.Map as M
+import           Data.Text.Lazy (unpack)
+import           Data.Text.Lazy.Builder (toLazyText)
+import           Data.Typeable (TypeRep, typeRep)
+import           Hedgehog (Gen, Group (..), Property, annotate, failure,
+                           forAllWith, property, success)
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import           Serokell.Data.Memory.Units (Byte)
+
+bshow :: Buildable a => a -> String
+bshow = unpack . toLazyText . bprint build
+
+testSizeBounds :: (Buildable a, Bi a) => Gen a -> Property
+testSizeBounds = testSizeBoundsWithBuilder bshow
+
+testListSizeBounds :: (Buildable [a], Bi [a]) => Gen a -> Property
+testListSizeBounds = testSizeBounds . Gen.list (Range.linear 0 300)
+
+testSizeBoundsWithBuilder :: Bi a => (a -> String) -> Gen a -> Property
+testSizeBoundsWithBuilder debug gen = property $ do
+    x <- forAllWith debug gen
+    case szVerify x of
+        WithinBounds -> success
+        BoundsAreSymbolic bounds -> do
+            annotate ("Bounds are symbolic: " <> bshow bounds)
+            failure
+        OutOfBounds sz bounds -> do
+            annotate ("Computed bounds: " <> bshow bounds)
+            annotate ("Actual size:     " <> show sz)
+            annotate ("Value: " <> debug x)
+            failure
+
+testSizeBoundsWithLength :: forall a. (Buildable a, Bi a) => (a -> Int) -> Gen a -> Property
+testSizeBoundsWithLength lengthOf gen = property $ do
+    x <- forAllWith bshow gen
+    let ctx = M.fromList [ (typeRep (Proxy @(LengthOf a)),
+                            SizeConstant $ fromIntegral (lengthOf x)) ]
+    case szVerifyCtx ctx x of
+        WithinBounds -> success
+        BoundsAreSymbolic bounds -> do
+            annotate ("Bounds are symbolic: " <> bshow bounds)
+            failure
+        OutOfBounds sz bounds -> do
+            annotate ("Computed bounds: " <> bshow bounds)
+            annotate ("Actual size:     " <> show sz)
+            annotate ("Value: " <> bshow x)
+            failure
+
+encodedSize :: Bi a => a -> Byte
+encodedSize = fromIntegral . BSL.length . toLazyByteString . encode
+
+data ComparisonResult
+    = WithinBounds
+    | BoundsAreSymbolic Size
+    | OutOfBounds Byte (Range Byte)
+
+{-
+instance Show ComparisonResult where
+    show = \case
+        WithinBounds         -> "WithinBounds"
+        BoundsAreSymbolic sz -> "BoundsAreSymbolic " <> bshow sz
+        OutOfBounds sz range -> "OutOfBounds " <> show sz <> " " <> bshow range
+-}
+
+szVerify :: Bi a => a -> ComparisonResult
+szVerify = szVerifyCtx (M.fromList [])
+
+szVerifyCtx :: Bi a => Map TypeRep SizeOverride -> a -> ComparisonResult
+szVerifyCtx ctx x = case szSimplify (szWithCtx ctx (pure x)) of
+    Left bounds -> BoundsAreSymbolic bounds
+    Right range | lo range <= sz && sz <= hi range -> WithinBounds
+    Right range | otherwise -> OutOfBounds sz range
+  where
+    sz = encodedSize x
+
+tests :: IO Bool
+tests =
+    H.checkParallel $ Group "Encoded size bounds for core types."
+    $ [ ("()"     , testSizeBoundsWithBuilder (const "()") (pure ()))
+      , ("Bool"   , testSizeBounds Gen.bool)
+      , ("Char"   , testSizeBounds Gen.unicode)
+      , ("Char 2" , testSizeBounds Gen.latin1)
+      , ("String" , testListSizeBounds Gen.unicode)
+      , ("String 2" , testListSizeBounds Gen.latin1)
+      , ("Word"   , testSizeBounds (Gen.word   Range.exponentialBounded))
+      , ("Word8"  , testSizeBounds (Gen.word8  Range.exponentialBounded))
+      , ("Word16" , testSizeBounds (Gen.word16 Range.exponentialBounded))
+      , ("Word32" , testSizeBounds (Gen.word32 Range.exponentialBounded))
+      , ("Word64" , testSizeBounds (Gen.word64 Range.exponentialBounded))
+      , ("Int"    , testSizeBounds (Gen.int    Range.exponentialBounded))
+      , ("Float"  , testSizeBounds (Gen.float  (Range.exponentialFloat 0 100000)))
+      , ("Int32"  , testSizeBounds (Gen.int32  Range.exponentialBounded))
+      , ("Int64"  , testSizeBounds (Gen.int64  Range.exponentialBounded))
+      -- , ("Tagged _ Char", testSizeBounds (Tagged <$> Gen.unicode))
+      , ("(Char, Bool)", testSizeBoundsWithBuilder
+                           (\(a,b) -> "(" <> bshow a <> "," <> bshow b <> ")")
+                           ((,) <$> Gen.unicode <*> Gen.bool))
+      , ("(Char, Char, Bool)", testSizeBoundsWithBuilder
+                               (\(a,b,c) -> "(" <> bshow a <> "," <> bshow b <> "," <> bshow c <> ")")
+                               ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool))
+      , ("(Char, Char, Bool, Bool)", testSizeBoundsWithBuilder
+                               (\(a,b,c,d) -> "(" <> bshow a <> "," <> bshow b <> "," <> bshow c <> "," <> bshow d <> ")")
+                               ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool))
+      , ("ByteString"     , testSizeBoundsWithBuilder (show . BS.unpack)  (Gen.bytes (Range.linear 0 1000)))
+      , ("Lazy.ByteString", testSizeBoundsWithBuilder (show . BSL.unpack) (BSL.fromStrict <$> Gen.bytes (Range.linear 0 1000)))
+      , ("Text"           , testSizeBoundsWithLength length (Gen.text (Range.linear 0 1000) Gen.latin1))
+      , ("Text 2"         , testSizeBoundsWithLength length (Gen.text (Range.linear 0 1000) Gen.unicode))
+      --, ("[Word16]"       , testListSizeBounds (Gen.word16 Range.exponentialBounded))
+      --, ("NonEmpty Word16"       , testListSizeBounds (Gen.word16 Range.exponentialBounded))
+      --, ("Either Char Bool"  , testSizeBoundsWithBuilder (either bshow bshow) (Left <$> Gen.unicode))
+      --, ("Either Char Bool 2", testSizeBoundsWithBuilder (either bshow bshow) (Right <$> Gen.bool))
+      , ("Maybe Char"     , testSizeBounds (Gen.maybe Gen.unicode))
+      , ("Maybe Char 2"   , testSizeBounds (Gen.maybe Gen.latin1))
+      ]
+

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Test.Pos.Binary.BiSizeBounds
     ( tests
@@ -13,6 +15,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Map (Map)
 import qualified Data.Map as M
+import           Data.Tagged (Tagged (..))
 import           Data.Text.Lazy (unpack)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Typeable (TypeRep, typeRep)
@@ -26,106 +29,137 @@ import           Serokell.Data.Memory.Units (Byte)
 bshow :: Buildable a => a -> String
 bshow = unpack . toLazyText . bprint build
 
-testSizeBounds :: (Buildable a, Bi a) => Gen a -> Property
-testSizeBounds = testSizeBoundsWithBuilder bshow
+-- | Configuration for a single test case.
+data TestConfig a = TestConfig
+    { debug    :: a -> String      -- ^ Pretty-print values
+    , lengthOf :: Maybe (a -> Int) -- ^ Compute the length of a value
+    , lengthTy :: TypeRep         -- ^ TypeRep used to represent the length.
+    , gen      :: Gen a           -- ^ Generator
+    , precise  :: Bool            -- ^ Must estimates be exact?
+    }
 
-testListSizeBounds :: (Buildable [a], Bi [a]) => Gen a -> Property
-testListSizeBounds = testSizeBounds . Gen.list (Range.linear 0 300)
+-- | Default configuration, for @Buildable@ types.
+cfg :: forall a. (Typeable a, Buildable a) => TestConfig a
+cfg = TestConfig { debug    = bshow
+                 , lengthOf = Nothing
+                 , lengthTy = typeRep (Proxy @(LengthOf a))
+                 , gen      = Gen.discard
+                 , precise  = False
+                 }
 
-testSizeBoundsWithBuilder :: Bi a => (a -> String) -> Gen a -> Property
-testSizeBoundsWithBuilder debug gen = property $ do
+-- | Default configuration, for @Show@able types.
+scfg :: forall a. (Typeable a, Show a) => TestConfig a
+scfg = TestConfig { debug    = show
+                  , lengthOf = Nothing
+                  , lengthTy = typeRep (Proxy @(LengthOf a))
+                  , gen      = Gen.discard
+                  , precise  = False
+                  }
+
+runTest :: forall a. Bi a => TestConfig a -> Property
+runTest TestConfig{..} = property $ do
     x <- forAllWith debug gen
-    case szVerify x of
-        WithinBounds -> success
-        BoundsAreSymbolic bounds -> do
-            annotate ("Bounds are symbolic: " <> bshow bounds)
-            failure
-        OutOfBounds sz bounds -> do
+
+    let ctx = case lengthOf of
+            Nothing  -> []
+            Just len -> [ (lengthTy, SizeConstant $ fromIntegral (len x)) ]
+
+        badBounds sz bounds = do
             annotate ("Computed bounds: " <> bshow bounds)
             annotate ("Actual size:     " <> show sz)
             annotate ("Value: " <> debug x)
             failure
 
-testSizeBoundsWithLength :: forall a. (Buildable a, Bi a) => (a -> Int) -> Gen a -> Property
-testSizeBoundsWithLength lengthOf gen = property $ do
-    x <- forAllWith bshow gen
-    let ctx = M.fromList [ (typeRep (Proxy @(LengthOf a)),
-                            SizeConstant $ fromIntegral (lengthOf x)) ]
-    case szVerifyCtx ctx x of
-        WithinBounds -> success
+    case szVerify (M.fromList ctx) x of
+        Exact -> success
+        WithinBounds _ _  | not precise -> success
+        WithinBounds sz bounds -> badBounds sz bounds
         BoundsAreSymbolic bounds -> do
             annotate ("Bounds are symbolic: " <> bshow bounds)
             failure
-        OutOfBounds sz bounds -> do
-            annotate ("Computed bounds: " <> bshow bounds)
-            annotate ("Actual size:     " <> show sz)
-            annotate ("Value: " <> bshow x)
-            failure
+        OutOfBounds sz bounds -> badBounds sz bounds
 
-encodedSize :: Bi a => a -> Byte
-encodedSize = fromIntegral . BSL.length . toLazyByteString . encode
-
+-- | The possible results from @szVerify@, describing various ways
+--   a size can or cannot be found within a certain range.
 data ComparisonResult
-    = WithinBounds
-    | BoundsAreSymbolic Size
-    | OutOfBounds Byte (Range Byte)
+    = Exact                          -- ^ Size matched the bounds, and the bounds were exact.
+    | WithinBounds Byte (Range Byte) -- ^ Size matched the bounds, but the bounds are not exact.
+    | BoundsAreSymbolic Size         -- ^ The bounds could not be reduced to a numerical range.
+    | OutOfBounds Byte (Range Byte)  -- ^ The size fell outside of the bounds.
 
-{-
-instance Show ComparisonResult where
-    show = \case
-        WithinBounds         -> "WithinBounds"
-        BoundsAreSymbolic sz -> "BoundsAreSymbolic " <> bshow sz
-        OutOfBounds sz range -> "OutOfBounds " <> show sz <> " " <> bshow range
--}
-
-szVerify :: Bi a => a -> ComparisonResult
-szVerify = szVerifyCtx (M.fromList [])
-
-szVerifyCtx :: Bi a => Map TypeRep SizeOverride -> a -> ComparisonResult
-szVerifyCtx ctx x = case szSimplify (szWithCtx ctx (pure x)) of
+-- | For a given value @x :: a@ with @Bi a@, check that the encoded size
+--   of @x@ falls within the statically-computed size range for @a@.
+szVerify :: Bi a => Map TypeRep SizeOverride -> a -> ComparisonResult
+szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
     Left bounds -> BoundsAreSymbolic bounds
-    Right range | lo range <= sz && sz <= hi range -> WithinBounds
+    Right range | lo range <= sz && sz <= hi range ->
+                      if lo range == hi range
+                      then Exact
+                      else WithinBounds sz range
     Right range | otherwise -> OutOfBounds sz range
   where
-    sz = encodedSize x
+    sz = fromIntegral $ BSL.length $ toLazyByteString $ encode x
 
 tests :: IO Bool
 tests =
-    H.checkParallel $ Group "Encoded size bounds for core types."
-    $ [ ("()"     , testSizeBoundsWithBuilder (const "()") (pure ()))
-      , ("Bool"   , testSizeBounds Gen.bool)
-      , ("Char"   , testSizeBounds Gen.unicode)
-      , ("Char 2" , testSizeBounds Gen.latin1)
-      , ("String" , testListSizeBounds Gen.unicode)
-      , ("String 2" , testListSizeBounds Gen.latin1)
-      , ("Word"   , testSizeBounds (Gen.word   Range.exponentialBounded))
-      , ("Word8"  , testSizeBounds (Gen.word8  Range.exponentialBounded))
-      , ("Word16" , testSizeBounds (Gen.word16 Range.exponentialBounded))
-      , ("Word32" , testSizeBounds (Gen.word32 Range.exponentialBounded))
-      , ("Word64" , testSizeBounds (Gen.word64 Range.exponentialBounded))
-      , ("Int"    , testSizeBounds (Gen.int    Range.exponentialBounded))
-      , ("Float"  , testSizeBounds (Gen.float  (Range.exponentialFloat 0 100000)))
-      , ("Int32"  , testSizeBounds (Gen.int32  Range.exponentialBounded))
-      , ("Int64"  , testSizeBounds (Gen.int64  Range.exponentialBounded))
-      -- , ("Tagged _ Char", testSizeBounds (Tagged <$> Gen.unicode))
-      , ("(Char, Bool)", testSizeBoundsWithBuilder
-                           (\(a,b) -> "(" <> bshow a <> "," <> bshow b <> ")")
-                           ((,) <$> Gen.unicode <*> Gen.bool))
-      , ("(Char, Char, Bool)", testSizeBoundsWithBuilder
-                               (\(a,b,c) -> "(" <> bshow a <> "," <> bshow b <> "," <> bshow c <> ")")
-                               ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool))
-      , ("(Char, Char, Bool, Bool)", testSizeBoundsWithBuilder
-                               (\(a,b,c,d) -> "(" <> bshow a <> "," <> bshow b <> "," <> bshow c <> "," <> bshow d <> ")")
-                               ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool))
-      , ("ByteString"     , testSizeBoundsWithBuilder (show . BS.unpack)  (Gen.bytes (Range.linear 0 1000)))
-      , ("Lazy.ByteString", testSizeBoundsWithBuilder (show . BSL.unpack) (BSL.fromStrict <$> Gen.bytes (Range.linear 0 1000)))
-      , ("Text"           , testSizeBoundsWithLength length (Gen.text (Range.linear 0 1000) Gen.latin1))
-      , ("Text 2"         , testSizeBoundsWithLength length (Gen.text (Range.linear 0 1000) Gen.unicode))
-      --, ("[Word16]"       , testListSizeBounds (Gen.word16 Range.exponentialBounded))
-      --, ("NonEmpty Word16"       , testListSizeBounds (Gen.word16 Range.exponentialBounded))
-      --, ("Either Char Bool"  , testSizeBoundsWithBuilder (either bshow bshow) (Left <$> Gen.unicode))
-      --, ("Either Char Bool 2", testSizeBoundsWithBuilder (either bshow bshow) (Right <$> Gen.bool))
-      , ("Maybe Char"     , testSizeBounds (Gen.maybe Gen.unicode))
-      , ("Maybe Char 2"   , testSizeBounds (Gen.maybe Gen.latin1))
-      ]
+    let listOf = Gen.list (Range.linear 0 300)
+        wordGen = Gen.word Range.exponentialBounded
+    in H.checkParallel $ Group "Encoded size bounds for core types."
+       $ [ ("()"     , runTest $ scfg { gen = pure (), precise = True })
+         , ("Bool"   , runTest $ cfg { gen = Gen.bool, precise = True })
+         , ("Char"   , runTest $ cfg { gen = Gen.unicode })
+         , ("Char 2" , runTest $ cfg { gen = Gen.latin1 })
+         , ("String"   , runTest $ cfg { gen = listOf Gen.unicode
+                                              , lengthOf = Just length
+                                              , lengthTy = typeRep (Proxy @(LengthOf [Char])) })
+         , ("String 2" , runTest $ cfg { gen = listOf Gen.latin1
+                                              , lengthOf = Just length
+                                              , lengthTy = typeRep (Proxy @(LengthOf [Char])) })
+         , ("Word"   , runTest $ cfg { gen = Gen.word   Range.exponentialBounded })
+         , ("Word8"  , runTest $ cfg { gen = Gen.word8  Range.exponentialBounded })
+         , ("Word16" , runTest $ cfg { gen = Gen.word16 Range.exponentialBounded })
+         , ("Word32" , runTest $ cfg { gen = Gen.word32 Range.exponentialBounded })
+         , ("Word64" , runTest $ cfg { gen = Gen.word64 Range.exponentialBounded })
+         , ("Int"    , runTest $ cfg { gen = Gen.int    Range.exponentialBounded })
+         , ("Float"  , runTest $ cfg { gen = Gen.float (Range.exponentialFloat (-1000000) 1000000) })
+         , ("Int32"  , runTest $ cfg { gen = Gen.int32  Range.exponentialBounded })
+         , ("Int64"  , runTest $ cfg { gen = Gen.int64  Range.exponentialBounded })
+         , ("Tagged () Word32", runTest $ (scfg :: TestConfig (Tagged () Word32))
+               { gen = Tagged <$> Gen.word32 Range.exponentialBounded })
+         , ("(Char, Bool)",
+               runTest $ scfg { gen = (,) <$> Gen.unicode <*> Gen.bool })
+         , ("(Char, Char, Bool)",
+               runTest $ scfg { gen = ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool) })
+         , ("(Char, Char, Bool, Bool)",
+               runTest $ scfg { gen = ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool) })
+         , ("ByteString"     , runTest $ (scfg :: TestConfig BS.ByteString)
+               { debug = show . (BS.unpack :: BS.ByteString -> [Word8])
+               , lengthOf = Just (fromIntegral . BS.length)
+               , gen = Gen.bytes (Range.linear 0 1000) })
+         , ("Lazy.ByteString", runTest $ (scfg :: TestConfig BSL.ByteString)
+               { debug = show . (BSL.unpack :: BSL.ByteString -> [Word8])
+               , lengthOf = Just (fromIntegral . BSL.length)
+               , gen = BSL.fromStrict <$> Gen.bytes (Range.linear 0 1000) })
+         , ("Text", runTest $ cfg
+               { lengthOf = Just length
+               , lengthTy = typeRep (Proxy @(LengthOf [Char]))
+               , gen = Gen.text (Range.linear 0 1000) Gen.latin1 })
+         , ("Text 2", runTest $ cfg
+               { lengthOf = Just length
+               , lengthTy = typeRep (Proxy @(LengthOf [Char]))
+               , gen = Gen.text (Range.linear 0 1000) Gen.unicode })
+         , ("[Bool]"       , runTest $ scfg
+               { gen = listOf Gen.bool
+               , lengthOf = Just length
+               , precise = True})
+         , ("NonEmpty Bool", runTest $ scfg
+               { gen = listOf Gen.bool
+               , lengthOf = Just length
+               , precise = True })
+         , ("Either Bool Word", runTest $ (scfg :: TestConfig (Either Bool Word))
+               { gen = Left  <$> Gen.bool })
+         , ("Either Bool Word", runTest $ (scfg :: TestConfig (Either Bool Word))
+               { gen = Right <$> wordGen })
+         , ("Maybe Word"      , runTest $ cfg { gen = wordGen })
+         ]
 

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -8,6 +8,7 @@ import           Universum
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map as M
 import           Data.Tagged (Tagged (..))
 import           Data.Typeable (typeRep)
 import           Hedgehog (Group (..), checkParallel)
@@ -30,6 +31,18 @@ tests =
          , ("String 2" , sizeTest $ cfg { gen = listOf Gen.latin1
                                               , lengthOf = Just length
                                               , lengthTy = typeRep (Proxy @(LengthOf [Char])) })
+         , ("String 3" , sizeTest $ cfg { gen = listOf Gen.alpha
+                                              , lengthOf = Just length
+                                              , lengthTy = typeRep (Proxy @(LengthOf [Char]))
+                                              , addlCtx = M.fromList
+                                                  [ (typeRep (Proxy @Char), SizeConstant 1) ]
+                                              , precise = True
+                                              })
+         , ("Char 3", sizeTest $ cfg { gen = Gen.alpha
+                                     , addlCtx = M.fromList
+                                         [ (typeRep (Proxy @Char), SizeConstant 2) ]
+                                     , precise = True
+                                     })
          , ("Word"   , sizeTest $ cfg { gen = Gen.word   Range.exponentialBounded })
          , ("Word8"  , sizeTest $ cfg { gen = Gen.word8  Range.exponentialBounded })
          , ("Word16" , sizeTest $ cfg { gen = Gen.word16 Range.exponentialBounded })

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -35,7 +35,7 @@ tests =
                                               , lengthOf = Just length
                                               , lengthTy = typeRep (Proxy @(LengthOf [Char]))
                                               , addlCtx = M.fromList
-                                                  [ (typeRep (Proxy @Char), SizeConstant 1) ]
+                                                  [ (typeRep (Proxy @[Char]), SelectCase "minChar") ]
                                               , precise = True
                                               })
          , ("Char 3", sizeTest $ cfg { gen = Gen.alpha

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -20,7 +20,6 @@ tests :: IO Bool
 tests =
     let listOf = Gen.list (Range.linear 0 300)
         longListOf = Gen.list (Range.linear 0 100000)
-        wordGen = Gen.word Range.exponentialBounded
     in checkParallel $ Group "Encoded size bounds for core types."
        $ [ ("()"     , sizeTest $ scfg { gen = pure (), precise = True })
          , ("Bool"   , sizeTest $ cfg { gen = Gen.bool, precise = True })
@@ -63,20 +62,25 @@ tests =
          , ("Int64"  , sizeTest $ cfg { gen = Gen.int64  Range.exponentialBounded })
          , ("Tagged () Word32", sizeTest $ (scfg @(Tagged () Word32))
                { gen = Tagged <$> Gen.word32 Range.exponentialBounded })
-         , ("(Char, Bool)",
-               sizeTest $ scfg { gen = (,) <$> Gen.unicode <*> Gen.bool })
-         , ("(Char, Char, Bool)",
-               sizeTest $ scfg { gen = ((,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool) })
-         , ("(Char, Char, Bool, Bool)",
-               sizeTest $ scfg { gen = ((,,,) <$> Gen.unicode <*> Gen.unicode <*> Gen.bool <*> Gen.bool) })
+         , ("(Bool, Bool)",
+               sizeTest $ scfg { gen = (,) <$> Gen.bool <*> Gen.bool
+                               , precise = True })
+         , ("(Bool, Bool, Bool)",
+               sizeTest $ scfg { gen = ((,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool)
+                               , precise = True })
+         , ("(Bool, Bool, Bool, Bool)",
+               sizeTest $ scfg { gen = ((,,,) <$> Gen.bool <*> Gen.bool <*> Gen.bool <*> Gen.bool)
+                               , precise = True})
          , ("ByteString"     , sizeTest $ (scfg @BS.ByteString)
                { debug = show . (BS.unpack :: BS.ByteString -> [Word8])
                , lengthOf = Just (fromIntegral . BS.length)
-               , gen = Gen.bytes (Range.linear 0 1000) })
+               , gen = Gen.bytes (Range.linear 0 1000)
+               , precise = True })
          , ("Lazy.ByteString", sizeTest $ (scfg @LBS.ByteString)
                { debug = show . (LBS.unpack :: LBS.ByteString -> [Word8])
                , lengthOf = Just (fromIntegral . LBS.length)
-               , gen = LBS.fromStrict <$> Gen.bytes (Range.linear 0 1000) })
+               , gen = LBS.fromStrict <$> Gen.bytes (Range.linear 0 1000)
+               , precise = True })
          , ("Text", sizeTest $ cfg
                { lengthOf = Just length
                , lengthTy = typeRep (Proxy @(LengthOf [Char]))
@@ -93,10 +97,13 @@ tests =
                { gen = listOf Gen.bool
                , lengthOf = Just length
                , precise = True })
-         , ("Either Bool Word", sizeTest $ (scfg @(Either Bool Word))
-               { gen = Left  <$> Gen.bool })
-         , ("Either Bool Word", sizeTest $ (scfg @(Either Bool Word))
-               { gen = Right <$> wordGen })
-         , ("Maybe Word"      , sizeTest $ cfg { gen = wordGen })
+         , ("Either Bool Bool", sizeTest $ (scfg @(Either Bool Bool))
+               { gen = Left  <$> Gen.bool
+               , precise = True })
+         , ("Either Bool Bool", sizeTest $ (scfg @(Either Bool Bool))
+               { gen = Right <$> Gen.bool
+               , precise = True })
+         , ("Maybe Bool"      , sizeTest $ cfg { gen = Gen.bool
+                                               , precise = True })
          ]
 

--- a/binary/test/Test/Pos/Binary/BiSizeBounds.hs
+++ b/binary/test/Test/Pos/Binary/BiSizeBounds.hs
@@ -67,6 +67,11 @@ tests =
          , ("Word32" , sizeTest $ cfg { gen = Gen.word32 Range.exponentialBounded })
          , ("Word64" , sizeTest $ cfg { gen = Gen.word64 Range.exponentialBounded })
          , ("Int"    , sizeTest $ cfg { gen = Gen.int    Range.exponentialBounded })
+         , ("Int (precision)", sizeTest $ cfg
+               { gen = Gen.int Range.exponentialBounded
+               , computedCtx = \x -> M.fromList
+                   [ (typeRep (Proxy @Int), SizeConstant $ fromIntegral (withWordSize x :: Integer)) ]
+               , precise = True })
          , ("Float"  , sizeTest $ cfg { gen = Gen.float (Range.exponentialFloat (-1000000) 1000000) })
          , ("Int32"  , sizeTest $ cfg { gen = Gen.int32  Range.exponentialBounded })
          , ("Int64"  , sizeTest $ cfg { gen = Gen.int64  Range.exponentialBounded })

--- a/binary/test/Test/Pos/Binary/Helpers.hs
+++ b/binary/test/Test/Pos/Binary/Helpers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE RankNTypes          #-}
-
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- Need this to avoid a warning on the `typeName` helper function.
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
@@ -28,6 +29,12 @@ module Test.Pos.Binary.Helpers
 
        -- * Message length
        , msgLenLimitedTest
+
+       -- * Static size estimates
+       , SizeTestConfig(..)
+       , cfg
+       , scfg
+       , sizeTest
        ) where
 
 import           Universum
@@ -35,22 +42,33 @@ import           Universum
 import           Codec.CBOR.FlatTerm (toFlatTerm, validFlatTerm)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Map (Map)
+import qualified Data.Map as M
 import           Data.SafeCopy (SafeCopy, safeGet, safePut)
 import           Data.Serialize (runGet, runPut)
-import           Data.Typeable (typeRep)
-import           Formatting (formatToString, int, (%))
+import           Data.Text.Lazy (unpack)
+import           Data.Text.Lazy.Builder (toLazyText)
+import           Data.Typeable (TypeRep, typeRep)
+import           Formatting (bprint, build, formatToString, int, (%))
+import           Hedgehog (annotate, failure, forAllWith, success)
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as HH.Gen
 import           Prelude (read)
+import           Serokell.Data.Memory.Units (Byte)
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSize, modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property, choose,
-                     conjoin, counterexample, forAll, property, resize,
-                     suchThat, vectorOf, (.&&.), (===))
+                                  conjoin, counterexample, forAll, property,
+                                  resize, suchThat, vectorOf, (.&&.), (===))
 import           Test.QuickCheck.Instances ()
 
-import           Pos.Binary.Class (AsBinaryClass (..), Bi (..), decodeFull,
-                     decodeListLenCanonicalOf, decodeUnknownCborDataItem,
-                     encodeListLen, encodeUnknownCborDataItem, serialize,
-                     serialize', unsafeDeserialize)
+import           Pos.Binary.Class (AsBinaryClass (..), Bi (..), LengthOf,
+                                   Range (..), Size, SizeOverride (..),
+                                   decodeFull, decodeListLenCanonicalOf,
+                                   decodeUnknownCborDataItem, encodeListLen,
+                                   encodeUnknownCborDataItem, serialize,
+                                   serialize', szSimplify, szWithCtx,
+                                   toLazyByteString, unsafeDeserialize)
 import           Pos.Binary.Limit (Limit (..))
 
 import           Test.Pos.Cbor.Canonicity (perturbCanonicity)
@@ -280,3 +298,88 @@ msgLenLimitedTest lim = msgLenLimitedTest' @a lim "" (const True)
 ----------------------------------------------------------------------------
 
 deriving instance Bi bi => Bi (SmallGenerator bi)
+
+----------------------------------------------------------------------------
+-- Static size estimates
+----------------------------------------------------------------------------
+
+bshow :: Buildable a => a -> String
+bshow = unpack . toLazyText . bprint build
+
+-- | Configuration for a single test case.
+data SizeTestConfig a = SizeTestConfig
+    { debug    :: a -> String      -- ^ Pretty-print values
+    , lengthOf :: Maybe (a -> Int) -- ^ Compute the length of a value
+    , lengthTy :: TypeRep         -- ^ TypeRep used to represent the length
+    , gen      :: HH.Gen a        -- ^ Generator
+    , precise  :: Bool            -- ^ Must estimates be exact?
+    , addlCtx  :: Map TypeRep SizeOverride -- ^ Additional size overrides
+    }
+
+-- | Default configuration, for @Buildable@ types.
+cfg :: forall a. (Typeable a, Buildable a) => SizeTestConfig a
+cfg = SizeTestConfig
+    { debug    = bshow
+    , lengthOf = Nothing
+    , lengthTy = typeRep (Proxy @(LengthOf a))
+    , gen      = HH.Gen.discard
+    , precise  = False
+    , addlCtx  = M.fromList []
+    }
+
+-- | Default configuration, for @Show@able types.
+scfg :: forall a. (Typeable a, Show a) => SizeTestConfig a
+scfg = SizeTestConfig
+    { debug    = show
+    , lengthOf = Nothing
+    , lengthTy = typeRep (Proxy @(LengthOf a))
+    , gen      = HH.Gen.discard
+    , precise  = False
+    , addlCtx  = M.fromList []
+    }
+
+-- | Create a test case from the given test configuration.
+sizeTest :: forall a. Bi a => SizeTestConfig a -> HH.Property
+sizeTest SizeTestConfig{..} = HH.property $ do
+    x <- forAllWith debug gen
+
+    let ctx = M.union addlCtx $ M.fromList $ case lengthOf of
+            Nothing  -> []
+            Just len -> [ (lengthTy, SizeConstant $ fromIntegral (len x)) ]
+
+        badBounds sz bounds = do
+            annotate ("Computed bounds: " <> bshow bounds)
+            annotate ("Actual size:     " <> show sz)
+            annotate ("Value: " <> debug x)
+            failure
+
+    case szVerify ctx x of
+        Exact -> success
+        WithinBounds _ _  | not precise -> success
+        WithinBounds sz bounds -> badBounds sz bounds
+        BoundsAreSymbolic bounds -> do
+            annotate ("Bounds are symbolic: " <> bshow bounds)
+            failure
+        OutOfBounds sz bounds -> badBounds sz bounds
+
+-- | The possible results from @szVerify@, describing various ways
+--   a size can or cannot be found within a certain range.
+data ComparisonResult
+    = Exact                          -- ^ Size matched the bounds, and the bounds were exact.
+    | WithinBounds Byte (Range Byte) -- ^ Size matched the bounds, but the bounds are not exact.
+    | BoundsAreSymbolic Size         -- ^ The bounds could not be reduced to a numerical range.
+    | OutOfBounds Byte (Range Byte)  -- ^ The size fell outside of the bounds.
+
+-- | For a given value @x :: a@ with @Bi a@, check that the encoded size
+--   of @x@ falls within the statically-computed size range for @a@.
+szVerify :: Bi a => Map TypeRep SizeOverride -> a -> ComparisonResult
+szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
+    Left bounds -> BoundsAreSymbolic bounds
+    Right range | lo range <= sz && sz <= hi range ->
+                      if lo range == hi range
+                      then Exact
+                      else WithinBounds sz range
+    Right range | otherwise -> OutOfBounds sz range
+  where
+    sz = fromIntegral $ LBS.length $ toLazyByteString $ encode x
+

--- a/binary/test/Test/Pos/Binary/Helpers.hs
+++ b/binary/test/Test/Pos/Binary/Helpers.hs
@@ -58,17 +58,16 @@ import           Serokell.Data.Memory.Units (Byte)
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSize, modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (arbitrary), Gen, Property, choose,
-                                  conjoin, counterexample, forAll, property,
-                                  resize, suchThat, vectorOf, (.&&.), (===))
+                     conjoin, counterexample, forAll, property, resize,
+                     suchThat, vectorOf, (.&&.), (===))
 import           Test.QuickCheck.Instances ()
 
 import           Pos.Binary.Class (AsBinaryClass (..), Bi (..), Range (..),
-                                   Size, SizeOverride (..), decodeFull,
-                                   decodeListLenCanonicalOf,
-                                   decodeUnknownCborDataItem, encodeListLen,
-                                   encodeUnknownCborDataItem, serialize,
-                                   serialize', szSimplify, szWithCtx,
-                                   toLazyByteString, unsafeDeserialize)
+                     Size, SizeOverride (..), decodeFull,
+                     decodeListLenCanonicalOf, decodeUnknownCborDataItem,
+                     encodeListLen, encodeUnknownCborDataItem, serialize,
+                     serialize', szSimplify, szWithCtx, toLazyByteString,
+                     unsafeDeserialize)
 import           Pos.Binary.Limit (Limit (..))
 
 import           Test.Pos.Cbor.Canonicity (perturbCanonicity)
@@ -383,4 +382,3 @@ szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
     Right range -> OutOfBounds sz range
   where
     sz = fromIntegral $ LBS.length $ toLazyByteString $ encode x
-

--- a/binary/test/Test/Pos/Binary/Helpers.hs
+++ b/binary/test/Test/Pos/Binary/Helpers.hs
@@ -380,7 +380,7 @@ szVerify ctx x = case szSimplify (szWithCtx ctx (pure x)) of
                       if lo range == hi range
                       then Exact
                       else WithinBounds sz range
-    Right range | otherwise -> OutOfBounds sz range
+    Right range -> OutOfBounds sz range
   where
     sz = fromIntegral $ LBS.length $ toLazyByteString $ encode x
 

--- a/binary/test/Test/Pos/Binary/Helpers.hs
+++ b/binary/test/Test/Pos/Binary/Helpers.hs
@@ -351,16 +351,21 @@ sizeTest SizeTestConfig{..} = HH.property $ do
             annotate ("Computed bounds: " <> bshow bounds)
             annotate ("Actual size:     " <> show sz)
             annotate ("Value: " <> debug x)
-            failure
 
     case szVerify ctx x of
         Exact -> success
         WithinBounds _ _  | not precise -> success
-        WithinBounds sz bounds -> badBounds sz bounds
+        WithinBounds sz bounds -> do
+            badBounds sz bounds
+            annotate "Bounds were not exact."
+            failure
         BoundsAreSymbolic bounds -> do
             annotate ("Bounds are symbolic: " <> bshow bounds)
             failure
-        OutOfBounds sz bounds -> badBounds sz bounds
+        OutOfBounds sz bounds -> do
+            badBounds sz bounds
+            annotate "Size fell outside of bounds."
+            failure
 
 -- | The possible results from @szVerify@, describing various ways
 --   a size can or cannot be found within a certain range.

--- a/binary/test/cardano-sl-binary-test.cabal
+++ b/binary/test/cardano-sl-binary-test.cabal
@@ -26,6 +26,8 @@ library
                      , cardano-sl-util-test
                      , cborg
                      , cereal
+                     , cryptonite
+                     , containers
                      , directory
                      , cryptonite
                      , filepath
@@ -37,6 +39,7 @@ library
                      , pretty-show
                      , quickcheck-instances
                      , safecopy
+                     , serokell-util
                      , template-haskell
                      , text
                      , universum

--- a/binary/test/test.hs
+++ b/binary/test/test.hs
@@ -5,6 +5,7 @@ import           Test.Hspec (hspec)
 import           Spec (spec)
 
 import qualified Test.Pos.Binary.BiSerialize
+import qualified Test.Pos.Binary.BiSizeBounds
 import           Test.Pos.Binary.Helpers (runTests)
 
 main :: IO ()
@@ -12,4 +13,5 @@ main = do
     hspec spec
     runTests
         [ Test.Pos.Binary.BiSerialize.tests
+        , Test.Pos.Binary.BiSizeBounds.tests
         ]

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -325,6 +325,7 @@ test-suite test
                      , cardano-sl-util
                      , cardano-sl-util-test
                      , containers
+                     , cryptonite
                      , deepseq
                      , ed25519
                      , formatting

--- a/core/src/Pos/Core/Common/AddrSpendingData.hs
+++ b/core/src/Pos/Core/Common/AddrSpendingData.hs
@@ -11,7 +11,7 @@ import           Data.SafeCopy (base, deriveSafeCopySimple)
 import           Formatting (bprint, build, int, (%))
 import qualified Formatting.Buildable as Buildable
 
-import           Pos.Binary.Class (Bi(..), szCases)
+import           Pos.Binary.Class (Bi(..), szCases, Case(..))
 import qualified Pos.Binary.Class as Bi
 import           Pos.Crypto.Signing (PublicKey, RedeemPublicKey)
 
@@ -92,11 +92,11 @@ instance Bi AddrSpendingData where
 
     encodedSizeExpr size _ = szCases
         [ let PubKeyASD pk = error "unused"
-          in size ((,) <$> pure (w8 0) <*> pure pk)
+          in  Case "PubKeyASD" $ size ((,) <$> pure (w8 0) <*> pure pk)
         , let ScriptASD script = error "unused"
-          in size ((,) <$> pure (w8 1) <*> pure script)
+          in  Case "ScriptASD" $ size ((,) <$> pure (w8 1) <*> pure script)
         , let RedeemASD redeemPK = error "unused"
-          in size ((,) <$> pure (w8 2) <*> pure redeemPK)
+          in  Case "RedeemASD" $ size ((,) <$> pure (w8 2) <*> pure redeemPK)
         ]
 
 -- | Type of an address. It corresponds to constructors of

--- a/core/src/Pos/Core/Common/AddrSpendingData.hs
+++ b/core/src/Pos/Core/Common/AddrSpendingData.hs
@@ -11,7 +11,7 @@ import           Data.SafeCopy (base, deriveSafeCopySimple)
 import           Formatting (bprint, build, int, (%))
 import qualified Formatting.Buildable as Buildable
 
-import           Pos.Binary.Class (Bi(..), szCases, Case(..))
+import           Pos.Binary.Class (Bi (..), Case (..), szCases)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Crypto.Signing (PublicKey, RedeemPublicKey)
 
@@ -124,8 +124,8 @@ instance Bi AddrType where
             1 -> ATScript
             2 -> ATRedeem
             tag -> ATUnknown tag
-    encodedSizeExpr _ _ = 1
-    
+    encodedSizeExpr size _ = encodedSizeExpr size (Proxy @Word8)
+
 -- | Convert 'AddrSpendingData' to the corresponding 'AddrType'.
 addrSpendingDataToType :: AddrSpendingData -> AddrType
 addrSpendingDataToType =
@@ -138,6 +138,6 @@ addrSpendingDataToType =
 
 -- Define these at the end of the file to avoid TH staging issues.
 deriveSafeCopySimple 0 'base ''AddrSpendingData
-deriveSafeCopySimple 0 'base ''AddrType -- ☃
+deriveSafeCopySimple 0 'base ''AddrType --
 
 

--- a/core/src/Pos/Core/Common/AddrSpendingData.hs
+++ b/core/src/Pos/Core/Common/AddrSpendingData.hs
@@ -138,6 +138,6 @@ addrSpendingDataToType =
 
 -- Define these at the end of the file to avoid TH staging issues.
 deriveSafeCopySimple 0 'base ''AddrSpendingData
-deriveSafeCopySimple 0 'base ''AddrType --
+deriveSafeCopySimple 0 'base ''AddrType -- ☃
 
 

--- a/core/src/Pos/Core/Common/AddrStakeDistribution.hs
+++ b/core/src/Pos/Core/Common/AddrStakeDistribution.hs
@@ -74,9 +74,9 @@ instance Bi AddrStakeDistribution where
     encodedSizeExpr size _ = szCases
         [ 1
         , let SingleKeyDistr id = error "unused"
-          in size ((,) <$> pure (w8 0) <*> pure id)
+          in size ((,) <$> pure (0 :: Word8) <*> pure id)
         , let UnsafeMultiKeyDistr distr = error "unused"
-          in size ((,) <$> pure (w8 1) <*> pure distr)
+          in size ((,) <$> pure (1 :: Word8) <*> pure distr)
         ]
 
 data MultiKeyDistrError

--- a/core/src/Pos/Core/Common/AddrStakeDistribution.hs
+++ b/core/src/Pos/Core/Common/AddrStakeDistribution.hs
@@ -72,11 +72,11 @@ instance Bi AddrStakeDistribution where
             len -> cborError $
                 "decode @AddrStakeDistribution: unexpected length " <> pretty len
     encodedSizeExpr size _ = szCases
-        [ 1
+        [ Bi.Case "BoostrapEraDistr" 1
         , let SingleKeyDistr id = error "unused"
-          in size ((,) <$> pure (0 :: Word8) <*> pure id)
+          in  Bi.Case "SingleKeyDistr" $ size ((,) <$> pure (0 :: Word8) <*> pure id)
         , let UnsafeMultiKeyDistr distr = error "unused"
-          in size ((,) <$> pure (1 :: Word8) <*> pure distr)
+          in  Bi.Case "UnsafeMultiKeyDistr" $ size ((,) <$> pure (1 :: Word8) <*> pure distr)
         ]
 
 data MultiKeyDistrError

--- a/core/src/Pos/Core/Common/AddrStakeDistribution.hs
+++ b/core/src/Pos/Core/Common/AddrStakeDistribution.hs
@@ -15,7 +15,7 @@ import           Formatting (bprint, (%))
 import qualified Formatting.Buildable as Buildable
 import           Serokell.Util (mapJson)
 
-import           Pos.Binary.Class (Bi, decode, encode)
+import           Pos.Binary.Class (Bi(..), szCases)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Crypto.Hashing (shortHashF)
 import           Pos.Util.Util (cborError, toCborError)
@@ -71,6 +71,13 @@ instance Bi AddrStakeDistribution where
                         pretty tag
             len -> cborError $
                 "decode @AddrStakeDistribution: unexpected length " <> pretty len
+    encodedSizeExpr size _ = szCases
+        [ 1
+        , let SingleKeyDistr id = error "unused"
+          in size ((,) <$> pure (w8 0) <*> pure id)
+        , let UnsafeMultiKeyDistr distr = error "unused"
+          in size ((,) <$> pure (w8 1) <*> pure distr)
+        ]
 
 data MultiKeyDistrError
     = MkdMapIsEmpty

--- a/core/src/Pos/Core/Common/AddrStakeDistribution.hs
+++ b/core/src/Pos/Core/Common/AddrStakeDistribution.hs
@@ -35,9 +35,9 @@ data AddrStakeDistribution
     -- has a value, portion of this value is stake). The constructor
     -- is unsafe because there are some predicates which must hold:
     --
-    --   the sum of portions must be @maxBound@ (basically 1);
-    --   all portions must be positive;
-    --   there must be at least 2 items, because if there is only one item,
+    -- • the sum of portions must be @maxBound@ (basically 1);
+    -- • all portions must be positive;
+    -- • there must be at least 2 items, because if there is only one item,
     -- 'SingleKeyDistr' can be used instead (which is smaller).
     deriving (Eq, Ord, Show, Generic, Typeable)
 

--- a/core/src/Pos/Core/Common/AddrStakeDistribution.hs
+++ b/core/src/Pos/Core/Common/AddrStakeDistribution.hs
@@ -15,7 +15,7 @@ import           Formatting (bprint, (%))
 import qualified Formatting.Buildable as Buildable
 import           Serokell.Util (mapJson)
 
-import           Pos.Binary.Class (Bi(..), szCases)
+import           Pos.Binary.Class (Bi (..), szCases)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Crypto.Hashing (shortHashF)
 import           Pos.Util.Util (cborError, toCborError)
@@ -35,9 +35,9 @@ data AddrStakeDistribution
     -- has a value, portion of this value is stake). The constructor
     -- is unsafe because there are some predicates which must hold:
     --
-    -- • the sum of portions must be @maxBound@ (basically 1);
-    -- • all portions must be positive;
-    -- • there must be at least 2 items, because if there is only one item,
+    --   the sum of portions must be @maxBound@ (basically 1);
+    --   all portions must be positive;
+    --   there must be at least 2 items, because if there is only one item,
     -- 'SingleKeyDistr' can be used instead (which is smaller).
     deriving (Eq, Ord, Show, Generic, Typeable)
 

--- a/core/src/Pos/Core/Common/Address.hs
+++ b/core/src/Pos/Core/Common/Address.hs
@@ -67,7 +67,7 @@ import qualified Formatting.Buildable as Buildable
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class (Bi (..), Encoding, biSize,
-                     encodeCrcProtected)
+                     encodeCrcProtected, encodeCrcProtectedSizeExpr, szCases)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Core.Common.Coin ()
 import           Pos.Core.Constants (accountGenesisIndex, wAddressGenesisIndex)
@@ -124,6 +124,10 @@ instance Bi Address where
         (addrRoot, addrAttributes, addrType) <- Bi.decodeCrcProtected
         let res = Address {..}
         pure res
+    encodedSizeExpr size pxy =
+        encodedCrcProtectedSizeExpr size ( (,,) <$> (addrRoot       <$> pxy)
+                                                <*> (addrAttributes <$> pxy)
+                                                <*> (addrType       <$> pxy) )
 
 instance Hashable Address where
     hashWithSalt s = hashWithSalt s . Bi.serialize

--- a/core/src/Pos/Core/Common/Address.hs
+++ b/core/src/Pos/Core/Common/Address.hs
@@ -67,7 +67,7 @@ import qualified Formatting.Buildable as Buildable
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Pos.Binary.Class (Bi (..), Encoding, biSize,
-                     encodeCrcProtected, encodeCrcProtectedSizeExpr, szCases)
+                     encodeCrcProtected, encodedCrcProtectedSizeExpr)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Core.Common.Coin ()
 import           Pos.Core.Constants (accountGenesisIndex, wAddressGenesisIndex)

--- a/core/src/Pos/Core/Common/BlockCount.hs
+++ b/core/src/Pos/Core/Common/BlockCount.hs
@@ -16,5 +16,6 @@ newtype BlockCount = BlockCount {getBlockCount :: Word64}
 instance Bi BlockCount where
     encode = encode . getBlockCount
     decode = BlockCount <$> decode
+    encodedSizeExpr size pxy = size (getBlockCount <$> pxy)
 
 deriveSafeCopySimple 0 'base ''BlockCount

--- a/core/src/Pos/Core/Common/Coin.hs
+++ b/core/src/Pos/Core/Common/Coin.hs
@@ -50,7 +50,8 @@ instance Bounded Coin where
 instance Bi Coin where
     encode = encode . unsafeGetCoin
     decode = Coin <$> decode
-
+    encodedSizeExpr size pxy = size (unsafeGetCoin <$> pxy)
+    
 -- | Maximal possible value of 'Coin'.
 maxCoinVal :: Word64
 maxCoinVal = 45000000000000000

--- a/core/src/Pos/Core/Common/Coin.hs
+++ b/core/src/Pos/Core/Common/Coin.hs
@@ -73,7 +73,7 @@ checkCoin (Coin c)
 coinF :: Format r (Coin -> r)
 coinF = build
 
--- | Unwraps 'Coin'. It's called  unsafe  so that people wouldn't use it
+-- | Unwraps 'Coin'. It's called “unsafe” so that people wouldn't use it
 -- willy-nilly if they want to sum coins or something. It's actually safe.
 unsafeGetCoin :: Coin -> Word64
 unsafeGetCoin = getCoin

--- a/core/src/Pos/Core/Common/Coin.hs
+++ b/core/src/Pos/Core/Common/Coin.hs
@@ -51,7 +51,7 @@ instance Bi Coin where
     encode = encode . unsafeGetCoin
     decode = Coin <$> decode
     encodedSizeExpr size pxy = size (unsafeGetCoin <$> pxy)
-    
+
 -- | Maximal possible value of 'Coin'.
 maxCoinVal :: Word64
 maxCoinVal = 45000000000000000
@@ -73,7 +73,7 @@ checkCoin (Coin c)
 coinF :: Format r (Coin -> r)
 coinF = build
 
--- | Unwraps 'Coin'. It's called “unsafe” so that people wouldn't use it
+-- | Unwraps 'Coin'. It's called  unsafe  so that people wouldn't use it
 -- willy-nilly if they want to sum coins or something. It's actually safe.
 unsafeGetCoin :: Coin -> Word64
 unsafeGetCoin = getCoin

--- a/core/src/Pos/Core/Txp/Tx.hs
+++ b/core/src/Pos/Core/Txp/Tx.hs
@@ -72,6 +72,11 @@ instance Bi Tx where
         enforceSize "Tx" 3
         UnsafeTx <$> decode <*> decode <*> decode
 
+    encodedSizeExpr size pxy = 1
+        + size (T._txInputs     <$> pxy)
+        + size (T._txOutputs    <$> pxy)
+        + size (T._txAttributes <$> pxy)
+
 instance NFData Tx
 
 -- | Specialized formatter for 'Tx'.
@@ -155,6 +160,9 @@ instance Bi TxIn where
         case tag of
             0 -> uncurry TxInUtxo <$> decodeKnownCborDataItem
             _ -> TxInUnknown tag  <$> decodeUnknownCborDataItem
+    encodedSizeExpr size pxy = szCases [ 2 + size ((,) <$> (T.txInHash  <$> pxy)
+                                                       <*> (T.txInIndex <$> pxy))
+                                       ]
 
 instance NFData TxIn
 

--- a/core/src/Pos/Core/Txp/Tx.hs
+++ b/core/src/Pos/Core/Txp/Tx.hs
@@ -160,9 +160,9 @@ instance Bi TxIn where
         case tag of
             0 -> uncurry TxInUtxo <$> decodeKnownCborDataItem
             _ -> TxInUnknown tag  <$> decodeUnknownCborDataItem
-    encodedSizeExpr size _ = 2 +
+    encodedSizeExpr size _ =
         szCases [ let TxInUtxo txInHash txInIndex = error "unused"
-                  in  Case "TxInUtxo" (2 + size ((,) <$> pure txInHash <*> pure txInIndex))
+                  in  Case "TxInUtxo" (4 + size ((,) <$> pure txInHash <*> pure txInIndex))
                 ]
 
 instance NFData TxIn

--- a/core/src/Pos/Core/Txp/Tx.hs
+++ b/core/src/Pos/Core/Txp/Tx.hs
@@ -32,7 +32,7 @@ import           Serokell.Util.Verify (VerificationRes (..), verResSingleF,
 import           Pos.Binary.Class (Bi (..), Cons (..), Field (..),
                      decodeKnownCborDataItem, decodeUnknownCborDataItem,
                      deriveSimpleBi, encodeKnownCborDataItem, encodeListLen,
-                     encodeUnknownCborDataItem, enforceSize, szCases)
+                     encodeUnknownCborDataItem, enforceSize, szCases, Case(..))
 import           Pos.Core.Common (Address (..), Coin (..), checkCoin, coinF)
 import           Pos.Crypto (Hash, hash, shortHashF)
 import           Pos.Data.Attributes (Attributes, areAttributesKnown)
@@ -162,7 +162,7 @@ instance Bi TxIn where
             _ -> TxInUnknown tag  <$> decodeUnknownCborDataItem
     encodedSizeExpr size _ = 2 +
         szCases [ let TxInUtxo txInHash txInIndex = error "unused"
-                  in 2 + size ((,) <$> pure txInHash <*> pure txInIndex)
+                  in  Case "TxInUtxo" (2 + size ((,) <$> pure txInHash <*> pure txInIndex))
                 ]
 
 instance NFData TxIn

--- a/core/src/Pos/Core/Txp/Tx.hs
+++ b/core/src/Pos/Core/Txp/Tx.hs
@@ -27,14 +27,13 @@ import qualified Formatting.Buildable as Buildable
 import           Serokell.Util.Base16 (base16F)
 import           Serokell.Util.Text (listJson)
 import           Serokell.Util.Verify (VerificationRes (..), verResSingleF,
-                                       verifyGeneric)
+                     verifyGeneric)
 
 import           Pos.Binary.Class (Bi (..), Case (..), Cons (..), Field (..),
-                                   decodeKnownCborDataItem,
-                                   decodeUnknownCborDataItem, deriveSimpleBi,
-                                   encodeKnownCborDataItem, encodeListLen,
-                                   encodeUnknownCborDataItem, enforceSize,
-                                   knownCborDataItemSizeExpr, szCases)
+                     decodeKnownCborDataItem, decodeUnknownCborDataItem,
+                     deriveSimpleBi, encodeKnownCborDataItem, encodeListLen,
+                     encodeUnknownCborDataItem, enforceSize,
+                     knownCborDataItemSizeExpr, szCases)
 import           Pos.Core.Common (Address (..), Coin (..), checkCoin, coinF)
 import           Pos.Crypto (Hash, hash, shortHashF)
 import           Pos.Data.Attributes (Attributes, areAttributesKnown)

--- a/core/src/Pos/Core/Txp/Tx.hs
+++ b/core/src/Pos/Core/Txp/Tx.hs
@@ -27,12 +27,14 @@ import qualified Formatting.Buildable as Buildable
 import           Serokell.Util.Base16 (base16F)
 import           Serokell.Util.Text (listJson)
 import           Serokell.Util.Verify (VerificationRes (..), verResSingleF,
-                     verifyGeneric)
+                                       verifyGeneric)
 
-import           Pos.Binary.Class (Bi (..), Cons (..), Field (..),
-                     decodeKnownCborDataItem, decodeUnknownCborDataItem,
-                     deriveSimpleBi, encodeKnownCborDataItem, encodeListLen,
-                     encodeUnknownCborDataItem, enforceSize, szCases, Case(..))
+import           Pos.Binary.Class (Bi (..), Case (..), Cons (..), Field (..),
+                                   decodeKnownCborDataItem,
+                                   decodeUnknownCborDataItem, deriveSimpleBi,
+                                   encodeKnownCborDataItem, encodeListLen,
+                                   encodeUnknownCborDataItem, enforceSize,
+                                   knownCborDataItemSizeExpr, szCases)
 import           Pos.Core.Common (Address (..), Coin (..), checkCoin, coinF)
 import           Pos.Crypto (Hash, hash, shortHashF)
 import           Pos.Data.Attributes (Attributes, areAttributesKnown)
@@ -160,10 +162,10 @@ instance Bi TxIn where
         case tag of
             0 -> uncurry TxInUtxo <$> decodeKnownCborDataItem
             _ -> TxInUnknown tag  <$> decodeUnknownCborDataItem
-    encodedSizeExpr size _ =
+    encodedSizeExpr size _ = 2 + (knownCborDataItemSizeExpr $
         szCases [ let TxInUtxo txInHash txInIndex = error "unused"
-                  in  Case "TxInUtxo" (4 + size ((,) <$> pure txInHash <*> pure txInIndex))
-                ]
+                  in  Case "TxInUtxo" (size ((,) <$> pure txInHash <*> pure txInIndex))
+                ])
 
 instance NFData TxIn
 

--- a/core/src/Pos/Core/Txp/TxWitness.hs
+++ b/core/src/Pos/Core/Txp/TxWitness.hs
@@ -89,6 +89,15 @@ instance Bi TxInWitness where
                 matchSize len "TxInWitness.UnknownWitnessType" 2
                 UnknownWitnessType tag <$> decodeUnknownCborDataItem
 
+    encodedSizeExpr size pxy = 2 +
+        szCases [ let PkWitness key sig     = error "unused"
+                  in knownCborDataItemSizeExpr ((,) <$> key <*> sig)
+                , let ScriptWitness key sig = error "unused"
+                  in knownCborDataItemSizeExpr ((,) <$> key <*> sig)
+                , let RedeemWitness key sig = error "unused"
+                  in knownCborDataItemSizeExpr ((,) <$> key <*> sig)
+                ]
+
 instance NFData TxInWitness
 
 -- | Data that is being signed when creating a TxSig.
@@ -101,6 +110,7 @@ data TxSigData = TxSigData
 instance Bi TxSigData where
     encode (TxSigData {..}) = encode txSigTxHash
     decode = TxSigData <$> decode
+    encodedSizeExpr size pxy = size (T.txSigTxHash <$> pxy)
 
 -- | 'Signature' of addrId.
 type TxSig = Signature TxSigData

--- a/core/src/Pos/Core/Txp/TxWitness.hs
+++ b/core/src/Pos/Core/Txp/TxWitness.hs
@@ -17,7 +17,7 @@ import           Pos.Binary.Class (Bi (..), decodeKnownCborDataItem,
                      decodeListLenCanonical, decodeUnknownCborDataItem,
                      encodeKnownCborDataItem, encodeListLen,
                      encodeUnknownCborDataItem, matchSize,
-                     knownCborDataItemSizeExpr, szCases)
+                     knownCborDataItemSizeExpr, szCases, Case(..))
 import           Pos.Core.Common (Script, addressHash)
 import           Pos.Crypto (Hash, PublicKey, RedeemPublicKey, RedeemSignature,
                      Signature, hash, shortHashF)
@@ -91,13 +91,13 @@ instance Bi TxInWitness where
                 UnknownWitnessType tag <$> decodeUnknownCborDataItem
 
     encodedSizeExpr size _ = 2 +
-        (szCases $ map knownCborDataItemSizeExpr $
+        (szCases $ map (fmap knownCborDataItemSizeExpr) $
             [ let PkWitness key sig     = error "unused"
-              in size ((,) <$> pure key <*> pure sig)
+              in  Case "PkWitness" $ size ((,) <$> pure key <*> pure sig)
             , let ScriptWitness key sig = error "unused"
-              in size ((,) <$> pure key <*> pure sig)
+              in  Case "ScriptWitness" $ size ((,) <$> pure key <*> pure sig)
             , let RedeemWitness key sig = error "unused"
-              in size ((,) <$> pure key <*> pure sig)
+              in  Case "RedeemWitness" $ size ((,) <$> pure key <*> pure sig)
             ])
 
 instance NFData TxInWitness

--- a/core/src/Pos/Core/Txp/TxWitness.hs
+++ b/core/src/Pos/Core/Txp/TxWitness.hs
@@ -90,14 +90,14 @@ instance Bi TxInWitness where
                 matchSize len "TxInWitness.UnknownWitnessType" 2
                 UnknownWitnessType tag <$> decodeUnknownCborDataItem
 
-    encodedSizeExpr size _ = 2 +
+    encodedSizeExpr size _ =
         (szCases $ map (fmap knownCborDataItemSizeExpr) $
             [ let PkWitness key sig     = error "unused"
-              in  Case "PkWitness" $ size ((,) <$> pure key <*> pure sig)
+              in  Case "PkWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
             , let ScriptWitness key sig = error "unused"
-              in  Case "ScriptWitness" $ size ((,) <$> pure key <*> pure sig)
+              in  Case "ScriptWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
             , let RedeemWitness key sig = error "unused"
-              in  Case "RedeemWitness" $ size ((,) <$> pure key <*> pure sig)
+              in  Case "RedeemWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
             ])
 
 instance NFData TxInWitness

--- a/core/src/Pos/Core/Txp/TxWitness.hs
+++ b/core/src/Pos/Core/Txp/TxWitness.hs
@@ -14,15 +14,13 @@ import qualified Formatting.Buildable as Buildable
 import           Serokell.Util.Base16 (base16F)
 
 import           Pos.Binary.Class (Bi (..), Case (..), decodeKnownCborDataItem,
-                                   decodeListLenCanonical,
-                                   decodeUnknownCborDataItem,
-                                   encodeKnownCborDataItem, encodeListLen,
-                                   encodeUnknownCborDataItem,
-                                   knownCborDataItemSizeExpr, matchSize,
-                                   szCases)
+                     decodeListLenCanonical, decodeUnknownCborDataItem,
+                     encodeKnownCborDataItem, encodeListLen,
+                     encodeUnknownCborDataItem, knownCborDataItemSizeExpr,
+                     matchSize, szCases)
 import           Pos.Core.Common (Script, addressHash)
 import           Pos.Crypto (Hash, PublicKey, RedeemPublicKey, RedeemSignature,
-                             Signature, hash, shortHashF)
+                     Signature, hash, shortHashF)
 
 import           Pos.Core.Txp.Tx (Tx)
 

--- a/core/src/Pos/Core/Txp/TxWitness.hs
+++ b/core/src/Pos/Core/Txp/TxWitness.hs
@@ -13,14 +13,16 @@ import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable as Buildable
 import           Serokell.Util.Base16 (base16F)
 
-import           Pos.Binary.Class (Bi (..), decodeKnownCborDataItem,
-                     decodeListLenCanonical, decodeUnknownCborDataItem,
-                     encodeKnownCborDataItem, encodeListLen,
-                     encodeUnknownCborDataItem, matchSize,
-                     knownCborDataItemSizeExpr, szCases, Case(..))
+import           Pos.Binary.Class (Bi (..), Case (..), decodeKnownCborDataItem,
+                                   decodeListLenCanonical,
+                                   decodeUnknownCborDataItem,
+                                   encodeKnownCborDataItem, encodeListLen,
+                                   encodeUnknownCborDataItem,
+                                   knownCborDataItemSizeExpr, matchSize,
+                                   szCases)
 import           Pos.Core.Common (Script, addressHash)
 import           Pos.Crypto (Hash, PublicKey, RedeemPublicKey, RedeemSignature,
-                     Signature, hash, shortHashF)
+                             Signature, hash, shortHashF)
 
 import           Pos.Core.Txp.Tx (Tx)
 
@@ -90,14 +92,14 @@ instance Bi TxInWitness where
                 matchSize len "TxInWitness.UnknownWitnessType" 2
                 UnknownWitnessType tag <$> decodeUnknownCborDataItem
 
-    encodedSizeExpr size _ =
+    encodedSizeExpr size _ = 2 +
         (szCases $ map (fmap knownCborDataItemSizeExpr) $
             [ let PkWitness key sig     = error "unused"
-              in  Case "PkWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
+              in  Case "PkWitness" $ size ((,) <$> pure key <*> pure sig)
             , let ScriptWitness key sig = error "unused"
-              in  Case "ScriptWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
+              in  Case "ScriptWitness" $ size ((,) <$> pure key <*> pure sig)
             , let RedeemWitness key sig = error "unused"
-              in  Case "RedeemWitness" $ 2 + size ((,) <$> pure key <*> pure sig)
+              in  Case "RedeemWitness" $ size ((,) <$> pure key <*> pure sig)
             ])
 
 instance NFData TxInWitness

--- a/core/test/Test/Pos/Core/Bi.hs
+++ b/core/test/Test/Pos/Core/Bi.hs
@@ -1838,7 +1838,7 @@ sizeEstimates =
 -----------------------------------------------------------------------
 
 tests :: IO Bool
-tests = all id <$> sequence
+tests = and <$> sequence
     [ H.checkSequential $$discoverGolden
     , H.checkParallel $$discoverRoundTrip
     , H.checkParallel sizeEstimates

--- a/core/test/Test/Pos/Core/Bi.hs
+++ b/core/test/Test/Pos/Core/Bi.hs
@@ -81,8 +81,7 @@ import           Pos.Merkle (mkMerkleTree, mtRoot)
 import           Serokell.Data.Memory.Units (Byte)
 
 import           Test.Pos.Binary.Helpers (SizeTestConfig (..), scfg, sizeTest)
-import           Test.Pos.Binary.Helpers.GoldenRoundTrip (discoverGolden,
-                     discoverRoundTrip, eachOf, goldenTestBi,
+import           Test.Pos.Binary.Helpers.GoldenRoundTrip (goldenTestBi,
                      roundTripsBiBuildable, roundTripsBiShow)
 import           Test.Pos.Core.Gen
 import           Test.Pos.Crypto.Bi (getBytes)

--- a/core/test/cardano-sl-core-test.cabal
+++ b/core/test/cardano-sl-core-test.cabal
@@ -38,7 +38,7 @@ library
                      , cardano-sl-util
                      , cardano-sl-util-test
                      , containers
-                     , cardano-sl-util-test
+                     , cryptonite
                      , data-default
                      , ed25519
                      , formatting

--- a/crypto/Pos/Crypto/Hashing.hs
+++ b/crypto/Pos/Crypto/Hashing.hs
@@ -60,7 +60,7 @@ import qualified Prelude
 import qualified Serokell.Util.Base16 as B16
 import           System.IO.Unsafe (unsafeDupablePerformIO)
 
-import           Pos.Binary.Class (Bi (..), Raw)
+import           Pos.Binary.Class (Bi (..), Raw, szCases, Length(..), withWordSize)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Binary.SafeCopy (getCopyBi, putCopyBi)
 import           Pos.Util.Util (parseJSONWithRead, toAesonError, toCborError)
@@ -89,6 +89,7 @@ instance Ord a => Ord (WithHash a) where
 instance Bi a => Bi (WithHash a) where
     encode = encode . whData
     decode = withHash <$> decode
+    encodedSizeExpr size pxy = size (whData <$> pxy)
 
 withHash :: Bi a => a -> WithHash a
 withHash a = WithHash a (force h)
@@ -145,6 +146,10 @@ instance (Typeable algo, Typeable a, HashAlgorithm algo) => Bi (AbstractHash alg
         toCborError $ case Hash.digestFromByteString bs of
             Nothing -> Left "AbstractHash.decode: invalid digest"
             Just x  -> Right (AbstractHash x)
+    encodedSizeExpr size _ =
+        let AbstractHash digest = (error "unused" :: AbstractHash algo a)
+            realSz = hashDigestSize (error "unused, I hope!" :: algo)
+        in fromInteger (toInteger (withWordSize realSz + realSz))
 
 instance (HashAlgorithm algo, Typeable algo, Typeable a) => SafeCopy (AbstractHash algo a) where
    putCopy = putCopyBi

--- a/crypto/Pos/Crypto/Hashing.hs
+++ b/crypto/Pos/Crypto/Hashing.hs
@@ -60,7 +60,7 @@ import qualified Prelude
 import qualified Serokell.Util.Base16 as B16
 import           System.IO.Unsafe (unsafeDupablePerformIO)
 
-import           Pos.Binary.Class (Bi (..), Raw, szCases, Length(..), withWordSize)
+import           Pos.Binary.Class (Bi (..), Raw, withWordSize)
 import qualified Pos.Binary.Class as Bi
 import           Pos.Binary.SafeCopy (getCopyBi, putCopyBi)
 import           Pos.Util.Util (parseJSONWithRead, toAesonError, toCborError)
@@ -146,9 +146,8 @@ instance (Typeable algo, Typeable a, HashAlgorithm algo) => Bi (AbstractHash alg
         toCborError $ case Hash.digestFromByteString bs of
             Nothing -> Left "AbstractHash.decode: invalid digest"
             Just x  -> Right (AbstractHash x)
-    encodedSizeExpr size _ =
-        let AbstractHash digest = (error "unused" :: AbstractHash algo a)
-            realSz = hashDigestSize (error "unused, I hope!" :: algo)
+    encodedSizeExpr _ _ =
+        let realSz = hashDigestSize (error "unused, I hope!" :: algo)
         in fromInteger (toInteger (withWordSize realSz + realSz))
 
 instance (HashAlgorithm algo, Typeable algo, Typeable a) => SafeCopy (AbstractHash algo a) where

--- a/crypto/Pos/Crypto/Orphans.hs
+++ b/crypto/Pos/Crypto/Orphans.hs
@@ -45,14 +45,17 @@ instance ToJSON Ed25519.Signature where
 instance Bi Ed25519.PublicKey where
     encode (Ed25519.PublicKey k) = encode k
     decode = Ed25519.PublicKey <$> decode
+    encodedSizeExpr _ _ = 2 + 32
 
 instance Bi Ed25519.SecretKey where
     encode (Ed25519.SecretKey k) = encode k
     decode = Ed25519.SecretKey <$> decode
+    encodedSizeExpr _ _ = 2 + 32
 
 instance Bi Ed25519.Signature where
     encode (Ed25519.Signature s) = encode s
     decode = Ed25519.Signature <$> decode
+    encodedSizeExpr _ _ = 2 + 64
 
 ----------------------------------------------------------------------------
 -- Bi instances for Scrape

--- a/crypto/Pos/Crypto/Orphans.hs
+++ b/crypto/Pos/Crypto/Orphans.hs
@@ -16,7 +16,7 @@ import           Data.Hashable (Hashable)
 import           Data.SafeCopy (base, deriveSafeCopySimple)
 import           Serokell.Util.Base64 (JsonByteString (..))
 
-import           Pos.Binary.Class (Bi (..), decodeBinary, encodeBinary)
+import           Pos.Binary.Class (Bi (..), decodeBinary, encodeBinary, withWordSize)
 
 instance Hashable Ed25519.PublicKey
 instance Hashable Ed25519.SecretKey
@@ -45,17 +45,21 @@ instance ToJSON Ed25519.Signature where
 instance Bi Ed25519.PublicKey where
     encode (Ed25519.PublicKey k) = encode k
     decode = Ed25519.PublicKey <$> decode
-    encodedSizeExpr _ _ = 2 + 32
+    encodedSizeExpr _ _ = bsSize 32
 
 instance Bi Ed25519.SecretKey where
     encode (Ed25519.SecretKey k) = encode k
     decode = Ed25519.SecretKey <$> decode
-    encodedSizeExpr _ _ = 2 + 32
+    encodedSizeExpr _ _ = bsSize 64
 
 instance Bi Ed25519.Signature where
     encode (Ed25519.Signature s) = encode s
     decode = Ed25519.Signature <$> decode
-    encodedSizeExpr _ _ = 2 + 64
+    encodedSizeExpr _ _ = bsSize 64
+
+-- Helper for encodedSizeExpr in Bi instances
+bsSize :: Int -> Size
+bsSize x = fromIntegral (x + withWordSize x)
 
 ----------------------------------------------------------------------------
 -- Bi instances for Scrape

--- a/crypto/Pos/Crypto/Orphans.hs
+++ b/crypto/Pos/Crypto/Orphans.hs
@@ -16,7 +16,7 @@ import           Data.Hashable (Hashable)
 import           Data.SafeCopy (base, deriveSafeCopySimple)
 import           Serokell.Util.Base64 (JsonByteString (..))
 
-import           Pos.Binary.Class (Bi (..), decodeBinary, encodeBinary, withWordSize)
+import           Pos.Binary.Class (Bi (..), decodeBinary, encodeBinary, withWordSize, Size)
 
 instance Hashable Ed25519.PublicKey
 instance Hashable Ed25519.SecretKey

--- a/crypto/Pos/Crypto/Orphans.hs
+++ b/crypto/Pos/Crypto/Orphans.hs
@@ -16,7 +16,8 @@ import           Data.Hashable (Hashable)
 import           Data.SafeCopy (base, deriveSafeCopySimple)
 import           Serokell.Util.Base64 (JsonByteString (..))
 
-import           Pos.Binary.Class (Bi (..), decodeBinary, encodeBinary, withWordSize, Size)
+import           Pos.Binary.Class (Bi (..), Size, decodeBinary, encodeBinary,
+                     withWordSize)
 
 instance Hashable Ed25519.PublicKey
 instance Hashable Ed25519.SecretKey

--- a/crypto/Pos/Crypto/Signing/Types/Signing.hs
+++ b/crypto/Pos/Crypto/Signing/Types/Signing.hs
@@ -89,6 +89,7 @@ decodeXPub = toCborError . over _Left fromString . CC.xpub =<< decode
 instance Bi PublicKey where
     encode (PublicKey a) = encodeXPub a
     decode = fmap PublicKey decodeXPub
+    encodedSizeExpr _ _ = 66
 
 -- | Wrapper around 'CC.XPrv'.
 newtype SecretKey = SecretKey CC.XPrv

--- a/crypto/test/Test/Pos/Crypto/Bi.hs
+++ b/crypto/test/Test/Pos/Crypto/Bi.hs
@@ -12,7 +12,8 @@ import           Universum
 
 import           Cardano.Crypto.Wallet (XPrv, unXPrv, xprv, xpub)
 
-import           Crypto.Hash (Blake2b_256)
+import           Crypto.Hash (Blake2b_224, Blake2b_256, Blake2b_384,
+                     Blake2b_512, SHA1)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as BS
 import           Data.List.NonEmpty (fromList)
@@ -20,6 +21,7 @@ import           Data.List.NonEmpty (fromList)
 import           Hedgehog (Gen, Property)
 import qualified Hedgehog as H
 
+import           Pos.Binary.Class (Bi)
 import           Pos.Crypto (AbstractHash, EncShare, PassPhrase,
                      ProtocolMagic (..), ProxyCert, ProxySecretKey,
                      PublicKey (..), RedeemSignature, SafeSigner (FakeSigner),
@@ -32,7 +34,10 @@ import           Pos.Crypto (AbstractHash, EncShare, PassPhrase,
                      safeCreateProxyCert, safeCreatePsk, sign, toPublic,
                      toVssPublicKey)
 
-import           Test.Pos.Binary.Helpers.GoldenRoundTrip (goldenTestBi,
+import           Test.Pos.Binary.Helpers (SizeTestConfig (..), scfg, sizeTest)
+import           Test.Pos.Binary.Helpers.GoldenRoundTrip (discoverGolden,
+                     discoverRoundTrip, eachOf, goldenTestBi,
+                     roundTripsAesonBuildable, roundTripsAesonShow,
                      roundTripsBiBuildable, roundTripsBiShow)
 import           Test.Pos.Crypto.Gen
 import           Test.Pos.Util.Golden (discoverGolden, eachOf)
@@ -395,6 +400,32 @@ constantByteString
 
 --------------------------------------------------------------------------------
 
+sizeEstimates :: H.Group
+sizeEstimates = let check :: forall a. (Show a, Bi a) => Gen a -> Property
+                    check g = sizeTest $ scfg { gen = g, precise = True } in
+    H.Group "Encoded size bounds for crypto types."
+        [ ("PublicKey"         , check genPublicKey)
+        , ("WithHash PublicKey", check $ genWithHash genPublicKey)
+        , ("AbstractHash Blake2b_224 PublicKey",
+           check @(AbstractHash Blake2b_224 PublicKey) $ genAbstractHash genPublicKey)
+        , ("AbstractHash Blake2b_256 PublicKey",
+           check @(AbstractHash Blake2b_256 PublicKey) $ genAbstractHash genPublicKey)
+        , ("AbstractHash Blake2b_384 PublicKey",
+           check @(AbstractHash Blake2b_384 PublicKey) $ genAbstractHash genPublicKey)
+        , ("AbstractHash Blake2b_512 PublicKey",
+           check @(AbstractHash Blake2b_512 PublicKey) $ genAbstractHash genPublicKey)
+        , ("AbstractHash SHA1 PublicKey",
+           check @(AbstractHash SHA1 PublicKey) $ genAbstractHash genPublicKey)
+        , ("RedeemPublicKey", check genRedeemPublicKey)
+        , ("RedeemSecretKey", check genRedeemSecretKey)
+        , ("RedeemSignature PublicKey", check (genRedeemSignature (ProtocolMagic 0) genPublicKey))
+        ]
+
+--------------------------------------------------------------------------------
+
 tests :: IO Bool
-tests = (&&) <$> H.checkSequential $$discoverGolden
-             <*> H.checkSequential $$discoverRoundTrip
+tests = all id <$> sequence
+    [ H.checkSequential $$discoverGolden
+    , H.checkSequential $$discoverRoundTrip
+    , H.checkParallel sizeEstimates
+    ]

--- a/crypto/test/Test/Pos/Crypto/Bi.hs
+++ b/crypto/test/Test/Pos/Crypto/Bi.hs
@@ -35,9 +35,7 @@ import           Pos.Crypto (AbstractHash, EncShare, PassPhrase,
                      toVssPublicKey)
 
 import           Test.Pos.Binary.Helpers (SizeTestConfig (..), scfg, sizeTest)
-import           Test.Pos.Binary.Helpers.GoldenRoundTrip (discoverGolden,
-                     discoverRoundTrip, eachOf, goldenTestBi,
-                     roundTripsAesonBuildable, roundTripsAesonShow,
+import           Test.Pos.Binary.Helpers.GoldenRoundTrip (goldenTestBi,
                      roundTripsBiBuildable, roundTripsBiShow)
 import           Test.Pos.Crypto.Gen
 import           Test.Pos.Util.Golden (discoverGolden, eachOf)

--- a/crypto/test/Test/Pos/Crypto/Bi.hs
+++ b/crypto/test/Test/Pos/Crypto/Bi.hs
@@ -424,7 +424,7 @@ sizeEstimates = let check :: forall a. (Show a, Bi a) => Gen a -> Property
 --------------------------------------------------------------------------------
 
 tests :: IO Bool
-tests = all id <$> sequence
+tests = and <$> sequence
     [ H.checkSequential $$discoverGolden
     , H.checkSequential $$discoverRoundTrip
     , H.checkParallel sizeEstimates

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15262,6 +15262,7 @@ QuickCheck
 quickcheck-instances
 safecopy
 serokell-util
+tagged
 template-haskell
 text
 time-units
@@ -15867,6 +15868,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-util
 , cardano-sl-util-test
 , containers
+, cryptonite
 , data-default
 , ed25519
 , formatting

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15176,6 +15176,7 @@ license = stdenv.lib.licenses.mit;
 , hedgehog
 , hspec
 , lens
+, micro-recursion-schemes
 , mtl
 , pretty-show
 , QuickCheck
@@ -15187,6 +15188,7 @@ license = stdenv.lib.licenses.mit;
 , tagged
 , template-haskell
 , text
+, text-format
 , th-utilities
 , time-units
 , universum
@@ -15215,12 +15217,16 @@ digest
 formatting
 hashable
 lens
+micro-recursion-schemes
+mtl
+QuickCheck
 safe-exceptions
 safecopy
 serokell-util
 tagged
 template-haskell
 text
+text-format
 th-utilities
 time-units
 universum
@@ -15281,6 +15287,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-util-test
 , cborg
 , cereal
+, containers
 , cpphs
 , cryptonite
 , directory
@@ -15294,6 +15301,7 @@ license = stdenv.lib.licenses.mit;
 , QuickCheck
 , quickcheck-instances
 , safecopy
+, serokell-util
 , stdenv
 , template-haskell
 , text
@@ -15317,6 +15325,7 @@ cardano-sl-binary
 cardano-sl-util-test
 cborg
 cereal
+containers
 cryptonite
 directory
 filepath
@@ -15329,6 +15338,8 @@ pretty-show
 QuickCheck
 quickcheck-instances
 safecopy
+serokell-util
+tagged
 template-haskell
 text
 universum
@@ -53269,6 +53280,34 @@ doHaddock = false;
 doCheck = false;
 description = "High-performance application metric tracking";
 license = stdenv.lib.licenses.mit;
+
+}) {};
+"micro-recursion-schemes" = callPackage
+({
+  mkDerivation
+, base
+, cpphs
+, stdenv
+, template-haskell
+, th-abstraction
+}:
+mkDerivation {
+
+pname = "micro-recursion-schemes";
+version = "5.0.2.2";
+sha256 = "3bddd1f22638f7e34563876e711e38351b8f36e50b45f3e5553068a2b25c5e9e";
+libraryHaskellDepends = [
+base
+template-haskell
+th-abstraction
+];
+libraryToolDepends = [
+cpphs
+];
+doHaddock = false;
+doCheck = false;
+description = "Simple recursion schemes";
+license = stdenv.lib.licenses.bsd3;
 
 }) {};
 "microformats2-parser" = callPackage

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15869,6 +15869,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-util
 , cardano-sl-util-test
 , containers
+, cryptonite
 , data-default
 , ed25519
 , formatting

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15219,7 +15219,6 @@ hashable
 lens
 micro-recursion-schemes
 mtl
-QuickCheck
 safe-exceptions
 safecopy
 serokell-util
@@ -15339,7 +15338,6 @@ QuickCheck
 quickcheck-instances
 safecopy
 serokell-util
-tagged
 template-haskell
 text
 universum

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15827,6 +15827,7 @@ cardano-sl-crypto-test
 cardano-sl-util
 cardano-sl-util-test
 containers
+cryptonite
 deepseq
 ed25519
 formatting
@@ -15868,7 +15869,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-util
 , cardano-sl-util-test
 , containers
-, cryptonite
 , data-default
 , ed25519
 , formatting

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15911,6 +15911,7 @@ cardano-sl-crypto-test
 cardano-sl-util
 cardano-sl-util-test
 containers
+cryptonite
 data-default
 ed25519
 formatting

--- a/stack.yaml
+++ b/stack.yaml
@@ -235,7 +235,7 @@ extra-deps:
 # CI hasn't run cabal update yet.
 # - formatting-6.3.6
 
-# Following 9 are not on stackage.
+# Following 10 are not on stackage.
 - pvss-0.2.0
 - systemd-1.1.2
 - base58-bytestring-0.1.0
@@ -245,6 +245,8 @@ extra-deps:
 - json-sop-0.2.0.3
 - lens-sop-0.2.0.2
 - lzma-clib-5.2.2
+- micro-recursion-schemes-5.0.2.2
+
 # The changelog for directory-1.3.1.1 indicate some potentially important
 # bugfixes over directory-1.3.0.2, which is what's on lts-11.
 - directory-1.3.1.1

--- a/test.hs
+++ b/test.hs
@@ -1,1 +1,0 @@
-main = putStrLn " "

--- a/test.hs
+++ b/test.hs
@@ -1,0 +1,1 @@
+main = putStrLn " "


### PR DESCRIPTION
## Description

This PR implements the "static size estimate" work from CBR-318. The idea is to provide a way to compute he upper- and lower-bounds on the encoded size for a given type.

To get this capability, I've added a `encodedSizeExpr` method to the `Bi` typeclass. At some type `a`, this method returns a symbolic expression describing the range of sizes that an encoded `a` could have. `encodedSizeExpr` has a default implementation that just returns a symbolic representation of the type: something like "the size of `a` is "the size of `a`"". I have only provided more specific implementations for basic types and whatever was needed to get estimates for `TxAux`.

The expressions are represented by the `Size` type. A variety of utility functions let you carry out basic operations like simplification, evaluation, forcing "thunks", and substituting values in the expressions.

The tests work by randomly generating values `x :: Bi a => a`, then comparing the actual encoded size of `x` to `encodedSizeExpr @a`. This can involve some annoying fiddling around, e.g. to set the number of `TxIn`s to the same amount as are in the generated `x`.

## Linked issue

CBR-318

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist

- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
