### PR TITLE
Remove `text-format` from repo

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17806,7 +17806,6 @@ license = stdenv.lib.licenses.mit;
 , tagged
 , template-haskell
 , text
-, text-format
 , time
 , time-units
 , transformers
@@ -17886,7 +17885,6 @@ quickcheck-instances
 stm
 template-haskell
 text
-text-format
 time
 time-units
 universum
@@ -17925,7 +17923,6 @@ license = stdenv.lib.licenses.mit;
 , tagged
 , template-haskell
 , text
-, text-format
 , time-units
 , universum
 , unordered-containers
@@ -17961,7 +17958,6 @@ quickcheck-instances
 tagged
 template-haskell
 text
-text-format
 time-units
 universum
 unordered-containers

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -151,7 +151,6 @@ test-suite test
                      , stm
                      , template-haskell
                      , text
-                     , text-format
                      , time
                      , time-units
                      , universum >= 1.1.0

--- a/util/test/cardano-sl-util-test.cabal
+++ b/util/test/cardano-sl-util-test.cabal
@@ -43,7 +43,6 @@ library
                      , quickcheck-instances
                      , tagged
                      , template-haskell
-                     , text-format
                      , text
                      , time-units
                      , universum


### PR DESCRIPTION
## Description

`text-format` isn't imported in `cardano-sl-util` or `cardano-sl-util-test`, despite being listed in their build-depends.

## Linked issue

This is a one-off fix.

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
^ We are just removing an unused module.