### PR TITLE
[CDEC-432] Free `networking` from the "blockchain packages"

### DIFF
--- a/block/cardano-sl-block.cabal
+++ b/block/cardano-sl-block.cabal
@@ -52,7 +52,6 @@ library
                       , cardano-sl-db
                       , cardano-sl-delegation
                       , cardano-sl-lrc
-                      , cardano-sl-networking
                       , cardano-sl-ssc
                       , cardano-sl-txp
                       , cardano-sl-update

--- a/block/src/Pos/Block/BListener.hs
+++ b/block/src/Pos/Block/BListener.hs
@@ -13,10 +13,10 @@ module Pos.Block.BListener
 import           Universum
 
 import           Control.Monad.Trans (MonadTrans (..))
-import           Mockable (SharedAtomicT)
 
 import           Pos.Block.Types (Blund)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Core.Mockable (SharedAtomicT)
 import           Pos.DB.BatchOp (SomeBatchOp)
 
 class Monad m => MonadBListener m where

--- a/block/src/Pos/Block/Logic/Creation.hs
+++ b/block/src/Pos/Block/Logic/Creation.hs
@@ -20,7 +20,6 @@ import           Control.Lens (uses, (-=), (.=), _Wrapped)
 import           Control.Monad.Except (MonadError (throwError), runExceptT)
 import           Data.Default (Default (def))
 import           Formatting (build, fixed, ords, sformat, stext, (%))
-import           JsonLog (CanJsonLog (..))
 import           Serokell.Data.Memory.Units (Byte, memory)
 import           System.Wlog (WithLogger, logDebug)
 
