### PR TITLE
[DEVOPS-985] add useStackBinaries parameter to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -123,6 +123,7 @@ let
     walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev useStackBinaries; };
     validateJson = pkgs.callPackage ./tools/src/validate-json {};
     demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev useStackBinaries; };
+    demoClusterDaedalusDev = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev useStackBinaries; disableClientAuth = true; numImportedWallets = 0; };
     demoClusterLaunchGenesis = pkgs.callPackage ./scripts/launch/demo-cluster {
       inherit gitrev useStackBinaries;
       launchGenesis = true;

--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,7 @@ in
 , enableDebugging ? false
 , enableBenchmarks ? true
 , allowCustomConfig ? true
+, useStackBinaries ? false
 }:
 
 with pkgs.lib;
@@ -156,15 +157,15 @@ let
     inherit (pkgs) purescript;
     connectScripts = {
       mainnet = {
-        wallet = connect {};
+        wallet = connect { inherit useStackBinaries;};
         explorer = connect { executable = "explorer"; };
       };
       staging = {
-        wallet = connect { environment = "mainnet-staging"; };
+        wallet = connect { inherit useStackBinaries; environment = "mainnet-staging"; };
         explorer = connect { executable = "explorer"; environment = "mainnet-staging"; };
       };
       testnet = {
-        wallet = connect { environment = "testnet"; };
+        wallet = connect { inherit useStackBinaries; environment = "testnet"; };
         explorer = connect { executable = "explorer"; environment = "testnet"; };
       };
       demoWallet = connect { environment = "demo"; };

--- a/default.nix
+++ b/default.nix
@@ -118,13 +118,13 @@ let
       walletConfigFile = ./custom-wallet-config.nix;
       walletConfig = if allowCustomConfig then (if builtins.pathExists walletConfigFile then import walletConfigFile else {}) else {};
     in
-      args: pkgs.callPackage ./scripts/launch/connect-to-cluster (args // { inherit gitrev; } // walletConfig );
+      args: pkgs.callPackage ./scripts/launch/connect-to-cluster (args // { inherit gitrev useStackBinaries; } // walletConfig );
   other = rec {
-    walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev; };
+    walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev useStackBinaries; };
     validateJson = pkgs.callPackage ./tools/src/validate-json {};
-    demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev; };
+    demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster { inherit gitrev useStackBinaries; };
     demoClusterLaunchGenesis = pkgs.callPackage ./scripts/launch/demo-cluster {
-      inherit gitrev;
+      inherit gitrev useStackBinaries;
       launchGenesis = true;
       configurationKey = "testnet_full";
       runWallet = false;
@@ -157,15 +157,15 @@ let
     inherit (pkgs) purescript;
     connectScripts = {
       mainnet = {
-        wallet = connect { inherit useStackBinaries;};
+        wallet = connect { };
         explorer = connect { executable = "explorer"; };
       };
       staging = {
-        wallet = connect { inherit useStackBinaries; environment = "mainnet-staging"; };
+        wallet = connect { environment = "mainnet-staging"; };
         explorer = connect { executable = "explorer"; environment = "mainnet-staging"; };
       };
       testnet = {
-        wallet = connect { inherit useStackBinaries; environment = "testnet"; };
+        wallet = connect { environment = "testnet"; };
         explorer = connect { executable = "explorer"; environment = "testnet"; };
       };
       demoWallet = connect { environment = "demo"; };

--- a/docs/how-to/demo-cluster.md
+++ b/docs/how-to/demo-cluster.md
@@ -1,0 +1,12 @@
+# How to launch a local demo cluster with nix
+
+1. Make sure nix is installed and IOHK binary cache is configured [nix setup] (https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md#nix-build-mode-recommended)
+2. To generate a script that will launch the demo cluster run `nix-build -A demoCluster -o launch_demo_cluster`
+3. To generate a script that will launch demo cluster suitable for Daedalus development, run `nix-build -A demoClusterDaedalusDev -o launch_demo_cluster`
+4. To launch cluster, run `./launch_demo_cluster`
+5. To stop, hit `ctrl-c` and it will terminate all the nodes.
+6. A `state-demo` state folder will be automatically created relative to your current
+   working directory.
+  * Logs will be found in `state-demo/logs`
+  * TLS certs/keys will be found in `state-demo/tls`
+  * 11 genesis wallets will be pre-loaded with 37 million Ada each

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ mode, it will run in `dev` mode as well, and if you built it in `prod` mode, it 
 ## Launch
 
 * `launch/demo.sh` - run nodes in `tmux`-session (3 nodes by default).
+* `launch/demo-nix.sh` - run demo cluster using nix with 4 core nodes, 1 relay, 1 wallet in background
 * `launch/demo-with-wallet-api.sh` - run nodes in `tmux`-session, with enabled wallet web API (3 nodes by default).
 * `launch/kill-demo.sh` - kill `tmux`-session with running nodes.
 * `launch/testnet-{public,staging}.sh` - connect one node to the cluster (testnet or testnet staging

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -101,7 +101,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   fi
   ''}
 
-  ${executables.${executable}}                                     \
+  exec ${executables.${executable}}                                     \
     ${configurationArgs}                                           \
     ${ ifWallet "--tlscert ${stateDir}/tls/server/server.crt"}     \
     ${ ifWallet "--tlskey ${stateDir}/tls/server/server.key"}      \

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -18,6 +18,7 @@
 , debug ? false
 , disableClientAuth ? false
 , extraParams ? ""
+, useStackBinaries ? false
 }:
 
 with localLib;
@@ -51,8 +52,9 @@ let
     };
   };
   executables =  {
-    wallet = "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-node";
+    wallet = if useStackBinaries then "stack exec -- cardano-node" else "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-node";
     explorer = "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
+    x509gen = if useStackBinaries then "stack exec -- cardano-x509-certificates" else "${iohkPkgs.cardano-sl-tools}/bin/cardano-x509-certificates";
   };
   ifWallet = localLib.optionalString (executable == "wallet");
   iohkPkgs = import ./../../../default.nix { inherit config system pkgs gitrev; };
@@ -92,7 +94,7 @@ in pkgs.writeScript "${executable}-connect-to-${environment}" ''
   ${utf8LocaleSetting}
   if [ ! -d ${stateDir}/tls ]; then
     mkdir -p ${stateDir}/tls/server && mkdir -p ${stateDir}/tls/client
-    ${iohkPkgs.cardano-sl-tools}/bin/cardano-x509-certificates   \
+    ${executables.x509gen}                                     \
       --server-out-dir ${stateDir}/tls/server                    \
       --clients-out-dir ${stateDir}/tls/client                   \
       ${configurationArgs}

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -53,7 +53,7 @@ let
   };
   executables =  {
     wallet = if useStackBinaries then "stack exec -- cardano-node" else "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-node";
-    explorer = "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
+    explorer = if useStackBinaries then "stack exec -- cardano-explorer" else "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
     x509gen = if useStackBinaries then "stack exec -- cardano-x509-certificates" else "${iohkPkgs.cardano-sl-tools}/bin/cardano-x509-certificates";
   };
   ifWallet = localLib.optionalString (executable == "wallet");

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -14,19 +14,16 @@
 , keepAlive ? true
 , launchGenesis ? false
 , configurationKey ? "default"
