### PR TITLE
Increase `genCoeff` range & document why

### DIFF
--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -430,7 +430,11 @@ genChainDifficulty = ChainDifficulty <$> genBlockCount
 
 genCoeff :: Gen Coeff
 genCoeff = do
-    integer <- Gen.integral (Range.constant 0 1000000000000)
+    -- A `Coeff` wraps a Nano-precision integral value, which corresponds to a
+    -- number of "Lovelace" (10^6 Lovelace == 1 ADA). The `Coeff` values used
+    -- in Cardano correspond to less than 1 ADA.
+    let exponent = 9 + 6 :: Integer
+    integer <- Gen.integral (Range.constant 0 (10^exponent))
     pure $ Coeff (MkFixed integer)
 
 genCoin :: Gen Coin


### PR DESCRIPTION
Bump range from 10^12 to 10^15. 10^12 is not enough to cover the
range used in Cardano, but 10^15 is.

This is a follow up to PR #3236, which [bumped the range of `Coeff`](https://github.com/input-output-hk/cardano-sl/pull/3236/files#diff-6ec2f26e2869d3c19cb621038f455659R433), but not by enough.