### PR TITLE
[CBR-305] SafeCopy instances for InDb types

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17778,6 +17778,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-binary
 , cardano-sl-binary-test
 , cardano-sl-chain
+, cardano-sl-chain-test
 , cardano-sl-client
 , cardano-sl-core
 , cardano-sl-core-test
@@ -17791,6 +17792,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-wallet
 , cardano-sl-wallet-test
 , cassava
+, cereal
 , conduit
 , connection
 , constraints
@@ -17799,6 +17801,7 @@ license = stdenv.lib.licenses.mit;
 , data-default
 , data-default-class
 , directory
+, ed25519
 , exceptions
 , filepath
 , formatting
@@ -17901,6 +17904,7 @@ cardano-sl-node-ipc
 cardano-sl-util
 cardano-sl-wallet
 cardano-sl-wallet-test
+cereal
 conduit
 connection
 containers
@@ -17908,6 +17912,7 @@ cryptonite
 data-default
 data-default-class
 directory
+ed25519
 exceptions
 formatting
 generics-sop
@@ -18004,6 +18009,7 @@ cardano-sl
 cardano-sl-binary
 cardano-sl-binary-test
 cardano-sl-chain
+cardano-sl-chain-test
 cardano-sl-client
 cardano-sl-core
 cardano-sl-core-test
@@ -18012,6 +18018,7 @@ cardano-sl-db
 cardano-sl-util
 cardano-sl-util-test
 cardano-sl-wallet
+cereal
 conduit
 constraints
 containers
@@ -18032,6 +18039,7 @@ quickcheck-instances
 random
 reflection
 safe-exceptions
+safecopy
 serokell-util
 servant
 servant-server

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -177,6 +177,7 @@ library
                      , cardano-sl-util
                      , cardano-sl-wallet
                      , cardano-sl-wallet-test
+                     , cereal
                      , conduit
                      , connection
                      , containers
@@ -184,6 +185,7 @@ library
                      , data-default
                      , data-default-class
                      , directory
+                     , ed25519
                      , exceptions
                      , formatting
                      , formatting

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -538,7 +538,7 @@ test-suite wallet-unit-tests
                     , time
 
 test-suite wallet-new-specs
-  ghc-options:      -Wall
+  ghc-options:      -Wall -O2 -threaded -rtsopts
   type:             exitcode-stdio-1.0
   main-is:          Spec.hs
   hs-source-dirs:   test test/unit
@@ -582,10 +582,12 @@ test-suite wallet-new-specs
   build-depends:      base
                     , aeson
                     , bytestring
+                    , cardano-crypto
                     , cardano-sl
                     , cardano-sl-binary-test
                     , cardano-sl-client
                     , cardano-sl-client
+                    , cardano-sl-chain-test
                     , cardano-sl-core
                     , cardano-sl-core-test
                     , cardano-sl-crypto
@@ -593,6 +595,7 @@ test-suite wallet-new-specs
                     , cardano-sl-util-test
                     , cardano-sl-wallet
                     , cardano-sl-wallet-new
+                    , cereal
                     , data-default
                     , directory
                     , directory
@@ -602,6 +605,7 @@ test-suite wallet-new-specs
                     , lens
                     , QuickCheck
                     , quickcheck-instances
+                    , safecopy
                     , safe-exceptions
                     , servant
                     , servant-server

