### PR TITLE
[DEVOPS-960] Clean up mechanism for streaming test output in CI logs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,17 +31,7 @@ let
     inherit (cardanoPkgs) ghc;
   };
   addRealTimeTestLogs = drv: overrideCabal drv (attrs: {
-    testTarget = "--log=test.log || (sleep 10 && kill $TAILPID && false)";
-    preCheck = ''
-      mkdir -p dist/test
-      touch dist/test/test.log
-      tail -F dist/test/test.log &
-      export TAILPID=$!
-    '';
-    postCheck = ''
-      sleep 10
-      kill $TAILPID
-    '';
+    testTarget = "--show-details=streaming";
   });
 
   cardanoPkgs = ((import ./pkgs { inherit pkgs; }).override {


### PR DESCRIPTION
## Description

Test output is very sparse in CI logs:

```
running tests
Running 1 test suites...
Test suite test: RUNNING...
Test suite test: PASS
```

In nix we have a mechanism for enabling streaming log output with more details. This was introduced in DEVOPS-274, and it was somewhat of a hack.

To enable streaming test output, we still need to explicitly apply `addRealTimeTestLogs` to the relevant derivations in the `cardanoPkgs` overrides in `default.nix`. As part of DEVOPS-960 I'd like to see it automatically applied to all Haskell package derivations coming from this repo or prefixed by `cardano`, but this is a start. After manually enabling it, e.g. by adding `cardano-sl-infra = addRealTimeTestLogs super.cardano-sl-infra;` to `default.nix`, I get output like this instead:

```
...
[12 of 12] Compiling Main             ( test/test.hs, dist/build/test/test-tmp/Main.o )
Linking dist/build/test/test ...
running tests
Running 1 test suites...
Test suite test: RUNNING...
Test suite test: PASS
Test suite logged to: dist/test/cardano-sl-infra-1.3.0-test.log
1 of 1 test suites (1 of 1 test cases) passed.

Subscription
  Status
    state change consistency
      +++ OK, passed 100 tests.
  Exception handling
    networkSubscribeTo squelches synchronous exceptions
    networkSubscribeTo does not squelch asynchronous exceptions

Finished in 0.0130 seconds
3 examples, 0 failures
━━━ Test.Pos.Infra.Bi ━━━
  ✓ golden_HandlerSpec_ConvHandler passed 1 test.
  ✓ golden_HandlerSpec_UnknownHandler passed 1 test.
  ✓ 2 succeeded.
━━━ Test.Pos.Infra.Bi ━━━
  ✓ roundTripHandlerSpecBi passed 1000 tests.
  ✓ 1 succeeded.
haddockPhase
...
```

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-960

## Type of change

- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [~] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This is a refactoring for optional test output behavior which will be self-evident in CI.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

1. Identify which derivations have `addRealTimeTestLogs` applied in `./default.nix`
2. For each of those derivations, verify that logs in Hydra are showing detailed test output like the example shown in the PR description.
3. Optional: to test locally, run `nix-build -A all-cardano-sl`.

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
