### PR TITLE
[DEVOPS-992] Fix x509 generator SANs to work with IP addresses

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17386,11 +17386,13 @@ license = stdenv.lib.licenses.mit;
 , Glob
 , hourglass
 , hspec
+, ip
 , lens
 , lifted-async
 , log-warper
 , mtl
 , neat-interpolation
+, network-transport
 , network-transport-tcp
 , optparse-applicative
 , optparse-generic
@@ -17477,11 +17479,13 @@ filepath
 formatting
 Glob
 hourglass
+ip
 lens
 lifted-async
 log-warper
 mtl
 neat-interpolation
+network-transport
 network-transport-tcp
 optparse-applicative
 optparse-generic
@@ -46469,6 +46473,48 @@ doHaddock = false;
 doCheck = false;
 homepage = "http://snapframework.com/";
 description = "HAProxy protocol 1.5 support for io-streams";
+license = stdenv.lib.licenses.bsd3;
+
+}) {};
+"ip" = callPackage
+({
+  mkDerivation
+, aeson
+, attoparsec
+, base
+, bytestring
+, fetchgit
+, hashable
+, primitive
+, stdenv
+, text
+, vector
+}:
+mkDerivation {
+
+pname = "ip";
+version = "1.3.0";
+src = fetchgit {
+
+url = "https://github.com/andrewthad/haskell-ip";
+sha256 = "199mfpbgca7rvwvwk2zsmcpibc0sk0ni7c5zlf4gk3cps8s85gyr";
+rev = "9bb453139aa82cc973125091800422a523e1eb8f";
+
+};
+libraryHaskellDepends = [
+aeson
+attoparsec
+base
+bytestring
+hashable
+primitive
+text
+vector
+];
+doHaddock = false;
+doCheck = false;
+homepage = "https://github.com/andrewthad/haskell-ip#readme";
+description = "Library for IP and MAC addresses";
 license = stdenv.lib.licenses.bsd3;
 
 }) {};

--- a/stack.yaml
+++ b/stack.yaml
@@ -92,6 +92,11 @@ packages:
     git: https://github.com/input-output-hk/cardano-crypto
     commit: 287cc575fafe86af9d24af9d012c47f9d3f04da0
   extra-dep: true
+  # to be removed when haskell-ip is in the current stackage version
+- location:
+    git: https://github.com/andrewthad/haskell-ip
+    commit: 9bb453139aa82cc973125091800422a523e1eb8f
+  extra-dep: true
 
 # Required for explorer.
 # We forked it because it has some unacceptable version bounds. We didn't

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -499,18 +499,21 @@ executable cardano-x509-certificates
                , aeson
                , asn1-encoding
                , asn1-types
-               , bytestring
                , base64-bytestring
+               , bytestring
                , cryptonite
+               , data-default-class
                , filepath
                , hourglass
+               , ip
+               , network-transport
                , optparse-applicative
+               , text
                , universum
                , unordered-containers
                , x509
-               , x509-validation
                , x509-store
-               , data-default-class
+               , x509-validation
                , yaml
 
   default-extensions:   DeriveGeneric


### PR DESCRIPTION
Currently on 1.3.0, if an IP SAN is set, it treats it as a DNS name instead and still throws an invalid certificate error, which also can break daedalus on the demo cluster. This is fixed in develop and proposed to be targeted to 1.3.1 release to fix this issue. This would also be an issue for any exchanges running the x509 tool manually to generate a CA that specified SAN's other than localhost, for example if they had a LAN or public IP they wanted the wallet to use and be secured/trusted with SSL by any application/browser with the ca.crt loaded into the trust store.

(cherry picked from commit 834ade85577c2fca8d8b3649582499e2abc78515)

## Description

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-992

## Linked issue
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-992


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