--- a/wallet-new/src/Cardano/Wallet/Kernel/ChainState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/ChainState.hs
@@ -16,7 +16,6 @@ module Cardano.Wallet.Kernel.ChainState (
 import           Universum
 
 import qualified Data.Map.Strict as Map
-import           Data.SafeCopy (SafeCopy (..))
 
 import           Pos.Chain.Block (HeaderHash, gbHeader, headerHash,
                      mainBlockSlot, prevBlockL)
@@ -248,14 +247,6 @@ data ChainStateException =
   deriving (Show)
 
 instance Exception ChainStateException
-
-{-------------------------------------------------------------------------------
-  Serialization
--------------------------------------------------------------------------------}
-
-instance SafeCopy ChainBrief where
-  getCopy = error "TODO: getCopy for ChainBrief"
-  putCopy = error "TODO: putCopy for ChainBrief"
 
 {-------------------------------------------------------------------------------
   Pretty printing

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -61,7 +61,7 @@ import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Delete as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Update as HD
-import           Cardano.Wallet.Kernel.DB.InDb (InDb(InDb))
+import           Cardano.Wallet.Kernel.DB.InDb (InDb (InDb))
 import           Cardano.Wallet.Kernel.DB.Spec
 import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
 import qualified Cardano.Wallet.Kernel.DB.Spec.Update as Spec

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -61,7 +61,7 @@ import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Create as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Delete as HD
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Update as HD
-import           Cardano.Wallet.Kernel.DB.InDb
+import           Cardano.Wallet.Kernel.DB.InDb (InDb(InDb))
 import           Cardano.Wallet.Kernel.DB.Spec
 import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
 import qualified Cardano.Wallet.Kernel.DB.Spec.Update as Spec
@@ -180,7 +180,7 @@ ensureExistsHdAddress newAddress = do
 -- transactions for all the wallets managed by this edge node.
 cancelPending :: Map HdAccountId (InDb (Set TxId)) -> Update DB ()
 cancelPending cancelled = void . runUpdate' . zoom dbHdWallets $
-    forM_ (Map.toList cancelled) $ \(accountId, InDb txids) ->
+    forM_ (Map.toList cancelled) $ \(accountId, InDb txids) -> do
         -- Here we are deliberately swallowing the possible exception
         -- returned by the wrapped 'zoom' as the only reason why this update
         -- might fail is if, in the meantime, the target account was cancelled,

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
@@ -63,6 +63,15 @@ instance Monoid AddressMeta where
 makeLenses ''AddressMeta
 deriveSafeCopy 1 'base ''AddressMeta
 
+instance SafeCopy (InDb AddressMeta) where
+    getCopy = contain $ do
+        isUsed <- safeGet
+        isChange <- safeGet
+        pure . InDb $ AddressMeta isUsed isChange
+    putCopy (InDb (AddressMeta isUsed isChange)) = contain $ do
+        safePut isUsed
+        safePut isChange
+
 {-------------------------------------------------------------------------------
   Block metadata
 -------------------------------------------------------------------------------}

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/BlockMeta.hs
@@ -76,13 +76,8 @@ data BlockMeta = BlockMeta {
     } deriving Eq
 
 makeLenses ''BlockMeta
-
--- TODO @uroboros/ryan [CBR 305] Implement Safecopy instances independently from legacy wallet
-instance SafeCopy (InDb (Map Core.Address AddressMeta)) where
-    putCopy (InDb h) = contain $ safePut h
-    getCopy = contain $ InDb <$> safeGet
-
 deriveSafeCopy 1 'base ''BlockMeta
+
 -- | Address metadata for the specified address
 --
 -- When the block metadata does not contain any information about this address,

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
@@ -1,10 +1,9 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.Wallet.Kernel.DB.InDb (
-    InDb(..)
-  , fromDb
-  ) where
+module Cardano.Wallet.Kernel.DB.InDb
+    ( InDb(..)
+    , fromDb
+    ) where
 
 import           Universum
 
@@ -18,14 +17,18 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import qualified Data.SafeCopy as SC
+import           Data.Serialize (Put)
 import qualified Data.Set as Set
 import qualified Data.Time.Units
 import qualified Data.Vector as V
+import           Test.QuickCheck (Arbitrary (..))
 
 import qualified Pos.Chain.Block as Core
 import qualified Pos.Chain.Txp as Core
 import qualified Pos.Core as Core
 import qualified Pos.Core.Attributes as Core
+import qualified Pos.Core.Delegation as Core
+import qualified Pos.Core.Ssc as Ssc
 import qualified Pos.Core.Txp as Txp
 import qualified Pos.Core.Update as Core
 import qualified Pos.Crypto as Core
@@ -38,14 +41,17 @@ import qualified Cardano.Crypto.Wallet as CCW
 
 -- | Wrapped type (with potentially different 'SC' instance)
 newtype InDb a = InDb { _fromDb :: a }
-  deriving (Eq, Ord)
+    deriving (Eq, Show, Ord)
 
 instance Functor InDb where
-  fmap f = InDb . f . _fromDb
+    fmap f = InDb . f . _fromDb
 
 instance Applicative InDb where
-  pure = InDb
-  InDb f <*> InDb x = InDb (f x)
+    pure = InDb
+    InDb f <*> InDb x = InDb (f x)
+
+instance (Arbitrary a) => Arbitrary (InDb a) where
+    arbitrary = InDb <$> arbitrary
 
 makeLenses ''InDb
 
@@ -57,55 +63,56 @@ makeLenses ''InDb
 -- choice doesn't show up in the types.
 
 instance SC.SafeCopy (InDb Core.Address) where
-  getCopy = SC.contain $ do
-    InDb (r :: Core.AddressHash Core.Address') <- SC.safeGet
-    InDb (a :: Core.Attributes Core.AddrAttributes) <- SC.safeGet
-    InDb (t :: Core.AddrType) <- SC.safeGet
-    pure (InDb (Core.Address r a t))
-  putCopy (InDb (Core.Address r a t)) = SC.contain $ do
-    SC.safePut (InDb (r :: Core.AddressHash Core.Address'))
-    SC.safePut (InDb (a :: Core.Attributes Core.AddrAttributes))
-    SC.safePut (InDb (t :: Core.AddrType))
+    getCopy = SC.contain $ do
+        InDb (r :: Core.AddressHash Core.Address') <- SC.safeGet
+        InDb (a :: Core.Attributes Core.AddrAttributes) <- SC.safeGet
+        InDb (t :: Core.AddrType) <- SC.safeGet
+        pure (InDb (Core.Address r a t))
+    putCopy (InDb (Core.Address r a t)) = SC.contain $ do
+        SC.safePut (InDb (r :: Core.AddressHash Core.Address'))
+        SC.safePut (InDb (a :: Core.Attributes Core.AddrAttributes))
+        SC.safePut (InDb (t :: Core.AddrType))
 
 instance SC.SafeCopy (InDb Core.AddrAttributes) where
-  getCopy = SC.contain $ do
-    yiap :: Maybe (InDb Core.HDAddressPayload) <- SC.safeGet
-    InDb (ast :: Core.AddrStakeDistribution) <- SC.safeGet
-    pure (InDb (Core.AddrAttributes (fmap _fromDb yiap) ast))
-  putCopy (InDb (Core.AddrAttributes yap asr)) = SC.contain $ do
-    SC.safePut (fmap InDb yap)
-    SC.safePut asr
+    getCopy = SC.contain $ do
+        yiap :: Maybe (InDb Core.HDAddressPayload) <- SC.safeGet
+        InDb (ast :: Core.AddrStakeDistribution) <- SC.safeGet
+        pure (InDb (Core.AddrAttributes (fmap _fromDb yiap) ast))
+    putCopy (InDb (Core.AddrAttributes yap asr)) = SC.contain $ do
+        SC.safePut (fmap InDb yap)
+        SC.safePut asr
 
 instance SC.SafeCopy (InDb Core.AddrStakeDistribution) where
-  getCopy = SC.contain $ fmap InDb $ do
-    SC.safeGet >>= \case
-      0 -> pure Core.BootstrapEraDistr
-      1 -> Core.SingleKeyDistr <$> fmap _fromDb SC.safeGet
-      2 -> Core.UnsafeMultiKeyDistr <$> fmap _fromDb SC.safeGet
-      (_ :: Word8) -> empty
-  putCopy (InDb x) = SC.contain $ case x of
-    Core.BootstrapEraDistr -> SC.safePut (0 :: Word8)
-    Core.SingleKeyDistr a -> do
-      SC.safePut (1 :: Word8)
-      SC.safePut (InDb (a :: Core.StakeholderId))
-    Core.UnsafeMultiKeyDistr m -> do
-      SC.safePut (2 :: Word8)
-      SC.safePut (InDb (m :: Map Core.StakeholderId Core.CoinPortion))
+    getCopy = SC.contain $ fmap InDb $ do
+        SC.safeGet >>= \case
+          0 -> pure Core.BootstrapEraDistr
+          1 -> Core.SingleKeyDistr <$> fmap _fromDb SC.safeGet
+          2 -> Core.UnsafeMultiKeyDistr <$> fmap _fromDb SC.safeGet
+          (n :: Word8) -> fail
+            $ "Expected one of 0,1,2 for tag of AddrStakeDistribution, got: "
+            <> show n
+    putCopy (InDb x) = SC.contain $ case x of
+        Core.BootstrapEraDistr -> SC.safePut (0 :: Word8)
+        Core.SingleKeyDistr a -> do
+            SC.safePut (1 :: Word8)
+            SC.safePut (InDb (a :: Core.StakeholderId))
+        Core.UnsafeMultiKeyDistr m -> do
+            SC.safePut (2 :: Word8)
+            SC.safePut (InDb (m :: Map Core.StakeholderId Core.CoinPortion))
 
 instance SC.SafeCopy (InDb Core.CoinPortion) where
-  getCopy = SC.contain $ do
-    w :: Word64 <- SC.safeGet
-    pure (InDb (Core.CoinPortion w))
-  putCopy (InDb (Core.CoinPortion w)) = SC.contain $ do
-    SC.safePut (w :: Word64)
+    getCopy = SC.contain $ do
+        w :: Word64 <- SC.safeGet
+        pure (InDb (Core.CoinPortion w))
+    putCopy (InDb (Core.CoinPortion w)) = SC.contain $ do
+        SC.safePut (w :: Word64)
 
 instance SC.SafeCopy (InDb Core.HDAddressPayload) where
-  getCopy = SC.contain $ do
-    bs :: B.ByteString <- SC.safeGet
-    pure (InDb (Core.HDAddressPayload bs))
-  putCopy (InDb (Core.HDAddressPayload bs)) = SC.contain $ do
-    SC.safePut (bs :: B.ByteString)
-
+    getCopy = SC.contain $ do
+        bs :: B.ByteString <- SC.safeGet
+        pure (InDb (Core.HDAddressPayload bs))
+    putCopy (InDb (Core.HDAddressPayload bs)) = SC.contain $ do
+        SC.safePut (bs :: B.ByteString)
 
 instance SC.SafeCopy (InDb Core.Coin) where
     getCopy = SC.contain $ do
@@ -124,265 +131,652 @@ instance SC.SafeCopy (InDb Core.SlotId) where
       SC.safePut (InDb s)
 
 instance SC.SafeCopy (InDb Core.Timestamp) where
-  getCopy = SC.contain $ do
-    msi :: Integer <- SC.safeGet
-    let ms :: Data.Time.Units.Microsecond = fromInteger msi
-    pure (InDb (Core.Timestamp ms))
-  putCopy (InDb (Core.Timestamp ms)) = SC.contain $ do
-    let msi :: Integer = toInteger (ms :: Data.Time.Units.Microsecond)
-    SC.safePut msi
+    getCopy = SC.contain $ do
+        msi :: Integer <- SC.safeGet
+        let ms :: Data.Time.Units.Microsecond = fromInteger msi
+        pure (InDb (Core.Timestamp ms))
+    putCopy (InDb (Core.Timestamp ms)) = SC.contain $ do
+        let msi :: Integer = toInteger (ms :: Data.Time.Units.Microsecond)
+        SC.safePut msi
 
 instance SC.SafeCopy (InDb Txp.TxAux) where
-  getCopy = SC.contain $ do
-    InDb (tx :: Txp.Tx) <- SC.safeGet
-    InDb (txw :: Txp.TxWitness) <- SC.safeGet
-    pure (InDb (Txp.TxAux tx txw))
-  putCopy (InDb (Txp.TxAux tx txw)) = SC.contain $ do
-    SC.safePut (InDb tx)
-    SC.safePut (InDb txw)
+    getCopy = SC.contain $ do
+        InDb (tx :: Txp.Tx) <- SC.safeGet
+        InDb (txw :: Txp.TxWitness) <- SC.safeGet
+        pure (InDb (Txp.TxAux tx txw))
+    putCopy (InDb (Txp.TxAux tx txw)) = SC.contain $ do
+        SC.safePut (InDb tx)
+        SC.safePut (InDb txw)
 
 instance SC.SafeCopy (InDb Txp.Tx) where
-  getCopy = SC.contain $ do
-    InDb (i :: NonEmpty Txp.TxIn) <- SC.safeGet
-    InDb (o :: NonEmpty Txp.TxOut) <- SC.safeGet
-    InDb (a :: Txp.TxAttributes) <- SC.safeGet
-    pure (InDb (Txp.UnsafeTx i o a))
-  putCopy (InDb (Txp.UnsafeTx i o a)) = SC.contain $ do
-    SC.safePut (InDb i)
-    SC.safePut (InDb o)
-    SC.safePut (InDb a)
+    getCopy = SC.contain $ do
+        InDb (i :: NonEmpty Txp.TxIn) <- SC.safeGet
+        InDb (o :: NonEmpty Txp.TxOut) <- SC.safeGet
+        InDb (a :: Txp.TxAttributes) <- SC.safeGet
+        pure (InDb (Txp.UnsafeTx i o a))
+    putCopy (InDb (Txp.UnsafeTx i o a)) = SC.contain $ do
+        SC.safePut (InDb i)
+        SC.safePut (InDb o)
+        SC.safePut (InDb a)
 
 instance SC.SafeCopy (InDb Txp.TxOut) where
-  getCopy = SC.contain $ do
-    InDb (a :: Core.Address) <- SC.safeGet
-    InDb (c :: Core.Coin) <- SC.safeGet
-    pure (InDb (Txp.TxOut a c))
-  putCopy (InDb (Txp.TxOut a c)) = SC.contain $ do
-    SC.safePut (InDb a)
-    SC.safePut (InDb c)
+    getCopy = SC.contain $ do
+        InDb (a :: Core.Address) <- SC.safeGet
+        InDb (c :: Core.Coin) <- SC.safeGet
+        pure (InDb (Txp.TxOut a c))
+    putCopy (InDb (Txp.TxOut a c)) = SC.contain $ do
+        SC.safePut (InDb a)
+        SC.safePut (InDb c)
 
 instance SC.SafeCopy (InDb Txp.TxOutAux) where
-  getCopy = SC.contain $ do
-    InDb (x :: Txp.TxOut) <- SC.safeGet
-    pure (InDb (Txp.TxOutAux x))
-  putCopy (InDb (Txp.TxOutAux x)) = SC.contain $ do
-    SC.safePut (InDb x)
+    getCopy = SC.contain $ do
+        InDb (x :: Txp.TxOut) <- SC.safeGet
+        pure (InDb (Txp.TxOutAux x))
+    putCopy (InDb (Txp.TxOutAux x)) = SC.contain $ do
+        SC.safePut (InDb x)
 
 instance SC.SafeCopy (InDb Txp.TxWitness) where
-  getCopy = SC.contain $ do
-    xsi :: [InDb Txp.TxInWitness] <- SC.safeGet
-    let v :: V.Vector Txp.TxInWitness = V.fromList (map _fromDb xsi)
-    pure (InDb v)
-  putCopy (InDb v) = SC.contain $ do
-    let xsi :: [InDb Txp.TxInWitness] = map InDb (V.toList v)
-    SC.safePut xsi
+    getCopy = SC.contain $ do
+        xsi :: [InDb Txp.TxInWitness] <- SC.safeGet
+        let v :: V.Vector Txp.TxInWitness = V.fromList (map _fromDb xsi)
+        pure (InDb v)
+    putCopy (InDb v) = SC.contain $ do
+        let xsi :: [InDb Txp.TxInWitness] = map InDb (V.toList v)
+        SC.safePut xsi
 
 instance SC.SafeCopy (InDb Txp.TxInWitness) where
-  getCopy = SC.contain $ fmap InDb $ do
-    SC.safeGet >>= \case
-      0 -> Txp.PkWitness
-        <$> fmap _fromDb SC.safeGet
-        <*> fmap _fromDb SC.safeGet
-      1 -> Txp.ScriptWitness
-        <$> fmap _fromDb SC.safeGet
-        <*> fmap _fromDb SC.safeGet
-      2 -> Txp.RedeemWitness
-        <$> fmap _fromDb SC.safeGet
-        <*> fmap _fromDb SC.safeGet
-      3 -> Txp.RedeemWitness <$> SC.safeGet <*> SC.safeGet
-      (_ :: Word8) -> empty
-  putCopy (InDb x) = SC.contain $ case x of
-    Txp.PkWitness a b -> do
-      SC.safePut (0 :: Word8)
-      SC.safePut (InDb (a :: Core.PublicKey))
-      SC.safePut (InDb (b :: Txp.TxSig))
-    Txp.ScriptWitness a b -> do
-      SC.safePut (1 :: Word8)
-      SC.safePut (InDb (a :: Core.Script))
-      SC.safePut (InDb (b :: Core.Script))
-    Txp.RedeemWitness a b -> do
-      SC.safePut (2 :: Word8)
-      SC.safePut (InDb (a :: Core.RedeemPublicKey))
-      SC.safePut (InDb (b :: Core.RedeemSignature Txp.TxSigData))
-    Txp.UnknownWitnessType a b -> do
-      SC.safePut (3 :: Word8)
-      SC.safePut (a :: Word8)
-      SC.safePut (b :: B.ByteString)
+    getCopy = SC.contain $ fmap InDb $ do
+        SC.safeGet >>= \case
+            0 -> Txp.PkWitness
+                <$> fmap _fromDb SC.safeGet
+                <*> fmap _fromDb SC.safeGet
+            1 -> Txp.ScriptWitness
+                <$> fmap _fromDb SC.safeGet
+                <*> fmap _fromDb SC.safeGet
+            2 -> Txp.RedeemWitness
+                <$> fmap _fromDb SC.safeGet
+                <*> fmap _fromDb SC.safeGet
+            3 -> Txp.RedeemWitness <$> SC.safeGet <*> SC.safeGet
+            (n :: Word8) -> fail
+                $ "Expected 0,1,2,3 for tag of TxInWitness, got: "
+                <> show n
+
+    putCopy (InDb x) = SC.contain $ case x of
+        Txp.PkWitness a b -> do
+            SC.safePut (0 :: Word8)
+            SC.safePut (InDb (a :: Core.PublicKey))
+            SC.safePut (InDb (b :: Txp.TxSig))
+        Txp.ScriptWitness a b -> do
+            SC.safePut (1 :: Word8)
+            SC.safePut (InDb (a :: Core.Script))
+            SC.safePut (InDb (b :: Core.Script))
+        Txp.RedeemWitness a b -> do
+            SC.safePut (2 :: Word8)
+            SC.safePut (InDb (a :: Core.RedeemPublicKey))
+            SC.safePut (InDb (b :: Core.RedeemSignature Txp.TxSigData))
+        Txp.UnknownWitnessType a b -> do
+            SC.safePut (3 :: Word8)
+            SC.safePut (a :: Word8)
+            SC.safePut (b :: B.ByteString)
 
 instance SC.SafeCopy (InDb Core.AddrType) where
-  getCopy = SC.contain $ fmap InDb $ do
-    SC.safeGet >>= \case
-      0 -> pure Core.ATPubKey
-      1 -> pure Core.ATScript
-      2 -> pure Core.ATRedeem
-      3 -> Core.ATUnknown <$> SC.safeGet
-      (_ :: Word8) -> empty
-  putCopy (InDb x) = SC.contain $ case x of
-    Core.ATPubKey -> SC.safePut (0 :: Word8)
-    Core.ATScript -> SC.safePut (1 :: Word8)
-    Core.ATRedeem -> SC.safePut (2 :: Word8)
-    Core.ATUnknown a -> do
-      SC.safePut (3 :: Word8)
-      SC.safePut (a :: Word8)
+    getCopy = SC.contain $ fmap InDb $ do
+        SC.safeGet >>= \case
+            0 -> pure Core.ATPubKey
+            1 -> pure Core.ATScript
+            2 -> pure Core.ATRedeem
+            3 -> Core.ATUnknown <$> SC.safeGet
+            (n :: Word8) -> fail
+                $ "Expected 0,1,2,3 for tag of AddrType, got: "
+                <> show n
+
+    putCopy (InDb x) = SC.contain $ case x of
+        Core.ATPubKey -> SC.safePut (0 :: Word8)
+        Core.ATScript -> SC.safePut (1 :: Word8)
+        Core.ATRedeem -> SC.safePut (2 :: Word8)
+        Core.ATUnknown a -> do
+            SC.safePut (3 :: Word8)
+            SC.safePut (a :: Word8)
 
 instance SC.SafeCopy (InDb (Core.Signature a)) where
-  getCopy = SC.contain $ do
-    bs :: B.ByteString <- SC.safeGet
-    Right xsig <- pure (CCW.xsignature bs)
-    pure (InDb (Core.Signature xsig))
-  putCopy (InDb (Core.Signature xsig)) = SC.contain $ do
-    let bs = CCW.unXSignature xsig
-    SC.safePut bs
+    getCopy = SC.contain $ do
+        bs :: B.ByteString <- SC.safeGet
+        Right xsig <- pure (CCW.xsignature bs)
+        pure (InDb (Core.Signature xsig))
+
+    putCopy (InDb (Core.Signature xsig)) = SC.contain $ do
+        let bs = CCW.unXSignature xsig
+        SC.safePut bs
 
 instance SC.SafeCopy (InDb Core.PublicKey) where
-  getCopy = SC.contain $ do
-    pkbs :: B.ByteString <- SC.safeGet
-    InDb (cc :: CCW.ChainCode) <- SC.safeGet
-    let xpub = CCW.XPub pkbs cc
-    pure (InDb (Core.PublicKey xpub))
-  putCopy (InDb (Core.PublicKey xpub)) = SC.contain $ do
-    let CCW.XPub pkbs cc = xpub
-    SC.safePut pkbs
-    SC.safePut (InDb cc)
+    getCopy = SC.contain $ do
+        pkbs :: B.ByteString <- SC.safeGet
+        InDb (cc :: CCW.ChainCode) <- SC.safeGet
+        let xpub = CCW.XPub pkbs cc
+        pure (InDb (Core.PublicKey xpub))
+    putCopy (InDb (Core.PublicKey xpub)) = SC.contain $ do
+        let CCW.XPub pkbs cc = xpub
+        SC.safePut pkbs
+        SC.safePut (InDb cc)
 
 instance SC.SafeCopy (InDb CCW.ChainCode) where
-  getCopy = SC.contain $ do
-    bs :: B.ByteString <- SC.safeGet
-    pure (InDb (CCW.ChainCode bs))
-  putCopy (InDb (CCW.ChainCode bs)) = SC.contain $ do
-    SC.safePut bs
+    getCopy = SC.contain $ do
+        bs :: B.ByteString <- SC.safeGet
+        pure (InDb (CCW.ChainCode bs))
+    putCopy (InDb (CCW.ChainCode bs)) = SC.contain $ do
+        SC.safePut bs
 
 instance SC.SafeCopy (InDb Txp.TxSigData) where
-  getCopy = SC.contain $ do
-    InDb (h :: Core.Hash Txp.Tx) <- SC.safeGet
-    pure (InDb (Txp.TxSigData h))
-  putCopy (InDb (Txp.TxSigData h)) = SC.contain $ do
-    SC.safePut (InDb h)
+    getCopy = SC.contain $ do
+        InDb (h :: Core.Hash Txp.Tx) <- SC.safeGet
+        pure (InDb (Txp.TxSigData h))
+    putCopy (InDb (Txp.TxSigData h)) = SC.contain $ do
+        SC.safePut (InDb h)
 
 instance SC.SafeCopy (InDb Core.RedeemPublicKey) where
-  getCopy = SC.contain $ do
-    bs :: B.ByteString <- SC.safeGet
-    pure (InDb (Core.RedeemPublicKey (Ed25519.PublicKey bs)))
-  putCopy (InDb (Core.RedeemPublicKey pk)) = SC.contain $ do
-    SC.safePut (Ed25519.unPublicKey pk :: B.ByteString)
+    getCopy = SC.contain $ do
+        bs :: B.ByteString <- SC.safeGet
+        pure (InDb (Core.RedeemPublicKey (Ed25519.PublicKey bs)))
+    putCopy (InDb (Core.RedeemPublicKey pk)) = SC.contain $ do
+        SC.safePut (Ed25519.openPublicKey pk :: B.ByteString)
 
 instance SC.SafeCopy (InDb (Core.RedeemSignature a)) where
-  getCopy = SC.contain $ do
-    bs :: B.ByteString <- SC.safeGet
-    pure (InDb (Core.RedeemSignature (Ed25519.Signature bs)))
-  putCopy (InDb (Core.RedeemSignature pk)) = SC.contain $ do
-    SC.safePut (Ed25519.unSignature pk :: B.ByteString)
+    getCopy = SC.contain $ do
+        bs :: B.ByteString <- SC.safeGet
+        pure (InDb (Core.RedeemSignature (Ed25519.Signature bs)))
+    putCopy (InDb (Core.RedeemSignature pk)) = SC.contain $ do
+        SC.safePut (Ed25519.unSignature pk :: B.ByteString)
 
-instance forall h. SC.SafeCopy (InDb h)
-  => SC.SafeCopy (InDb (Core.Attributes h)) where
-  getCopy = SC.contain $ do
-    InDb (d :: h) <- SC.safeGet
-    InDb (r :: Core.UnparsedFields) <- SC.safeGet
-    pure (InDb (Core.Attributes d r))
-  putCopy (InDb (Core.Attributes d r)) = SC.contain $ do
-    SC.safePut (InDb d)
-    SC.safePut (InDb r)
+instance SC.SafeCopy (InDb h) => SC.SafeCopy (InDb (Core.Attributes h)) where
+    getCopy = SC.contain $ do
+        InDb (d :: h) <- SC.safeGet
+        InDb (r :: Core.UnparsedFields) <- SC.safeGet
+        pure (InDb (Core.Attributes d r))
+    putCopy (InDb (Core.Attributes d r)) = SC.contain $ do
+        SC.safePut (InDb d)
+        SC.safePut (InDb r)
 
 instance SC.SafeCopy (InDb Core.Script) where
-  getCopy = SC.contain $ do
-    v :: Word16 <- SC.safeGet
-    bs :: B.ByteString <- SC.safeGet
-    pure (InDb (Core.Script v bs))
-  putCopy (InDb (Core.Script v bs)) = SC.contain $ do
-    SC.safePut (v :: Word16)
-    SC.safePut (bs :: B.ByteString)
+    getCopy = SC.contain $ do
+        v :: Word16 <- SC.safeGet
+        bs :: B.ByteString <- SC.safeGet
+        pure (InDb (Core.Script v bs))
+    putCopy (InDb (Core.Script v bs)) = SC.contain $ do
+        SC.safePut (v :: Word16)
+        SC.safePut (bs :: B.ByteString)
 
 instance SC.SafeCopy (InDb Core.LocalSlotIndex) where
-  getCopy = SC.contain $ do
-    w :: Word16 <- SC.safeGet
-    pure (InDb (Core.UnsafeLocalSlotIndex w))
-  putCopy (InDb (Core.UnsafeLocalSlotIndex w)) = SC.contain $ do
-    SC.safePut (w :: Word16)
+    getCopy = SC.contain $ do
+        w :: Word16 <- SC.safeGet
+        pure (InDb (Core.UnsafeLocalSlotIndex w))
+    putCopy (InDb (Core.UnsafeLocalSlotIndex w)) = SC.contain $ do
+        SC.safePut (w :: Word16)
 
 instance SC.SafeCopy (InDb Core.EpochIndex) where
-  getCopy = SC.contain $ do
-    w :: Word64 <- SC.safeGet
-    pure (InDb (Core.EpochIndex w))
-  putCopy (InDb (Core.EpochIndex w)) = SC.contain $ do
-    SC.safePut (w :: Word64)
+    getCopy = SC.contain $ do
+        w :: Word64 <- SC.safeGet
+        pure (InDb (Core.EpochIndex w))
+    putCopy (InDb (Core.EpochIndex w)) = SC.contain $ do
+        SC.safePut (w :: Word64)
 
 instance SC.SafeCopy (InDb Core.UnparsedFields) where
-  getCopy = SC.contain $ do
-    m :: Map Word8 BL.ByteString <- SC.safeGet
-    pure (InDb (Core.UnparsedFields m))
-  putCopy (InDb (Core.UnparsedFields m)) = SC.contain $ do
-    SC.safePut m
+    getCopy = SC.contain $ do
+        m :: Map Word8 BL.ByteString <- SC.safeGet
+        pure (InDb (Core.UnparsedFields m))
+    putCopy (InDb (Core.UnparsedFields m)) = SC.contain $ do
+        SC.safePut m
 
 instance SC.SafeCopy (InDb ()) where
-  getCopy = SC.contain (fmap InDb SC.safeGet)
-  putCopy (InDb ()) = SC.contain (SC.safePut ())
+    getCopy = SC.contain (fmap InDb SC.safeGet)
+    putCopy (InDb ()) = SC.contain (SC.safePut ())
 
-instance forall a b.
-  (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b))
-  => SC.SafeCopy (InDb (a, b)) where
-  getCopy = SC.contain $ do
-    InDb (a :: a) <- SC.safeGet
-    InDb (b :: b) <- SC.safeGet
-    pure (InDb (a, b))
-  putCopy (InDb (a, b)) = SC.contain $ do
-    SC.safePut (InDb a)
-    SC.safePut (InDb b)
+instance (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b))
+    => SC.SafeCopy (InDb (a, b)) where
+    getCopy = SC.contain $ do
+        InDb (a :: a) <- SC.safeGet
+        InDb (b :: b) <- SC.safeGet
+        pure (InDb (a, b))
+    putCopy (InDb (a, b)) = SC.contain $ do
+        SC.safePut (InDb a)
+        SC.safePut (InDb b)
 
 instance SC.SafeCopy (InDb Txp.TxIn) where
-  getCopy = SC.contain $ fmap InDb $ do
-    SC.safeGet >>= \case
-      0 -> Txp.TxInUtxo <$> SC.safeGet <*> SC.safeGet
-      1 -> Txp.TxInUnknown <$> SC.safeGet <*> SC.safeGet
-      (_ :: Word8) -> empty
-  putCopy (InDb a) = SC.contain $ case a of
-    Txp.TxInUtxo (txId :: Txp.TxId) (w :: Word32) -> do
-      SC.safePut (0 :: Word8)
-      SC.safePut (InDb txId)
-      SC.safePut w
-    Txp.TxInUnknown (w :: Word8) (b :: ByteString) -> do
-      SC.safePut (1 :: Word8)
-      SC.safePut w
-      SC.safePut b
+    getCopy = SC.contain $ fmap InDb $ do
+        SC.safeGet >>= \case
+            0 -> Txp.TxInUtxo <$> SC.safeGet <*> SC.safeGet
+            1 -> Txp.TxInUnknown <$> SC.safeGet <*> SC.safeGet
+            (n :: Word8) -> fail
+                $  "Expected one of 0,1 for TxIn tag, got: "
+                <> show n
 
-instance forall a.
-    (SC.SafeCopy (InDb a))
-    => SC.SafeCopy (InDb (NonEmpty a)) where
+    putCopy (InDb a) = SC.contain $ case a of
+        Txp.TxInUtxo (txId :: Txp.TxId) (w :: Word32) -> do
+            SC.safePut (0 :: Word8)
+            SC.safePut (InDb txId)
+            SC.safePut w
+        Txp.TxInUnknown (w :: Word8) (b :: ByteString) -> do
+            SC.safePut (1 :: Word8)
+            SC.safePut w
+            SC.safePut b
+
+instance (SC.SafeCopy (InDb a)) => SC.SafeCopy (InDb (NonEmpty a)) where
     getCopy = SC.contain $ do
-      xsi :: [InDb a] <- SC.safeGet
-      case NEL.nonEmpty xsi of
-         Nothing -> empty
-         Just nxs -> pure (InDb (fmap _fromDb nxs))
+        xsi :: [InDb a] <- SC.safeGet
+        case NEL.nonEmpty xsi of
+            Nothing  -> fail
+                $ "Expected at least one element in non-empty list."
+            Just nxs -> pure (InDb (fmap _fromDb nxs))
     putCopy (InDb sa) = SC.contain $ do
-      let xsi :: [InDb a] = map InDb (NEL.toList sa)
-      SC.safePut xsi
+        let xsi :: [InDb a] = map InDb (NEL.toList sa)
+        SC.safePut xsi
 
-instance forall a.
-    (SC.SafeCopy (InDb a), Ord a)
-    => SC.SafeCopy (InDb (Set a)) where
+instance (SC.SafeCopy (InDb a), Ord a) => SC.SafeCopy (InDb (Set a)) where
     getCopy = SC.contain $ do
-      xsi :: [InDb a] <- SC.safeGet
-      pure (InDb (Set.fromList (map _fromDb xsi)))
+        xsi :: [InDb a] <- SC.safeGet
+        pure (InDb (Set.fromList (map _fromDb xsi)))
     putCopy (InDb sa) = SC.contain $ do
-      let xsi :: [InDb a] = map InDb (Set.toList sa)
-      SC.safePut xsi
+        let xsi :: [InDb a] = map InDb (Set.toList sa)
+        SC.safePut xsi
 
-instance forall a b.
-    (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b), Ord a)
+instance SC.SafeCopy (InDb Core.BlockHeader) where
+    getCopy = SC.contain $ do
+        constrTag <- SC.safeGet
+        case constrTag :: Word8 of
+            0 -> do -- BlockHeaderGenesis
+                genBlockHeader <- SC.safeGet
+                pure (Core.BlockHeaderGenesis <$> genBlockHeader)
+            1 -> do -- BlockHeaderMain
+                mainBlockHeader <- SC.safeGet
+                pure (Core.BlockHeaderMain <$> mainBlockHeader)
+            _ ->
+                fail
+                    $ "Expected a tag of 1 or 0 for BlockHeader, got: "
+                    <> show constrTag
+    putCopy (InDb blockHeader) = SC.contain $ do
+        case blockHeader of
+            Core.BlockHeaderGenesis genBlockHeader -> do
+                SC.safePut (0 :: Word8)
+                SC.safePut (InDb genBlockHeader)
+            Core.BlockHeaderMain mainBlockHeader -> do
+                SC.safePut (1 :: Word8)
+                SC.safePut (InDb mainBlockHeader)
+
+-- The instances for 'MainBlockHeader' and 'GenesisBlockHeader' seem like
+-- duplicates, but the constructor fields use type families on the 'Blockchain'
+-- class for the actual fields, so they are actually totally different types.
+instance SC.SafeCopy (InDb Core.MainBlockHeader) where
+    getCopy = SC.contain $ do
+        InDb protocolMagic <- SC.safeGet
+        InDb prevBlock <- SC.safeGet
+        InDb bodyProof <- SC.safeGet
+        InDb consensus <- SC.safeGet
+        InDb extra <- SC.safeGet
+        pure . InDb $
+            Core.UnsafeGenericBlockHeader
+                protocolMagic
+                prevBlock
+                bodyProof
+                consensus
+                extra
+    putCopy (InDb (Core.UnsafeGenericBlockHeader a b c d e)) = SC.contain $ do
+        safePutDb a
+        safePutDb b
+        safePutDb c
+        safePutDb d
+        safePutDb e
+
+safePutDb :: SC.SafeCopy (InDb a) => a -> Put
+safePutDb = SC.safePut . InDb
+
+instance SC.SafeCopy (InDb Core.MainProof) where
+    getCopy = SC.contain $ do
+        InDb txProof <- SC.safeGet
+        InDb mpcProof <- SC.safeGet
+        InDb proxySKsProof <- SC.safeGet
+        InDb updateProof <- SC.safeGet
+        pure . InDb $
+            Core.MainProof
+                txProof
+                mpcProof
+                proxySKsProof
+                updateProof
+    putCopy (InDb (Core.MainProof txP mpcP proxySKsP updateP)) = SC.contain $ do
+        SC.safePut (InDb txP)
+        SC.safePut (InDb mpcP)
+        SC.safePut (InDb proxySKsP)
+        SC.safePut (InDb updateP)
+
+instance SC.SafeCopy (InDb Ssc.SscProof) where
+    getCopy = SC.contain $ do
+        constrTag <- SC.safeGet
+        case constrTag :: Word8 of
+            0 -> do -- CommitmentsProof
+                InDb hash <- SC.safeGet
+                InDb cert <- SC.safeGet
+                pure . InDb $
+                    Ssc.CommitmentsProof hash cert
+            1 -> do -- OpeningsProof
+                InDb hash <- SC.safeGet
+                InDb cert <- SC.safeGet
+                pure . InDb $
+                    Ssc.OpeningsProof hash cert
+            2 -> do -- SharesProof
+                InDb hash <- SC.safeGet
+                InDb cert <- SC.safeGet
+                pure . InDb $
+                    Ssc.SharesProof hash cert
+            3 -> do -- CertificatesProof
+                InDb cert <- SC.safeGet
+                pure . InDb $
+                    Ssc.CertificatesProof cert
+            _ ->
+                fail
+                    $ "Expected 0,1,2,3 tag when parsing SscProof, got: "
+                    <> show constrTag
+
+    putCopy (InDb proof) = SC.contain $ do
+        case proof of
+            Ssc.CommitmentsProof hash cert -> do
+                SC.safePut (0 :: Word8)
+                safePutDb hash
+                safePutDb cert
+            Ssc.OpeningsProof hash cert -> do
+                SC.safePut (1 :: Word8)
+                safePutDb hash
+                safePutDb cert
+            Ssc.SharesProof hash cert -> do
+                SC.safePut (2 :: Word8)
+                safePutDb hash
+                safePutDb cert
+            Ssc.CertificatesProof cert -> do
+                SC.safePut (3 :: Word8)
+                safePutDb cert
+
+instance SC.SafeCopy (InDb Txp.TxProof) where
+    getCopy = SC.contain $ do
+        number <- SC.safeGet
+        InDb txRoot <- SC.safeGet
+        InDb witness <- SC.safeGet
+        pure . InDb $
+            Txp.TxProof
+                number
+                txRoot
+                witness
+    putCopy (InDb (Txp.TxProof n root witness)) = SC.contain $ do
+        SC.safePut n
+        safePutDb root
+        safePutDb witness
+
+instance SC.SafeCopy (InDb (Core.MerkleRoot Txp.Tx)) where
+    getCopy = SC.contain $ do
+        InDb rootHash <- SC.safeGet
+        pure . InDb $
+            Core.MerkleRoot rootHash
+    putCopy (InDb (Core.MerkleRoot rootHash)) = SC.contain $ do
+        safePutDb rootHash
+
+instance SC.SafeCopy (InDb Core.MainConsensusData) where
+    getCopy = SC.contain $ do
+        slotId <- SC.safeGet
+        leaderKey <- SC.safeGet
+        difficulty <- SC.safeGet
+        sig <- SC.safeGet
+        pure $ Core.MainConsensusData
+            <$> slotId
+            <*> leaderKey
+            <*> difficulty
+            <*> sig
+
+    putCopy (InDb (Core.MainConsensusData slot l d sig)) = SC.contain $ do
+        safePutDb slot
+        safePutDb l
+        safePutDb d
+        safePutDb sig
+
+instance SC.SafeCopy (InDb Core.MainExtraHeaderData) where
+    getCopy = SC.contain $ do
+        blockVers <- SC.safeGet
+        softVers <- SC.safeGet
+        attrs <- SC.safeGet
+        ebDataProof <- SC.safeGet
+        pure $ Core.MainExtraHeaderData
+            <$> blockVers
+            <*> softVers
+            <*> attrs
+            <*> ebDataProof
+
+    putCopy (InDb (Core.MainExtraHeaderData b s a e)) = SC.contain $ do
+        safePutDb b
+        safePutDb s
+        safePutDb a
+        safePutDb e
+
+instance SC.SafeCopy (InDb Core.BlockVersion) where
+    getCopy = SC.contain $ do
+        (\a b c -> InDb (Core.BlockVersion a b c))
+            <$> SC.safeGet
+            <*> SC.safeGet
+            <*> SC.safeGet
+
+    putCopy (InDb (Core.BlockVersion a b c)) = SC.contain $ do
+        SC.safePut a
+        SC.safePut b
+        SC.safePut c
+
+instance SC.SafeCopy (InDb Core.SoftwareVersion) where
+    getCopy = SC.contain $ do
+        appName <- SC.safeGet
+        appNumber <- SC.safeGet
+        pure $ Core.SoftwareVersion
+            <$> appName
+            <*> pure appNumber
+
+    putCopy (InDb (Core.SoftwareVersion name number)) = SC.contain $ do
+        safePutDb name
+        SC.safePut number
+
+instance SC.SafeCopy (InDb Core.ApplicationName) where
+    getCopy = SC.contain $ do
+        InDb . Core.ApplicationName <$> SC.safeGet
+
+    putCopy (InDb (Core.ApplicationName name)) = SC.contain $ do
+        SC.safePut name
+
+instance SC.SafeCopy (InDb Core.BlockSignature) where
+    getCopy = SC.contain $ do
+        constrTag <- SC.safeGet
+        case constrTag :: Word8 of
+            0 -> do -- BlockSignature
+                sigMain <- SC.safeGet
+                pure $ Core.BlockSignature
+                    <$> sigMain
+            1 -> do -- BlockPSignatureLight
+                sigLight <- SC.safeGet
+                pure $ Core.BlockPSignatureLight
+                    <$> sigLight
+            2 -> do -- BlockPSignatureHeavy
+                sigHeavy <- SC.safeGet
+                pure $ Core.BlockPSignatureHeavy
+                    <$> sigHeavy
+            _ -> fail
+                $ "Expected one of 0,1,2 while reading BlockSignature, got: "
+                <> show constrTag
+
+    putCopy (InDb blockSig) = SC.contain $ do
+        case blockSig of
+            Core.BlockSignature o -> do
+                SC.safePut (0 :: Word8)
+                safePutDb o
+            Core.BlockPSignatureLight o -> do
+                SC.safePut (1 :: Word8)
+                safePutDb o
+            Core.BlockPSignatureHeavy o -> do
+                SC.safePut (2 :: Word8)
+                safePutDb o
+
+instance SC.SafeCopy (InDb w)
+    => SC.SafeCopy (InDb (Core.ProxySignature w a)) where
+    getCopy = SC.contain $ do
+        psk <- SC.safeGet
+        sig <- SC.safeGet
+        pure $ Core.ProxySignature
+            <$> psk
+            <*> sig
+
+    putCopy (InDb (Core.ProxySignature psk sig)) = SC.contain $ do
+        safePutDb psk
+        safePutDb sig
+
+instance SC.SafeCopy (InDb w) => SC.SafeCopy (InDb (Core.ProxySecretKey w)) where
+    getCopy = SC.contain $ do
+        omega <- SC.safeGet
+        issuer <- SC.safeGet
+        delegate <- SC.safeGet
+        cert <- SC.safeGet
+        pure $ Core.UnsafeProxySecretKey
+            <$> omega
+            <*> issuer
+            <*> delegate
+            <*> cert
+
+    putCopy (InDb (Core.UnsafeProxySecretKey o i d c)) = SC.contain $ do
+        safePutDb o
+        safePutDb i
+        safePutDb d
+        safePutDb c
+
+instance SC.SafeCopy (InDb (Core.ProxyCert w)) where
+    getCopy = SC.contain $ do
+        xsig <- SC.safeGet
+        pure $ Core.ProxyCert <$> xsig
+
+    putCopy (InDb (Core.ProxyCert xsig)) = SC.contain $ do
+        safePutDb xsig
+
+instance SC.SafeCopy (InDb CCW.XSignature) where
+    getCopy = SC.contain $ do
+        bs <- SC.safeGet
+        case CCW.xsignature bs of
+            Left err ->
+                fail err
+            Right xsig ->
+                pure . InDb $ xsig
+
+    putCopy (InDb xsig) = SC.contain $ do
+        SC.safePut (CCW.unXSignature xsig)
+
+instance SC.SafeCopy (InDb (Core.HeavyDlgIndex)) where
+    getCopy = SC.contain $ do
+        epoch <- SC.safeGet
+        pure $ Core.HeavyDlgIndex
+            <$> epoch
+
+    putCopy (InDb (Core.HeavyDlgIndex epoch)) = SC.contain $ do
+        safePutDb epoch
+
+instance SC.SafeCopy (InDb (Core.LightDlgIndices)) where
+    getCopy = SC.contain $ do
+        idx0 <- SC.safeGet
+        idx1 <- SC.safeGet
+        pure $ curry Core.LightDlgIndices
+            <$> idx0
+            <*> idx1
+
+    putCopy (InDb (Core.LightDlgIndices (i0, i1))) = SC.contain $ do
+        safePutDb i0
+        safePutDb i1
+
+instance SC.SafeCopy (InDb Core.ChainDifficulty) where
+    getCopy = SC.contain $ do
+        blockCount <- SC.safeGet
+        pure $ Core.ChainDifficulty
+            <$> blockCount
+
+    putCopy (InDb (Core.ChainDifficulty i)) = SC.contain $ do
+        safePutDb i
+
+instance SC.SafeCopy (InDb Core.BlockCount) where
+    getCopy = SC.contain $ do
+        InDb . Core.BlockCount <$> SC.safeGet
+
+    putCopy (InDb (Core.BlockCount i)) = SC.contain $ do
+        SC.safePut i
+
+instance SC.SafeCopy (InDb Core.GenesisBlockHeader) where
+    getCopy = SC.contain $ do
+        InDb protocolMagic <- SC.safeGet
+        InDb prevBlock <- SC.safeGet
+        InDb bodyProof <- SC.safeGet
+        InDb consensus <- SC.safeGet
+        InDb extra <- SC.safeGet
+        pure . InDb $
+            Core.UnsafeGenericBlockHeader
+                protocolMagic
+                prevBlock
+                bodyProof
+                consensus
+                extra
+
+    putCopy (InDb (Core.UnsafeGenericBlockHeader pm pb bp co ex)) = SC.contain $ do
+        safePutDb pm
+        safePutDb pb
+        safePutDb bp
+        safePutDb co
+        safePutDb ex
+
+instance SC.SafeCopy (InDb Core.ProtocolMagic) where
+    getCopy = SC.contain $ do
+        InDb . Core.ProtocolMagic <$> SC.safeGet
+
+    putCopy (InDb (Core.ProtocolMagic i)) = SC.contain $ do
+        SC.safePut i
+
+instance SC.SafeCopy (InDb Core.GenesisProof) where
+    getCopy = SC.contain $ do
+        hashLeaders <- SC.safeGet
+        pure $ Core.GenesisProof
+            <$> hashLeaders
+
+    putCopy (InDb (Core.GenesisProof hash)) = SC.contain $ do
+        safePutDb hash
+
+instance SC.SafeCopy (InDb Core.GenesisConsensusData) where
+    getCopy = SC.contain $ do
+        epoch <- SC.safeGet
+        difficulty <- SC.safeGet
+        pure $ Core.GenesisConsensusData
+            <$> epoch
+            <*> difficulty
+
+    putCopy (InDb (Core.GenesisConsensusData e d)) = SC.contain $ do
+        safePutDb e
+        safePutDb d
+
+instance SC.SafeCopy (InDb Core.GenesisExtraHeaderData) where
+    getCopy = SC.contain $ do
+        attrs <- SC.safeGet
+        pure $ Core.GenesisExtraHeaderData
+            <$> attrs
+
+    putCopy (InDb (Core.GenesisExtraHeaderData attrs)) = SC.contain $ do
+        safePutDb attrs
+
+instance (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b), Ord a)
     => SC.SafeCopy (InDb (Map a b)) where
     getCopy = SC.contain $ do
-      xsi :: [(InDb a, InDb b)] <- SC.safeGet
-      let m :: Map a b = Map.fromList (map (_fromDb *** _fromDb) xsi)
-      pure (InDb m)
+        xsi :: [(InDb a, InDb b)] <- SC.safeGet
+        let m :: Map a b = Map.fromList (map (_fromDb *** _fromDb) xsi)
+        pure (InDb m)
     putCopy (InDb m) = SC.contain $ do
       let xsi :: [(InDb a, InDb b)] = map (InDb *** InDb) (Map.toList m)
       SC.safePut xsi
 
 instance forall algo a.
-  (Core.HashAlgorithm algo)
-  => SC.SafeCopy (InDb (Core.AbstractHash algo a)) where
-  getCopy = SC.contain $ do
-    b :: B.ByteString <- SC.safeGet
-    Just (d :: Digest algo) <- pure (digestFromByteString b)
-    pure (InDb (Core.AbstractHash d))
-  putCopy (InDb (Core.AbstractHash (d :: Digest algo))) = SC.contain $ do
-    SC.safePut (BA.convert d :: B.ByteString)
+    (Core.HashAlgorithm algo)
+    => SC.SafeCopy (InDb (Core.AbstractHash algo a)) where
+    getCopy = SC.contain $ do
+        b :: B.ByteString <- SC.safeGet
+        Just (d :: Digest algo) <- pure (digestFromByteString b)
+        pure (InDb (Core.AbstractHash d))
+    putCopy (InDb (Core.AbstractHash (d :: Digest algo))) = SC.contain $ do
+        SC.safePut (BA.convert d :: B.ByteString)

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/InDb.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.Wallet.Kernel.DB.InDb (
     InDb(..)
@@ -7,20 +8,35 @@ module Cardano.Wallet.Kernel.DB.InDb (
 
 import           Universum
 
+import           Control.Arrow ((***))
 import           Control.Lens.TH (makeLenses)
-import           Data.SafeCopy (SafeCopy (..))
+import           Crypto.Hash (Digest, digestFromByteString)
+import qualified Crypto.Sign.Ed25519 as Ed25519
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as Map
+import qualified Data.SafeCopy as SC
+import qualified Data.Set as Set
+import qualified Data.Time.Units
+import qualified Data.Vector as V
 
 import qualified Pos.Chain.Block as Core
 import qualified Pos.Chain.Txp as Core
 import qualified Pos.Core as Core
+import qualified Pos.Core.Attributes as Core
+import qualified Pos.Core.Txp as Txp
 import qualified Pos.Core.Update as Core
 import qualified Pos.Crypto as Core
+
+import qualified Cardano.Crypto.Wallet as CCW
 
 {-------------------------------------------------------------------------------
   Wrap core types so that we can make independent serialization decisions
 -------------------------------------------------------------------------------}
 
--- | Wrapped type (with potentially different 'SafeCopy' instance)
+-- | Wrapped type (with potentially different 'SC' instance)
 newtype InDb a = InDb { _fromDb :: a }
   deriving (Eq, Ord)
 
@@ -33,78 +49,340 @@ instance Applicative InDb where
 
 makeLenses ''InDb
 
-{-------------------------------------------------------------------------------
-  Specific SafeCopy instances
--------------------------------------------------------------------------------}
+--------------------------------------------------------------------------------
+-- SafeCopy instances for InDb types
+--
+-- Notice that when serializing and deserializing, a type like `InDb foo` will
+-- distribute `InDb` among the non-primitive types that make up `foo`. This
+-- choice doesn't show up in the types.
 
--- TODO @uroboros/ryan [CBR 305] Implement Safecopy instances independently from legacy wallet
+instance SC.SafeCopy (InDb Core.Address) where
+  getCopy = SC.contain $ do
+    InDb (r :: Core.AddressHash Core.Address') <- SC.safeGet
+    InDb (a :: Core.Attributes Core.AddrAttributes) <- SC.safeGet
+    InDb (t :: Core.AddrType) <- SC.safeGet
+    pure (InDb (Core.Address r a t))
+  putCopy (InDb (Core.Address r a t)) = SC.contain $ do
+    SC.safePut (InDb (r :: Core.AddressHash Core.Address'))
+    SC.safePut (InDb (a :: Core.Attributes Core.AddrAttributes))
+    SC.safePut (InDb (t :: Core.AddrType))
 
-instance SafeCopy (InDb Core.Utxo) where
-    getCopy = error "TODO: getCopy for (InDb Core.Utxo)"
-    putCopy = error "TODO: putCopy for (InDb Core.Utxo)"
+instance SC.SafeCopy (InDb Core.AddrAttributes) where
+  getCopy = SC.contain $ do
+    yiap :: Maybe (InDb Core.HDAddressPayload) <- SC.safeGet
+    InDb (ast :: Core.AddrStakeDistribution) <- SC.safeGet
+    pure (InDb (Core.AddrAttributes (fmap _fromDb yiap) ast))
+  putCopy (InDb (Core.AddrAttributes yap asr)) = SC.contain $ do
+    SC.safePut (fmap InDb yap)
+    SC.safePut asr
 
--- TODO: This is really a UTxO again..
-instance SafeCopy (InDb (NonEmpty (Core.TxIn, Core.TxOutAux))) where
-    getCopy = error "TODO: getCopy for (InDb (NonEmpty (Core.TxIn, Core.TxOutAux)))"
-    putCopy = error "TODO: putCopy for (InDb (NonEmpty (Core.TxIn, Core.TxOutAux)))"
+instance SC.SafeCopy (InDb Core.AddrStakeDistribution) where
+  getCopy = SC.contain $ fmap InDb $ do
+    SC.safeGet >>= \case
+      0 -> pure Core.BootstrapEraDistr
+      1 -> Core.SingleKeyDistr <$> fmap _fromDb SC.safeGet
+      2 -> Core.UnsafeMultiKeyDistr <$> fmap _fromDb SC.safeGet
+      (_ :: Word8) -> empty
+  putCopy (InDb x) = SC.contain $ case x of
+    Core.BootstrapEraDistr -> SC.safePut (0 :: Word8)
+    Core.SingleKeyDistr a -> do
+      SC.safePut (1 :: Word8)
+      SC.safePut (InDb (a :: Core.StakeholderId))
+    Core.UnsafeMultiKeyDistr m -> do
+      SC.safePut (2 :: Word8)
+      SC.safePut (InDb (m :: Map Core.StakeholderId Core.CoinPortion))
 
-instance SafeCopy (InDb Core.Address) where
-    getCopy = error "TODO: getCopy for (InDb Core.Address)"
-    putCopy = error "TODO: putCopy for (InDb Core.Address)"
+instance SC.SafeCopy (InDb Core.CoinPortion) where
+  getCopy = SC.contain $ do
+    w :: Word64 <- SC.safeGet
+    pure (InDb (Core.CoinPortion w))
+  putCopy (InDb (Core.CoinPortion w)) = SC.contain $ do
+    SC.safePut (w :: Word64)
 
-instance SafeCopy (InDb (Core.AddressHash Core.PublicKey)) where
-    getCopy = error "TODO: getCopy for (InDb (Core.AddressHash Core.PublicKey))"
-    putCopy = error "TODO: putCopy for (InDb (Core.AddressHash Core.PublicKey))"
+instance SC.SafeCopy (InDb Core.HDAddressPayload) where
+  getCopy = SC.contain $ do
+    bs :: B.ByteString <- SC.safeGet
+    pure (InDb (Core.HDAddressPayload bs))
+  putCopy (InDb (Core.HDAddressPayload bs)) = SC.contain $ do
+    SC.safePut (bs :: B.ByteString)
 
-instance SafeCopy (InDb Core.Coin) where
-    getCopy = error "TODO: getCopy for (InDb Core.Coin)"
-    putCopy = error "TODO: putCopy for (InDb Core.Coin)"
 
-instance SafeCopy (InDb Core.SlotId) where
-    getCopy = error "TODO: getCopy for (InDb Core.SlotId)"
-    putCopy = error "TODO: putCopy for (InDb Core.SlotId)"
+instance SC.SafeCopy (InDb Core.Coin) where
+    getCopy = SC.contain $ do
+       w :: Word64 <- SC.safeGet
+       pure (InDb (Core.Coin w))
+    putCopy (InDb (Core.Coin w)) = SC.contain $ do
+       SC.safePut (w :: Word64)
 
-instance SafeCopy (InDb Core.BlockHeader) where
-    getCopy = error "TODO: getCopy for (InDb Core.BlockHeader)"
-    putCopy = error "TODO: putCopy for (InDb Core.BlockHeader)"
+instance SC.SafeCopy (InDb Core.SlotId) where
+    getCopy = SC.contain $ do
+      InDb (e :: Core.EpochIndex) <- SC.safeGet
+      InDb (s :: Core.LocalSlotIndex) <- SC.safeGet
+      pure (InDb (Core.SlotId e s))
+    putCopy (InDb (Core.SlotId e s)) = SC.contain $ do
+      SC.safePut (InDb e)
+      SC.safePut (InDb s)
 
-instance SafeCopy (InDb Core.HeaderHash) where
-    getCopy = error "TODO: getCopy for (InDb Core.HeaderHash)"
-    putCopy = error "TODO: putCopy for (InDb Core.HeaderHash)"
+instance SC.SafeCopy (InDb Core.Timestamp) where
+  getCopy = SC.contain $ do
+    msi :: Integer <- SC.safeGet
+    let ms :: Data.Time.Units.Microsecond = fromInteger msi
+    pure (InDb (Core.Timestamp ms))
+  putCopy (InDb (Core.Timestamp ms)) = SC.contain $ do
+    let msi :: Integer = toInteger (ms :: Data.Time.Units.Microsecond)
+    SC.safePut msi
 
-instance SafeCopy (InDb Core.Timestamp) where
-    getCopy = error "TODO: getCopy for (InDb Core.Timestamp)"
-    putCopy = error "TODO: putCopy for (InDb Core.Timestamp)"
+instance SC.SafeCopy (InDb Txp.TxAux) where
+  getCopy = SC.contain $ do
+    InDb (tx :: Txp.Tx) <- SC.safeGet
+    InDb (txw :: Txp.TxWitness) <- SC.safeGet
+    pure (InDb (Txp.TxAux tx txw))
+  putCopy (InDb (Txp.TxAux tx txw)) = SC.contain $ do
+    SC.safePut (InDb tx)
+    SC.safePut (InDb txw)
 
--- TODO this should live with other core type safecopy instances
-instance SafeCopy Core.TxAux where
-    getCopy = error "TODO: getCopy for (InDb Core.TxAux)"
-    putCopy = error "TODO: putCopy for (InDb Core.TxAux)"
+instance SC.SafeCopy (InDb Txp.Tx) where
+  getCopy = SC.contain $ do
+    InDb (i :: NonEmpty Txp.TxIn) <- SC.safeGet
+    InDb (o :: NonEmpty Txp.TxOut) <- SC.safeGet
+    InDb (a :: Txp.TxAttributes) <- SC.safeGet
+    pure (InDb (Txp.UnsafeTx i o a))
+  putCopy (InDb (Txp.UnsafeTx i o a)) = SC.contain $ do
+    SC.safePut (InDb i)
+    SC.safePut (InDb o)
+    SC.safePut (InDb a)
 
-instance SafeCopy (InDb Core.TxAux) where
-    getCopy = error "TODO: getCopy for (InDb Core.TxAux)"
-    putCopy = error "TODO: putCopy for (InDb Core.TxAux)"
+instance SC.SafeCopy (InDb Txp.TxOut) where
+  getCopy = SC.contain $ do
+    InDb (a :: Core.Address) <- SC.safeGet
+    InDb (c :: Core.Coin) <- SC.safeGet
+    pure (InDb (Txp.TxOut a c))
+  putCopy (InDb (Txp.TxOut a c)) = SC.contain $ do
+    SC.safePut (InDb a)
+    SC.safePut (InDb c)
 
-instance SafeCopy (InDb (Map Core.TxId Core.TxAux)) where
-    getCopy = error "TODO: getCopy for (InDb (Map Core.TxId Core.TxAux))"
-    putCopy = error "TODO: putCopy for (InDb (Map Core.TxId Core.TxAux))"
+instance SC.SafeCopy (InDb Txp.TxOutAux) where
+  getCopy = SC.contain $ do
+    InDb (x :: Txp.TxOut) <- SC.safeGet
+    pure (InDb (Txp.TxOutAux x))
+  putCopy (InDb (Txp.TxOutAux x)) = SC.contain $ do
+    SC.safePut (InDb x)
 
-instance SafeCopy (InDb Core.TxId) where
-    getCopy = error "TODO: getCopy for (InDb Core.TxId)"
-    putCopy = error "TODO: putCopy for (InDb Core.TxId)"
+instance SC.SafeCopy (InDb Txp.TxWitness) where
+  getCopy = SC.contain $ do
+    xsi :: [InDb Txp.TxInWitness] <- SC.safeGet
+    let v :: V.Vector Txp.TxInWitness = V.fromList (map _fromDb xsi)
+    pure (InDb v)
+  putCopy (InDb v) = SC.contain $ do
+    let xsi :: [InDb Txp.TxInWitness] = map InDb (V.toList v)
+    SC.safePut xsi
 
-instance SafeCopy (InDb Core.TxIn) where
-    getCopy = error "TODO: getCopy for (InDb Core.TxIn)"
-    putCopy = error "TODO: putCopy for (InDb Core.TxIn)"
+instance SC.SafeCopy (InDb Txp.TxInWitness) where
+  getCopy = SC.contain $ fmap InDb $ do
+    SC.safeGet >>= \case
+      0 -> Txp.PkWitness
+        <$> fmap _fromDb SC.safeGet
+        <*> fmap _fromDb SC.safeGet
+      1 -> Txp.ScriptWitness
+        <$> fmap _fromDb SC.safeGet
+        <*> fmap _fromDb SC.safeGet
+      2 -> Txp.RedeemWitness
+        <$> fmap _fromDb SC.safeGet
+        <*> fmap _fromDb SC.safeGet
+      3 -> Txp.RedeemWitness <$> SC.safeGet <*> SC.safeGet
+      (_ :: Word8) -> empty
+  putCopy (InDb x) = SC.contain $ case x of
+    Txp.PkWitness a b -> do
+      SC.safePut (0 :: Word8)
+      SC.safePut (InDb (a :: Core.PublicKey))
+      SC.safePut (InDb (b :: Txp.TxSig))
+    Txp.ScriptWitness a b -> do
+      SC.safePut (1 :: Word8)
+      SC.safePut (InDb (a :: Core.Script))
+      SC.safePut (InDb (b :: Core.Script))
+    Txp.RedeemWitness a b -> do
+      SC.safePut (2 :: Word8)
+      SC.safePut (InDb (a :: Core.RedeemPublicKey))
+      SC.safePut (InDb (b :: Core.RedeemSignature Txp.TxSigData))
+    Txp.UnknownWitnessType a b -> do
+      SC.safePut (3 :: Word8)
+      SC.safePut (a :: Word8)
+      SC.safePut (b :: B.ByteString)
 
-instance SafeCopy (InDb a) => SafeCopy (InDb (Set a)) where
-  getCopy = error "TODO: getCopy for (InDb (Set a))"
-  putCopy = error "TODO: putCopy for (InDb (Set a))"
+instance SC.SafeCopy (InDb Core.AddrType) where
+  getCopy = SC.contain $ fmap InDb $ do
+    SC.safeGet >>= \case
+      0 -> pure Core.ATPubKey
+      1 -> pure Core.ATScript
+      2 -> pure Core.ATRedeem
+      3 -> Core.ATUnknown <$> SC.safeGet
+      (_ :: Word8) -> empty
+  putCopy (InDb x) = SC.contain $ case x of
+    Core.ATPubKey -> SC.safePut (0 :: Word8)
+    Core.ATScript -> SC.safePut (1 :: Word8)
+    Core.ATRedeem -> SC.safePut (2 :: Word8)
+    Core.ATUnknown a -> do
+      SC.safePut (3 :: Word8)
+      SC.safePut (a :: Word8)
 
-instance SafeCopy (InDb (Map Core.TxId Core.SlotId)) where
-    getCopy = error "TODO: getCopy for (InDb (Map Core.TxId Core.SlotId))"
-    putCopy = error "TODO: putCopy for (InDb (Map Core.TxId Core.SlotId))"
+instance SC.SafeCopy (InDb (Core.Signature a)) where
+  getCopy = SC.contain $ do
+    bs :: B.ByteString <- SC.safeGet
+    Right xsig <- pure (CCW.xsignature bs)
+    pure (InDb (Core.Signature xsig))
+  putCopy (InDb (Core.Signature xsig)) = SC.contain $ do
+    let bs = CCW.unXSignature xsig
+    SC.safePut bs
 
-instance SafeCopy (InDb Core.SoftwareVersion) where
-    getCopy = error "TODO: getCopy for (InDb Core.SoftwareVersion)"
-    putCopy = error "TODO: putCopy for (InDb Core.SoftwareVersion)"
+instance SC.SafeCopy (InDb Core.PublicKey) where
+  getCopy = SC.contain $ do
+    pkbs :: B.ByteString <- SC.safeGet
+    InDb (cc :: CCW.ChainCode) <- SC.safeGet
+    let xpub = CCW.XPub pkbs cc
+    pure (InDb (Core.PublicKey xpub))
+  putCopy (InDb (Core.PublicKey xpub)) = SC.contain $ do
+    let CCW.XPub pkbs cc = xpub
+    SC.safePut pkbs
+    SC.safePut (InDb cc)
+
+instance SC.SafeCopy (InDb CCW.ChainCode) where
+  getCopy = SC.contain $ do
+    bs :: B.ByteString <- SC.safeGet
+    pure (InDb (CCW.ChainCode bs))
+  putCopy (InDb (CCW.ChainCode bs)) = SC.contain $ do
+    SC.safePut bs
+
+instance SC.SafeCopy (InDb Txp.TxSigData) where
+  getCopy = SC.contain $ do
+    InDb (h :: Core.Hash Txp.Tx) <- SC.safeGet
+    pure (InDb (Txp.TxSigData h))
+  putCopy (InDb (Txp.TxSigData h)) = SC.contain $ do
+    SC.safePut (InDb h)
+
+instance SC.SafeCopy (InDb Core.RedeemPublicKey) where
+  getCopy = SC.contain $ do
+    bs :: B.ByteString <- SC.safeGet
+    pure (InDb (Core.RedeemPublicKey (Ed25519.PublicKey bs)))
+  putCopy (InDb (Core.RedeemPublicKey pk)) = SC.contain $ do
+    SC.safePut (Ed25519.unPublicKey pk :: B.ByteString)
+
+instance SC.SafeCopy (InDb (Core.RedeemSignature a)) where
+  getCopy = SC.contain $ do
+    bs :: B.ByteString <- SC.safeGet
+    pure (InDb (Core.RedeemSignature (Ed25519.Signature bs)))
+  putCopy (InDb (Core.RedeemSignature pk)) = SC.contain $ do
+    SC.safePut (Ed25519.unSignature pk :: B.ByteString)
+
+instance forall h. SC.SafeCopy (InDb h)
+  => SC.SafeCopy (InDb (Core.Attributes h)) where
+  getCopy = SC.contain $ do
+    InDb (d :: h) <- SC.safeGet
+    InDb (r :: Core.UnparsedFields) <- SC.safeGet
+    pure (InDb (Core.Attributes d r))
+  putCopy (InDb (Core.Attributes d r)) = SC.contain $ do
+    SC.safePut (InDb d)
+    SC.safePut (InDb r)
+
+instance SC.SafeCopy (InDb Core.Script) where
+  getCopy = SC.contain $ do
+    v :: Word16 <- SC.safeGet
+    bs :: B.ByteString <- SC.safeGet
+    pure (InDb (Core.Script v bs))
+  putCopy (InDb (Core.Script v bs)) = SC.contain $ do
+    SC.safePut (v :: Word16)
+    SC.safePut (bs :: B.ByteString)
+
+instance SC.SafeCopy (InDb Core.LocalSlotIndex) where
+  getCopy = SC.contain $ do
+    w :: Word16 <- SC.safeGet
+    pure (InDb (Core.UnsafeLocalSlotIndex w))
+  putCopy (InDb (Core.UnsafeLocalSlotIndex w)) = SC.contain $ do
+    SC.safePut (w :: Word16)
+
+instance SC.SafeCopy (InDb Core.EpochIndex) where
+  getCopy = SC.contain $ do
+    w :: Word64 <- SC.safeGet
+    pure (InDb (Core.EpochIndex w))
+  putCopy (InDb (Core.EpochIndex w)) = SC.contain $ do
+    SC.safePut (w :: Word64)
+
+instance SC.SafeCopy (InDb Core.UnparsedFields) where
+  getCopy = SC.contain $ do
+    m :: Map Word8 BL.ByteString <- SC.safeGet
+    pure (InDb (Core.UnparsedFields m))
+  putCopy (InDb (Core.UnparsedFields m)) = SC.contain $ do
+    SC.safePut m
+
+instance SC.SafeCopy (InDb ()) where
+  getCopy = SC.contain (fmap InDb SC.safeGet)
+  putCopy (InDb ()) = SC.contain (SC.safePut ())
+
+instance forall a b.
+  (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b))
+  => SC.SafeCopy (InDb (a, b)) where
+  getCopy = SC.contain $ do
+    InDb (a :: a) <- SC.safeGet
+    InDb (b :: b) <- SC.safeGet
+    pure (InDb (a, b))
+  putCopy (InDb (a, b)) = SC.contain $ do
+    SC.safePut (InDb a)
+    SC.safePut (InDb b)
+
+instance SC.SafeCopy (InDb Txp.TxIn) where
+  getCopy = SC.contain $ fmap InDb $ do
+    SC.safeGet >>= \case
+      0 -> Txp.TxInUtxo <$> SC.safeGet <*> SC.safeGet
+      1 -> Txp.TxInUnknown <$> SC.safeGet <*> SC.safeGet
+      (_ :: Word8) -> empty
+  putCopy (InDb a) = SC.contain $ case a of
+    Txp.TxInUtxo (txId :: Txp.TxId) (w :: Word32) -> do
+      SC.safePut (0 :: Word8)
+      SC.safePut (InDb txId)
+      SC.safePut w
+    Txp.TxInUnknown (w :: Word8) (b :: ByteString) -> do
+      SC.safePut (1 :: Word8)
+      SC.safePut w
+      SC.safePut b
+
+instance forall a.
+    (SC.SafeCopy (InDb a))
+    => SC.SafeCopy (InDb (NonEmpty a)) where
+    getCopy = SC.contain $ do
+      xsi :: [InDb a] <- SC.safeGet
+      case NEL.nonEmpty xsi of
+         Nothing -> empty
+         Just nxs -> pure (InDb (fmap _fromDb nxs))
+    putCopy (InDb sa) = SC.contain $ do
+      let xsi :: [InDb a] = map InDb (NEL.toList sa)
+      SC.safePut xsi
+
+instance forall a.
+    (SC.SafeCopy (InDb a), Ord a)
+    => SC.SafeCopy (InDb (Set a)) where
+    getCopy = SC.contain $ do
+      xsi :: [InDb a] <- SC.safeGet
+      pure (InDb (Set.fromList (map _fromDb xsi)))
+    putCopy (InDb sa) = SC.contain $ do
+      let xsi :: [InDb a] = map InDb (Set.toList sa)
+      SC.safePut xsi
+
+instance forall a b.
+    (SC.SafeCopy (InDb a), SC.SafeCopy (InDb b), Ord a)
+    => SC.SafeCopy (InDb (Map a b)) where
+    getCopy = SC.contain $ do
+      xsi :: [(InDb a, InDb b)] <- SC.safeGet
+      let m :: Map a b = Map.fromList (map (_fromDb *** _fromDb) xsi)
+      pure (InDb m)
+    putCopy (InDb m) = SC.contain $ do
+      let xsi :: [(InDb a, InDb b)] = map (InDb *** InDb) (Map.toList m)
+      SC.safePut xsi
+
+instance forall algo a.
+  (Core.HashAlgorithm algo)
+  => SC.SafeCopy (InDb (Core.AbstractHash algo a)) where
+  getCopy = SC.contain $ do
+    b :: B.ByteString <- SC.safeGet
+    Just (d :: Digest algo) <- pure (digestFromByteString b)
+    pure (InDb (Core.AbstractHash d))
+  putCopy (InDb (Core.AbstractHash (d :: Digest algo))) = SC.contain $ do
+    SC.safePut (BA.convert d :: B.ByteString)

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/IxSet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/IxSet.hs
@@ -140,10 +140,7 @@ data Indexed a = Indexed {
   }
 
 Lens.makeLenses ''Indexed
-
-instance SafeCopy a => SafeCopy (Indexed a) where
-    getCopy = error "TODO"
-    putCopy = error "TODO"
+deriveSafeCopy 1 'base ''Indexed
 
 instance Buildable a => Buildable (Indexed a) where
     build (Indexed (AutoIncrementKey idx) r) =

--- a/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
@@ -309,7 +309,7 @@ mkBlockMeta slotId addrs_ = LocalBlockMeta BlockMeta{..}
         indexedAddrs = indexByAddr addrs_
 
         _blockMetaSlotId      = InDb . Map.fromList . map (,slotId) $ txIds'
-        _blockMetaAddressMeta = InDb $ Map.map mkAddressMeta indexedAddrs
+        _blockMetaAddressMeta = Map.map mkAddressMeta indexedAddrs
 
 -- | This function is called once for each address found in a particular block of
 --   transactions. The collection of address summaries passed to this function
@@ -347,11 +347,11 @@ mkAddressMeta addrs
 -- | Index the list of address summaries by Address.
 --   NOTE: Since there will be at least one AddressSummary per Address,
 --   we can safely use NE.fromList.
-indexByAddr :: [AddressSummary] -> Map Address (NE.NonEmpty AddressSummary)
+indexByAddr :: [AddressSummary] -> Map (InDb Address) (NE.NonEmpty AddressSummary)
 indexByAddr addrs =
     Map.map NE.fromList (Map.fromListWith (++) addrs')
     where
-        fromAddrSummary addrSummary = (addrSummaryAddr addrSummary, [addrSummary])
+        fromAddrSummary addrSummary = (InDb (addrSummaryAddr addrSummary), [addrSummary])
         addrs' = map fromAddrSummary addrs
 
 fromUtxoSummary :: Map TxIn (TxOutAux,AddressSummary)

--- a/wallet-new/test/MarshallingSpec.hs
+++ b/wallet-new/test/MarshallingSpec.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module MarshallingSpec (spec) where
 
 import           Universum
 
 import           Control.Lens (from, to)
 import           Data.Aeson
+import qualified Data.ByteString as BS
+import           Data.SafeCopy hiding (Migrate)
+import           Data.Serialize (runGet, runPut)
 import           Data.Time (UTCTime (..), fromGregorian)
 import           Data.Time.Clock.POSIX (POSIXTime)
 import           Data.Typeable (typeRep)
@@ -18,9 +25,18 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 import qualified Test.QuickCheck.Property as Property
 
+import qualified Cardano.Crypto.Wallet as CCW
+import qualified Pos.Chain.Block as Core
 import qualified Pos.Core as Core
-import qualified Pos.Core.Txp as Core
+import qualified Pos.Core.Attributes as Core
+import qualified Pos.Core.Delegation as Core
+import qualified Pos.Core.Ssc as Ssc
+import qualified Pos.Core.Txp as Txp
 import qualified Pos.Core.Update as Core
+import qualified Pos.Crypto as Core
+
+import           Test.Pos.Chain.Block.Arbitrary ()
+import           Test.Pos.Core.Arbitrary ()
 
 import           Cardano.Wallet.API.Indices
 import           Cardano.Wallet.API.Request.Pagination (Page, PerPage)
@@ -28,13 +44,15 @@ import           Cardano.Wallet.API.Response (JSONValidationError)
 import           Cardano.Wallet.API.V1.Migration.Types (Migrate (..),
                      MigrationError)
 import           Cardano.Wallet.API.V1.Types
+import           Cardano.Wallet.Kernel.DB.InDb (InDb (..))
 import           Cardano.Wallet.Orphans ()
 import qualified Cardano.Wallet.Util as Util
 
 -- | Tests whether or not some instances (JSON, Bi, etc) roundtrips.
-spec :: Spec
+spec :: HasCallStack => Spec
 spec = parallel $ describe "Marshalling & Unmarshalling" $ do
     parallel $ describe "Roundtrips" $ do
+        pc <- runIO $ generate arbitrary
         aesonRoundtripProp @Account Proxy
         aesonRoundtripProp @AssuranceLevel Proxy
         aesonRoundtripProp @BackupPhrase Proxy
@@ -72,7 +90,7 @@ spec = parallel $ describe "Marshalling & Unmarshalling" $ do
 
         -- HttpApiData roundtrips
         httpApiDataRoundtripProp @AccountIndex Proxy
-        httpApiDataRoundtripProp @(V1 Core.TxId) Proxy
+        httpApiDataRoundtripProp @(V1 Txp.TxId) Proxy
         httpApiDataRoundtripProp @WalletId Proxy
         httpApiDataRoundtripProp @(V1 Core.Timestamp) Proxy
         httpApiDataRoundtripProp @(V1 Core.Address) Proxy
@@ -88,6 +106,65 @@ spec = parallel $ describe "Marshalling & Unmarshalling" $ do
         migrateRoundtripProp @(WalletId, AccountIndex) @V0.AccountId Proxy Proxy
         migrateRoundtripProp @PaymentDistribution @(V0.CId V0.Addr, Core.Coin) Proxy Proxy
         migrateRoundtripProp @EstimatedFees @V0.TxFee Proxy Proxy
+
+        -- SafeCopy roundtrips
+        safeCopyRoundTrip @(InDb Core.Address)
+        safeCopyRoundTrip @(InDb Core.AddrAttributes)
+        safeCopyRoundTrip @(InDb Core.AddrStakeDistribution)
+        safeCopyRoundTrip @(InDb Core.CoinPortion)
+        safeCopyRoundTrip @(InDb Core.HDAddressPayload)
+        safeCopyRoundTrip @(InDb Core.Coin)
+        safeCopyRoundTrip @(InDb Core.Timestamp)
+        safeCopyRoundTrip @(InDb Txp.TxAux)
+        safeCopyRoundTrip @(InDb Txp.Tx)
+        safeCopyRoundTrip @(InDb Txp.TxOut)
+        safeCopyRoundTrip @(InDb Txp.TxOutAux)
+        safeCopyRoundTrip @(InDb Txp.TxWitness)
+        safeCopyRoundTrip @(InDb Txp.TxInWitness)
+        safeCopyRoundTrip @(InDb Core.AddrType)
+        safeCopyRoundTrip @(InDb (Core.Signature Int))
+        safeCopyRoundTrip @(InDb Core.PublicKey)
+        safeCopyRoundTrip @(InDb CCW.ChainCode)
+        safeCopyRoundTrip @(InDb Txp.TxSigData)
+        safeCopyRoundTrip @(InDb Core.RedeemPublicKey)
+        -- safeCopyRoundTrip @(InDb (Core.RedeemSignature Raw))
+        safeCopyRoundTrip @(InDb Core.Script)
+        safeCopyRoundTrip @(InDb Core.EpochIndex)
+        safeCopyRoundTrip @(InDb Core.UnparsedFields)
+        safeCopyRoundTrip @(InDb ())
+        safeCopyRoundTrip @(InDb Txp.TxIn)
+        safeCopyRoundTrip @(InDb Core.MainProof)
+        safeCopyRoundTrip @(InDb Ssc.SscProof)
+        safeCopyRoundTrip @(InDb Txp.TxProof)
+        safeCopyRoundTrip @(InDb (Core.MerkleRoot Txp.Tx))
+        safeCopyRoundTrip @(InDb Core.MainExtraHeaderData)
+        safeCopyRoundTrip @(InDb Core.BlockVersion)
+        safeCopyRoundTrip @(InDb Core.SoftwareVersion)
+        safeCopyRoundTrip @(InDb Core.ApplicationName)
+        -- safeCopyRoundTrip @(InDb (Core.ProxySignature w)
+        -- safeCopyRoundTrip @(InDb (Core.ProxySecretKey w))
+        -- safeCopyRoundTrip @(InDb (Core.ProxyCert w))
+        safeCopyRoundTrip @(InDb CCW.XSignature)
+        safeCopyRoundTrip @(InDb (Core.HeavyDlgIndex))
+        safeCopyRoundTrip @(InDb (Core.LightDlgIndices))
+        safeCopyRoundTrip @(InDb Core.ChainDifficulty)
+        safeCopyRoundTrip @(InDb Core.BlockCount)
+        safeCopyRoundTrip @(InDb Core.GenesisBlockHeader)
+        safeCopyRoundTrip @(InDb Core.ProtocolMagic)
+        safeCopyRoundTrip @(InDb Core.GenesisProof)
+        safeCopyRoundTrip @(InDb Core.GenesisConsensusData)
+        safeCopyRoundTrip @(InDb Core.GenesisExtraHeaderData)
+        safeCopyRoundTrip @(InDb (Core.AddressHash Core.Address'))
+        safeCopyRoundTrip @(InDb (Core.Attributes Core.AddrAttributes))
+        safeCopyRoundTrip @(InDb (Core.AddrType))
+        describe "Needing protocol constants ... " $ do
+            Core.withProtocolConstants pc $ do
+                safeCopyRoundTrip @(InDb Core.SlotId)
+                safeCopyRoundTrip @(InDb Core.LocalSlotIndex)
+                safeCopyRoundTrip @(InDb Core.BlockHeader)
+                safeCopyRoundTrip @(InDb Core.MainBlockHeader)
+                safeCopyRoundTrip @(InDb Core.MainConsensusData)
+                safeCopyRoundTrip @(InDb Core.BlockSignature)
 
         -- Other roundtrips
         generalRoundtripProp "UTC time" Util.showApiUtcTime Util.parseApiUtcTime
@@ -177,6 +254,15 @@ httpApiDataRoundtripProp
 httpApiDataRoundtripProp proxy =
     prop ("HttpApiData " <> show (typeRep proxy) <> " roundtrips") (httpApiDataRoundtrip proxy)
 
+safeCopyRoundTrip
+    :: forall a
+    . (HasCallStack, Arbitrary a, SafeCopy a, Show a, Eq a, Typeable a)
+    => Spec
+safeCopyRoundTrip = prop propName $ \(a :: a) ->
+    runGet safeGet (runPut (safePut a)) === Right a
+  where
+    propName = "Safe Copy Roundtrip for: " <> show (typeRep (Proxy @a))
+
 generalRoundtrip
     :: (Arbitrary from, Eq from, Show from, Show e)
     => (from -> to) -> (to -> Either e from) -> Property
@@ -200,3 +286,13 @@ decodingFails s (_ :: proxy a) = eitherDecode @a s `shouldSatisfy` isLeft
 -- | Take a string value, and make a JSON-string from it.
 jsonString :: LByteString -> LByteString
 jsonString bs = "\"" <> bs <> "\""
+
+instance Arbitrary CCW.XSignature where
+    arbitrary = do
+        bs <- BS.pack <$> replicateM 64 arbitrary
+        case CCW.xsignature bs of
+            Left _  -> arbitrary
+            Right a -> pure a
+
+instance Arbitrary CCW.ChainCode where
+    arbitrary = CCW.ChainCode <$> arbitrary

--- a/wallet-new/test/unit/UTxO/Interpreter.hs
+++ b/wallet-new/test/unit/UTxO/Interpreter.hs
@@ -558,12 +558,12 @@ instance DSL.Hash h Addr => Interpret h (BlockMeta' h) where
       _blockMetaAddressMeta <- intAddrMetas addrMeta'
       return $ BlockMeta {..}
       where
-          intAddrMetas :: Map Addr AddressMeta -> IntT h e m (InDb (Map Address AddressMeta))
-          intAddrMetas addrMetas= InDb . Map.fromList <$> mapM intAddrMeta (Map.toList addrMetas)
+          intAddrMetas :: Map Addr AddressMeta -> IntT h e m (Map (InDb Address) AddressMeta)
+          intAddrMetas addrMetas= Map.fromList <$> mapM intAddrMeta (Map.toList addrMetas)
 
           -- Interpret only the key, leaving the indexed value AddressMeta unchanged
-          intAddrMeta :: (Addr,AddressMeta) -> IntT h e m (Address,AddressMeta)
-          intAddrMeta (addr,addrMeta) = (,addrMeta) . addrInfoCardano <$> int addr
+          intAddrMeta :: (Addr,AddressMeta) -> IntT h e m (InDb Address, AddressMeta)
+          intAddrMeta (addr,addrMeta) = (,addrMeta) . InDb . addrInfoCardano <$> int addr
 
           intTxIds :: Map (h (DSL.Transaction h Addr)) SlotId -> IntT h e m (InDb (Map TxId SlotId))
           intTxIds txIds = InDb . Map.fromList <$> mapM intTxId (Map.toList txIds)


### PR DESCRIPTION
Some things to keep in mind:

* Round-trip QuickCheck tests are missing.

* The basic approach to defining instances for types wrapped in `InDb` is described in the code:

   > -- Notice that when serializing and deserializing, a type like `InDb foo` will
   > -- distribute `InDb` among the non-primitive types that make up `foo`. This
   > -- choice doesn't show up in the types. 

* There are a lot of redundant type signatures. This is deliberate, so that changing the definition of a datatype in the future triggers a type-checker error if possible. 