### PR TITLE
Change the hard-coded size estimates to use Bi.

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17519,6 +17519,8 @@ license = stdenv.lib.licenses.mit;
 , bytestring
 , cardano-crypto
 , cardano-sl
+, cardano-sl-binary
+, cardano-sl-block
 , cardano-sl-chain
 , cardano-sl-client
 , cardano-sl-core
@@ -17666,6 +17668,8 @@ base
 bytestring
 cardano-crypto
 cardano-sl
+cardano-sl-binary
+cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17723,7 +17723,6 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl
 , cardano-sl-binary
 , cardano-sl-binary-test
-, cardano-sl-block
 , cardano-sl-chain
 , cardano-sl-client
 , cardano-sl-core
@@ -17837,7 +17836,6 @@ bytestring
 cardano-crypto
 cardano-sl
 cardano-sl-binary
-cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core
@@ -17954,7 +17952,6 @@ cardano-crypto
 cardano-sl
 cardano-sl-binary
 cardano-sl-binary-test
-cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16503,6 +16503,8 @@ libraryHaskellDepends = [
 base
 bytestring
 cardano-sl
+cardano-sl-binary
+cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16503,7 +16503,6 @@ libraryHaskellDepends = [
 base
 bytestring
 cardano-sl
-cardano-sl-binary
 cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
@@ -17521,7 +17520,6 @@ license = stdenv.lib.licenses.mit;
 , bytestring
 , cardano-crypto
 , cardano-sl
-, cardano-sl-binary
 , cardano-sl-block
 , cardano-sl-chain
 , cardano-sl-client
@@ -17670,7 +17668,6 @@ base
 bytestring
 cardano-crypto
 cardano-sl
-cardano-sl-binary
 cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
@@ -17727,6 +17724,7 @@ license = stdenv.lib.licenses.mit;
 , bytestring
 , cardano-crypto
 , cardano-sl
+, cardano-sl-binary
 , cardano-sl-binary-test
 , cardano-sl-chain
 , cardano-sl-client
@@ -17840,6 +17838,8 @@ beam-sqlite
 bytestring
 cardano-crypto
 cardano-sl
+cardano-sl-binary
+cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core
@@ -17954,6 +17954,7 @@ base
 bytestring
 cardano-crypto
 cardano-sl
+cardano-sl-binary
 cardano-sl-binary-test
 cardano-sl-chain
 cardano-sl-client

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16503,7 +16503,6 @@ libraryHaskellDepends = [
 base
 bytestring
 cardano-sl
-cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core
@@ -17520,7 +17519,6 @@ license = stdenv.lib.licenses.mit;
 , bytestring
 , cardano-crypto
 , cardano-sl
-, cardano-sl-block
 , cardano-sl-chain
 , cardano-sl-client
 , cardano-sl-core
@@ -17668,7 +17666,6 @@ base
 bytestring
 cardano-crypto
 cardano-sl
-cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core
@@ -17726,6 +17723,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl
 , cardano-sl-binary
 , cardano-sl-binary-test
+, cardano-sl-block
 , cardano-sl-chain
 , cardano-sl-client
 , cardano-sl-core
@@ -17956,6 +17954,7 @@ cardano-crypto
 cardano-sl
 cardano-sl-binary
 cardano-sl-binary-test
+cardano-sl-block
 cardano-sl-chain
 cardano-sl-client
 cardano-sl-core

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -141,6 +141,8 @@ library
                      , bytestring
                      , cardano-crypto
                      , cardano-sl
+                     , cardano-sl-binary
+                     , cardano-sl-block
                      , cardano-sl-chain
                      , cardano-sl-client
                      , cardano-sl-core

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -457,6 +457,8 @@ test-suite wallet-unit-tests
                     , bytestring
                     , cardano-crypto
                     , cardano-sl
+                    , cardano-sl-binary
+                    , cardano-sl-block
                     , cardano-sl-chain
                     , cardano-sl-client
                     , cardano-sl-core

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -142,7 +142,6 @@ library
                      , cardano-crypto
                      , cardano-sl
                      , cardano-sl-binary
-                     , cardano-sl-block
                      , cardano-sl-chain
                      , cardano-sl-client
                      , cardano-sl-core
@@ -458,7 +457,6 @@ test-suite wallet-unit-tests
                     , cardano-crypto
                     , cardano-sl
                     , cardano-sl-binary
-                    , cardano-sl-block
                     , cardano-sl-chain
                     , cardano-sl-client
                     , cardano-sl-core

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -45,7 +45,6 @@ import           Pos.Core.Attributes (Attributes)
 import           Pos.Core.Txp (TxAux, TxIn, TxInWitness, TxOut, TxSigData)
 import           Pos.Crypto (Signature)
 import qualified Pos.Crypto as Core
-import qualified Pos.Txp as Core
 import           Serokell.Data.Memory.Units (Byte, toBytes)
 
 import           Cardano.Wallet.Kernel.CoinSelection.Generic

--- a/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -31,7 +31,8 @@ import qualified Data.ByteString as B
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric (Cardano,
                      CoinSelFinalResult (..), CoinSelectionOptions,
-                     estimateCardanoFee, mkStdTx)
+                     dummyAddrAttrSize, dummyTxAttrSize, estimateCardanoFee,
+                     estimateMaxTxInputs, mkStdTx)
 import qualified Cardano.Wallet.Kernel.CoinSelection.FromGeneric as CoinSelection
 import           Cardano.Wallet.Kernel.CoinSelection.Generic
                      (CoinSelHardErr (..))
@@ -145,9 +146,10 @@ newTransaction :: ActiveWallet
                -> IO (Either NewTransactionError TxAux, Utxo)
 newTransaction ActiveWallet{..} spendingPassword options accountId payees = do
 
-    -- | NOTE(adn) This number was computed out of the work Matt Noonan did
-    -- on the size estimation. See [CBR-318].
-    let maxInputs = 350
+    -- | NOTE(mn) 65536 is the current maximum transaction size, but this can change
+    --   over time. @newTransaction@ should be parameterized over this value, perhaps
+    --   adding it to @CoinSelectionOptions@.
+    let maxInputs = estimateMaxTxInputs dummyAddrAttrSize dummyTxAttrSize 65536
 
     snapshot <- getWalletSnapshot walletPassive
     let availableUtxo = accountAvailableUtxo snapshot accountId

--- a/wallet-new/test/unit/Test/Spec/CoinSelection.hs
+++ b/wallet-new/test/unit/Test/Spec/CoinSelection.hs
@@ -29,7 +29,6 @@ import           Pos.Core (Coeff (..), TxSizeLinear (..))
 import qualified Pos.Core as Core
 import           Pos.Core.Attributes (mkAttributes)
 import           Pos.Crypto (SecretKey)
-import qualified Pos.Txp as Core
 import           Serokell.Data.Memory.Units (Byte, fromBytes)
 import           Serokell.Util.Text (listJsonIndent)
 


### PR DESCRIPTION
## Description

This PR takes out the hard-coded transaction size estimates in the new wallet , replacing them with uses of the new size-expression code in `Bi`. 

## Linked issue

CBR-291, perhaps?

## Type of change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
