### PR TITLE
[DEVOPS-999] explorer frontend: Replace @GITREV@ with actual rev

### DIFF
--- a/explorer/frontend/default.nix
+++ b/explorer/frontend/default.nix
@@ -59,7 +59,7 @@ let
 
     # Patch the build recipe for nix
     echo "patching webpack.config.babel.js"
-    sed -e "s/COMMIT_HASH.*/COMMIT_HASH': '\"@GITREV@\"',/" \
+    sed -e "s/COMMIT_HASH.*/COMMIT_HASH': '\"${gitrev}\"',/" \
         -e "s/import GitRevisionPlugin.*//" \
         -e "s/path:.*/path: process.env.out,/" \
         -e "/new ProgressPlugin/d" \


### PR DESCRIPTION
## Description

Cardano explorer was showing `v. 0.2.0( @GITREV )` in the footer.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-999

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing checklist

```
nix-build -A cardano-sl-explorer-frontend
cd result
grep -Ri gitrev
# check for absence of @GITREV@
python3 -m http.server --bind 127.0.0.1 8000
# check that site footer is correct
```

## QA Steps

1. Check the cardano explorer site footer for a correct git revision.