@@ -40,6 +39,7 @@ import           Pos.Core.Block (BlockHeader (..), GenesisBlock, MainBlock,
 import qualified Pos.Core.Block as BC
 import           Pos.Core.Block.Constructors (mkGenesisBlock, mkMainBlock)
 import           Pos.Core.Context (HasPrimaryKey, getOurSecretKey)
+import           Pos.Core.JsonLog (CanJsonLog (..))
 import           Pos.Core.JsonLog.LogEvents (MemPoolModifyReason (..))
 import           Pos.Core.Reporting (HasMisbehaviorMetrics, reportError)
 import           Pos.Core.Ssc (SscPayload)

--- a/block/src/Pos/Block/Logic/Internal.hs
+++ b/block/src/Pos/Block/Logic/Internal.hs
@@ -29,7 +29,6 @@ import           Universum
 import           Control.Lens (each, _Wrapped)
 import qualified Crypto.Random as Rand
 import           Formatting (sformat, (%))
-import           Mockable (CurrentTime, Mockable)
 import           Serokell.Util.Text (listJson)
 import           UnliftIO (MonadUnliftIO)
 
@@ -44,6 +43,7 @@ import           Pos.Core (ComponentBlock (..), IsGenesisHeader, epochIndexL,
                      mainBlockUpdatePayload)
 import           Pos.Core.Block (Block, GenesisBlock, MainBlock)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Core.Mockable (CurrentTime, Mockable)
 import           Pos.Core.Reporting (MonadReporting)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.DB (MonadDB, MonadDBRead, MonadGState, SomeBatchOp (..))

--- a/block/src/Pos/Block/Lrc.hs
+++ b/block/src/Pos/Block/Lrc.hs
@@ -20,7 +20,6 @@ import           Data.Conduit (ConduitT, runConduitRes, (.|))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import           Formatting (build, ords, sformat, (%))
-import           Mockable (forConcurrently)
 import qualified System.Metrics.Counter as Metrics
 import           System.Wlog (logDebug, logInfo, logWarning)
 import           UnliftIO (MonadUnliftIO)
@@ -32,6 +31,7 @@ import           Pos.Core (Coin, EpochIndex, EpochOrSlot (..), SharedSeed,
                      StakeholderId, blkSecurityParam, crucialSlot, epochIndexL,
                      epochSlots, getEpochOrSlot)
 import           Pos.Core.Chrono (NE, NewestFirst (..), toOldestFirst)
+import           Pos.Core.Mockable (forConcurrently)
 import           Pos.Core.Reporting (HasMisbehaviorMetrics (..),
                      MisbehaviorMetrics (..))
 import           Pos.Core.Slotting (MonadSlots)

--- a/delegation/cardano-sl-delegation.cabal
+++ b/delegation/cardano-sl-delegation.cabal
@@ -39,7 +39,6 @@ library
                      , cardano-sl-crypto
                      , cardano-sl-db
                      , cardano-sl-lrc
-                     , cardano-sl-networking
                      , cardano-sl-util
                      , conduit
                      , ether

--- a/delegation/src/Pos/Delegation/Logic/Mempool.hs
+++ b/delegation/src/Pos/Delegation/Logic/Mempool.hs
@@ -22,12 +22,12 @@ import           Universum
 import           Control.Lens (at, uses, (%=), (+=), (-=), (.=))
 import qualified Data.Cache.LRU as LRU
 import qualified Data.HashMap.Strict as HM
-import           Mockable (CurrentTime, Mockable, currentTime)
 import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Binary.Class (biSize)
 import           Pos.Core (ProxySKHeavy, addressHash, bvdMaxBlockSize,
                      epochIndexL, headerHash)
+import           Pos.Core.Mockable (CurrentTime, Mockable, currentTime)
 import           Pos.Core.StateLock (StateLock, withStateLockNoMetrics)
 import           Pos.Crypto (ProtocolMagic, ProxySecretKey (..), PublicKey)
 import           Pos.DB (MonadDBRead, MonadGState)

--- a/delegation/src/Pos/Delegation/Logic/VAR.hs
+++ b/delegation/src/Pos/Delegation/Logic/VAR.hs
@@ -21,7 +21,6 @@ import qualified Data.HashSet as HS
 import           Data.List ((\\))
 import           Formatting (bprint, build, sformat, (%))
 import qualified Formatting.Buildable as B
-import           Mockable (CurrentTime, Mockable)
 import           Serokell.Util (listJson, mapJson)
 import           System.Wlog (WithLogger, logDebug)
 import           UnliftIO (MonadUnliftIO)
@@ -31,6 +30,7 @@ import           Pos.Core (ComponentBlock (..), EpochIndex (..), StakeholderId,
                      prevBlockL, siEpoch)
 import           Pos.Core.Block (Block, mainBlockDlgPayload, mainBlockSlot)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Core.Mockable (CurrentTime, Mockable)
 import           Pos.Crypto (ProtocolMagic, ProxySecretKey (..), shortHashF)
 import           Pos.DB (DBError (DBMalformed), MonadDBRead, SomeBatchOp (..))
 import qualified Pos.DB as DB

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -48,7 +48,6 @@ library
                      , cardano-sl-delegation
                      , cardano-sl-infra
                      , cardano-sl-lrc
-                     , cardano-sl-networking
                      , cardano-sl-ssc
                      , cardano-sl-txp
                      , cardano-sl-update

--- a/generator/src/Pos/Generator/Block/Mode.hs
+++ b/generator/src/Pos/Generator/Block/Mode.hs
@@ -28,7 +28,6 @@ import qualified Control.Monad.Catch as UnsafeExc
 import           Control.Monad.Random.Strict (RandT)
 import qualified Crypto.Random as Rand
 import           Data.Default (Default)
-import           Mockable (MonadMockable, Promise)
 import           System.Wlog (WithLogger, logWarning)
 import           UnliftIO (MonadUnliftIO)
 
@@ -40,6 +39,7 @@ import           Pos.Core (Address, GenesisWStakeholders (..), HasConfiguration,
                      HasPrimaryKey (..), SlotId (..), Timestamp,
                      epochOrSlotToSlot, getEpochOrSlot,
                      largestPubKeyAddressBoot)
+import           Pos.Core.Mockable (MonadMockable, Promise)
 import           Pos.Core.Reporting (HasMisbehaviorMetrics (..),
                      MonadReporting (..))
 import           Pos.Crypto (SecretKey)

--- a/generator/src/Test/Pos/Block/Logic/Emulation.hs
+++ b/generator/src/Test/Pos/Block/Logic/Emulation.hs
@@ -20,14 +20,15 @@ import qualified Control.Monad.Trans.Control as MC
 import qualified Crypto.Random as Rand
 import           Data.Coerce (coerce)
 import           Data.Time.Units (Microsecond)
-import           Mockable (Async, Channel, ChannelT, Concurrently,
+import           System.Wlog (CanLog (..))
+import           UnliftIO (MonadUnliftIO)
+
+import           Pos.Core.Mockable (Async, Channel, ChannelT, Concurrently,
                      CurrentTime (..), Delay (..), Fork, MFunctor' (hoist'),
                      Mockable (..), MyThreadId (..), Production (..), Promise,
                      SharedAtomic (..), SharedAtomicT, SharedExclusive (..),
                      SharedExclusiveT, ThreadId)
-import qualified Mockable.Metrics as Metrics
-import           System.Wlog (CanLog (..))
-import           UnliftIO (MonadUnliftIO)
+import qualified Pos.Core.Mockable.Metrics as Metrics
 
 newtype ClockVar = ClockVar (IORef Microsecond)
 

--- a/generator/src/Test/Pos/Block/Logic/Mode.hs
+++ b/generator/src/Test/Pos/Block/Logic/Mode.hs
@@ -49,7 +49,6 @@ import qualified Data.Map as Map
 import           Data.Time.Units (TimeUnit (..))
 import           Formatting (bprint, build, formatToString, shown, (%))
 import qualified Formatting.Buildable
-import           Mockable (Production, currentTime, runProduction)
 import qualified Prelude
 import           System.Wlog (HasLoggerName (..), LoggerName)
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, forAll,
@@ -69,6 +68,7 @@ import           Pos.Core (BlockVersionData, CoreConfiguration (..),
                      withGenesisSpec)
 import           Pos.Core.Configuration (HasGenesisBlockVersionData,
                      withGenesisBlockVersionData)
+import           Pos.Core.Mockable (Production, currentTime, runProduction)
 import           Pos.Core.Reporting (HasMisbehaviorMetrics (..),
                      MonadReporting (..))
 import           Pos.Core.Slotting (MonadSlotsData)

--- a/infra/src/Pos/Infra/Communication/Protocol.hs
+++ b/infra/src/Pos/Infra/Communication/Protocol.hs
@@ -29,13 +29,14 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NE
 import           Formatting (bprint, build, sformat, (%))
 import qualified Formatting.Buildable as B
-import           Mockable (Async, Delay, Mockable, Mockables, SharedAtomic)
 import qualified Network.Broadcast.OutboundQueue as OQ
 import qualified Node as N
 import           Node.Message.Class (Message (..), MessageCode, messageCode)
 import           Pos.Util.Trace (Severity (..), Trace, traceWith)
 import           Serokell.Util.Text (listJson)
 
+import           Pos.Core.Mockable (Async, Delay, Mockable, Mockables,
+                     SharedAtomic)
 import           Pos.Core.Slotting (MonadSlots)
 import           Pos.Infra.Communication.Types.Protocol
 import           Pos.Infra.Recovery.Info (MonadRecoveryInfo)

--- a/infra/src/Pos/Infra/DHT/Workers.hs
+++ b/infra/src/Pos/Infra/DHT/Workers.hs
@@ -9,12 +9,12 @@ import           Universum
 
 import qualified Data.ByteString.Lazy as BSL
 import           Formatting (sformat, (%))
-import           Mockable (Async, Delay, Mockable)
 import           Network.Kademlia (takeSnapshot)
 import           System.Wlog (WithLogger, logNotice)
 
 import           Pos.Binary.Class (serialize)
 import           Pos.Core (HasProtocolConstants)
+import           Pos.Core.Mockable (Async, Delay, Mockable)
 import           Pos.Core.Slotting (MonadSlots, flattenSlotId, slotIdF)
 import           Pos.Infra.Binary.DHTModel ()
 import           Pos.Infra.DHT.Constants (kademliaDumpInterval)

--- a/infra/src/Pos/Infra/Discovery/Model/Class.hs
+++ b/infra/src/Pos/Infra/Discovery/Model/Class.hs
@@ -4,13 +4,15 @@ module Pos.Infra.Discovery.Model.Class
        , withPeersConcurrently
        ) where
 
