### PR TITLE
package-dep-graph.sh: add SVG output option

### DIFF
--- a/scripts/package-dep-graph.sh
+++ b/scripts/package-dep-graph.sh
@@ -22,8 +22,9 @@ script=$(basename "$0")
 stack_dot_flags=""
 include_test_bench="0"
 use_tred="1"
+format="png"
 
-while getopts "hetf" opt; do
+while getopts "hetfs" opt; do
   case $opt in
     h)
       echo "usage: ./${script} OPTS" >&2
@@ -32,6 +33,7 @@ while getopts "hetf" opt; do
       echo "    -e : include external dependencies in graph" >&2
       echo "    -t : include test+bench packages in graph" >&2
       echo "    -f : don't use \`tred\` - render full deg graph" >&2
+      echo "    -s : render as SVG" >&2
       exit 0
       ;;
     e)
@@ -42,6 +44,9 @@ while getopts "hetf" opt; do
       ;;
     f)
       use_tred="0"
+      ;;
+    s)
+      format="svg"
       ;;
     ?)
       echo "Invalid option: -$OPTARG" >&2
@@ -56,7 +61,6 @@ done
 ################################################################################
 
 tmpdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename "$0").XXXXXXXXXXXX")
-outfile="cardano-sl-pkg-deps.png"
 
 # 'tred' and 'dot' are in the 'graphviz' of most Linux distributions.
 
@@ -80,7 +84,13 @@ else
     final_dotfile="${tmpdir}/full-dependencies.dot"
 fi
 
-dot -Tpng "${final_dotfile}" -o ${outfile}
+if [ "${format}" = "svg" ]; then
+    outfile="cardano-sl-pkg-deps.svg"
+    dot -Tsvg "${final_dotfile}" -o ${outfile}
+elif [ "${format}" = "png" ]; then
+    outfile="cardano-sl-pkg-deps.png"
+    dot -Tpng "${final_dotfile}" -o ${outfile}
+fi
 
 rm -rf "${tmpdir:?}/"
 


### PR DESCRIPTION
## Description

Add SVG output option to script.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-429
^ technically closed, but this was requested to be added, and seems too small to open a new ticket for.

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.