### PR TITLE
Restart worker threads if they fail

### DIFF
--- a/lib/src/Pos/Launcher/Scenario.hs
+++ b/lib/src/Pos/Launcher/Scenario.hs
@@ -84,7 +84,7 @@ runNode' NodeResources {..} workers' plugins' = \diffusion -> do
 
     waitSystemStart
     let runWithReportHandler action =
-            action diffusion `catch` reportHandler
+            forever (action diffusion `catch` reportHandler)
 
     void (mapConcurrently runWithReportHandler (workers' ++ plugins'))
 


### PR DESCRIPTION
## Description

[IOHKS-32](https://iohk.myjetbrains.com/youtrack/issue/IOHKS-32) details a case where block syncing fails to finish. While investigating the code, I noticed that the current thread supervision in the launcher doesn't restart threads if they fail, and it doesn't kill the entire process if one fails. A possible scenario is thus:

1. The node starts, launching many workers, including the `syncWorker`.
2. The `syncWorker` thread dies with an exception that is caught by the top-level handler. The exception is reported, and the other workers/threads continue on.
3. The program continues, but syncing is totally stopped.

This PR causes failed threads to restart on exceptions. Alternatively, we could bring the entire process down on a failed thread. I believe that either would be an improvement over the current behavior.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/IOHKS-32

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
