### PR TITLE
[RCD-28]

### DIFF
--- a/networking/src/Network/Broadcast/OutboundQueue.hs
+++ b/networking/src/Network/Broadcast/OutboundQueue.hs
@@ -1036,9 +1036,7 @@ intDequeue outQ@OutQ{..} threadRegistry@TR{} sendMsg = do
                   logFailure outQ FailedSend (Some p, err)
                   intFailure outQ p sendStartTime err
                 Nothing ->
-                  return ()
-
-              logDebugOQ outQ $ debugSent p
+                  logDebugOQ outQ $ debugSent p
 
           return (PacketDequeued theThread)
       return ()


### PR DESCRIPTION
## Description

This PR adds `IOException` handler in `retrievalWorker`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/RCD-28

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
