### PR TITLE
[DEVOPS-906] configuration.yaml: staging applicationVersion -> 14

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14904,7 +14904,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14914,7 +14914,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14924,7 +14924,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1


### PR DESCRIPTION
## Description

Increases the staging wallet applicationVersion so that RC5 can be proposed through the update system.

[Daedalus Installer History](https://github.com/input-output-hk/internal-documentation/wiki/Daedalus-installer-history)

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-906
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-944
