### PR TITLE
[DEVOPS-398] Update testnet launch genesis data

### DIFF
--- a/docs/how-to/launch-testnet.md
+++ b/docs/how-to/launch-testnet.md
@@ -18,28 +18,50 @@ generate genesis data are specified in the `testnet_launch` section of
 All values are inherited from the `mainnet_base` section, unless
 overridden.
 
+### Initializer
+
  * `protocolMagic` -- this number is different from mainnet's magic to
    ensure that the address format of testnet is different to mainnet.
- * `totalBalance` -- 200,000,000,000 Ada -- is a third of mainnet's
-   total balance.
- * `richmenShare` -- 99% -- same as mainnet. This means that
-   2,000,000,000 Ada will be "in circulation".
+ * `totalBalance` -- 42,000,000,000 Ada -- is close to the maximum
+   possible coin value (45B Ada).
  * `avvmDistr` -- this is the empty hashmap, unlike in mainnet which
    has many Ada redemption addresses.
  * `fakeAvvmBalances` -- there are 100 fake AVVM seeds which can be
-   used to redeem 10,000,000 Ada each on the testnet.
- * `poors` -- Unlike mainnet, there are 100 "poor" nodes with
-   generated keys. Each of these will have 10,000,000 testnet Ada
-   which can be spent.
+   used to redeem 20,000,000 Ada each on the testnet.
+ * `poors` -- Unlike mainnet which has none, there are 100 "poor"
+   nodes with generated keys.
  * `richmen` -- There are 7 testnet richmen, i.e. core nodes, same as
    mainnet.
+ * `richmenShare` -- 95%. After subtracting the total balance of fake
+   AVVM certificates, there will be 40,000,000,000 Ada divided between
+   the 7 rich and 100 poor nodes. A single poor node will recieve
+   0.05% of that total, which is 20,000,000 Ada.
+
+### `blockVersionData`
+
+The mainnet `blockVersionData` has been updated since its genesis. The
+testnet will be launched with these new parameters matching mainnet's
+current `blockVersionData`.
+
+| `blockVersionData` | Value | Description                                |
+| :----------------- | ----: | :------------------------------------------|
+| `maxHeaderSize`    | 2KB   | Maximum size of block's header             |
+| `maxProposalSize`  | 70KB  | Maximum size of Cardano SL update proposal |
+| `maxTxSize`        | 64KiB | Maximum size of transaction                |
+
+### Update system block version
+
+In addition, the `update.lastKnownBlockVersion` is set at `0.0.0` in
+the `testnet_full`. The nodes will refuse to create blocks if this
+value is higher than zero.
  
 ## Faucet
 
 The testnet faucet will dispense a random amount in the range of 500
 to 1500 Ada.
 