+import           Universum
+
 import           Data.Proxy (Proxy)
 import           Data.Set (Set)
 import qualified Data.Set as Set (toList)
-import           Mockable (Mockable)
-import           Mockable.Concurrent (Concurrently, forConcurrently)
+
+import           Pos.Core.Mockable (Mockable)
+import           Pos.Core.Mockable.Concurrent (Concurrently, forConcurrently)
 import           Pos.Infra.Communication.Protocol (NodeId)
-import           Universum
 
 -- | Provides a set of known peers.
 class Discovery which m where

--- a/infra/src/Pos/Infra/Discovery/Model/Neighbors.hs
+++ b/infra/src/Pos/Infra/Discovery/Model/Neighbors.hs
@@ -3,15 +3,17 @@ module Pos.Infra.Discovery.Model.Neighbors
        , converseToNeighbors
        ) where
 
+import           Universum
+
 import           Formatting (sformat, shown, (%))
-import           Mockable (MonadMockable, handleAll)
+import           System.Wlog (WithLogger, logDebug, logWarning)
+
 import           Pos.Binary.Class (Bi)
+import           Pos.Core.Mockable (MonadMockable, handleAll)
 import           Pos.Infra.Communication.Protocol (ConversationActions, Message,
                      NodeId (..), SendActions (..))
 import           Pos.Infra.Discovery.Model.Class (Discovery (..),
                      withPeersConcurrently)
