### PR TITLE
DO NOT MERGE [DEVOPS-398] explorer frontend: reword Testnet banner

### DIFF
--- a/explorer/frontend/src/Explorer/Util/Config.purs
+++ b/explorer/frontend/src/Explorer/Util/Config.purs
@@ -18,9 +18,6 @@ foreign import versionImpl :: String
 version :: String
 version = versionImpl
 
-testNetVersion :: String
-testNetVersion = "0.5"
-
 foreign import commitHashImpl :: String
 
 commitHash :: String

--- a/explorer/frontend/src/Explorer/View/Common.purs
+++ b/explorer/frontend/src/Explorer/View/Common.purs
@@ -39,7 +39,6 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (initialState)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), PageNumber(..), State)
-import Explorer.Util.Config (testNetVersion)
 import Explorer.Util.DOM (enterKeyPressed)
 import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
 import Explorer.Util.String (formatADA)
@@ -362,7 +361,7 @@ logoView' mRoute isTestnet =
                 ! S.className "logo__img bg-logo"
                 $ S.div
                     ! S.className ("testnet-icon" <> iconHiddenClazz)
-                    $ S.text ("TN " <> testNetVersion)
+                    $ S.text ("Testnet")
 
 logoView :: Boolean -> P.HTML Action
 logoView isTestnet = logoView' Nothing isTestnet


### PR DESCRIPTION
DO NOT MERGE yet - this is for `release/1.3.1`.

## Description

In the banner of cardano-sl-explorer-frontend, rather than "TN 0.5", just have "Testnet".

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-398

## QA Steps

    yarn build:prod
    cd dist
    python -m http.server
    # then visit http://testnet.localhost:8000 in web browser.

## Screenshots

![cardano-explorer-testnet-banner](https://user-images.githubusercontent.com/1019641/43643364-691d320c-976e-11e8-9add-66cbe9e870da.png)
