### PR TITLE
[CBR-364] Generalize zoomCreate

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -662,7 +662,7 @@ zoomOrCreateHdRoot :: HdRoot
                    -> Update' HdRoot    e a
                    -> Update' HdWallets e a
 zoomOrCreateHdRoot newRoot rootId upd =
-    zoomCreate newRoot (hdWalletsRoots . at rootId) $ upd
+    zoomCreate (return newRoot) (hdWalletsRoots . at rootId) $ upd
 
 -- | Variation on 'zoomHdAccountId' that creates the 'HdAccount' if it doesn't exist
 --
@@ -674,7 +674,7 @@ zoomOrCreateHdAccount :: (HdRootId -> Update' HdWallets e ())
                       -> Update' HdWallets e a
 zoomOrCreateHdAccount checkRootExists newAccount accId upd = do
     checkRootExists $ accId ^. hdAccountIdParent
-    zoomCreate newAccount (hdWalletsAccounts . at accId) $ upd
+    zoomCreate (return newAccount) (hdWalletsAccounts . at accId) $ upd
 
 -- | Variation on 'zoomHdAddressId' that creates the 'HdAddress' if it doesn't exist
 --
@@ -686,7 +686,7 @@ zoomOrCreateHdAddress :: (HdAccountId -> Update' HdWallets e ())
                       -> Update' HdWallets e a
 zoomOrCreateHdAddress checkAccountExists newAddress addrId upd = do
     checkAccountExists $ addrId ^. hdAddressIdParent
-    zoomCreate newAddress (hdWalletsAddresses . at addrId) $ upd
+    zoomCreate (return newAddress) (hdWalletsAddresses . at addrId) $ upd
 
 -- | Assume that the given HdRoot exists
 --


### PR DESCRIPTION
As it stood, zoomCreate took a concrete value to use as default. However, in
certain circumstances we actually want to run an /action/ when the value does
not exist. This is now supported.

## Description

https://iohk.myjetbrains.com/youtrack/issue/CBR-364

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