+, useStackBinaries ? false
 }:
 
 with localLib;
 
 let
-  executables =  {
-    corenode = "${iohkPkgs.cardano-sl-node-static}/bin/cardano-node-simple";
-    wallet = "${iohkPkgs.cardano-sl-wallet-new}/bin/cardano-node";
-    integration-test = "${iohkPkgs.cardano-sl-wallet-new}/bin/wal-integr-test";
-    keygen = "${iohkPkgs.cardano-sl-tools}/bin/cardano-keygen";
-    explorer = "${iohkPkgs.cardano-sl-explorer-static}/bin/cardano-explorer";
-  };
-  demoClusterDeps = with pkgs; (with iohkPkgs; [ jq coreutils pkgs.curl gnused openssl cardano-sl-tools cardano-sl-wallet-new cardano-sl-node-static ]);
+  stackExec = optionalString useStackBinaries "stack exec -- ";
+  cardanoDeps = with iohkPkgs; [ cardano-sl-tools cardano-sl-wallet-new cardano-sl-node-static ];
+  demoClusterDeps = with pkgs; [ jq coreutils curl gnused openssl ];
+  allDeps =  demoClusterDeps ++ (optionals (!useStackBinaries ) cardanoDeps);
   walletConfig = {
     inherit stateDir;
     topologyFile = walletTopologyFile;
@@ -39,9 +36,9 @@ let
   } else {
     environment = "demo";
   };
