### PR TITLE
[CDEC-499] Run `Test.Pos.Chain.Txp.tests`

### DIFF
--- a/chain/test/test.hs
+++ b/chain/test/test.hs
@@ -7,6 +7,7 @@ import           Spec (spec)
 import           Test.Pos.Binary.Helpers (runTests)
 import qualified Test.Pos.Chain.Block.Bi
 import qualified Test.Pos.Chain.Ssc.Json
+import qualified Test.Pos.Chain.Txp.Json
 
 main :: IO ()
 main = do
@@ -14,4 +15,5 @@ main = do
     runTests
         [ Test.Pos.Chain.Block.Bi.tests
         , Test.Pos.Chain.Ssc.Json.tests
+        , Test.Pos.Chain.Txp.Json.tests
         ]


### PR DESCRIPTION
## Description

These were [added to the package](https://github.com/input-output-hk/cardano-sl/pull/3416/commits/c8a1b7e85bdac72363c8a7c783130eb801ae90e3), but the changeset which added
them to the test executable was checked out by accident.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-499

***

I'm omitting the usual fields because this is a hotfix PR for #3416.