### PR TITLE
[CDEC-470] Catch IOExceptions in `productionReporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Fixes
 
+- #### Make productionReporter more robust
+  Add exception handling code in reporting exception handler, to prevent IOExceptions from killing
+  the main thread. This was noticed when the network connection was interrupted, and the reporter
+  died when it tried to report over the down network. (CDEC-470 / [PR 3365])
+
+[PR 3365]: https://github.com/input-output-hk/cardano-sl/pull/3365
+
 ### Improvements
 
 ### Specifications


### PR DESCRIPTION
## Description

Reporting is currently complex and brittle, and one failure mode occurs
when the network connection goes down, and reporting tries to report,
but dies due to an IOException because the network is down.

Installing a simple `catchIO` handler around `reportNode` should catch
such exceptions and report their occurence in the log.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-470

## Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
^ this PR modifies IO/orchestration layer code, which is not currently covered by tests.

## QA Steps
```
$ git checkout develop

# start a cardano node using nix scripts
$ nix-shell
...
$ (in nix-shell) stack --nix build --ghc-options=-optl-Wl,-dead_strip_dylibs
$ (in reg shell) nix-build -A connectScripts.mainnet.wallet -o connect-to-mainnet
$ (in nix-shell) ./scripts/launch/connect-to-cluster/mainnet-staging.sh --nix

# look at log output - see blocks streaming by

# disable wifi. observe that blocks no longer stream by, and error messages complaining that network is down.

"""
[diffusion:ERROR:ThreadId 317] [2018-08-07 19:01:40.44 UTC] exception while resolving domains [NodeAddrDNS "relays.awstest.iohkdev.io" Nothing]: /etc/resolv.conf: openFile: does not exist (No such file or directory)
"""

# wait 3-5 minutes. enable wifi. observe (on develop) that block streaming does not resume.

$ <ctrl-c> to kill process

***


$ git checkout mhuesch/CDEC-470-develop

# repeat above process to build & prepare for deployment

...

# on re-enabling wifi, observe that block streaming resumes

```

## Screenshots (if available)
https://asciinema.org/a/DlqCqrcv01NgUzNEiZhIKVP9w
~2:10 to ~8:30 are boring (just waiting until the worker should die, if exceptions weren't handled properly)