-  demoWallet = pkgs.callPackage ./../connect-to-cluster ({ inherit gitrev; debug = false; } // walletEnvironment // walletConfig);
-  ifWallet = localLib.optionalString (runWallet);
-  ifKeepAlive = localLib.optionalString (keepAlive);
+  demoWallet = pkgs.callPackage ./../connect-to-cluster ({ inherit gitrev useStackBinaries; debug = false; } // walletEnvironment // walletConfig);
+  ifWallet = optionalString (runWallet);
+  ifKeepAlive = optionalString (keepAlive);
   iohkPkgs = import ./../../.. { inherit config system pkgs gitrev; };
   src = ./../../..;
   topologyFile = import ./make-topology.nix { inherit (pkgs) lib; cores = numCoreNodes; relays = numRelayNodes; };
@@ -52,8 +49,8 @@ let
       fallbacks = 1;
     };
   });
-  assetLockFile = pkgs.writeText "asset-lock-file" (localLib.intersperse "\n" assetLockAddresses);
-  ifAssetLock = localLib.optionalString (assetLockAddresses != []);
+  assetLockFile = pkgs.writeText "asset-lock-file" (intersperse "\n" assetLockAddresses);
+  ifAssetLock = optionalString (assetLockAddresses != []);
   configFiles = pkgs.runCommand "cardano-config" {} ''
       mkdir -pv $out
       cd $out
@@ -69,7 +66,7 @@ let
 
 in pkgs.writeScript "demo-cluster" ''
   #!${pkgs.stdenv.shell}
-  export PATH=${pkgs.lib.makeBinPath demoClusterDeps}
+  export PATH=${pkgs.lib.makeBinPath allDeps}:$PATH
   # Set to 0 (passing) by default. Tests using this cluster can set this variable
   # to force the `stop_cardano` function to exit with a different code.
   EXIT_STATUS=0
@@ -111,7 +108,7 @@ in pkgs.writeScript "demo-cluster" ''
   '' else ''
     echo "Creating genesis keys..."
     config_files=${configFiles}
-    cardano-keygen --system-start 0 generate-keys-by-spec --genesis-out-dir ${stateDir}/genesis-keys --configuration-file $config_files/configuration.yaml --configuration-key ${configurationKey}
+    ${stackExec}cardano-keygen --system-start 0 generate-keys-by-spec --genesis-out-dir ${stateDir}/genesis-keys --configuration-file $config_files/configuration.yaml --configuration-key ${configurationKey}
   ''}
 
   trap "stop_cardano" INT TERM
@@ -120,7 +117,7 @@ in pkgs.writeScript "demo-cluster" ''
   do
     node_args="--db-path ${stateDir}/core-db$i --rebuild-db ${if launchGenesis then "--keyfile ${stateDir}/genesis-keys/generated-keys/rich/key$((i - 1)).sk" else "--genesis-secret $i"} --listen 127.0.0.1:$((3000 + i)) --json-log ${stateDir}/logs/core$i.json --logs-prefix ${stateDir}/logs --system-start $system_start --metrics +RTS -N2 -qg -A1m -I0 -T -RTS --node-id core$i --topology ${topologyFile} --configuration-file $config_files/configuration.yaml --configuration-key ${configurationKey} ${ifAssetLock "--asset-lock-file ${assetLockFile}"}"
     echo Launching core node $i: cardano-node-simple $node_args
-    cardano-node-simple $node_args &> ${stateDir}/logs/core$i.log &
+    ${stackExec}cardano-node-simple $node_args &> ${stateDir}/logs/core$i.log &
     core_pid[$i]=$!
 
   done
@@ -128,7 +125,7 @@ in pkgs.writeScript "demo-cluster" ''
   do
     node_args="--db-path ${stateDir}/relay-db$i --rebuild-db --listen 127.0.0.1:$((3100 + i)) --json-log ${stateDir}/logs/relay$i.json --logs-prefix ${stateDir}/logs --system-start $system_start --metrics +RTS -N2 -qg -A1m -I0 -T -RTS --node-id relay$i --topology ${topologyFile} --configuration-file $config_files/configuration.yaml --configuration-key ${configurationKey}"
     echo Launching relay node $i: cardano-node-simple $node_args
-    cardano-node-simple $node_args &> ${stateDir}/logs/relay$i.log &
+    ${stackExec}cardano-node-simple $node_args &> ${stateDir}/logs/relay$i.log &
     relay_pid[$i]=$!
 
   done

--- a/scripts/launch/demo-nix.sh
+++ b/scripts/launch/demo-nix.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if ! [ -x "$(command -v nix-build)" ]; then
+  echo 'Error: nix is not installed.' >&2
+  # shellcheck disable=SC2016
+  echo 'Run `curl https://nixos.org/nix/install | sh` and re-run this script' >&2
+  exit 1
+fi
+
+GITREV=$(git rev-parse HEAD)
+
+nix-build -A demoClusterDaedalusDev --argstr gitrev "$GITREV" -o "launch_$GITREV"
+exec ./launch_"$GITREV"

