### PR TITLE
Make date command more portable in exchange onboarding

### DIFF
--- a/docs/exchange-onboarding.md
+++ b/docs/exchange-onboarding.md
@@ -120,19 +120,19 @@ For exchanges we recommend creating the following `custom-wallet-config.nix`:
 
       ## Wallet doc API server.
       #walletDocListen = "127.0.0.1:8091";
-    
+
       ## Runtime metrics server.
       #ekgListen = "127.0.0.1:8000";
-    
+
       ## Directory for the wallet's local state. Must be set BEFORE
       ## running nix-build to have any effect, and it must be enclosed in
       ## double quotes.
       stateDir = "./state-wallet-mainnet";
       topologyFile = ./exchange-topology.yaml;
-    
+
       ## See https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/runtime_control.html#running-a-compiled-program
       #ghcRuntimeArgs = "-N2 -qg -A1m -I0 -T";
-    
+
       ## Primarily used for troubleshooting.
       #additionalNodeArgs = "";
     }
@@ -162,7 +162,7 @@ By default the wallet's local state goes in
 Build the wallet and generate the shell script to connect to
 mainnet (use `connectScripts.staging.wallet` for testnet)
 
-    nix-build -A connectScripts.mainnet.wallet -o "./launch_$(date -I)_$(git rev-parse --short HEAD)"
+    nix-build -A connectScripts.mainnet.wallet -o "./launch_$(date "+%Y-%m-%d")_$(git rev-parse --short HEAD)"
 
 After the build finishes the generated connection script is
 available as a symlink called `./launch_2018-01-30_0d4f79eea`, or


### PR DESCRIPTION
## Description

The current command, `date -I` is only available on Linux-flavored platforms.
For BSD-based platforms `-I` is not a valid command-line option. Available
options can be seen on the FreeBSD man page for [`date`](https://www.freebsd.org/cgi/man.cgi?date).

This change manually recreates the output of the `-I` command using the format
syntax. This version works across both Linux, macOS, and BSD and has been
tested on all three.

## Linked issue

N/A

## Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
Verify that the new command works on macOS, Linux, and BSD.
