### PR TITLE
[DEVOPS-944] resolve off-by-one in block stream

### DIFF
--- a/block/src/Pos/GState/BlockExtra.hs
+++ b/block/src/Pos/GState/BlockExtra.hs
@@ -113,7 +113,8 @@ instance HasCoreConfiguration => RocksBatchOp BlockExtraOp where
 -- Loops on forward links
 ----------------------------------------------------------------------------
 
--- | Creates a Producer for blocks from a given HeaderHash.
+-- | Creates a Producer for blocks from a given HeaderHash, exclusive: the
+-- block for that hash is not produced, its child is the first thing produced.
 streamBlocks
     :: ( Monad m )
     => (HeaderHash -> m (Maybe SerializedBlock))
@@ -121,7 +122,8 @@ streamBlocks
     -> HeaderHash
     -> Producer SerializedBlock m ()
 streamBlocks loadBlock forwardLink base = do
-    loop base
+    mFirst <- lift $ forwardLink base
+    maybe (pure ()) loop mFirst
   where
     loop hhash = do
         mb <- lift $ loadBlock hhash

--- a/lib/src/Pos/Diffusion/Full/Block.hs
+++ b/lib/src/Pos/Diffusion/Full/Block.hs
@@ -654,6 +654,9 @@ handleStreamStart logTrace logic oq = listenerConv logTrace oq $ \__ourVerInfo n
                 send conv $ MsgStreamNoBlock "handleStreamStart:strean Failed to find lca"
                 traceWith logTrace (Debug, sformat ("handleStreamStart:strean getBlockHeaders from "%shown%" failed for "%listJson) nodeId (cl:cxs))
                 return ()
+             -- 'lca' is the newest client-supplied checkpoint that we have.
+             -- We need to begin streaming from its child, which is what
+             -- 'Logic.streamBlocks' does.
              lca : _ -> do
                 let producer = do
                         Logic.streamBlocks logic lca


### PR DESCRIPTION
## Description

The fix in #3235 had an off-by-one error: the streaming began with the newest client-supplied checkpoint in the server's chain, whereas it apparently should have begun with the child of that block (that's how it was before the patch, but it leaked memory). The demo script seems to work with this patch.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