-import           System.Wlog (WithLogger, logDebug, logWarning)
-import           Universum
 
 sendToNeighbors
     :: ( Discovery which m

--- a/infra/src/Pos/Infra/Network/CLI.hs
+++ b/infra/src/Pos/Infra/Network/CLI.hs
@@ -34,7 +34,6 @@ import qualified Data.Map.Strict as M
 import           Data.Maybe (fromJust, mapMaybe)
 import qualified Data.Yaml as Yaml
 import           Formatting (build, sformat, shown, (%))
-import           Mockable.Concurrent ()
 import           Network.Broadcast.OutboundQueue (Alts, Peers, peersFromList)
 import qualified Network.DNS as DNS
 import qualified Network.Transport.TCP as TCP
@@ -42,6 +41,7 @@ import qualified Options.Applicative as Opt
 import           System.Wlog (LoggerNameBox, WithLogger, askLoggerName,
                      logError, logNotice, usingLoggerName)
 
+import           Pos.Core.Mockable.Concurrent ()
 import           Pos.Core.NetworkAddress (NetworkAddress, addrParser,
                      addrParserNoWildcard)
 import qualified Pos.Infra.DHT.Real.Param as DHT (KademliaParams (..),

--- a/infra/src/Pos/Infra/Slotting/Impl/Simple.hs
+++ b/infra/src/Pos/Infra/Slotting/Impl/Simple.hs
@@ -19,9 +19,8 @@ module Pos.Infra.Slotting.Impl.Simple
 
 import           Universum
 
-import           Mockable (CurrentTime, Mockable, currentTime)
-
 import           Pos.Core.Configuration (HasProtocolConstants)
+import           Pos.Core.Mockable (CurrentTime, Mockable, currentTime)
 import           Pos.Core.Slotting (MonadSlotsData, SlotId (..), Timestamp (..),
                      getCurrentNextEpochIndexM, unflattenSlotId,
                      waitCurrentEpochEqualsM)

--- a/infra/src/Pos/Infra/Slotting/Util.hs
+++ b/infra/src/Pos/Infra/Slotting/Util.hs
@@ -30,12 +30,12 @@ import           Universum
 
 import           Data.Time.Units (Millisecond, fromMicroseconds)
 import           Formatting (int, sformat, shown, stext, (%))
-import           Mockable (Async, Delay, Mockable, delay, timeout)
 import           System.Wlog (WithLogger, logDebug, logInfo, logNotice,
                      logWarning, modifyLoggerName)
 
 import           Pos.Core (HasProtocolConstants, LocalSlotIndex, SlotId (..),
                      Timestamp (..), slotIdF)
+import           Pos.Core.Mockable (Async, Delay, Mockable, delay, timeout)
 import           Pos.Core.Slotting (ActionTerminationPolicy (..),
                      EpochSlottingData (..), MonadSlotsData,
                      OnNewSlotParams (..), SlottingData, computeSlotStart,

--- a/lrc/cardano-sl-lrc.cabal
+++ b/lrc/cardano-sl-lrc.cabal
@@ -46,7 +46,6 @@ library
                      , cardano-sl-core
                      , cardano-sl-crypto
                      , cardano-sl-db
-                     , cardano-sl-networking
                      , cardano-sl-txp
                      , cardano-sl-util
                      , conduit

--- a/lrc/src/Pos/Lrc/Mode.hs
+++ b/lrc/src/Pos/Lrc/Mode.hs
@@ -8,10 +8,10 @@ module Pos.Lrc.Mode
 
 import           Universum
 
-import           Mockable (Async, Concurrently, Delay, Mockables)
 import           System.Wlog (WithLogger)
 import           UnliftIO (MonadUnliftIO)
 
+import           Pos.Core.Mockable (Async, Concurrently, Delay, Mockables)
 import           Pos.DB.Class (MonadDB, MonadGState)
 import           Pos.Lrc.Context (HasLrcContext)
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15355,7 +15355,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-delegation
 , cardano-sl-delegation-test
 , cardano-sl-lrc
-, cardano-sl-networking
 , cardano-sl-ssc
 , cardano-sl-ssc-test
 , cardano-sl-txp
@@ -15418,7 +15417,6 @@ cardano-sl-crypto
 cardano-sl-db
 cardano-sl-delegation
 cardano-sl-lrc
-cardano-sl-networking
 cardano-sl-ssc
 cardano-sl-txp
 cardano-sl-update
@@ -16161,7 +16159,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-crypto
 , cardano-sl-db
 , cardano-sl-lrc
-, cardano-sl-networking
 , cardano-sl-util
 , conduit
 , cpphs
@@ -16203,7 +16200,6 @@ cardano-sl-core
 cardano-sl-crypto
 cardano-sl-db
 cardano-sl-lrc
-cardano-sl-networking
 cardano-sl-util
 conduit
 ether
@@ -16504,7 +16500,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-delegation-test
 , cardano-sl-infra
 , cardano-sl-lrc
-, cardano-sl-networking
 , cardano-sl-ssc
 , cardano-sl-ssc-test
 , cardano-sl-txp
@@ -16560,7 +16555,6 @@ cardano-sl-db
 cardano-sl-delegation
 cardano-sl-infra
 cardano-sl-lrc
-cardano-sl-networking
 cardano-sl-ssc
 cardano-sl-txp
 cardano-sl-update
@@ -16832,7 +16826,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-core-test
 , cardano-sl-crypto
 , cardano-sl-db
-, cardano-sl-networking
 , cardano-sl-txp
 , cardano-sl-util
 , cardano-sl-util-test
@@ -16868,7 +16861,6 @@ cardano-sl-binary
 cardano-sl-core
 cardano-sl-crypto
 cardano-sl-db
-cardano-sl-networking
 cardano-sl-txp
 cardano-sl-util
 conduit
@@ -17179,7 +17171,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-crypto
 , cardano-sl-db
 , cardano-sl-lrc
-, cardano-sl-networking
 , cardano-sl-util
 , containers
 , cpphs
@@ -17228,7 +17219,6 @@ cardano-sl-core
 cardano-sl-crypto
 cardano-sl-db
 cardano-sl-lrc
-cardano-sl-networking
 cardano-sl-util
 containers
 cryptonite
@@ -17493,7 +17483,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-core-test
 , cardano-sl-crypto
 , cardano-sl-db
-, cardano-sl-networking
 , cardano-sl-util
 , cardano-sl-util-test
 , conduit
@@ -17550,7 +17539,6 @@ cardano-sl-binary
 cardano-sl-core
 cardano-sl-crypto
 cardano-sl-db
-cardano-sl-networking
 cardano-sl-util
 conduit
 containers

--- a/ssc/cardano-sl-ssc.cabal
+++ b/ssc/cardano-sl-ssc.cabal
@@ -65,7 +65,6 @@ library
                      , cardano-sl-crypto
                      , cardano-sl-db
                      , cardano-sl-lrc
-                     , cardano-sl-networking
                      , cardano-sl-util
                      , containers
                      , cryptonite

--- a/ssc/src/Pos/Ssc/Toss/Trans.hs
+++ b/ssc/src/Pos/Ssc/Toss/Trans.hs
@@ -15,8 +15,8 @@ import           Universum hiding (id)
 
 import           Control.Lens (at, (%=), (.=))
 import qualified Ether
-import           Mockable (ChannelT, Promise, SharedAtomicT, ThreadId)
 
+import           Pos.Core.Mockable (ChannelT, Promise, SharedAtomicT, ThreadId)
 import           Pos.Core.Ssc (insertVss)
 import           Pos.Ssc.Base (deleteSignedCommitment, insertSignedCommitment)
 import           Pos.Ssc.Toss.Class (MonadToss (..), MonadTossEnv (..),

--- a/txp/cardano-sl-txp.cabal
+++ b/txp/cardano-sl-txp.cabal
@@ -65,7 +65,6 @@ library
                      , cardano-sl-core
                      , cardano-sl-crypto
                      , cardano-sl-db
-                     , cardano-sl-networking
                      , cardano-sl-util
                      , conduit
                      , containers

--- a/txp/src/Pos/Txp/Logic/Local.hs
+++ b/txp/src/Pos/Txp/Logic/Local.hs
@@ -25,12 +25,12 @@ import           Data.Default (Default (def))
 import qualified Data.HashMap.Strict as HM
 import           Data.Reflection (given)
 import           Formatting (build, sformat, (%))
-import           JsonLog (CanJsonLog (..))
 import           System.Wlog (NamedPureLogger, WithLogger, launchNamedPureLog,
                      logDebug, logError, logWarning)
 
 import           Pos.Core (BlockVersionData, EpochIndex, HeaderHash,
                      ProtocolMagic, siEpoch)
+import           Pos.Core.JsonLog (CanJsonLog (..))
 import           Pos.Core.JsonLog.LogEvents (MemPoolModifyReason (..))
 import           Pos.Core.Reporting (reportError)
 import           Pos.Core.Slotting (MonadSlots (..))

--- a/txp/src/Pos/Txp/MemState/Class.hs
+++ b/txp/src/Pos/Txp/MemState/Class.hs
@@ -28,8 +28,9 @@ import           Universum
 import qualified Control.Concurrent.STM as STM
 import           Data.Default (Default (..))
 import qualified Data.HashMap.Strict as HM
-import           Mockable (CurrentTime, Mockable)
+
 import           Pos.Core (HeaderHash)
+import           Pos.Core.Mockable (CurrentTime, Mockable)
 import           Pos.Core.Reporting (MonadReporting)
 import           Pos.Core.Slotting (MonadSlots (..))
 import           Pos.Core.Txp (TxAux, TxId)


### PR DESCRIPTION
## Description

Change the imports of `JsonLog` and `Mockable` from `networking` to `core` (where the modules are now prefixed by `Pos.Core.`). This allows `networking` to float up until it is right below `infra`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-432

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
^ Module level refactoring (switching of imports between packages). Existing tests should be sufficient.