--- a/scripts/test/wallet/integration/default.nix
+++ b/scripts/test/wallet/integration/default.nix
@@ -7,13 +7,18 @@
 , gitrev ? "123456" # Dummy git revision to prevent mass rebuilds
 , ghcRuntimeArgs ? "-N2 -qg -A1m -I0 -T"
 , additionalNodeArgs ? ""
+, useStackBinaries ? false
 }:
 
 with localLib;
 
 let
+  stackExec = optionalString useStackBinaries "stack exec -- ";
+  cardanoDeps = with iohkPkgs; [ cardano-sl-tools ];
+  integrationTestDeps = with pkgs; [ gnugrep ];
+  allDeps = integrationTestDeps ++ (optionals (!useStackBinaries ) cardanoDeps);
   demo-cluster = iohkPkgs.demoCluster.override {
-    inherit gitrev numCoreNodes stateDir;
+    inherit gitrev numCoreNodes stateDir useStackBinaries;
     keepAlive = false;
     assetLockAddresses = [ "DdzFFzCqrhswMWoTiWaqXUDZJuYUx63qB6Aq8rbVbhFbc8NWqhpZkC7Lhn5eVA7kWf4JwKvJ9PqQF78AewMCzDZLabkzm99rFzpNDKp5" ];
   };
@@ -22,14 +27,16 @@ let
   };
   iohkPkgs = import ./../../../.. { inherit config system pkgs gitrev; };
 in pkgs.writeScript "integration-tests" ''
+  #!${pkgs.stdenv.shell}
+  export PATH=${pkgs.lib.makeBinPath allDeps}:$PATH
   set -e
   source ${demo-cluster}
-  ${executables.integration-test} --tls-ca-cert ${stateDir}/tls/client/ca.crt --tls-client-cert ${stateDir}/tls/client/client.pem --tls-key ${stateDir}/tls/client/client.key
+  ${stackExec}wal-integr-test --tls-ca-cert ${stateDir}/tls/client/ca.crt --tls-client-cert ${stateDir}/tls/client/client.pem --tls-key ${stateDir}/tls/client/client.key
   EXIT_STATUS=$?
   # Verify we see "transaction list is empty after filtering out asset-locked source addresses" in at least 1 core node log file
   if [[ $EXIT_STATUS -eq 0 ]]
   then
-    ${pkgs.gnugrep}/bin/grep "transaction list is empty after filtering out asset-locked source addresses" state-demo/logs/core*.json
+    grep "transaction list is empty after filtering out asset-locked source addresses" state-demo/logs/core*.json
     EXIT_STATUS=$?
   fi
   stop_cardano


### PR DESCRIPTION
## Description

This adds a top level argument to cardano-sl nix to `useStackBinaries`. By passing this argument, None of the nix built cardano binaries are used or even in the dependency tree. All this requires is nix to be installed to generate scripts developers can run to:

1) run a wallet against any environments supported by the scripts
2) override wallet configs for custom settings (see https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exchange-onboarding.md#generate-custom-configuration)
3) run a full demo cluster with 4 core nodes, 1 relay and 1 wallet
4) run the wallet integration test suite against demo cluster listed in 3.

The way this works is if `useStackBinaries` is specified, the binary being executed that normal comes from `iohkPkgs` built by nix is prefixed with `stack exec -- ` and those binaries are removed from the nix dependency tree. Essentially, it treats the binaries as strings and prepends a string making for super fast nix builds and shifting the burden to stack at run-time.

To test you need:

1) stack in your PATH
2) be in the root of the `cardano-sl` repo
2) run any of the following, or read the exchange docs for more complex examples:

    * `nix-build -A connectScripts.mainnet.wallet -o launch_mainnet_wallet_stack --arg useStackBinaries true && ./launch_mainnet_wallet_stack`
    * `nix-build -A demoCluster -o launch_demo_cluster_stack --arg useStackBinaries true && ./launch_demo_cluster_stack`
    * `nix-build -A walletIntegrationTests -o wallet_integration_tests_stack --arg useStackBinaries true && ./wallet_integration_tests_stack`

One final note, since these are not run in an isolated sandbox, there is a potential of your system interfering with the behavior. For example, If `walletIntegrationTests` throws SSL errors, there's a good chance you have a wallet already listening on port 8090.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-985

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