-It is not currently rate limited.
+It is not rate limited, but automatic withdrawals are prevented with
+[reCAPTCHA](https://developers.google.com/recaptcha/).
 
 According to the parameters above, up to 2,000,000,000 Ada could be
 dispensed, though not all should be made available to the faucet.
@@ -50,7 +72,7 @@ IOHK will retain control of the majority of testnet Ada to minimise
 the risk of the testnet becoming a threat blockchain and the testnet
 currency assuming value.
 
-The core nodes (richmen) control 99% of stake.
+The core nodes (richmen) control 95% of stake.
 
 Additionally, not all AVVM certificates and "poor" addresses should be
 sent to the faucet.

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14820,7 +14820,7 @@ testnet_full: &testnet_full
     genesis:
       src:
         file: testnet-genesis.json
-        hash: 5d30b2fac276907d36ed2ae9b6fe847f18c7457bce6ccb68535aa8b01bc67726
+        hash: 6300910ff7d8ca51a61df661a09dfd1486be756f32eff7f348e1f4e3b6166c54
 
   update: &testnet_full_update
     applicationName: cardano-sl
@@ -14875,15 +14875,20 @@ testnet_launch: &testnet_launch
           testBalance:
             poors:        100
             richmen:      7
-            richmenShare: 0.99
-            totalBalance: 200000000000000000
+            richmenShare: 0.95
+            totalBalance: 42000000000000000 # 42e9 ADA
             useHDAddresses: True
           fakeAvvmBalance:
             count: 100
-            oneBalance: 10000000000000 # 1e7 ADA
+            oneBalance: 20000000000000 # 2e7 ADA
           avvmBalanceFactor: 1
           useHeavyDlg: True
           seed: 0 # should be overridden using --configuration-seed
+        blockVersionData:
+          <<: *mainnet_base_blockVersionData
+          maxHeaderSize:      2000
+          maxProposalSize:   70000 # 70KB
+          maxTxSize:         65536 # 64KiB
 
 ##############################################################################
 ##                                                                          ##

--- a/lib/testnet-genesis.json
+++ b/lib/testnet-genesis.json
@@ -1,359 +1,359 @@
 { "bootStakeholders":
-    { "0a781ac82f20a55ed409c27ab143a97f41619eb17d2d9bc5b851ca09": 1
-    , "20e53106620128c3285669dbdb1d1578867e90ab8c38e355ea93ac0d": 1
-    , "58dcb76d7a9f913c6b28652e9d64a856eba2508d0b68aa235ea73b4b": 1
-    , "6605bed51c9d4fada9883dea520b556830d9443a1547ce315c4220bd": 1
-    , "8ded62115e1732d1e65502787ad7a3df64af731af1f2a343194c9cd5": 1
-    , "950ef2729b83030eb2cbe53d1bbf652aa27578b9f9a0b9fc86df1444": 1
-    , "fe8b4b1ccb3137fd9c92d36075de1bcb66be760f9082dbf57f7fba5f": 1
+    { "00a9c32607d8c8f50fba2dec2674798c33b8ad9f50fe4170db146f3f": 1
+    , "9f43183be5cf79a46ada7f5855f91f13c24bc5c30e684d371a397078": 1
+    , "b217d6b255a26ce380105950c3339190f3662ff67a73350b4c173020": 1
+    , "bf80a86feab63a24a9c24e99b2920d10617e80016a83dda06b58ca5a": 1
+    , "d2405b538b5ef360aa20f70f0b405444347140b0bbbaed7b808a5e72": 1
+    , "e9b0a0c66a03a7bc4ffa421744d44d06c9119568c9ffbe0f3d2a7138": 1
+    , "f048ed187a5d557cb7e293c147a03b67980d3adf835ff60d5dc38a24": 1
     }
 , "heavyDelegation":
-    { "8ded62115e1732d1e65502787ad7a3df64af731af1f2a343194c9cd5":
+    { "f048ed187a5d557cb7e293c147a03b67980d3adf835ff60d5dc38a24":
         { "omega": 0
         , "issuerPk":
-            "PUasUTx3P78CIAw6Z5zFDk+bIdlq9kkcN00BCHeMjGAJ59YXa5CXOdYtkKow0p7GjkxCewR9zsjuy6N82NfE9A=="
+            "lka5K9yUlg/cjK4Y6xRjSz7lhOeG6V8zdHIy43RMWs4AFzeXnP16AJhlWqtUxKw5v+3nBzQuNYfdUOR9uyao2Q=="
         , "delegatePk":
-            "ehyzF2brz0ya3J2popvN2i9ef7GYzQI/9Kr2xCflIlKCByKTC85QUUFc9sMELzeBD+diLsP8cAIACD6y4sQrCA=="
+            "aaLbNu/AtY0CGL5WtZbSjg2pl3+50gD7l4ZrRqp4XmPi+0ejmF3QTjTq9lk1mikKrkybLyiLBN2G+sDIgiX5tQ=="
         , "cert":
-            "f47e55ad4d7ec0195150e925ed28c1ffe70b8d18d73f2554b817a73ac6179aa4bd219b4d30ae69f7ecbfb4eadc1c0bf2f9ba72800f89623f8253a7b39625a50b"
+            "e967cf76a8fc34fe819c746e65f9630db6279e6a2363d03b925dd3ddd399bf9c7f2bb3fa2c1762d247aa04071d4c2d0e4aca313845ffee651a1a442c75533e0c"
         }
-    , "58dcb76d7a9f913c6b28652e9d64a856eba2508d0b68aa235ea73b4b":
+    , "bf80a86feab63a24a9c24e99b2920d10617e80016a83dda06b58ca5a":
         { "omega": 0
         , "issuerPk":
-            "MYf/cptadfWfBVHTYXfW1Yd2Wya8/j5rBWWfDhNAbI4oGCjLWbflcu6GyTVsNvccjWBMsM/lZpKoWKV13jBABw=="
+            "L2n4XjMpkAEvE+Mg7KbqRUveb/vMUXCfylEIQ0IbedoI2z7xXgrcgQWv0alpY1VwJnluTE4zVLy0QzERWzdMrA=="
         , "delegatePk":
-            "5OQLmrFV4LvcIJ/XJxsVPddulc5VkbCVPueHpvOdOmgea/vNIG5m0HpE6NJNDk5E7tuvjAZ/p5oZ4tXhWwEWVg=="
+            "KZ+s5H5lMQxMqXUeQte211QI6hZhMHur+p3EXPgn4WO5j0D8HCtBXkp85EdWg0MHX5mtbGfXd11ktfiWxuW86w=="
         , "cert":
-            "b6a67f2c116cc281f7ee6c2364bc4703f068984813d637e2712fa61faa7e60cdd82a47d45f89351a4dfb4a113b61892cab94dba67b0f8ccfde9c7f2644217802"
+            "6a1fbfe928708a9fb93680e73877bff45b246bec70a8f55142e7dc997e2a4c10832329f7a29b507c100dcb2a665b1645f4b796f0728c9a104a52a0d16f42b803"
         }
-    , "0a781ac82f20a55ed409c27ab143a97f41619eb17d2d9bc5b851ca09":
+    , "e9b0a0c66a03a7bc4ffa421744d44d06c9119568c9ffbe0f3d2a7138":
         { "omega": 0
         , "issuerPk":
-            "40vdgKJ1B8BdtFPihflnWYXnRB3v/VDWlsWgYNGYPjKf0TNvGdY1LNksvFNXNJt9rpYaaJPXlvalXugX9Jz2eg=="
+            "wHA/R4mqdHtfGpUL3LW7zLQnkbTaOz9uaSFiCX64mzbwISHfE6eQHoPKKPm+ZvA42GJehDoxT3cnX9sYIfS1JQ=="
         , "delegatePk":
-            "FYAhifXh1M4gURiFzCw/fnaBk4Vy9BlMwt8Bt7L81vP4Fw+afOP18SPdSS7H4aucvg2OnmbBzuNOngaMIeJgyQ=="
+            "EQu0gdSuZro6DPHR96b5g6e66vGqCCwx+nSEib85UpVPURSI/C5rO8cZTJLm4Vc36wqsmSWeI34BbGrMGCtVwQ=="
         , "cert":
-            "ae030f8fdeab0bfb1bc03c226bd0734cd497bb1a1797965815942e6fea1e04f4a107ee0637f88d7cd89bab1210aed6b39c9fe23f0a95c2d3a8bdb37d8a859700"
+            "9285f26ac40a67e3df448863900209d182da0446a39680026ebca5ddce727cc4a12a2d32d7fa91f462f6d3df20f2424751e36faf6621c51c1d96b6301185ed08"
         }
-    , "950ef2729b83030eb2cbe53d1bbf652aa27578b9f9a0b9fc86df1444":
+    , "00a9c32607d8c8f50fba2dec2674798c33b8ad9f50fe4170db146f3f":
         { "omega": 0
         , "issuerPk":
-            "CrJspf3pmeTPTQNRaZPOuhcETT8LiJdCeZkFUQk1JfUWXKXp0D99InwCB+q+xG2L3Bp1BdUJCPd1j0erEdzzPg=="
+            "G9JlJWqpIC+Qkp1U2Jq3BBbyNkW7rC9oi+7vtGELciUFji1n15B6eT+uk/EUQ/Ak4wXknhhYpcZ6rBTdy3N3xA=="
         , "delegatePk":
-            "ZA6OomTj2vQcou1w/4DZql1ngmVG6tfsJWUiR5HHuKXkSlOdOa294CzTXeQ2tt60DvPTk5giC1TUT+9j2w1b8Q=="
+            "gR3HdAxv7jfxx30JPW+1DPSfyCA3bvGC4/m820i2Yd87zD++vnT+44Vtx4XlFjq6VRI5hJib0i+tUNhTT3arbw=="
         , "cert":
-            "1eef589f4f6c31d82428a205e768f7af19babc5480f1e820a3d753176905efd57240a18d251464c54dd0d880b15eb47d59549bf17f774744e63efedeeb79050c"
+            "2228095d3f16dae811292080f2133dabca53d243bdf842829370d2fbc0fd0465a7698d53254f4153c5cf657ec0fdd52183c3cf5d112f2e30fee53727944b3f09"
         }
-    , "fe8b4b1ccb3137fd9c92d36075de1bcb66be760f9082dbf57f7fba5f":
+    , "d2405b538b5ef360aa20f70f0b405444347140b0bbbaed7b808a5e72":
         { "omega": 0
         , "issuerPk":
-            "qQOb5zP8UvDh7D2t9NnCiV/lL2eROuFoqJflaCZiL9X7LjeaMG5HhK9OPD651M/D938+uN1iyBTSpOhH6smHvw=="
+            "dF4U2RMz7MRZE2wdT3l9gtBd6JjeAs9IdKVmdJAe/Uo/X39q8Zxkh7hpnoy+f6VjPKNOdH+U9pKvdIG/19ErjQ=="
         , "delegatePk":
-            "WfkabBWSl9hARYyxxrtZUZ1+qSmLbEih512bTB9sM6SE9GVqP4pj4zSQXaju76gyyVSCmqgWlNKjXB04ukO+5Q=="
+            "gt+QETfxLff/at/lyjeqii1zGexMU8wKkkB8DCP+g+6MHz9NqfIUdjnLjQdrvKJ0mBNB0O+0Rwys6df4PCanIQ=="
         , "cert":
-            "0b3b6a320e9a1a51b2c5e936560fe94141806bebac632660063d7a9d97458faa2f5e3372afd7a7b6a9352931363fdfd8263703f6be7e054dd6667e43f5d3b300"
+            "48a4d346fa7116605ac3f12f00b9d3db89021842cfd0a1622e13e15de390ea9f06eab86e15a7e6d5cec980e5eb95210216d2c1a84096b8c46462b9624903430e"
         }
-    , "6605bed51c9d4fada9883dea520b556830d9443a1547ce315c4220bd":
+    , "9f43183be5cf79a46ada7f5855f91f13c24bc5c30e684d371a397078":
         { "omega": 0
         , "issuerPk":
-            "edHUCG/Vf9/lKjUM7+v+gJuGJ8JX8cdbqcOtH6a5KvsMxG09r9bJUrBvwi5Y6rf4Oy0NlWy6E6eQ5MptwOyFJA=="
+            "bV+TpuFjxoJtlcjzAkbUqZi3k6pLFw4dO7aJGOwN/BWWH4gUMO5XOsn0PhRQnM3GkjdJUQpV5GwfhEkDMdu4rA=="
         , "delegatePk":
-            "q2uxjfU3rR7OruLK7O63rmXv8FpT9c3quCAet5NE8MeBMWZdDhAlvr7PWauKIVGJJTjrBFBb7B/Nh+EF6KCm2A=="
+            "9b52lztlFqdpmjC4jztfrF1MoLDJK5F8PW5Raz7kx7CfBZsPwy1POkPIKHfO4LssRm/v/H7K0niTYUGe7Yda+w=="
         , "cert":
-            "31cf8c1325164f3475d5dae84e715a75aec1349a78437fc3a3ee83182da7ce011136301eb4b0d7ca3ccd059ca4a04d8b023b2fddb96eb78ab9376797f1002002"
+            "86705f10decaa9769e519c22ceb902e878697ec6ff1d2c81d70e64a8c4a5f0ea004cb3fbd34f653fabac52f48c5747934001c7cc9ac7a0e6086247f253295607"
         }
-    , "20e53106620128c3285669dbdb1d1578867e90ab8c38e355ea93ac0d":
+    , "b217d6b255a26ce380105950c3339190f3662ff67a73350b4c173020":
         { "omega": 0
         , "issuerPk":
-            "05WV0BuWWC+Q9gJqFv4naSFdGxbf2K1c1QO5V/XBhbzx5/wnBwFFej+ZsW/P4PUJDE3r1V5etRN5wuRtbP8eJw=="
+            "2hZRYl7pyMvsEX38af8rhPv5K18b6BYtTbgbPbUtrc3GdlRrcAE9WA0RcEiMR/buE48serYD7h6WJOUgr/s3kA=="
         , "delegatePk":
-            "nqpquFKptzzxIF7JhCwwZswXnHL9JEFJexqoV5wVbSKEEMWAUNf5aWSGVHQ4skP3nuMmWnOXW7MJOkXrScPLmQ=="
+            "CCwc2HDia5Ci7LCYxVVW3jwqg3PPePDnP1m5vpQ7KE/O3CR0/mAdCBFzz6wbTlKHJ6hp2zNDV090HxTFeLwUWw=="
         , "cert":
-            "57a3f7e15cbb247e6fe59edb3106a0cc0cb784f1699d828ac9fb97864ec6fe540df768a78c0462507249874f691c82575094d392c17011dd9c11a49a6d99d601"
+            "70060f379a5c8a5af51f378e8de2757710d9243a405d6bb69017275aecc7cb57e52dbbe08934fc18f17ae352de3b05b0a0fe65fe2c52f14f8d51a99243044400"
         }
     }
-, "startTime": 1530828000
+, "startTime": 1531692000
 , "vssCerts":
-    { "33699d03b6ab8f3bf664c80faf2da893489a371c6adebe0af1630dcc":
-        { "vssKey": "WCEC+dqE+sQJ1tVM+aVpyToe9008GZV+iQJyIdebwlXYmOg="
-        , "expiryEpoch": 4
-        , "signature":
-            "e72b829e1c17d7de85a398088efbbb022fa2dc806b8ff1eabf82b5fd617cb65336009d10ad2f8e10d723c2c43b0b1f83fb7480094463050d00f472038b078906"
-        , "signingKey":
-            "nqpquFKptzzxIF7JhCwwZswXnHL9JEFJexqoV5wVbSKEEMWAUNf5aWSGVHQ4skP3nuMmWnOXW7MJOkXrScPLmQ=="
-        }
-    , "8a1ae5c8f92283504573c6f252ad04dc784533475683ca7d91d75137":
-        { "vssKey": "WCEDUol+JPCoiU8j+k5wPPOSu6RHZ1f/fyRmdCNavyR/c2o="
+    { "92dbddc858d353036eb15511051edb96c878300274eb448564489239":
+        { "vssKey": "WCECAFJSaDFGZ492OQJoyKOdRO9xNmwhtlUe7GI6t6dni2w="
         , "expiryEpoch": 3
         , "signature":
-            "56c241f5b6a47ecb7d8a28b4b05dbf722ca23f9fa4085e4b466f4d975c7e64f6399e94c8734bec345cbde2ad5289d9bbd4e49438b7114747a4e23368fe40320a"
+            "8f5fda65dab2d7aa6f635b7bbdc0fe14fa667fdfe473e8830c46c1ef30b8cef880d8a67d16cff822bf07d77c89bebb6f8f148a938d335f62e1d4bc27d17f090f"
         , "signingKey":
-            "FYAhifXh1M4gURiFzCw/fnaBk4Vy9BlMwt8Bt7L81vP4Fw+afOP18SPdSS7H4aucvg2OnmbBzuNOngaMIeJgyQ=="
+            "CCwc2HDia5Ci7LCYxVVW3jwqg3PPePDnP1m5vpQ7KE/O3CR0/mAdCBFzz6wbTlKHJ6hp2zNDV090HxTFeLwUWw=="
         }
-    , "e9adf09493da73f3f9d1879ed57a85cd826cc325a4d2a2f5704dee04":
-        { "vssKey": "WCEDPJFIFt8tSskE5ReWTfAHx62mlPhuJru3J1U9Mu1QwOg="
+    , "ee8268c62fa962d2ae98cb6364ca8cafcd983140bac7edd56509568a":
+        { "vssKey": "WCEC3OUIYjQUBKcc9gL2lL7HV2h20w4kcmzxaF7nFVGutIE="
+        , "expiryEpoch": 3
+        , "signature":
+            "a76d14bb176cf1f64a525ce677da91948cd9b2e7c493b4e877e18a9c6d0cb3df002e2b162d1f0bcb0631a0ea37d773446e604ba5eb18cb6b10f27d038434a303"
+        , "signingKey":
+            "KZ+s5H5lMQxMqXUeQte211QI6hZhMHur+p3EXPgn4WO5j0D8HCtBXkp85EdWg0MHX5mtbGfXd11ktfiWxuW86w=="
+        }
+    , "c69e46f1bc9153640b3645ebe79be9158e9c267b87fc50196326d02f":
+        { "vssKey": "WCEC6PGFJELMMwhMGPlvqZ3mosB+xR8r3fyvyzkR5D/DwXc="
         , "expiryEpoch": 2
         , "signature":
-            "58af2754f758d4186dc2e956ad8109f1a606f0ff982ff52153c0900422e82750990e9fd0ad00d7aafe895bb6224808561c7da3b856fce423343c30505171b70f"
+            "a256adf50ad19ecea2dc32d8a34cb584df11580490524fad268120111b48b51b30f35a746c97583574dec252cf867c534a4301dc1de8de133c43917005a5f906"
         , "signingKey":
-            "q2uxjfU3rR7OruLK7O63rmXv8FpT9c3quCAet5NE8MeBMWZdDhAlvr7PWauKIVGJJTjrBFBb7B/Nh+EF6KCm2A=="
+            "gt+QETfxLff/at/lyjeqii1zGexMU8wKkkB8DCP+g+6MHz9NqfIUdjnLjQdrvKJ0mBNB0O+0Rwys6df4PCanIQ=="
         }
-    , "00b9129a76e6ce08b54706f9c224d357faa4b5d51bd525294a4e328b":
-        { "vssKey": "WCED16IYVTCtVek7Cm9xMfTWUW/uqN63cTQuPZPNDGhBexo="
-        , "expiryEpoch": 4
+    , "e649d57c5f1afd5a6dcbd86b7616f1d7e03c4c2e1519cfd90d5c8a2c":
+        { "vssKey": "WCED7/qrnPG4DJSAvvd16C4PvLwW1V79YRbKXegpDrGsvxg="
+        , "expiryEpoch": 2
         , "signature":
-            "0789b45aa7527c8c58ea1b3825a4df086430096973a0ae0296d861732f379c1a257d07b3b31e4f5d020f21f0c0137cf96ca747fb4db1f093b0b6c0bb6548260d"
+            "dc3dc1a031d070ba5876f5e518cecb5fef7ef34f38bb064660aa867def60f28749a41bf9c0384ec9b55ce870e2c5c79c59600419ae1b26293b092751cd242300"
         , "signingKey":
-            "ZA6OomTj2vQcou1w/4DZql1ngmVG6tfsJWUiR5HHuKXkSlOdOa294CzTXeQ2tt60DvPTk5giC1TUT+9j2w1b8Q=="
+            "gR3HdAxv7jfxx30JPW+1DPSfyCA3bvGC4/m820i2Yd87zD++vnT+44Vtx4XlFjq6VRI5hJib0i+tUNhTT3arbw=="
         }
-    , "09a06437fe30787410a26f7a8b10bf2d16645017e578226b70bdd913":
-        { "vssKey": "WCEDGd1NY7HDPvSCngD5oweZR+ubuLOYS1PaxzM+9ltWycE="
-        , "expiryEpoch": 1
-        , "signature":
-            "b4299cec35136fa72988bb4803c99d519789cf723e17283fdca4218f380aa27b10cab6321bc0e607dbb4f80ede4f27e481233fd7d7358b8f78f906bf5c9a7b05"
-        , "signingKey":
-            "ehyzF2brz0ya3J2popvN2i9ef7GYzQI/9Kr2xCflIlKCByKTC85QUUFc9sMELzeBD+diLsP8cAIACD6y4sQrCA=="
-        }
-    , "2823e77b8282d88902eecafdb863d98a15c8611dfddf166c0b7b8b58":
-        { "vssKey": "WCECBEaG5ezWkPDceMU6Dftd1d1jq35gKg6k3A7Qamhgb+M="
+    , "354c24be776032d5c5431ec38a2721d5022ba476d8372f6cdbcc9369":
+        { "vssKey": "WCECy4DDzXq9A/sBvCiJs7O0b7Vokb3BuPYDm42eq1/wBtc="
         , "expiryEpoch": 5
         , "signature":
-            "4bc99fe0377cfe986e79dcee23ff15220b2a11752112d49afd048534d23853f865b7eb79b40f5cf8c7e7f1b1715d9f4ee04cf9adbeb7598c706b778daf7fc307"
+            "69faabc13d0cd4c87c4b9637d9bb08637c52ee6ef0b49aab0d8e775b5e686c9ec7029915a8cf7577251dc0a8611929390fb888f8cbd4f544ab884630e164210b"
         , "signingKey":
-            "WfkabBWSl9hARYyxxrtZUZ1+qSmLbEih512bTB9sM6SE9GVqP4pj4zSQXaju76gyyVSCmqgWlNKjXB04ukO+5Q=="
+            "EQu0gdSuZro6DPHR96b5g6e66vGqCCwx+nSEib85UpVPURSI/C5rO8cZTJLm4Vc36wqsmSWeI34BbGrMGCtVwQ=="
         }
-    , "bf793c4a7b86d764d75c9b30c3cb09d9f19bca3918b2072a195ec1de":
-        { "vssKey": "WCECXIaLfsLPSFSfoj4/KUMOOG1qVci/irQyOaKGYBUwTvE="
+    , "0c432223bd3d6403860490c366885f7aeb2b6194cec9b7e44f9b20db":
+        { "vssKey": "WCECQgP2a1Lbah4QLnrFpebY1gfnvBqjzc3c3AIkpsqAeO0="
         , "expiryEpoch": 3
         , "signature":
-            "54c988531eba2c503be20c3c18620517b0f9ee47c3dafd747fb5fac249798dee0c82190955d4fc7ed508cb9581c115054ffbb17e5ab0798160962e57c620a009"
+            "4c2d13531dbf7cffc9d5abc34a67e6225060fbf7286e1c54ea22aac0f8e3c7e8f24d895bf2a802658aa0b8f2b8e5ca21afa3c4b146b42c97e747e8b3f5e4310f"
         , "signingKey":
-            "5OQLmrFV4LvcIJ/XJxsVPddulc5VkbCVPueHpvOdOmgea/vNIG5m0HpE6NJNDk5E7tuvjAZ/p5oZ4tXhWwEWVg=="
+            "9b52lztlFqdpmjC4jztfrF1MoLDJK5F8PW5Raz7kx7CfBZsPwy1POkPIKHfO4LssRm/v/H7K0niTYUGe7Yda+w=="
+        }
+    , "1353cef518093ccc75e3a4585e9ef378ec232cbaad2a2316d56afed6":
+        { "vssKey": "WCEDOLD9AR6Ipbi01du5w0sd4QDS6Co8GjPLjjTnnIqitwg="
+        , "expiryEpoch": 1
+        , "signature":
+            "7c8c6577cd9ec68e7877607ee40d2a850caf12ca8e59f321ac7d5b99d0e44ddcf1d33dd9625f7d113cd7dbf2e819181b21bb84aa6e1788c43d173fb4c4f7c50c"
+        , "signingKey":
+            "aaLbNu/AtY0CGL5WtZbSjg2pl3+50gD7l4ZrRqp4XmPi+0ejmF3QTjTq9lk1mikKrkybLyiLBN2G+sDIgiX5tQ=="
         }
     }
 , "nonAvvmBalances":
-    { "DdzFFzCqrhtDGac4tWPA4dbRaXEh58TTHx9BZZgJXbBR7JjW6M5PsSFzbEum7N5dmFvhLzG7wWw58M4qkDdaQ7uLy8ABGPY5KG6gf2ab":
-        "4399999999999"
-    , "DdzFFzCqrhssKp5Ryc5H7wDPXGGYYqbaWJymWQbUUY7hrtVJ5iGRTikZmPLi9JsEkuHrW2CkfFabV5EtAhA2oPDBYV2Vit1MptZXACx9":
-        "4399999999999"
-    , "DdzFFzCqrht743wvCyaPfueQsjtye626cdBa3SmB8tDKoKD2yuibbG4aYE3FsxA2W9GNcQy1Q3ypjcYMdQd38487am6wQxTgTjfFRvwu":
-        "4399999999999"
-    , "DdzFFzCqrhsgGxtgiy6ZtRhj14v6BHJ1ssi8HiiSrShBBccWoEb2ZftreK8pkXeav2gybMZWDxe3NZwhjGS3EhmCc9vXs5YXg5pNg5gX":
-        "4399999999999"
-    , "DdzFFzCqrhsqY4rxKVY7yZXYrFcDUa8DbgbDS87Xgpv1chJX6ecz2fsRLM13mzzQwJqYK8hiBqeSDkAL1xRctqMzf2ac8GmBYkUXV5LQ":
-        "4399999999999"
-    , "DdzFFzCqrht7CpPsCsiu2kWByKNDA8PtNjy3YRMsed7JRaQq9vE5r97Ha1KtpMoKx2WPbf3bBYUGY1PZDiwAwKyXdzNM3QM3BE94r2jJ":
-        "4399999999999"
-    , "DdzFFzCqrhsx1xt4cRXwakLkXStrqcBW5HEYPgh4KJp6q8vPkrTNztr9NbE9b3upRytbtm8LwdxaFTG7DwU2Sgt6F9x1n1tBmzDCLeEx":
-        "4399999999999"
-    , "DdzFFzCqrhssio3UaCNJiWsedrTHYBqXRRYaN9RzMWnYhaHfpaqdit6zFpVc9TTLPW8XssEoY2dPJARLxaQquSWiiCzXZfKvMWjSUqfS":
-        "4399999999999"
-    , "DdzFFzCqrht8mCo4MCTUmjz4DWQGsKtKL3gYqg8TLpv6JYRisfUGqsMeTSmXM7TyWvhzmUBnkYWBm2u2e3rvhKSNEfzxfBYxHH2mFH9J":
-        "4399999999999"
-    , "DdzFFzCqrhspfBgdNocTn5sptSRfwPGXxoMKuDu4x5TswyFXUW4e1s4JLckaV9Zw1fT5bqSnpuUFwntU3gJrHMJc2AKtUXWGiFSn9vPG":
-        "4399999999999"
-    , "DdzFFzCqrhsptq8LawPXkDUBtkUiR9MPeaxCcWLU2FDgPvd3NRe3dcB6BqR6sU5CB9oJj1x8t1CmDw722tNeMUVdbc6ST8zxphTmcY2y":
-        "4399999999999"
-    , "Ae2tdPwUPEZH4CF1cSHK9xsV2EjpQtrfoZGFMzydaa7ioo2YdKZjTQi3eV2":
-        "6222857142857143"
-    , "DdzFFzCqrhsfUtGPLNqmMLc1fkLNcofkJEKDUCoM5otj5rQWBa1TgAPPBx3FPrMKbhmwigQ9CrKTfWUm9EFAVSCgLgBfNHcY9LmBJ9Ux":
-        "4399999999999"
-    , "DdzFFzCqrhsvLenoPiy24cDCYzwjqKRn8vMDTvm5SNLny7WmYvonz43XcH3kYXd8TtgZnHfZXhzS9n2oZati9SFbEkjtL4FEwcPhmCxR":
-        "4399999999999"
-    , "DdzFFzCqrht24ZhrU6tmJkBj6msb9bkqScdw3qNfG4wMZDSkyMffKX2mP2aYRT3vLbuT1qCQSwgyZ23Vu1YmAeFZL6iPz7cxk9X4t6nN":
-        "4399999999999"
-    , "DdzFFzCqrhsxK5kAo3o1aQAbGaDVeh7wCdgqdTnLhVJzRLC3bzF3XHyp6FF6QcGL7Hvxj4JwPC13MRqUa8VCQaCksFhzFLbVZvcbycM4":
-        "4399999999999"
-    , "DdzFFzCqrhsdxE99yA91kmc7k6euPuLaEywE8JxPsU2M2Rcrxfq9cwYWZRJvNo6YEw51c2pGV7t87w6phMXt4FrbhfP71JrRWPrNwBJY":
-        "4399999999999"
-    , "DdzFFzCqrhsueBtUEZSydeQrWUqJyVYyJmJeAN63vnMyyXGc8xMayu781wbCU7kc67BF54ARdic8X478cDhEokujM4oF3ALuau5AFJFV":
-        "4399999999999"
-    , "DdzFFzCqrht5SDVRCsuv5xnb1xb26jq7rYbyCWYHtDrWy65QsqD5CTqYUVu7intaouSuee7y6cctCJU2ynD4d5drzxhV4j5dNwNxJZLX":
-        "4399999999999"
-    , "DdzFFzCqrht8WoyPwbpUuV38T9fuzR2d3gVXksBiriXSA5zD3Yk3GGsvaUWyzGbdBjv8JK5m9zHuoRNLjjrpkkuSDMp1HLtHX1tw1WRP":
-        "4399999999999"
-    , "DdzFFzCqrhsyKfqjH7G6WQhxkDe9BYYsNPr5TXxLdorJtwq8LeUk8XQrsfjgUHoViRj5y4ZCzQRAh7Zy3GWNkL4v9rNYnRutTC97Wpu1":
-        "4399999999999"
-    , "DdzFFzCqrhstfPajRvpykcrapjoEJnNwPCtVdWhJ4Js1BwKcy2HFwhTABHPgMjb87aNPpkkxo17Mi4N3gB7S1MkSQx5uAa4Dwx72DCVN":
-        "4399999999999"
-    , "DdzFFzCqrht3bipJghXE6b4i9HuCLp41XV4VwSUwyvrTQAp7AHENzmWCrihdxw4MrLBDaB1Gg8oY5tQubuAKnJi5kogZ5iRFrVyEMw2d":
-        "4399999999999"
-    , "DdzFFzCqrhsiwxNXEXjFhJaHT4NMMDjjcVSiVqYZvsrTRzU2GD3A7n59sdHCxTv4fcHBdkcchcsUDgByLDg3cVz7ParqngMr2GJZnuZm":
-        "4399999999999"
-    , "DdzFFzCqrht5e2doi6XwssVsjShVzwAqaGdbjMMZpxR1Hw81YcLyrreJgmgBVav7Rf2kwUneme38kGkhPjaRn1siSmuUFUVDqw8qGLho":
-        "4399999999999"
-    , "DdzFFzCqrhsehLaKeowsmzhiSQu1xvA7Ty62TGgMhDMhKLGSQTy7DK3Nqut4tR6RgY9rYHUkNytNL1ru1oc1w7f276DZgdtxwFnfTxqT":
-        "4399999999999"
-    , "DdzFFzCqrhsenLMnnYYr49311t6eBJHb4QjhLEKuZeYnwt7emjnP6mypUFBoijfCRwBJ3ACKfMLVZPL2nwcnd4asSxKHPaLY4cxj1m6T":
-        "4399999999999"
-    , "DdzFFzCqrhszvNmWDYBVKcc2Ke52tRsWaZYixn9iw4sU7mEy4teVvzyWdtsfQqTH3wtv4Njq44N21d2oXiJfM3znB5XWv1NWt2aZfXPF":
-        "4399999999999"
-    , "DdzFFzCqrhsiJam729G2jkAShHfrfbbms9SaLqZywDUWaxfwseBbRa2NVLPoLy65TdHEhwhRUW3Lq4TXNX3u9P2vuZdpTXt81WZDvk17":
-        "4399999999999"
-    , "DdzFFzCqrhtCbRZQyJDqfyGW9Jm42wiuujSkp5E7Vcvbz2z3Kt3LCHx1utSBLnpLfzSqj4umb6girwahkmkLoGCEhZc4UnqnJ7VmEAxN":
-        "4399999999999"
-    , "DdzFFzCqrhshhuoMsSXvy5nTKWF2kxhzPtU8F4VBVEhgEJ6LZgW5LDmzNpTA1NxdVikyLnTXtV4W9o4bfMv99ju9n6MjDjR9MMU646Xy":
-        "4399999999999"
-    , "DdzFFzCqrhswesWxaQsX76JZZ33wsXEBNiG96fdJ1HrfzNfYgnz2rhW3ZwjdcavWXf6mgkErC3zLjiwcQZXDEAJGf1ZF4xECNaf1xUSz":
-        "4399999999999"
-    , "DdzFFzCqrhsg85JQcVRxBrkUqYqC5G9XcCKQjw3zQEgCNSH3iJ5k5uoUhq2Si5BhJNiH1kM8LcS7uW4rmDbjbGZeYveyG36LCRWcdUpY":
-        "4399999999999"
-    , "DdzFFzCqrht1Cet2ru2RssiEggzpoybYCUkuVEEM6K4jLBqhzYqmjFQBwkhPA5TWb8chTMSjkntyewo2hUKJbUyJEg3arQobwfWh6Ufa":
-        "4399999999999"
-    , "DdzFFzCqrhsycrHAACVDVQMZkgcAVhejwkRfD7vcZXndFv7Wt6tT3xzznv8ERVfh5J6ScHo9LpcGC6hARuj9UpqjwBu5kfb4vCzSSiay":
-        "4399999999999"
-    , "DdzFFzCqrhsrnMoQsBz4iaUZZsYzehiEH2JpQLXJ7bmjHQEFV2FxDbtXps9GaRUrmRSdDEprG4EiGc9zxbuM53UPX6aXYiekbQZ6FtUr":
-        "4399999999999"
-    , "DdzFFzCqrhsrh3z6qrJCGsKvG8CanG3Vwt7Ykbns9UEZqVDpqRcW6UHxiEaq8NxT4uETPVin8osWxYuuDaUWrB4JGjwLC6YxJRXLfPfk":
-        "4399999999999"
-    , "DdzFFzCqrhtB9rKXzV2LWXmcXqkD2FuQwUu1DLYU4PSLTeoaXyQF6CSDWXnii6efkzGj9zebWP9XGLKghUSq5htMey7ZhwKvZMAwqgdB":
-        "4399999999999"
-    , "DdzFFzCqrhsiPXYAwaPbJbL9wWaXERFupjtXedB6poBs9CwERRhwvFaYesZpXeU75ZMrFfu6r1236EzF8tkHA1h4FNHbXeDkM1KYS815":
-        "4399999999999"
-    , "DdzFFzCqrht4ErvceJ3P81GbW5gi6vy7tjNZaHJayT8Jzx1eeNeLTPAPxuJdGoDsrxyapu7SWLizDAj67gA4wvc7ubSm7qt9pjheQNX9":
-        "4399999999999"
-    , "DdzFFzCqrhskbDpHr4LVTNx9uFJ2puJWjTWp2sJTe2D42A47RGBYVATDk2LTGQRQVJ4TTABgrEG1bFkfKExK6JGbrZt86qHDDsu96wKa":
-        "4399999999999"
-    , "DdzFFzCqrhswKwwrvSFL88eqmW1BDhG48GHbZPQ55nz4o5g6N7PJktexssXycN4NjnN1A1euB4VjHHy1bd8MKzEADs7vot9XQdoGpTPe":
-        "4399999999999"
-    , "DdzFFzCqrhst6bPbdCukajHJcuH2hg1mjNZYoj7q54yBfBdM97DgooaXC1iDU4BouanJzYETfyTadDKiTukZqL9snxpjL6YAaj8oqnnC":
-        "4399999999999"
-    , "DdzFFzCqrht3ZV3VXxj1oJ76MbUiqa5wnSHrcM1DNUPDnXMkS3gKWyaFHEcrahbYfq2VmYptTGu14WdZm3Wimmffv2FkHukhqGeqgZXy":
-        "4399999999999"
-    , "DdzFFzCqrht9yKTNZZMb6UpxBUWPm3HCBfwUVCTKqXnAdxVUbE8ibnc5w8gGT9p17LF4D2AfvJBketvU9hb2h86TFUakeoD3t6EzpArE":
-        "4399999999999"
-    , "Ae2tdPwUPEZKFkJWPXCQQU6mmdmYi4hQ5wqYfTP75upae6QkxkvfiBjwniZ":
-        "6222857142857143"
-    , "DdzFFzCqrhsfU2KWkJRRmN2um7Tf2tAHY74S5y6dkTYRgoUvpGYw8AfznFnwPvfCw5C5bcijHtQuwhWLiAQpmt6fz7ntpxWjM11JruL9":
-        "4399999999999"
-    , "DdzFFzCqrht4U4CK7GcXGaLhrRFjiWyxgiSdXyYomWUzcQGQTyMtRMZPtWNME4yEHHFyfxg3KkaF1eMJLZxJneFP8V7vS9rpZP7J1SgK":
-        "4399999999999"
-    , "DdzFFzCqrhsmuZuQwuYqzhs1egSAqACAj83SQkkPaWBr6vsJLX7c94WhTaiqxsjLCCE3NyGu9yyDb9D3QJ4bDzi58qJ1KMWwWmdK5698":
-        "4399999999999"
-    , "DdzFFzCqrht9BLsx6rtn48wZFB6ZRbfv8G8PwrWYWNT6q6izM4DmkPG4Do5135zoCwZ4xL5FmRt4nutML6Rs4Ys7TbodskCBAffyRqbG":
-        "4399999999999"
-    , "DdzFFzCqrhswP3ChTD5bxWMYv4977Sejn7vmVfV5owZo8doWTpK9yat1ntycwYyiiUvk6o58D3WphnR4JRxtSyY6LCbqCirpSfRy5ikW":
-        "4399999999999"
-    , "DdzFFzCqrhsrtWS7ok32QFWrLoNQjkDvF6R34b9ShSrp9zWiPLqX81HKvvJMkN5wBSc5H5wLCnp5ftabU57BNJx714FNfZDJ5UJdwSVf":
-        "4399999999999"
-    , "DdzFFzCqrht4Q51TzcYxmxc21BChupnxX9F9oQLbzfLimeXCGpujTXaTDWTPVP1CaV8qFcJEVMtgoTiYpALzqkxmigLx41PuuamR9brs":
-        "4399999999999"
-    , "DdzFFzCqrht6CnMFV6e2ZECEo2RDGHWe5HWxSyqgEqyfU7KkPrszSv8briebZJGPcCBgzXv3PTyCKGHamxBdHEsMsQ3DEjUBM3VPcYfu":
-        "4399999999999"
-    , "DdzFFzCqrhso4ukmm8bk4eEyw62VxHVhg8sAfhJyHQGPwactMfde5ttaZ8KEKwX74XgZdT2zBigDo34PuXNDm6FEn22cEJpXFgeAkt55":
-        "4399999999999"
-    , "DdzFFzCqrhspXHb14GWQPzx8DQUsCNSRix2QTA3p6yyWB7ijjTNUHxVJjFigksnm89jJFixbw3w5p5MSwAUFuS1t3yjTAnjXezSpCieW":
-        "4399999999999"
-    , "DdzFFzCqrhsojzKS8M5u4QpfWxqAB1GD45FkrLSWtccy8DiCZbLDRECTGBuYvr53FZH2ntnYrxjiKZFHupmF9Fx5FvnYm775Fq3upRpN":
-        "4399999999999"
-    , "DdzFFzCqrht7XhNqEtsdf4iytW3MBRj8Zt59yegxgxr3EcMooTq655GvTJENnR681KwdwH6E8GVkoPK6EhQsQAhjup5hgJJG8rep1SXD":
-        "4399999999999"
-    , "DdzFFzCqrht9RVHxMMsmfM6hCnq41fqhUW9FmpKB6SWkxLUTHdeEmhVjU3ApX6wQDFKNhtixKsGRVC48PyFqDXnNxm2uuQMWACpD3z3g":
-        "4399999999999"
-    , "DdzFFzCqrhswuczniWKhWHxtaLjR6hkbBXdV55aFF3WfBKofdUXPGcwzrqqbp45Ruga2L4z7oixfaKiLS5jwbwePQimBiHgmK9FTwoWN":
-        "4399999999999"
-    , "DdzFFzCqrhtAzxL9fhDPYcqG5nXnsZ4ZpysrBTiJWAav5TpdtTfekFxHomZgr5gjRyhg4K2aPTtyP677eF9ATxSsqaJtMzEPPx4orivZ":
-        "4399999999999"
-    , "DdzFFzCqrhsxd7qTY5sbCmRWkGUEBTxsbqtvaY6jKSj3xCX7tXHPY8dfEjYVCz4RyzaLwj3S7osetLhQ4THnGcn17dkKDA7uy8Qt2ZUn":
-        "4399999999999"
-    , "DdzFFzCqrhsrbaoP1yfLmoZPMPiWJx5NeEuNCgXhNRpsyzaWVcSC4ykFbUKxHcqi6q3981n5QyyUiBTqUpGxhX9nwK3xXhkxahddswyn":
-        "4399999999999"
-    , "Ae2tdPwUPEYy3y3eGHk7zSrBEc9SCyga57ef4y5kbXRVDxQxvgbjBWmdhcR":
-        "6222857142857143"
-    , "DdzFFzCqrht4DBuGTJU5GWQjoVdkZaSqxmuWaJwd8eaUFpyGjGv1X45FTXfKZehASj13gHjzPmKnn1ZcufGrGS6FkzY3g8mTZFMoSx97":
-        "4399999999999"
-    , "DdzFFzCqrhtChn4AYYLyFNEFUNDw8Q8aooEq1GyToiydC54N53ndWC4Wke2euNKi89CWJLfrJWjQy1PVmuRtU7GB2iGKibgq6VxMMrar":
-        "4399999999999"
-    , "DdzFFzCqrhsjgGD99QwEyVTU61gPJ6HP9qEjdJ7K84oRF5K3oTtAimbbL53PiHjbj7dz3FWgpY4obkvFGfNzcGtFRTbemVBFb49XKEd2":
-        "4399999999999"
-    , "Ae2tdPwUPEZ4SxMuLqijiLMfeCfRq75anrsL8YqSduHgjpvK8bYr4XHXKFw":
-        "6222857142857143"
-    , "DdzFFzCqrhsguMBhC9SB6A9myFzFmbNFBAr7DkYiBzXfAqtxQvGHYfeKMVYFEeKRBPiXYPWmeB4yfvoqoCMoSyRXYnreE4D7huFkaruU":
-        "4399999999999"
-    , "DdzFFzCqrhtBen8Wq7fJYyGLn1HaCdzD36oe1xHbPzXX6QzpjXh41bEcf2LVA7MoAx4QAmkPsWjtdPxw9TNRNhG3en2sApLHnMXeqpdJ":
-        "4399999999999"
-    , "DdzFFzCqrhsdsWtrW2HtrocMM4qy4GsrfZUZLrvU3LJgMK9LwaH8kRGgXYMxQtdnPaY1nFF3aYnRQWMFFS9rGjV4wAthdioHFzGifb6M":
-        "4399999999999"
-    , "DdzFFzCqrhsjS9o34mpgorkg1fTL7y5WrUw8SR2XZrLhQtNuC6Lau6nYyfSiQpRUfR2qESqPYuDdCiisCj28DRkjn7zkH9tkKEJxQcNj":
-        "4399999999999"
-    , "DdzFFzCqrhtBdJQ8eqz4iW7Ciw7dcbECS5PCgtqrU5hsJ8kQacfHu9uwMq5SuHLJ3WAzYTKj3XQ6eGMayP3UT3bqJKSbFkcJsQRU6CK2":
-        "4399999999999"
-    , "DdzFFzCqrht3mGww3fqtAehuACvjheBCvGQ5WzyoD2qgwAfR3KSa5qWPdQqnQKyeJCkhXeFRusQrkC3gcpTLw1t6d5M6HPCNQGUe54Dq":
-        "4399999999999"
-    , "DdzFFzCqrhsgPsG9xWwvyzJupkLgZZqDy4CQv73QmX3RQ7rPzKkHzz3AhMojjwxsb3WRMTdbFqQkjJNodB6FLQg4XqEhY5xX86QbDRgB":
-        "4399999999999"
-    , "DdzFFzCqrhszoysio7tAou8xRSrGKTCt7Mt2VUhE52k7NR4fDtBkAdza6R4SzgkAJrbir9ww1x9GspM6Ft1g7nxJHhWMAdRkP36KJpZM":
-        "4399999999999"
-    , "DdzFFzCqrhsuME9XZbVG4iqwGm26WMiATMtbX9zz2uE8aBWcKMjWzbmt4QLos1myiEgkiWjhsEKXRAZBvPuB5H4thuZqC6X4sTMtPEbE":
-        "4399999999999"
-    , "DdzFFzCqrht8bbuKJ4ZLwuP8KuCG2fpE2xfNCRumW3iW2FMq7s6PdMADUSSbreGigERS14QthHksLqB7y3dbMSz7VFhxhpE14wJtbqwu":
-        "4399999999999"
-    , "DdzFFzCqrht3YQCVVouZeCzFXwz2KtShdo8rvGFte2giUQbniJDnSes8bBZKrVLRqK1ChnzcaVwYKFE8w9hjPUy8RXdXBa6YW2AUQUsr":
-        "4399999999999"
-    , "DdzFFzCqrhsqTbHFZkzh8KRyXKt8dPkzZK6oidoEMCMAijJHfV9AS912e3wF2Sq99NuXh9KT1KxXG9Nw1hx1GD2g9jRtvTQeR2hXirb2":
-        "4399999999999"
-    , "DdzFFzCqrhstL2WDSyLhfCzdh2x7QiwhUbuJZt3CdTumd1WqHzzy8GkcUuP5o3vdcw3vbLGytmGyJZZv5r5m35Z76FrYL1mXxVwPZ386":
-        "4399999999999"
-    , "Ae2tdPwUPEZDNXRuaVitf4fHNjc73tcSVdzG3PCBWnQtpaYqqxJhH78rZfj":
-        "6222857142857143"
-    , "DdzFFzCqrht74caF3EoUfBYjsQDtvmFqLznHWia4LzotzH7VirwyWFBaVPvvoRT5KHXF8zdR7e9HkfjrhSZBVJUHkPoxM2BFbt1dwZgj":
-        "4399999999999"
-    , "DdzFFzCqrhsicgwwQuro3NCUY8idU5yUn62GoLhJbdnsf9hLgPjt9sidBKsb4gVEnGokTHttvci7YVs5kesBGZ9jMN8WZNNoZ5oYujzE":
-        "4399999999999"
-    , "DdzFFzCqrhszpyNsg49bSnVVqG8of9so3GbbJbrWuU1rEQszqFrLSCw7rWDV31PAeLYQQ5hVxpSgKBeKoTXfEtBifMtNpjyMTrdMgVw9":
-        "4399999999999"
-    , "DdzFFzCqrhstmZMUAdvmYEzLPwVQov2JukqUx4Y4y2tqgMKCFp2Zt2ftE3KUonAdVvVjJoNCkuKPVvpA71t3kbb3ojV3sq5AAHyMbZ56":
-        "4399999999999"
-    , "Ae2tdPwUPEZAwuWXddbCCCtFV58jFW1pDeCDVSpcGgzrx1bmock3S4wmYVE":
-        "6222857142857143"
-    , "DdzFFzCqrhss85QwfpcwtCXfddKzBVGzN9FNUAoBq7j6cSNfdQyiHgHg5o5MJn2oVUL9v7FgQXKaEwmmZ8UQiiuQx12bEWUwfNQ8Rs9B":
-        "4399999999999"
-    , "DdzFFzCqrhsz8eu8jGxHGRUg24MDB1M6d1V83f1WLqBqXiKyKDpZRL7RnHjLdmmboaHEtQMs6DEJoRxM3SPZjNC7HedFqwgqrvUiuoph":
-        "4399999999999"
-    , "DdzFFzCqrhsfLQtuajuPQhZ9PHJmv2dF49thWc5NJBpaUhGDnAGv6g6a5s96B4kNhr7PNPB9Ci94XZFKtPDC66vZ6SauK65MPvQsZXHP":
-        "4399999999999"
-    , "DdzFFzCqrhseYuz3usPQXLtrdWm7QC8KjKUGn13Ggi1Rz43xwzgm6HmsVcBoj67iPgKfC6dPfgLma3HK7TGv2rGYddVCsTqR89m3JqFk":
-        "4399999999999"
-    , "DdzFFzCqrhsxLMkAY6opkXQ3HyJWoRri6trG7n4obX6KKp9pbcWDJAXZYmzFgPWWmgMdNjEnXptJSoy89cYvLb9NZphvp8DodBDsSWFD":
-        "4399999999999"
-    , "DdzFFzCqrhskqEkccQvrR3FvehdqiK3QFthpnXKe3WiQaeQrD8hfpC1fNMBqovfrMvWm6P1iuhfq94zv4cCWbcWdbuKpvqHxf5q5nAF5":
-        "4399999999999"
-    , "DdzFFzCqrht96adY6EwSB2YDjMGL5TtXanSzrwJ2knSiHGUV9eP5BQw4UsXKZBQPu6qs7PZU3L7UPBJnvTeC4bzbDEm8Zsv6jsyXFygF":
-        "4399999999999"
-    , "DdzFFzCqrhsmijpziR7MydduES5cMKLqCoxsbuYeHMvkEZZaUZXwZpshGXYiGHK2XoSRFasJ7gnGoME74PFbbVPnBzLsttxm2746vmHH":
-        "4399999999999"
-    , "DdzFFzCqrhsqm1vFYrUwTrVcEaTnaZ8KMoySYQejTTbfkmbJHvFSWsDQSsR6395y1bThfxMWuARE7Uim3gyertyp2AprknN45nczCzzq":
-        "4399999999999"
-    , "DdzFFzCqrhsi8mbxcFdxy9S7LS8x4BgmyzQeXztUX3KwNfuYDuuEtE18GNLzHALEhiCbdQ7dV2HHFSDniAZkTXjtLSRJqtsXVSx4iWAt":
-        "4399999999999"
-    , "Ae2tdPwUPEZ6obSZyUqzyDWDgSBPueJhGGZgqv4xTTgD1gZaPSqXq636GKr":
-        "6222857142857143"
-    , "DdzFFzCqrht6TzDc8XTXKeGpiUACr8N222cb4iaPLTAdvi1kpvJuSXmRGoAx7hYzdkmEp6tW9Jt28tKjsmgYQ7Q9NzubakYih5MEHbvy":
-        "4399999999999"
-    , "DdzFFzCqrhtBGqf57YpqYuYML33YrBnkkUvfpTRjLQ1z92AajtErrxx53aFV7GVSWip7eGCbBjRzxfKEBqXUJiepu1A5oD3Mvv27QC2u":
-        "4399999999999"
-    , "DdzFFzCqrht4kvhfBorV2RptuAPvpCdYHWrULEt9RrMYKHWu1nfehzJ3h1k3z8a3uERqF47Wv22LHNcKwxv49Vy6q7kDn8RzEGE9Zuk2":
-        "4399999999999"
-    , "DdzFFzCqrhsqgMVgcUJcDrg2HPabfCycvYKb6WNnU7vTePsbT2LLsYM6XSztFQGgpYr8gs7ehP34RTJ4jwsmWiY5GU58s9rHW3uoJgS4":
-        "4399999999999"
-    , "DdzFFzCqrhsdsaWhrDEXLsE5mSMA85SrZWr9vtX4zuJFeo3kH1PC9AKKvM7HQKCWPtuqybz7ETSqE4wnRVX1RtpmcBKYUo4fNj2VLeU1":
-        "4399999999999"
-    , "DdzFFzCqrhsu3GkPgByczSQSyEEa3J8kbWFW7cxpBsL5FUdEKEVHXaaGSDWvpJ4BQjgPtXACGG4jvwvQhhR1YpAZB85LwA4f2C6AYiab":
-        "4399999999999"
-    , "DdzFFzCqrhsx3rrbCCSKWZuPPeJ9kFW53zzgj62hiACXWkjHWFNkCrmJnP1WZjju3mNvGA3D34pgahJDqUYGa9Jp9kk56QT4D4WZ5YB6":
-        "4399999999999"
-    , "DdzFFzCqrhswgwYa59MLi7L5xHqyBtMaMoA2QVDQtncCTeL1d6xzNKJCRMFQ9K8qfQv5XWNda5Skx1WWpPmsTi1DouAMHBUZHkQwMAdb":
-        "4399999999999"
-    , "DdzFFzCqrhsh4fUutNs1G9a6BBUPPmBbHpwELbsaXG4V55R7En7JZ8yvYhcWVg5oEWjxJmcuPBmptj3enctvspnbpyQ9nwFSHazaHG2E":
-        "4399999999999"
+    { "DdzFFzCqrhsxdsSm1fsnFJLa22uzTjmzpmVJSEGJhz3xd6e7ydRmLzo37SXGBovq43MU6Hr9v5X2iB1yMfrXYNrb7fHuk1bQEKwPxbKV":
+        "19999999999999"
+    , "DdzFFzCqrhsjuWHtjd1chdKukZ4aQB3K14z99iQwGz9LfBu2nLUEhoRCqcG7hoMphCkL5jSQbNnRJ5p56zHFdi9y1ZDgd6SGNQjn28Rh":
+        "19999999999999"
+    , "DdzFFzCqrht8jMjhKTPxuMrbVixoXfmcGuVVwFmhATSnuUcYEq1HGtUpUVAxVqKa1zDGhNoADYkWmtfRMv6UVXHPUH2y7ERKoxw9JqFn":
+        "19999999999999"
+    , "DdzFFzCqrht32RFMeBKqcFB3dJFNvPp8z5YFgtBVJVtmEUNnng4bZdgzHGoZLMDdshjyS3jtpCs43ZCxhTdFPY21FvZVnZAT8NFRr6ee":
+        "19999999999999"
+    , "DdzFFzCqrhsvCGatXq3tDo6N22pcFx45tx31TbUqA57WQ8rC64qTQgDe4CXCfDcsD2kTxrNievpPzFHqag7ynWGyN1Ud62oyZQbdg6WX":
+        "19999999999999"
+    , "DdzFFzCqrhtAwCp82XgxBDXpr9Aote66kNzHvZfpGfNYvQNSRt7gUSbXmtnmHcfD3RgJ8A1WuRqnTFwBjRponqJ9HJiLKRfZjz38jwZc":
+        "19999999999999"
+    , "DdzFFzCqrht2EVFtiZVwHC6qHqEgfmNimUMoA8wueD2VUKq6BwjhQemMDXdyemrgi1XMyY5swQ6jM13AErKH6LpHBEjT51Hv9Ni82Bsz":
+        "19999999999999"
+    , "DdzFFzCqrhszyiWGZj91UkiS6o7Aa3XXRzZxfckUVoqjWBL7Y7VL4hBFS6JPH1kGALS3CQ5ch5qm2a9o7uXJsVA6aNrNusZD259zYsEU":
+        "19999999999999"
+    , "DdzFFzCqrht9yjbtPVZLcJUN3Fc2oa5FSCJdEYM6jmW9SAiZEjnegjnT2THvzNtmyUtajkmDhL3cyuG6fF1wMxS3x1gYLJcf8stPTkjg":
+        "19999999999999"
+    , "DdzFFzCqrhsnZLN2DMzjtwbaGfmSY8pohWPpetYH23fFwpvTQog4cWj1ngypn8tVSrtQ1sDSonJ16zbAF9VhUsfEjREE58K8HoY3YuQm":
+        "19999999999999"
+    , "DdzFFzCqrhsy7mVEE7gzmYPRcvdqLQbuc65sQLYHSx9aA921WihfxFcsLP5MGscEBqJh2TszeL75NguUHSstSKHZYcXvsdKNMhcjSxp2":
+        "19999999999999"
+    , "DdzFFzCqrht4bRz6aqwM3qHvugY7RFkn9WGuFmohQTtntCCLeA1mrRGMQYnBk1o5NkA9Gg6DcaWGRfv2aVnD9rmaPuJsHK7EpCi5roGJ":
+        "19999999999999"
+    , "DdzFFzCqrhspTwde4BK6TEXjCXHZihjW6v2Q8CgdkAa79fbZGxD7ytDYWUjtfapdDYW9xyTw7GcHqJ9aePTt14RqndvW8XRvp5rpsAMj":
+        "19999999999999"
+    , "DdzFFzCqrht1nzhvPnesSL3KSaxXmue6gNX5PkUJsRcitynFzBUWnjFw25N1Cvx4i2vEiikjWsiuoMxZLubd2Zb2WrBrfsatPqKVUMsL":
+        "19999999999999"
+    , "DdzFFzCqrht3pLDTjADWoFyhtHAHmXB4dRMjjzvAJobroC67o4qiKbpHzb3knqhfSGhjL7dDkgwVPbJJW9Mr8pmwpKDsgJMG7s6Roaqx":
+        "19999999999999"
+    , "DdzFFzCqrhsxX2b8JbmABAE8nsRVHCMwMSGXLrYhog7Z33KGSoLdkD62utpnYsas6w4xyUSSof1pzZaXr3tVm3Yct9i9o14qoTtwCSvQ":
+        "19999999999999"
+    , "DdzFFzCqrht2w4bHhahm256WLLzz2hJkrryS6VH7AByUPVLSY4JoRghUnCiDPVSHrLiLQJNzjmH8kbWKYEi5DRuP9upPZ9MdmYwZky89":
+        "19999999999999"
+    , "DdzFFzCqrhswTKWHRGV1uzvErYiPjUoDbY45AoyhKnFbg7HPP2LUoC21H8mNxPPGAofMBJUBCBRMmB9vTUpKs86z1Evyy7qYwZfdLGi3":
+        "19999999999999"
+    , "DdzFFzCqrhsoNbnSqVpKviFW8RwZxhr8DEpuCQNRu41Pmf1NEY9JnFo4knfYrcNXZ9VwCohLxx1HGCgGZpqBKJnCfJKXVHbByhJsw8zp":
+        "19999999999999"
+    , "DdzFFzCqrhsrcnEsqCzKhPEiuR8V1LX76UfLUTJbzb1wCzP46WW13wm6mrsRKBuJPph8h5Q8ELrYWeXsjvCdCD5seG9wmAQ1WcrGWxjp":
+        "19999999999999"
+    , "DdzFFzCqrhtA6TqnE6A7iYQFeptcnS3utjfLYeoMrZnVVZPGaVvGSKVMGEkYtemuBV322uhJrUygfFMiqG1bSFSyJNmQqdtXQTxgYjL9":
+        "19999999999999"
+    , "DdzFFzCqrhsujRZQu1LSVVdu7W9nYqyENzZMGm2ACDdh7UV2BHkAmRafBKXiVaymRwaRZwpZnyueNiPdAXv1W4G6wPZ3weyKifugxMh5":
+        "19999999999999"
+    , "DdzFFzCqrht8xHrzcr2iLSmvAwj6qG7KFMvaT2n2NbgMDt9GXJrEVpQAiihwJu3oes2Z1krKKM2NQKeN3oFEC9FERrmKELC4qPLWeDew":
+        "19999999999999"
+    , "DdzFFzCqrhsujxuEfX4mfwHvcnnoyjwRevYGwA2Lu9h1bjfWFqGRpCTsKPeVn6W5zkDPW2oyJhnuuvjEyGrUDLE8rhMZhkMWSPvsi8wC":
+        "19999999999999"
+    , "DdzFFzCqrhtDAnS82CaKhBfC4Jen5dFth2LExaQH5c1qmbCAptb6diALMKsWaRdtk3aqJ1koEq4SHE3J1wx3gMv8FPsuUBY5ifydZ9rC":
+        "19999999999999"
+    , "DdzFFzCqrhsjRh6CnzNw2yVxE4BGZBUAFXmtpsAtDaqwno8JS98f572F3RgjTJ7fsV5ccnyabrCmoaVcuEFa5LVf5SYtbYGXyof9s1o5":
+        "19999999999999"
+    , "DdzFFzCqrhsvMCAcFpKQ637NGSMeKQ5orzPTkadfS7UtX9vmx1NTLjd36M6dgjCpfrq4f1JXkj7iRqL5xeGfLxWjm2JDjyCzhA7uGqJr":
+        "19999999999999"
+    , "DdzFFzCqrhsuyEdSf6aggu4jAC1uePxham7NRQgZVSQ14Mamyj35B5ypokUr9naMrvwU6fXoVaXZbgBEeZqqXJnoMby4EZQnyD8YDof9":
+        "19999999999999"
+    , "DdzFFzCqrht1sp4aaoZSQHcrDwCWxCG3qiGQ377vEzRt2jXTc9Cjs5J7MZrWF1dsixLwffN3mFjzfpLkFvoAvmV8fJP63WZxeYg7eSsC":
+        "19999999999999"
+    , "DdzFFzCqrht5e5ALjXv5TMa2X9U4jTMJkFtSRCqZHWuVY6iXDA4TBp1MJF4qt7VBn1LgCzsirgUvJnV5iDoHZFaZU2norWLq3JFJXV3K":
+        "19999999999999"
+    , "Ae2tdPwUPEZLN2Xne3MCDcR5CS6MSPBGzPtJqi4vjsPExvNMi4HBxCMQW97":
+        "5428571428571429"
+    , "DdzFFzCqrhsvU3PfQZ3t8KFzak2MqgFC7K2AoVPLH3N7TPtT3ikxWv5RX3rn6RxJEMmCwKhf4jSqBJX4Fh67TtAfw8ibtvpX1yR3b9PQ":
+        "19999999999999"
+    , "DdzFFzCqrht3a1jT6VNwZVerxNKAP49YbGku56X7Gehbu5tRg6g5Xv39ihcuuG2KnbiW49w7rKGfvRsTWP5YPQaP3z7niWYTrtjRDHd8":
+        "19999999999999"
+    , "DdzFFzCqrht4akQuiMy2BX1yc9FRnFSFoFrxvtbTkEoxECPB1S6AXnBvKHTFJcyQvBvs15KWp9mgFy7CsFUrriKJ6jjU48YJpDp7uwaw":
+        "19999999999999"
+    , "DdzFFzCqrhsgVE9hBJtYvL3FZzqe6vAkKBFqdu8mFE4WLoWGhztc4cAaUo2FdR6CwKpo9jApf4C9X3X9egcYhp9XMEugmhKsMyyh85W5":
+        "19999999999999"
+    , "DdzFFzCqrhswHBeFpT9Zee6FuUopipoE7bKRJBcY86TxgzNnwRrL8fPMEFyuMfrsn6efhf2ZWD56Y81nNZ1Mh57aSGRRpqpZW9y3PvtK":
+        "19999999999999"
+    , "DdzFFzCqrhsfa7htaHnCs2UgreBPqdig7yBZGug1rakCDkKxKjxV2dXba5D531Ej6ETSDqk4EczLtutJzzntFpkRWrpM41XeTzHCq3hX":
+        "19999999999999"
+    , "DdzFFzCqrhtDAf5RgkRMHPvaW9tGc8RTYe689cqM6gUitWd5JHBn9GbSFT5eTh7as98LZdExn4BFGDePHh2wMfB5GDwMzRTomo7ZSLYZ":
+        "19999999999999"
+    , "DdzFFzCqrhsxDgDJAn9NhzvGquBWT1CUSQRuRxBzuLsswVM2t8PexJ4iD7Cfnbm55NPc1mHKASYvYstUMLW5o6VsZLYhXnR9gyK6VqB6":
+        "19999999999999"
+    , "DdzFFzCqrhsqh2tFdfrZbCKiNY9Se35o9ey15ehPX4GzXKfKCAsbZZJZ7ydySYwHaU6p7rRinAUrcPnzhkvMiBJ4Sf4LVwfqkC3tumRp":
+        "19999999999999"
+    , "DdzFFzCqrhskcdyyFA7M65fkpHhHvW9GuPiLgRS8EuzFmy8wtftaFRsoztJHUqzAtwDNbsj81T8TV5un8C8VjCk3uGEfda9MU6fPSw2p":
+        "19999999999999"
+    , "DdzFFzCqrhsxExdZ4ooCcAoAoTcoJUCA8mmj68kkbZJSgHRrYj46GWinqjgETf8cN2Rwyj5nTRhqh6ZEYKVznokJA14k2e3WXskcffwk":
+        "19999999999999"
+    , "DdzFFzCqrht839DXLJR6or7P6hCwnAAw5UgBRJh2wWf5ufsCCR7qH7NV33mzUbxt1xw7sg8iC8kF4ARTgnPV5D58MtyJq6gPuMA7LdyW":
+        "19999999999999"
+    , "DdzFFzCqrht5nCZ4RbqqZ6q88cdkhDM7nG5Yu1Q4Ssv7m5yeWL1u4tKVKngVdZbmpp6mGurCjzddfrcNwmbEtdN15sRECaHvv5DETa9k":
+        "19999999999999"
+    , "DdzFFzCqrhswNvtojTAEWXa1pht2bELQfP3updkescXd3KLDnVjWTdZjRiFmGDYgEo7uJ1m9vKVdBu6TZLNiUHHPf6uDGnkU4CjN9LGj":
+        "19999999999999"
+    , "DdzFFzCqrhstKiv2yeDj2aUFHvfejSR3q4CTNTPrUty6x7DtYnXVUVao97pxwWE7H8mYbqwbVWCf6NHaGFeEGvmFiB6aesyW4i8vyimr":
+        "19999999999999"
+    , "DdzFFzCqrhsps82ppBmBPWaApvuL44pvGSaVeo5g1C99gxbNiuK72R4j3wtfAxaj7B9aWpiYjFBJBn6PNZZ37m7GgQDvjvhUmyWFH3UL":
+        "19999999999999"
+    , "DdzFFzCqrht7PYCyFPUnYFk62itwjELEWhrgyXVJJjjsTquBRNDVNxRgnWr3Akdqi2MGM7zDmwWbbQ4HohXXeEpjQ6i6HVwt3K7xQvhM":
+        "19999999999999"
+    , "Ae2tdPwUPEZAB8DtYFv7AWG2fCRLCvznKS1G8D7FUEQpWZav7S1UoHchQ2Y":
+        "5428571428571429"
+    , "DdzFFzCqrht5gaQHTLxBDZp5RxvCfNABcRo4kjEj8Pw1Joi3ViUV1f92tNUPmTfan8ipnzb2Nn1588YWbhgx8WVN5ME8ksCobuSNcigS":
+        "19999999999999"
+    , "DdzFFzCqrhssdDfkvZ4FqWYpz3goo4M1dUAMYqZF3Z2ctesnEJVjWrniBpCcUtsys9UwpyMBwvnpvBUeyMTRjmSzyu22r6zhKpwesrRP":
+        "19999999999999"
+    , "DdzFFzCqrhtB1WrSJAtvHxUHkKZoK8j2WCHd18dw9kcEg9T27b3hNWTRXpoYrMsAo78GVsJDnh9pAGB3i5Z5xrbzxyUcyqkweUhJgkCa":
+        "19999999999999"
+    , "DdzFFzCqrht1C9Rw82SD2LTDRw9L3WeSYernw8TWrH92canpCZnNeCnukp95KA6rVE1VG3E7AMxXwmxzJKYwbqVm6Ea7egMi9vTqnZjP":
+        "19999999999999"
+    , "DdzFFzCqrhsqK9wbCymGGCJWwExd5YKRVRXLG7m4edaaQfrEBohU2qGjHf8EKoHcvJhXkqZqeEFNTMLEZTqygLxet13U9jYbZDSFUwrR":
+        "19999999999999"
+    , "DdzFFzCqrhtBSRyWb7GPqeQeLrdyKSdyD6CL6aPPSuGqvsHxXBv1xJxLiZBTFNA6KuMLZxSDr6BzXyt7evgqaoZoT4SrUHnNqTmuPsDP":
+        "19999999999999"
+    , "DdzFFzCqrht5TZJryHF2tG4a5886MsX3tUMdiLbA4bdE66zf8Y24TCk9vduqyBVdpdvcm7uGG4jSAuiBqtKWQU86985fCZuzEtdRQMLm":
+        "19999999999999"
+    , "DdzFFzCqrhsvAEwwHMq6DtWwbicNu6UiuAroZ53Cow6ucZoWHcxPVctkEv2fLmPyxcHVeEEn8pjTryyuxizGe7nw66VADcANGkmeqJYv":
+        "19999999999999"
+    , "DdzFFzCqrht11AxF1GWdU2HTzXmrtG96bbQgQdL815viWWCDNkSQan7rSq8NUxzZQNQGwSXFetFmPTTE4XrSMJkCopnwJdkEDzePL7P2":
+        "19999999999999"
+    , "DdzFFzCqrhstexC6dvVjS3mbDgeUE7wfpkrs841CkbbkPkmAVoHjAnYyouTUMc417XHXPssTzJvxTu8A4Dcs8BPMMVpHJt5hKRs6Q91F":
+        "19999999999999"
+    , "DdzFFzCqrhshzT3G2hY14d3EAVFQyz8GKwKfuf5u4XDasnfbU7ZWiEqcadXzGT6oQienzrSoFa5ZZceTh3u8xJVczF9VQiccpBrsDQAv":
+        "19999999999999"
+    , "DdzFFzCqrht4r1pL4HAQHzmfAx17nXidzmdCSQsUGvBowAeACh9pMYgAqPgmCBCCFwkWoVmgJG37xUaMh1cenz3VDt2ioJeGmUYyH82J":
+        "19999999999999"
+    , "DdzFFzCqrht74HB2JuupMAcDc9Ddq5cJ8RVcUG4VsTvSgPJPhCggmiHfwCzBUhfVwRdXXDiBcYHKvpmGeErorxZfxydNQG6kX1gizpRq":
+        "19999999999999"
+    , "DdzFFzCqrhsgwswt9BbCD3UxHYMJKQAEYYz48qefXnWbFmxtTzZMETnxveeJEyMesQfT31BJBjBHrfvMX3Af7e978bvgtj7uRqYcxEFG":
+        "19999999999999"
+    , "DdzFFzCqrhsr6V2J1wgqfnz8bsQrgs3p81ijJy6yfTnYB6hPaYtMkJaC3MW9488QjuuK2LSrQjgky8Tgs9fZwP2Wus3WznbnD9aN3UQj":
+        "19999999999999"
+    , "DdzFFzCqrht5BfYxpKdzjDQkcF58qWFCQFdV1ov4Jinzx4rCCyGHSvojA7wst3yNcyn3dtPgNZzsDUJ32M9qCQk1WyNAnwY7QNjtiFYz":
+        "19999999999999"
+    , "DdzFFzCqrht2p7DGg5jdT3ii9yeJKNAwKu6TnN3HVS577LxU4npCdbxVWCmsm2Y1neQSRWGiXcAB1NpS182ambmkQuLJfLMByBbYbyZG":
+        "19999999999999"
+    , "Ae2tdPwUPEZCZ56X2C33r14yXcE8WZNWPGdNVBrxuBmWhCewz9Bfdk9aoLU":
+        "5428571428571429"
+    , "DdzFFzCqrhseAhsvrTUMVMDJqXi2GCNVaMPW1iJq38MWfdxNM3a17ACVM3sBDbqcLS5yiXtdLycgXTtKLnWYtkRoHcNjh5TUVUgrPgbU":
+        "19999999999999"
+    , "DdzFFzCqrhsuBhhwSTXEYHmJkNGhmXcDrcx2m6LvXSmkEmmtM9DvFrkx85mLcCaGQuFNgZZBnD2XYedNsNnnbS1jG4DwsiPhQWFtY3Tt":
+        "19999999999999"
+    , "DdzFFzCqrhshucFmGzLPBHP1Ztf3sGt2oCxGG31FXsYhK12fMQ9AbV7mWVNeEPwnNYeG8TvQZmNAzZZ1bUrJz5LXdnT7VHX1dyEh1Wok":
+        "19999999999999"
+    , "DdzFFzCqrhsi49og8QaHvCRJEWNhhfXYUeryiqhU5KujoGYW487mXi9tFEsYdfTaNuct7NaWPhrJFQr87wqzCqwKMy9K34deerHGVgiF":
+        "19999999999999"
+    , "DdzFFzCqrhsjXKdztoizmjUdGFZ2pPidc5qauEvJnS1Db5XG6Aogu6RFTpWH4xMXucPq5BXr5d6vqZAtVVQ4EZ5Dh4Jj7kWuJ4Xr4PXV":
+        "19999999999999"
+    , "DdzFFzCqrhsehjmuS5SEEuk8n9rG1GgTETZvRcMMN8wM2gK4qJ5uuUjCDdyi8YHEDu9cANYgNmLmH2QoNMEn3Q7kqYCHUGUy5v7cGmBU":
+        "19999999999999"
+    , "DdzFFzCqrhtCLe9LL1fALd5oyD2HusY1U2Vghg5wf7uBbtdkGsbD43aGexyHNdWM5ZBucjZrxmc1c1qCFBxAWiYJgq56zUE2bsJ33AQw":
+        "19999999999999"
+    , "DdzFFzCqrht7eKnD2whXQidYs2doQyxQan5KQ7PAKrZtRCQq3bMaB2mgwuN9SiGw8g4ZZXNPnUgK8h64VaT41m9Dd6TGWpzcMFwWQGZu":
+        "19999999999999"
+    , "DdzFFzCqrhsxhiK36VKwZSmUCpBwaNEMNMfCnUqZHF8ZfV8AQwa1T3LYBVC8VCWu8pJYEUKQDJBvDFso22hJfyuCZ5tab7Au79hJKLtA":
+        "19999999999999"
+    , "DdzFFzCqrhsryn1oDA2Ha2j4qZs5JUpuiw8jevQqFgtW5a57jBX95wAcgDwLm5v1gbrcVzBWr8HCydnzYAiAL7QHMyJcsQQHqrqmcsvn":
+        "19999999999999"
+    , "DdzFFzCqrhsgq166tFLaa3VZfUcS1142yS8eHigGybvjHZPV7eiRA1eDPFEz3Vg17cXaYEu1s7P7gu81G4KQo6Qg6WXBxRyzHPVq1xTn":
+        "19999999999999"
+    , "DdzFFzCqrhstFvqWnMumMABzHzfhRLWTYqFNcHPDw5gahMwiKGxmMNZR11YuoMP7cXDGV1aLRis9fzXRmyBsSYJPjpbefVgXu9VTYaYi":
+        "19999999999999"
+    , "Ae2tdPwUPEZN5aWiXCueHo32N6Vgdpn8dzWnQSTLBerCP7CP4dxPM9EM2Mq":
+        "5428571428571429"
+    , "DdzFFzCqrht1h6KtX86LpEazp59KoLjKstKWLsNL3rHgsmZp6U7b91udj99LmqrEEYMVadQrQmqgSzqcsETtbbU2b4ESL2e2rEh6rJr3":
+        "19999999999999"
+    , "Ae2tdPwUPEZ61PR8Va9Hae3AP321WfUcbNAbqDRAhYaaFXQnCqBoEgNRjRs":
+        "5428571428571429"
+    , "DdzFFzCqrhsfZ92GyHjSdDBxBSuEvVM3VVNLPsQcVW2gMouJJBaavmk3scHvv4gKxGc1xgfb5mh7YakHGGiNu4K3sUP5gcAeaKsmSXcN":
+        "19999999999999"
+    , "DdzFFzCqrht879HCqPUFyxbB5c1VaH2VbUbsXEarcuxYeh4HSk36zD9bCy4T9bSiRQhK14D9P7iHoiURczhSacpazXhejV5LgQJAogt3":
+        "19999999999999"
+    , "DdzFFzCqrhtBwbnzJYRYgExaj3dZhEKzLV8DJc56J4eUnbGGGHZrx3Y1e3QYribuuCxAirFYDay2GLcuJfCxfVzgsbjpWmjeFSAiVgKn":
+        "19999999999999"
+    , "Ae2tdPwUPEZAANgNqcr28x2Snargc4JpZLNgZnsBPAXkZts2soXHZpdaQwG":
+        "5428571428571429"
+    , "DdzFFzCqrhsoQC5g5ZfpBsZELhXRQ6xTT4iJcvGW1osFRXiksvoX59yqXLvhL49nrEMo1pPgxjHSSTQtrGVDEGJZTWhzxB2U3vqHhfZA":
+        "19999999999999"
+    , "DdzFFzCqrhsnPyP1mtHX6WC1Lo5v9DkD5bwKKcS26X2zjCrPLj42bAn2V48D1KW1vZHr8vtr6a13e6mEuoCq5c5DFkbYUmcbEvMTuGsu":
+        "19999999999999"
+    , "DdzFFzCqrhshxUqMH4vU3wiP4nUfLvo2JFeYGZUhMfys62qiAmp4DXAMrVURFmkcdprjHpy2ueXnX8V8sNzn5PBB58anCHaU3VBzepDU":
+        "19999999999999"
+    , "DdzFFzCqrhsnn2TpP1xHemgpuCawJs2ede32vxjvjvzakoscwe8Xv1uhDbnn5NZqHq7QrWexBs9Jm37gpSkojJgaxiFjZG61Qwhy1uZh":
+        "19999999999999"
+    , "DdzFFzCqrht1QTbD1gcYDLP83pnGxN72MsR8EaSkDwdn48vvaCwbtrNH1kvKxkGZFMy4DPLWzb2an8eBG5Jidftr8LWH9oLx6d5VnN45":
+        "19999999999999"
+    , "Ae2tdPwUPEYyzNVJ6ggmvVjpKxqMN1m635vmc4edRYbQoaF5bXBzZEQTdxn":
+        "5428571428571429"
+    , "DdzFFzCqrhsfSbsb3cdamfcUk8FbrduDSN4UXN7bHeBTR9UydhDpTrv7xB5p9v1w8fc3Pp69kEC23stkgmsLQHVYcqXyn9LtgksPG9dF":
+        "19999999999999"
+    , "DdzFFzCqrhtAtYSW536SyFUpB3b3jXVF3BhGTN3qu9FyqVxvt43Sk4733urgCMi4a71BKR25HRsBB59so7WeJgmxNwkwJBLHsv8iFZuk":
+        "19999999999999"
+    , "DdzFFzCqrhssoggin94NmpE1mAgqKCSVqiXnFinSge4CutUxD3TNGSbTMfvcFuXTBkM25SWgGVZzVCAvTU4kjpqhdgcJhGZFM2YWPkUP":
+        "19999999999999"
+    , "DdzFFzCqrhsvDxdkvFAQQiW7jbBHS8d6sgY8x1MqN6x78gBsRBdTzYvpo3gkQh2vaDxLTPfmQj2XL2VcnSBPL422LHqdjspjJqov6zkE":
+        "19999999999999"
+    , "DdzFFzCqrht8NHb4aWnxyeiED1j6hih3XU7YYkidmQ6jEmkk5pYhkZQfqQgZfmL6Xau55w23TbpDRnS4rFB4X2WqRb5q6WMtxTk2LSNW":
+        "19999999999999"
+    , "DdzFFzCqrhsyYi4icnVbL6SMKNFLs9foWcruwjpLHW1QwjsjyCwRtysUG4zRD19ZKYaNcDxN2MN9RdGqEPhvAuf9XpUuaGchZB2eLpBN":
+        "19999999999999"
+    , "DdzFFzCqrhsv3rHMmdDH6nV4FpuLAi8peVmXpW4jF4Timzek836pK1Sc9fV5QyNgfmDhJLMzfMeJaKqv5hM3tJfT4CNp1MchjPBCfE6N":
+        "19999999999999"
+    , "DdzFFzCqrhst9RHfsjMCC8JW4iVBWkJvdYiDaL6Yu7PketRGo89R1CeSTbdxZV4DqTXHZLnhz3NUBQue7QvuGHkxDNd7fbcpz3o81MtS":
+        "19999999999999"
+    , "DdzFFzCqrhsnEwPMQS7UKbWE7MHsw3KCZ565g71YeqwbfVsECjR8k9QVbbqvfSevZr24vi2Q9JwQj6GNXzvoiZ2iza2VVktFHsVA3dyM":
+        "19999999999999"
+    , "DdzFFzCqrht8GyFPoM1BXLnoukEoGrbu2eJ3fvbqNJxUiifVGq91LGFt57sFDnTagFmwvMGT9q5RLGTpNZ5Qd7ybH32AXWwmXNnsFP3a":
+        "19999999999999"
+    , "DdzFFzCqrht7AkqP4G3Kfm6TNMAXQFoumBF7Bn5uHNksuDizdu6Pc2GuqZDgAe1M3vDZ6P37VYG4p9NraQuELkVFQaHPfJAgjBe2EQ82":
+        "19999999999999"
+    , "DdzFFzCqrhstwSRE4yzVUp7BWkveXmaHJrXyZCQL8q2xG7rY2ta33gCSLgowQB7Fh81dKJ61Hm68zfETpWzBM1JMVgQdLwfsPA4AHWm5":
+        "19999999999999"
+    , "DdzFFzCqrhsvXE6G1zrCSKdhBuTatK62EFAmyqmBFaMtsMo9AkZny5TUSobomnGtYSCyg3KCXWnf7UsLxJKuuCWZtV4BWuEXW8vEMPZH":
+        "19999999999999"
+    , "DdzFFzCqrhsxiK4bTUWabpGS9qDfDHLKizMtg188JfhfyRuLEnPFx6FW1SmDECYpMEGVs7yYbXoae69qzpkANnK6tWacHqegWSmgAPp2":
+        "19999999999999"
+    , "DdzFFzCqrhszmhyFpYchfJpaN5BXAQtJL4i5p6T5RjDoqaXXrCTD2BjnpWpdSfi7HWe8Kk497xMq5KGkJABi2MpMfcRzTUvRpLr2WBRg":
+        "19999999999999"
     }
 , "blockVersionData":
     { "scriptVersion": 0
     , "slotDuration": "20000"
     , "maxBlockSize": "2000000"
-    , "maxHeaderSize": "2000000"
-    , "maxTxSize": "4096"
-    , "maxProposalSize": "700"
+    , "maxHeaderSize": "2000"
+    , "maxTxSize": "65536"
+    , "maxProposalSize": "70000"
     , "mpcThd": "20000000000000"
     , "heavyDelThd": "300000000000"
     , "updateVoteThd": "1000000000000"
@@ -375,106 +375,106 @@
     , "vssMinTTL": 2
     }
 , "avvmDistr":
-    { "TSGDuwG0PLKfMKJdIvzIcnzL6joeypGt72FB5AmSPIg=": "10000000000000"
-    , "HGiaKsRTeDXjKJzl329AXmMpxUkbYt9z6WES-3PRiVk=": "10000000000000"
-    , "XkfJ7am54TL6ge8fODlLE0hVl0ov9J4HbOLcCWOfXQI=": "10000000000000"
-    , "wLVZqUMcfo4HyOPqwITyP6NfF-bZxZDl7pReqvmSHIw=": "10000000000000"
-    , "3dIiDDt1Hpmgtd_tbl7k3okC8Sw-upnsZZ_Mw8nMqT0=": "10000000000000"
-    , "aYrvQ235hj3ice4vdY5VpD9I5aU6Fqbd_kZKNTFjiEE=": "10000000000000"
-    , "YMag8FpShJvNFhxO53j-EMRrcMhUEa8ntehY-CfEYBs=": "10000000000000"
-    , "cWzsw770HIhHppvHqwh_MDWI-6G0At3ixqhpxPbZ9Mk=": "10000000000000"
-    , "9Fz8OdN663iTssjPIFrI17OXH7hK_3N58s1sVJsM234=": "10000000000000"
-    , "gvOVLuc4xxmNUZOBzxlgu3zLIXsMOcolNvdMhF9EEX8=": "10000000000000"
-    , "4b88TrUOfJJIh42mM0GqidzF70bLdKgPdA2FCTvDfLg=": "10000000000000"
-    , "UVyh_wyOSetwBtkH7XWV9b9c32Ptp-Z4maaEe6yTU28=": "10000000000000"
-    , "pua0pA7Q99-_HyIrE0Ppr7zvdHIStkIqjqoM4ZNJQrE=": "10000000000000"
-    , "FFw40GxZfx4iW_XtdICXaq3sNVPC1FkhN5SxUXGeD8Q=": "10000000000000"
-    , "fcRowmzA4udaRSaoUL1xXGHBURfwt97dO55_wxBHX-g=": "10000000000000"
-    , "RqB8LOT-vHhVMBfVbj2TrdqG7aG8a8WkUDiV2XMv6PQ=": "10000000000000"
-    , "LuAhSO2Kfa0iqEEk7VWVquJTE3EILPtCO1FYyUPheOk=": "10000000000000"
-    , "CYVkBCHvJsnLC-mDIyxeN50HuvIgoLKxUOXok70kB3I=": "10000000000000"
-    , "zdujL1LUukehxVyqUBmd_rb4yThSec4o2zUfda7spV4=": "10000000000000"
-    , "DCkGYHt7jIwX3_2Y9elZYTUrs60weXrPAeUwJDvhg6E=": "10000000000000"
-    , "eFhGD61Tkyi2LTHIeQWdje2V9sEpcjrUwmC9NdIj1SY=": "10000000000000"
-    , "7HP3P8WvFXRIeAKL5tArhEFXgWeI5GOLECo9uharQng=": "10000000000000"
-    , "JZXfmmVX1G10SA1FcIFpbY_GDBzGE2n_0-DJrroJkEM=": "10000000000000"
-    , "wPbcJxXVbQvwMY_GPFxv2WDmeU1EHfl3co92oRhAZKU=": "10000000000000"
-    , "iaczTSCzAgDjZ-J4gU8EDNX-T9V4i4Jocco9OoMUZjE=": "10000000000000"
-    , "_Bb-dAn3U2BPtFSu3PMrN6k2w5HISrHAbSLpUsvElBY=": "10000000000000"
-    , "2BZ86I6SOYWGRy_homwZfLpGA1lOJ_bg1nZMEVvF8J4=": "10000000000000"
-    , "ESuIkKO0DD7oc_DUeWPXaprpxNPJKmaVOXKbqVoek1E=": "10000000000000"
-    , "Ds_bOUWBBqdXw9q7mOR8QcWdjZV6rjofQGyq-5hKvvE=": "10000000000000"
-    , "OyyL_EhDYAB0IxE4cQ7EU6pO1itA0LIvvMWu74PDLrQ=": "10000000000000"
-    , "YdMfmXyMsKVA9mO-uiEBEBlajbXq0Ak5QsmmTN6F41k=": "10000000000000"
-    , "h7q9vL51lR99Th9MJEwEQYjv6mDfUDDaIhHh54Qd6Oc=": "10000000000000"
-    , "5labLuxZCmcvLJAewrfd54uwmq-fJvYNB69SCDdneF4=": "10000000000000"
-    , "mEHgu1mOZItLENUjPjQOJCPtsKGnkTBTZnuq8vL69vk=": "10000000000000"
-    , "KfeyZ_Vr1Z-MjlPxQSIuZj4NUGa0n91l1P_d4kvhYZk=": "10000000000000"
-    , "dXOK8a_tzlN7S4VHW67V6n588Bwu744O_juiGV6r-Hw=": "10000000000000"
-    , "C0-YH9I-s3i0Wdd6Q3I_2IptRKrhw7_azI6c0515TbA=": "10000000000000"
-    , "wnQZk_UXp5cid3G8rVcn-QS5pmIHFle0KUYgcoG-bTo=": "10000000000000"
-    , "4qMxmKdWvnvBTKcYCcolkUsfd5adRL-cCIOGlcm896c=": "10000000000000"
-    , "hNJzGH6gVVIlN3t57Xfz7aPIcI1poUYBtGt_3oKA2_E=": "10000000000000"
-    , "d1NarJyuf66vZjJ04OzqEPfIJzz_FferOJHgjnHi5W4=": "10000000000000"
-    , "vg8_BQdtI2lPw5-zab7xwF0SlToOAZHevOgk13S_z78=": "10000000000000"
-    , "oTAf8GdRAQXDdaurim7VnwFGt12NmQO2Q8kKlI9fO6Q=": "10000000000000"
-    , "pl4c_CxI8bQnq7z1i4BEyh1meA9pQa4nyuItUZfniZI=": "10000000000000"
-    , "r0PzzgJfaOOVxbE4hokCrsGwntSmHEXJXvzFZdY9iRM=": "10000000000000"
-    , "Up719N67sodCrhNtmNo_tzbG_rgEB-hiUxHzypEIf0o=": "10000000000000"
-    , "y6gGNBStCzy9DSTQcY205PuKOQ2PS_4SBihV38eFxI4=": "10000000000000"
-    , "AGTfrHMv783BaQ3xybpIYV2pxYbRqOo-9OMZ5PlkKp4=": "10000000000000"
-    , "pKo5ZReGudLbNVcVXG2CqkAmzWds_D4vaVIQMmx-qJU=": "10000000000000"
-    , "QRsl7cINlYlPleGKOTTJMJT0Yz4voKv1d7YczdAOZY8=": "10000000000000"
-    , "xcZQjIzp4yDmwbHY7_kJ-ifmgjsPhmOnndyRmpam6qc=": "10000000000000"
-    , "6urioYq7xRDxi1oWUCfRbiQ9QKbOAy0SGWQPKRpIpVI=": "10000000000000"
-    , "AjUqVActNHUFMcHHrqu0gPEfJViLIykebwWkEOXAxZM=": "10000000000000"
-    , "2kNvNTFKWgKEgfKQdiQ451PQnOBc0rGe-9FpgFK4Pc8=": "10000000000000"
-    , "CqX_3zHlpVb7zZJPV534FeYGHV_xGsl4S2swm-7AzT0=": "10000000000000"
-    , "cHdNGpAuoNXG5bsPlOZxbpddbuBeNW_D-H5xAPqLb1A=": "10000000000000"
-    , "DTAZ2CM8gTALvyEVCOWlGwHtVrWyt2WZlOZMk_8LBg0=": "10000000000000"
-    , "REVx-HWKh2dHepeigUbU0cmtBkVU0VWAjDqmTFTQsK8=": "10000000000000"
-    , "MB_EDWnXhorKGbsUQkxWFgfwvYsXNOwPJFz3S_-NQV0=": "10000000000000"
-    , "BYz1UOaq6ekmRXYTLDJi4rc1sAa8MPAEZOq6atXwzG8=": "10000000000000"
-    , "RERe0k2NvvP2c48l8AMZ7r64BYz9Brrg8vnL5cDdyQ0=": "10000000000000"
-    , "S1yFsByS_2OqvaOWqeSPkd201rhJzcIuZwL9XC3dD48=": "10000000000000"
-    , "Peon7OeoFkB3_DHaK6TxNdmZsPDaKc2b7JgronL1_G8=": "10000000000000"
-    , "GqgjpJ13IM0fjjFUYcvN9AonZn6zTapjOCP1Z-w8uZs=": "10000000000000"
-    , "9vB2tyNEZ3h5YwOuDX78MSoj9I2XF6Gfl_GeQ9lCvio=": "10000000000000"
-    , "MZl0W_rMWTm7hJvmDZUNtgY32MWpi__bOJL5XBglRyU=": "10000000000000"
-    , "iWrkL96zewk26mMzEH2kH_t6Y-gFm_cHt8C-LZvaTk4=": "10000000000000"
-    , "43tnTui97-aNk-6RHMDPY_lw2vYDKt6yN96_C321t7I=": "10000000000000"
-    , "gquzHF_ofhAzcWFhCpTyaRE7nxKaaY8hCCxD_fkYYQ8=": "10000000000000"
-    , "8_-nsrHZvE2bQ4lJbeHO5rSMoK6O0ujgBv_FZwbBoGs=": "10000000000000"
-    , "V-myOyfgKeV5UjeSCegsNbnACccQC47_ljyV_-q_FRw=": "10000000000000"
-    , "3F2_jaEKPkut29VGw1KaBw_5_iykvCvxZQH06pRxXD4=": "10000000000000"
-    , "HPXX248Ao65zBKteLBNjdDiKSuTqMBTE4Vq_OPYMl5s=": "10000000000000"
-    , "ACs_dp-AW9TLsJ0OBsoNwg7Q_DBMk3JwNVYOOHqJtgM=": "10000000000000"
-    , "5A33hQZND7y_BaTukyh1MQQ3-KheiXb5Vx-qGO0ampk=": "10000000000000"
-    , "X_jN0isEp0SCvUVpREfMuYkLlCDKZs7g386GqLv9ZIM=": "10000000000000"
-    , "-Fx7eR8WXSDGYZMjr26Zr32CsuEHCwRRYouqtLZRzqE=": "10000000000000"
-    , "-5iY9dJKHRezj67zElDKIidBQLmyb9Pl2SGqeSdXEcU=": "10000000000000"
-    , "pckos7k716OWAO3KDzHLRCR2PClzvZhgoIo9D1AuIBI=": "10000000000000"
-    , "rtOUIt9_cM3Qg-Uo2o1DwXTJDbTXtSlf8m56kDJfx2c=": "10000000000000"
-    , "kryXMzIWiiQ_vxn2pLib5IrXNZO96waK0mfOcrtTZL4=": "10000000000000"
-    , "Ev3xWvKO8jU3OEWIYM7SX4C-63M82QLVLKaliP9vKrM=": "10000000000000"
-    , "sQ8fZmYG4cWTBUkMT4zUawn_7Eqvq55Ax8Q3y-StNT8=": "10000000000000"
-    , "p_snIvwk5VHbnFxo-c2Oc8-q-SC80bv9sP5YmmhrmxI=": "10000000000000"
-    , "Nvc0jP1xPwKKIdZB4r6PwukNPQ_w6g5Gv3KUTmkx27Q=": "10000000000000"
-    , "8l1BNZZX0NwL02vSvIiXiYhUXABoi6SBzS7p_YWlE34=": "10000000000000"
-    , "T6XqX7f2B0L7GP1nlnTskNtAIxx1yfqnZrxFq1QLQ0Q=": "10000000000000"
-    , "qe6yDwJA3WrNVt_BifyaKsW6Fy2GDhHpaxUR_uVyKqk=": "10000000000000"
-    , "ni67AnesDfzRTcJeQMnBjfFx-Mummt4HPQ4VOQWJ-V8=": "10000000000000"
-    , "Di7HwMWHXvKyEiqdBGtoCbAg9n-eXBqtL1FBW5YV2EI=": "10000000000000"
-    , "rkaRc2B8ODt3q5DtRzlOVcrD38Boq8Q55puq1u3NSZA=": "10000000000000"
-    , "IIms0ZoR5IORYpk8CTPihrSEL8oTFEcUPTM1jjmX1RI=": "10000000000000"
-    , "wCSlgn9eh2kQTM6GPa-h5UtRc8oGDzA-MW2EPSW7cMI=": "10000000000000"
-    , "y0kNdBo3rftMCQMm_CxtsobUsYZCjY7ElgljLpJca1U=": "10000000000000"
-    , "XHL4uL301yin4erKln2nAH_26u8QhwnrEyGaN_pk5To=": "10000000000000"
-    , "yIvcLaWvb1Yc5m5v12JolgZdDS5G_Sbc4lLAzmYD8ps=": "10000000000000"
-    , "ObxJfcSpL-NSFePyXx1ZM714TYN9VckeEHwzYH2jdWI=": "10000000000000"
-    , "sbmyc7YLqGQY1KYb9vlnOJCPgF71-jeKKE4iPuNG-VM=": "10000000000000"
-    , "dYsCHjSXfPUdueQQ3gMbY0qCWrg3qPSnlRoH9lBz6wA=": "10000000000000"
-    , "MpkvrVvE4gPVbZqy78UpESB19pigzr7-8ZPrv3nzyKM=": "10000000000000"
+    { "Dh1b1lTQMIdiLKh6GbVcBzACTEdIWYZEzIAq65t2FN4=": "20000000000000"
+    , "Ds9Bk626o736HQ9LSaslefn6i2sbi5iCL2Q0z5ag24E=": "20000000000000"
+    , "eGfTaSUDFEUBt8SCc_XS6RCpLZlj1neJxe-GstpQlpM=": "20000000000000"
+    , "8br8hOcUU2BJI7AMKl6deDNgcKwhWFCR8Z4LY1MDp9k=": "20000000000000"
+    , "qjBA9FASvtidJwYGkFrLZym4GuxSwmA9y8XhzYQmdb0=": "20000000000000"
+    , "TuFb6CHnHyhp3Npwyf7xOdmI7c8biybg-6YXDVgrdBo=": "20000000000000"
+    , "Zi1rFWN9E6en5Al6LLVAM0x4vXADza8XCiRcGZWarOU=": "20000000000000"
+    , "HkVA0JL_IovjrUU8Qi03joYsGp30ldZM-fWlEbx9be0=": "20000000000000"
+    , "Y2G7hQ7WrS1UsNW9m9CLCsvImRBl8upCdtS-Ww9KMGA=": "20000000000000"
+    , "aaFogUIZUE9VWNVaP3K4c3WquxM9G1c6xKxaq7OgFnk=": "20000000000000"
+    , "EJ0dLef0XCL2AroVOFuxXY8eebpBBWR6iYXKVs3qSvc=": "20000000000000"
+    , "UtTtu58MUX-lOawleAb1B7eU-BJrv8TkTijwg8g5OE0=": "20000000000000"
+    , "cvJcSNiubJiJ9DIBw1JG5mfC8MP-yspcJAxSmU9m5WI=": "20000000000000"
+    , "D34xGlOZEVxZleHpF_7biyhXLzCSwNylXhdpFfLJf4o=": "20000000000000"
+    , "FLx-st81HrEVZ0kG41-5C88hQQn0HAcJfp1R7M4owtQ=": "20000000000000"
+    , "6bwjX9OqeJCFizLsfSQu2txUVZbEnanr1jUX9z1WSME=": "20000000000000"
+    , "xTBCuTDCuctaDAtxTWyO_ucEAJ8qrj_zzWsEiAR7JSQ=": "20000000000000"
+    , "aTFirrrPHPtna_cPaqKSJutTOAofzwn8rzaSroStZfM=": "20000000000000"
+    , "FMZH_VxCoB9DcDfcvr6GjX_5QkD-qE6EAaMvxyWGBd0=": "20000000000000"
+    , "SXiWzUxE5nrc5zlnQdrrPUG4JUx85LmckqRJvs1h4JM=": "20000000000000"
+    , "chGr5LKzyEdQPWdBvDnaOxi_GOVh2SjJBdaT6OHwKQM=": "20000000000000"
+    , "KSU7xGGG7hYUcbnNPuRsk14fWxFpE2lr3yl6FLgAOBA=": "20000000000000"
+    , "WWoHQaMDge61zCaU8uloLQALHTrmEYJQL9kC_NX-4XE=": "20000000000000"
+    , "8mJDpyMNNXs9ySY9tiPN1JOGrk8eBlI041qpMvUDQ9Y=": "20000000000000"
+    , "yE6_542Yt6NzBiZo6HEj-8QHxmAhkdMnHEFqq54ulB4=": "20000000000000"
+    , "WBMzbglq20gH1XpQOl78_oKE479Bv4d2z2udTsRnkTw=": "20000000000000"
+    , "PDpX_E2QuoOyCXZRDzUfp7WjMkdQjI2zDU69pz5M2HE=": "20000000000000"
+    , "g-GXlERjAxetIyUSB9pWQ1ACZps7tR-XBsjpDJcRBJs=": "20000000000000"
+    , "e34JjNMGuQkPX_3qY9ajW6Nr4e3sQk1gH5BorayXRMg=": "20000000000000"
+    , "kocUxcds1GvDfvi6on_dPN3qYZq1gagKl-L3cActXlA=": "20000000000000"
+    , "YxQe1eZu-k2wIP_GFSYdeQ9n3cM5epfvoUHVcjHGEO8=": "20000000000000"
+    , "TmrlhKnu-_ykt9AqAdNe9W9WGvf_OKkUboSJZXvzM3c=": "20000000000000"
+    , "8fyWhY8krCWqqWa4ZiacLGjhBBaGIqeDNIX7IlFrHLc=": "20000000000000"
+    , "KQiiifJgHXyaft88Jwc69w3bi9L_RtOpYH5Jg6RWtb0=": "20000000000000"
+    , "AEjai68nhPBEVZjSVwFbT0D5CIWBNIjIudV0mlPRslI=": "20000000000000"
+    , "ip2pNpFaKGmpINMvXxbLeTQjtD9atatPJqOsmstTsrg=": "20000000000000"
+    , "1rgie3DofKzmPE0_zLU-WqwkdVGBhiSe6tP1HNCqbRw=": "20000000000000"
+    , "BS2gP_RDszeUozyQ8Tzi3olJ_ZwsepZURk6TKoPGTrE=": "20000000000000"
+    , "o2KneL9_TPzPB5icrQbwSKiCTbdvoJLMhTu0zw2i6tg=": "20000000000000"
+    , "SAbpiv1GZZEuJl8WIu1z3kTf5Q_snHD447Q379L5vI4=": "20000000000000"
+    , "3o0Q3cLM9-So9DIreVSjmTZdFX8MNHhSqHr0cRobNmA=": "20000000000000"
+    , "c1Ge_gyJqkppfwh33hKoapJjmytnWAumH9j9oFRcfMQ=": "20000000000000"
+    , "n-oT-ATZWUiyHDqmfOrKjHuMooDjXMkcGusSAgJ6Ek8=": "20000000000000"
+    , "uAKzyKWOHJU4XSaLmPeMuLRNg2YF-dsrkscW7aQEtRA=": "20000000000000"
+    , "Q62ZcNWHHeUwNAqgeCMBaHtoeZQDeQ09igyy-Xy_dcU=": "20000000000000"
+    , "ZsXUcsHvIS05q9LX22gVvL3gBPnEXgj8EMiuxU5ip_0=": "20000000000000"
+    , "NFsKjzegO8o_-pwgpQDaHCBIb-IiEe1Lh-uuT5THCxg=": "20000000000000"
+    , "SoQA7v-YCo9NY58QlEdaxHa7CB7tkku-rytJd7ozVDE=": "20000000000000"
+    , "_4qotcAit6bDlp6vBtet-RQCWh5IGoaaH_9uPcgCEHk=": "20000000000000"
+    , "eSU19XLetcFx-jEKQ1-DLe0jI633D6KB7VDXhsZJpsQ=": "20000000000000"
+    , "7SEZJpTgZz01W4uIvFHaRu7P2Z9oTa5SzRpUKQhMMZQ=": "20000000000000"
+    , "_0cJzmOzakrN6NPOOy4n9LD7u1cVePFdqcHd0cHxQC0=": "20000000000000"
+    , "l238Qujcggm-fIaPtqIj9MnO-b9V1y47mG_P_MjwlOA=": "20000000000000"
+    , "_x-jIWEX4Hk8mt4COyWpt0e5okQJf5iYeSMLMOtKsY8=": "20000000000000"
+    , "e6UW4seBmHaHk_DyBJ4MMqEqaNHe4iHlVCN_4o3Bt6I=": "20000000000000"
+    , "VvSUYRm9xhm3ZKNCROh8rqQoE-_vkhEHr-qYGWW7eLQ=": "20000000000000"
+    , "E8sZluJ3afJEBEBH8Yapj0BBxpgH50xVyuNY_THTlAQ=": "20000000000000"
+    , "YoMfpP9lPECp2modGbNYW0xjNgUj57qb4RDi2PDAO6M=": "20000000000000"
+    , "ID4hk1bd26IDDpYFxJMyDVxvmyKtzsW9P-6w5GW7_Vg=": "20000000000000"
+    , "X276yrCIhqWs7Z_NcmzULb1UQAzRSrRwe7qvwMIsmBI=": "20000000000000"
+    , "rx-GLLYTzD-JY4AkM3X5gSZrPu1CgeR-815-OxCJmJo=": "20000000000000"
+    , "FLwPkjYLkcyk2I4w8CHACZTDMca_DZ-KfTzUGLa9O20=": "20000000000000"
+    , "T2XHbhi3ayeBB1gQ4Xcbk_Z14afu2yaGi_CuFvm84Go=": "20000000000000"
+    , "UERrFU0fXRbH8CG9wk5ijHzZcEqpn_azOkGOFJ8em5s=": "20000000000000"
+    , "oEfZTU3BVN2agEyPezaMDVuasoO5TWfYiXUjPJgLDOY=": "20000000000000"
+    , "FvS4YwTjxQlNjgFCiSpv-8QjA4_ZwA5wmrloCkJ6pvM=": "20000000000000"
+    , "yd75pgN9nTQ8i3HFDb0hQk2oxy3CoZQSM0vSuqYZfo8=": "20000000000000"
+    , "K8gUVGsehdxKVQWgD1U57KG4IIsxsDodX2tjWefEZdU=": "20000000000000"
+    , "2UfxfnXK8_kuAz4R-f46M1JLwPVVJNp_p8lV8Fcs5WY=": "20000000000000"
+    , "6-cMO-aGtF4xn6LCkH9BSs7HwZ24HLDUZTBbI_2Ophw=": "20000000000000"
+    , "ZhiN815vDf5XjnT2tTH5a8U_k-VzD6ebKADD9k5Esjo=": "20000000000000"
+    , "qrQAbQQZjB2mWFBm-si8IRVViyLhulqX71FcSmeHSYY=": "20000000000000"
+    , "gCxBuvZkHdaOpZBsAW3nqsME1qziWGxTQDbPxoMa0PQ=": "20000000000000"
+    , "5syvRT_HO8UMYCKjQo7DHZgk-nHMr9uq89iR-q0uUNc=": "20000000000000"
+    , "mtP0JLKtbr8Yebp084OvAYT8oAPwYDkOJCII47iWTTg=": "20000000000000"
+    , "I7qJyZrKvKTZ6kevvw6_l7WtpWRtxkWiRI10Qef8Vlk=": "20000000000000"
+    , "frdF8GpgENzrVypp20Z9Wwsn78U-ZY-xaIgARatC1EE=": "20000000000000"
+    , "GeShTPqrzNls3IITn36KqCiwusDB-NE352jFf5hEDqs=": "20000000000000"
+    , "ZmTd29-CHbQJLaqvRcS0Zs4h_vqQfTF-eXCWiJZWwHM=": "20000000000000"
+    , "RD3N7vrPBjqxYXYitSlsBgmgSic16EUvEKU0DLRKfjY=": "20000000000000"
+    , "nPU0U3R0rDhlQhJG-yZbvjgmusCTp0GUWOlcSpUperg=": "20000000000000"
+    , "c07tsp59NPu0nicHDy0nGF2sDGvmIxtJqUGHZc7GHW4=": "20000000000000"
+    , "ZOQZvtIMLiUdslVneCygBhVUfxQgyVSuEXqq8EqVlEc=": "20000000000000"
+    , "KKCNVeYu1vMM2_ZnY8Zzk_YBb6lx87-jxzIX2P0PAiA=": "20000000000000"
+    , "f6XicmzDnlO6o-3mbC5pnHosV3fvlz7nekMJsI5udiE=": "20000000000000"
+    , "do1BQSAyTeLhcxkEvPqo7EQDX4yQArFlevt8bsAirjw=": "20000000000000"
+    , "h_3hmG1zTkEcBdgTG3tV7cpg-0VbxWX_NyNmcr1Wqns=": "20000000000000"
+    , "QdUciUE8Pg0suk6yU4OIZ-P3p4noEOkhwT0hxoYSAJ0=": "20000000000000"
+    , "dTyfZbreXW_SsvwPBRX9kZ4qrQH6x9by2ZvhMr3Y-jk=": "20000000000000"
+    , "OyS8U5q-deGju3O0EUzXcsSZgDDQBQ1NfLWrVi5yWjs=": "20000000000000"
+    , "t9C26tbsyGoLTE-R5h-V2lQBk3MwKXFRsOuav8FDc4k=": "20000000000000"
+    , "bUGJzXsRLmJHjxC-ZRzknSst4Gco3woVAuk06pW5pMw=": "20000000000000"
+    , "lg28Ni2r4-X1d8nmiGR4GddAD-R3Z8erlvAi1K5WcOc=": "20000000000000"
+    , "kuxk5oVgLTe3AGxaBjDgK_BXFVMjKZPJxaY4yRz4brY=": "20000000000000"
+    , "0kSgoX4kwgX8GwbIdCkc5aKLjV7HUQlyYtEhDexKu-c=": "20000000000000"
+    , "yo8T7TKlBwssBS4HA0QTq1x-8ymLtW9xoOOspVEuCAE=": "20000000000000"
+    , "0tuzBzTeFLr2C1OOs0PzRr9w-FdrHGvibdyk8-SEYPM=": "20000000000000"
+    , "t4wZMkG3-wyvGaR9uTW0xYrvpKNZQ85-kBSP--PjItQ=": "20000000000000"
+    , "Yq8nGXittgNXcGCmm_jLNBx-KSZBVhd0mkvVAYyVSac=": "20000000000000"
+    , "gKQr1SH40SvzCg2fKzTq2zNAgTsysnPICr_FfLyTJRU=": "20000000000000"
     }
 , "ftsSeed":
     "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461"


### PR DESCRIPTION
## Description

Fix the testnet genesis parameters total balance and block version data.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-398

## Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## QA Steps

    nix-build -A demoClusterLaunchGenesis -o demo-cluster-launch-genesis.sh
    ./demo-cluster-launch-genesis.sh
    (check logs to see that it works ok)

Current testnet is running with this genesis data. Poor addresses have 19,999,999.999999 Ada and fake AVVM seeds redeem 20,000,000 Ada.