### PR TITLE
[CBR-369] Inform submission layer in BListener

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -112,6 +112,7 @@ import           Cardano.Wallet.Kernel.DB.Spec
 import           Cardano.Wallet.Kernel.DB.Util.AcidState
 import           Cardano.Wallet.Kernel.DB.Util.IxSet
 import           Cardano.Wallet.Kernel.Util (modifyAndGetOld, neHead)
+import           Cardano.Wallet.Kernel.Util.StrictStateT
 
 {-------------------------------------------------------------------------------
   Supporting types
@@ -647,17 +648,17 @@ matchHdAccountState :: Update' HdAccountUpToDate e a
                     -> Update' HdAccountWithinK  e a
                     -> Update' HdAccountOutsideK e a
                     -> Update' HdAccount         e a
-matchHdAccountState updUpToDate updWithinK updOutsideK = StateT $ \acc ->
+matchHdAccountState updUpToDate updWithinK updOutsideK = strictStateT $ \acc ->
     case acc ^. hdAccountState of
       HdAccountStateUpToDate st ->
             second (\st' -> acc & hdAccountState .~ HdAccountStateUpToDate st')
-        <$> runStateT updUpToDate st
+        <$> runStrictStateT updUpToDate st
       HdAccountStateWithinK  st ->
             second (\st' -> acc & hdAccountState .~ HdAccountStateWithinK st')
-        <$> runStateT updWithinK st
+        <$> runStrictStateT updWithinK st
       HdAccountStateOutsideK st ->
             second (\st' -> acc & hdAccountState .~ HdAccountStateOutsideK st')
-        <$> runStateT updOutsideK st
+        <$> runStrictStateT updOutsideK st
 
 -- | Zoom to the current checkpoints of the wallet
 zoomHdAccountCheckpoints :: (   forall c. IsCheckpoint c

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/AcidState.hs
@@ -22,15 +22,18 @@ import           Universum
 
 import           Control.Monad.Except
 import           Data.Acid (Update)
+import qualified Data.Map.Strict as Map
 
-import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexable, IxSet)
+import           Cardano.Wallet.Kernel.DB.Util.IxSet (HasPrimKey, Indexable,
+                     IxSet, PrimKey)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
+import           Cardano.Wallet.Kernel.Util.StrictStateT
 
 {-------------------------------------------------------------------------------
   Acid-state updates with support for errors (and zooming, see below).
 -------------------------------------------------------------------------------}
 
-type Update' st e = StateT st (Except e)
+type Update' st e = StrictStateT st (Except e)
 
 -- | NOTA BENE: Your acid-state 'Update' queries should be composed by one
 -- @and only one@ \"runUpdate'\", as each call to \"runUpdate'\" will return
@@ -45,7 +48,7 @@ runUpdate' upd = do
       Right (a, st') -> put st' >> return (Right (st, a))
   where
     upd' :: st -> Either e (a, st)
-    upd' = runExcept . runStateT upd
+    upd' = runExcept . runStrictStateT upd
 
 -- | Variation on 'runUpdate' for functions with no result
 --
@@ -57,7 +60,7 @@ runUpdateNoErrors :: Update' st Void a -> Update st a
 runUpdateNoErrors = fmap (snd . mustBeRight) . runUpdate'
 
 mapUpdateErrors :: (e -> e') -> Update' st e a -> Update' st e' a
-mapUpdateErrors f upd = StateT $ withExcept f . runStateT upd
+mapUpdateErrors f upd = strictStateT $ withExcept f . runStrictStateT upd
 
 -- | Like \"runUpdate'\", but it discards the DB after running the query.
 -- Use this function sparingly only when you are sure you won't need the
@@ -73,10 +76,10 @@ runUpdateDiscardSnapshot upd = fmap snd <$> runUpdate' upd
 
 -- | Run an update on part of the state.
 zoom :: Lens' st st' -> Update' st' e a -> Update' st e a
-zoom l upd = StateT $ \large -> do
+zoom l upd = strictStateT $ \large -> do
     let update small' = large & l .~ small'
         small         = large ^. l
-    fmap update <$> runStateT upd small
+    fmap update <$> runStrictStateT upd small
 
 -- | Run an update on part of the state.
 --
@@ -85,12 +88,12 @@ zoomDef :: Update' st  e a      -- ^ Run when lens returns 'Nothing'
         -> Lens' st (Maybe st') -- ^ Index the state
         -> Update' st' e a      -- ^ Action to run on the smaller state
         -> Update' st  e a
-zoomDef def l upd = StateT $ \large -> do
+zoomDef def l upd = strictStateT $ \large -> do
     let update small' = large & l .~ Just small'
         mSmall        = large ^. l
     case mSmall of
-      Nothing    -> runStateT def large
-      Just small -> fmap update <$> runStateT upd small
+      Nothing    -> runStrictStateT def large
+      Just small -> fmap update <$> runStrictStateT upd small
 
 -- | Run an update on part of the state.
 --
@@ -101,30 +104,29 @@ zoomCreate :: Update' st  e st'     -- ^ Action to create small state if needed
            -> Lens' st (Maybe st')  -- ^ Index the state
            -> Update' st' e a       -- ^ Action to run on the smaller state
            -> Update' st  e a
-zoomCreate mkSmall l upd = StateT $ \large -> do
+zoomCreate mkSmall l upd = strictStateT $ \large -> do
     case large ^. l of
       Just small -> do
         let update small' = large & l .~ Just small'
-        fmap update <$> runStateT upd small
+        fmap update <$> runStrictStateT upd small
       Nothing -> do
-        (small, large') <- runStateT mkSmall large
+        (small, large') <- runStrictStateT mkSmall large
         let update small' = large' & l .~ Just small'
-        fmap update <$> runStateT upd small
-
-    --    small         = fromMaybe def (large ^. l)
+        fmap update <$> runStrictStateT upd small
 
 -- | Run an update on /all/ parts of the state.
 --
--- NOTE: Uses 'otraverse' under the hood, and therefore needs to reconstruct
--- the entire 'IxSet' and associated indices. Only use for small sets.
-zoomAll :: Indexable st'
-        => Lens' st (IxSet st')
-        -> Update' st' e ()
-        -> Update' st  e ()
-zoomAll l upd = StateT $ \large -> do
-    let update ixset' = large & l .~ ixset'
-        ixset         = large ^. l
-    (((),) . update) <$> IxSet.otraverse (execStateT upd) ixset
+-- NOTE: Uses 'otraverseCollect' under the hood, and therefore needs to
+-- reconstruct the entire 'IxSet' and associated indices. Only use for small
+-- sets.
+zoomAll :: (Indexable a, HasPrimKey a)
+        => Lens' st (IxSet a)
+        -> Update' a  e b
+        -> Update' st e (Map (PrimKey a) b)
+zoomAll l upd = strictStateT $ \large -> do
+    let update (ixset', bs) = (Map.fromList bs, large & l .~ ixset')
+        ixset               = large ^. l
+    update <$> IxSet.otraverseCollect (fmap swap . runStrictStateT upd) ixset
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
@@ -7,6 +7,7 @@ module Cardano.Wallet.Kernel.Submission (
     -- * Public API
       newWalletSubmission
     , addPending
+    , addPendings
     , remPending
     , remPendingById
     , tick
@@ -295,6 +296,10 @@ addPending accId newPending ws =
     let ws' = ws & over (pendingByAccId accId)
                         (Pending.union newPending)
     in schedulePending accId newPending ws'
+
+-- | Variant on 'addPending' which accepts transactions from multiple accounts
+addPendings :: Map HdAccountId Pending -> WalletSubmission -> WalletSubmission
+addPendings ps ws = foldl' (flip (uncurry addPending)) ws (M.toList ps)
 
 -- | Removes the input set of 'Txp.TxId' from the local 'WalletSubmission' pending set.
 remPending :: Map HdAccountId (Set Txp.TxId)

--- a/wallet-new/src/Cardano/Wallet/Kernel/Util/StrictStateT.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Util/StrictStateT.hs
@@ -6,6 +6,7 @@ module Cardano.Wallet.Kernel.Util.StrictStateT (
     StrictStateT -- opaque
   , runStrictStateT
   , evalStrictStateT
+  , execStrictStateT
   , strictStateT
     -- * Conduit support
   , strictStateC
@@ -46,6 +47,9 @@ runStrictStateT = runStateT . unStrictStateT
 
 evalStrictStateT :: Monad m => StrictStateT s m a -> s -> m a
 evalStrictStateT = evalStateT . unStrictStateT
+
+execStrictStateT :: Monad m => StrictStateT s m a -> s -> m s
+execStrictStateT = execStateT . unStrictStateT
 
 strictStateT :: forall s m a. Monad m => (s -> m (a, s)) -> StrictStateT s m a
 strictStateT f = StrictStateT $ StateT f'


### PR DESCRIPTION
## Description

It is important that the submission layer gets notified after a block is
applied (to tell when transactions confirmed) and after rollback (which may
reintroduce pending transactions).

In order to do this, this commit makes a number of changes:

* The submission layer is moved to the passive wallet. This is important,
  because that's all the `BListener` has access to. The passive wallet is still
  passive of course, since the thread that actually "ticks" the submission
  layer and sends transactions is still (and can only be) started in the active
  wallet.

* The apply block and rollback primitives return the set of transactions that
  removed from pending or added to pending, respectively. This changes is then
  propagated all the way up to the top-levels functions that get called by the
  BListener.

* Generalized the `AccountUpdate` infrastructure to allow for return values,
  and made related changes (introduced `otraverseCollect`, generalized
  `zoomAll`).

This PR also makes a few unrelated but important changes:

* The `Update'` monad that we use throughout to modify the acid-state DB now
  uses StrictStateT instead of StateT.

This does not yet introduce tests; I've opened a separate ticket about that at https://iohk.myjetbrains.com/youtrack/issue/CBR-383 but I need to fix https://iohk.myjetbrains.com/youtrack/issue/CBR-382 first.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-369

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
