### PR TITLE
[CBR-375] Create transaction metadata for incoming transactions

### DIFF
--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -413,6 +413,7 @@ test-suite wallet-unit-tests
                       Test.Spec.NewPayment
                       Test.Spec.Submission
                       Test.Spec.Translation
+                      Test.Spec.TxMetaScenarios
                       Test.Spec.Wallets
                       Test.Spec.WalletWorker
                       TxMetaStorageSpecs

--- a/wallet-new/src/Cardano/Wallet/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel.hs
@@ -64,17 +64,18 @@ bracketPassiveWallet logMsg keystore node f =
                   (\_ -> return ())
                   f)
 
-
 data WalletHandles = Handles {
     hAcid :: AcidState DB,
     hMeta :: MetaDBHandle
 }
 
+-- TODO(kde): this will be run with asynchronous exceptions masked.
+-- and we should rethink if migrateMetaDB should happen here.
 handlesOpen :: IO WalletHandles
 handlesOpen = do
     db <- openMemoryState defDB
     metadb <- openMetaDB ":memory:" -- TODO: CBR-378
-    migrateMetaDB metadb            -- TODO: this will be run with asynchronous exceptions masked.
+    migrateMetaDB metadb
     return $ Handles db metadb
 
 handlesClose :: WalletHandles -> IO ()

--- a/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
@@ -12,7 +12,6 @@ import           Universum hiding (State)
 
 import           Control.Concurrent.MVar (modifyMVar_)
 import           Data.Acid.Advanced (update')
-import qualified Data.Map.Strict as Map
 
 import           Pos.Core (SlotId)
 import           Pos.Core.Chrono (OldestFirst)
@@ -24,6 +23,7 @@ import           Cardano.Wallet.Kernel.DB.AcidState (ApplyBlock (..),
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock, rbSlotId)
+import           Cardano.Wallet.Kernel.DB.TxMeta.Types
 import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock (..),
@@ -41,16 +41,15 @@ import           Cardano.Wallet.Kernel.Types (WalletId (..))
 -- TODO: Improve performance (CBR-379)
 prefilterBlock' :: PassiveWallet
                 -> ResolvedBlock
-                -> IO (SlotId, Map HdAccountId PrefilteredBlock)
+                -> IO ((SlotId, Map HdAccountId PrefilteredBlock), [TxMeta])
 prefilterBlock' pw b = do
     aux <$> getWalletCredentials pw
   where
     aux :: [(WalletId, EncryptedSecretKey)]
-        -> (SlotId, Map HdAccountId PrefilteredBlock)
-    aux ws = (
-        b ^. rbSlotId
-      , Map.unions $ map (uncurry (prefilterBlock b)) ws
-      )
+        -> ((SlotId, Map HdAccountId PrefilteredBlock), [TxMeta])
+    aux ws =
+      let (conMap, conMeta) = mconcat $ map (uncurry (prefilterBlock b)) ws
+      in ((b ^. rbSlotId, conMap), conMeta)
 
 -- | Notify all the wallets in the PassiveWallet of a new block
 applyBlock :: PassiveWallet
@@ -58,10 +57,11 @@ applyBlock :: PassiveWallet
            -> IO ()
 applyBlock pw@PassiveWallet{..} b = do
     k <- Node.getSecurityParameter _walletNode
-    (slotId, blocksByAccount) <- prefilterBlock' pw b
+    ((slotId, blocksByAccount), metas) <- prefilterBlock' pw b
     -- apply block to all Accounts in all Wallets
     confirmed <- update' _wallets $ ApplyBlock k (InDb slotId) blocksByAccount
     modifyMVar_ _walletSubmission $ return . Submission.remPending confirmed
+    mapM_ (putTxMeta _walletMeta) metas
 
 -- | Apply multiple blocks, one at a time, to all wallets in the PassiveWallet
 --
@@ -81,11 +81,13 @@ switchToFork :: PassiveWallet
              -> IO (Either RollbackDuringRestoration ())
 switchToFork pw@PassiveWallet{..} n bs = do
     k <- Node.getSecurityParameter _walletNode
-    blockssByAccount <- mapM (prefilterBlock' pw) bs
+    blocksAndMeta <- mapM (prefilterBlock' pw) bs
+    let (blockssByAccount, metas) = unzip blocksAndMeta
     res <- update' _wallets $ SwitchToFork k n blockssByAccount
     case res of
       Left  err     -> return $ Left err
-      Right changes -> do modifyMVar_ _walletSubmission $
+      Right changes -> do mapM_ (putTxMeta _walletMeta) $ concat metas
+                          modifyMVar_ _walletSubmission $
                             return . Submission.addPendings (fst <$> changes)
                           modifyMVar_ _walletSubmission $
                             return . Submission.remPending (snd <$> changes)
@@ -94,6 +96,7 @@ switchToFork pw@PassiveWallet{..} n bs = do
 -- | Observable rollback
 --
 -- Only used for tests. See 'switchToFork'.
+-- TODO(kde): Do we want tests to deal with metadata?
 observableRollbackUseInTestsOnly :: PassiveWallet
                                  -> IO (Either RollbackDuringRestoration ())
 observableRollbackUseInTestsOnly PassiveWallet{..} = do

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
@@ -24,6 +24,8 @@ module Cardano.Wallet.Kernel.DB.Sqlite (
     , fromInputs
     , mkOutputs
     , fromOutputs
+    , putTxMetaT
+    , getAllTxMetas
     ) where
 
 import           Universum
@@ -60,7 +62,7 @@ import           Data.Time.Units (Second, fromMicroseconds, toMicroseconds)
 import           Database.Beam.Migrate (CheckedDatabaseSettings, DataType (..),
                      Migration, MigrationSteps, boolean, createTable,
                      evaluateDatabase, executeMigration, field, migrationStep,
-                     notNull, runMigrationSteps, unCheckDatabase, unique)
+                     notNull, runMigrationSteps, unCheckDatabase)
 import           Formatting (sformat)
 import           GHC.Generics (Generic)
 
@@ -68,8 +70,8 @@ import           Cardano.Wallet.Kernel.DB.TxMeta.Types (AccountFops (..),
                      FilterOperation (..), Limit (..), Offset (..),
                      SortCriteria (..), SortDirection (..), Sorting (..))
 import qualified Cardano.Wallet.Kernel.DB.TxMeta.Types as Kernel
--- execution time should move out of WalletLayer so that we don`t depend on it.
 import           Cardano.Wallet.WalletLayer.ExecutionTimeLimit
+
 import qualified Pos.Core as Core
 import qualified Pos.Core.Txp as Txp
 import           Pos.Crypto.Hashing (decodeAbstractHash, hashHexF)
@@ -87,13 +89,14 @@ instance Database Sqlite MetaDB
 {--
 
 * Table 1: ~tx_metas~
-** Primary kehy: ~tx_meta_id~
+** Primary key: ~(tx_meta_id, tx_meta_wallet, tx_meta_account)~
 
 | tx_meta_id | tx_meta_amount | tx_meta_created_at | tx_meta_is_local | tx_meta_is_outgoing | tx_meta_account | tx_meta_wallet
 |------------+----------------+--------------------+------------------+---------------------+-----------------+-----------------
 | Txp.TxId   | Core.Coin      | Core.Timestamp     | Bool             | Bool                | Word32          | Core.Address
 
 --}
+
 data TxMetaT f = TxMeta {
       _txMetaTableId         :: Beam.Columnar f Txp.TxId
     , _txMetaTableAmount     :: Beam.Columnar f Core.Coin
@@ -107,6 +110,7 @@ data TxMetaT f = TxMeta {
 type TxMeta = TxMetaT Identity
 
 deriving instance Eq TxMeta
+
 deriving instance Show TxMeta
 
 -- | Creates a storage-specific 'TxMeta' out of a 'Kernel.TxMeta'.
@@ -124,30 +128,37 @@ mkTxMeta txMeta = TxMeta {
 instance Beamable TxMetaT
 
 instance Table TxMetaT where
-    data PrimaryKey TxMetaT f = TxIdPrimKey (Beam.Columnar f Txp.TxId) deriving Generic
-    primaryKey = TxIdPrimKey . _txMetaTableId
+    data PrimaryKey TxMetaT f = TxPrimKey
+                                    (Beam.Columnar f Txp.TxId)
+                                    (Beam.Columnar f Core.Address)
+                                    (Beam.Columnar f Word32) deriving Generic
+    primaryKey TxMeta{..} = TxPrimKey
+                                _txMetaTableId
+                                _txMetaTableWalletId
+                                _txMetaTableAccountIx
+
 
 instance Beamable (PrimaryKey TxMetaT)
 
 {--
 
 * Table 2: ~tx_meta_inputs~
-** Primary key: ~input_id~, ~input_foreign_txid~, ~input_foreign_index~
+** Primary key: (~input_id~, ~input_foreign_txid~, ~input_foreign_index~)
 
-input_id   | input_address | input_coin | input_foreign_txid | input_foreign_index
------------|---------------+------------+--------------------+--------------------
-Txp.TxId   | Core.Address  | Core.Coin  | Txp.TxId           | Word32
+input_id   | input_foreign_txid | input_foreign_index | input_address | input_coin
+-----------+--------------------+---------------------+---------------+------------
+Txp.TxId   | Txp.TxId           | Word32              | Core.Address  | Core.Coin
 
 
 --}
 
 -- | The inputs' table.
 data TxInputT f = TxInputT {
-      _inputTableTxId         :: Beam.PrimaryKey TxMetaT f
-    , _inputTableAddress      :: Beam.Columnar f Core.Address
-    , _inputTableCoin         :: Beam.Columnar f Core.Coin
+    _inputTableTxId           :: Beam.Columnar f Txp.TxId
     , _inputTableForeignTxid  :: Beam.Columnar f Txp.TxId
     , _inputTableForeignIndex :: Beam.Columnar f Word32
+    , _inputTableAddress      :: Beam.Columnar f Core.Address
+    , _inputTableCoin         :: Beam.Columnar f Core.Coin
     } deriving Generic
 
 type TxInput = TxInputT Identity
@@ -156,13 +167,13 @@ instance Beamable TxInputT
 
 instance Table TxInputT where
     data PrimaryKey TxInputT f = TxInputPrimKey
-                         (Beam.PrimaryKey TxMetaT f)
+                         (Beam.Columnar f Txp.TxId)
                          (Beam.Columnar f Txp.TxId)
                          (Beam.Columnar f Word32) deriving Generic
     primaryKey TxInputT{..} = TxInputPrimKey
-                         (_inputTableTxId)
-                         (_inputTableForeignTxid)
-                         (_inputTableForeignIndex)
+                         _inputTableTxId
+                         _inputTableForeignTxid
+                         _inputTableForeignIndex
 
 instance Beamable (PrimaryKey TxInputT)
 
@@ -170,42 +181,37 @@ instance Beamable (PrimaryKey TxInputT)
 mkInputs :: Kernel.TxMeta -> NonEmpty TxInput
 mkInputs Kernel.TxMeta{..}  = toTxInput <$> _txMetaInputs
     where
-        toTxInput :: (Core.Address, Core.Coin, Txp.TxId, Word32) -> TxInput
-        toTxInput (addr, coin, fTxId, fIndex) =
+        toTxInput :: (Txp.TxId, Word32, Core.Address, Core.Coin) -> TxInput
+        toTxInput (fTxId, fIndex, addr, coin) =
             TxInputT {
-              _inputTableTxId = TxIdPrimKey _txMetaId
-            , _inputTableAddress = addr
-            , _inputTableCoin = coin
+              _inputTableTxId = _txMetaId
             , _inputTableForeignTxid = fTxId
             , _inputTableForeignIndex = fIndex
+            , _inputTableAddress = addr
+            , _inputTableCoin = coin
             }
 
-fromInputs :: NonEmpty TxInput -> NonEmpty (Core.Address, Core.Coin, Txp.TxId, Word32)
+fromInputs :: NonEmpty TxInput -> NonEmpty (Txp.TxId, Word32, Core.Address, Core.Coin)
 fromInputs ls = go <$> ls
     where
-        go TxInputT{..} = (_inputTableAddress, _inputTableCoin,
-                          _inputTableForeignTxid, _inputTableForeignIndex)
-
-getTxIdfromInput :: (TxInputT f) -> Beam.Columnar f Txp.TxId
-getTxIdfromInput inp =
-    let TxIdPrimKey txid = _inputTableTxId inp
-    in txid
+        go TxInputT{..} = (_inputTableForeignTxid, _inputTableForeignIndex,
+                           _inputTableAddress, _inputTableCoin)
 
 {--
 
 ** Table 3: ~tx_meta_outputs~
 ** Primary Key: ~output_id~, ~output_index~
 
-output_id   | output_address | output_coin | output_index
-------------|----------------+-------------+--------------------
-Txp.TxId    | Core.Address   | Core.Coin   | Word32
+output_id   | output_index | output_address | output_coin
+------------|--------------+----------------+--------------
+Txp.TxId    | Word32       | Core.Address   | Core.Coin
 
 --}
 
 -- | The outputs' table. Order of fields is important for right Ord instance.
 data TxOutputT f = TxOutputT {
-          _outputTableTxId    :: Beam.PrimaryKey TxMetaT f
-        , _outputTableIndex   :: Beam.Columnar f Word32
+          _outputTableTxId    :: Beam.Columnar f Txp.TxId
+        , _outputTableIndex   :: Beam.Columnar f Word32 -- The order of output.
         , _outputTableAddress :: Beam.Columnar f Core.Address
         , _outputTableCoin    :: Beam.Columnar f Core.Coin
     } deriving Generic
@@ -215,7 +221,7 @@ type TxOutput = TxOutputT Identity
 forOrder :: TxOutputT f0
          -> (Beam.Columnar f0 Txp.TxId, Beam.Columnar f0 Word32,
              Beam.Columnar f0 Core.Address, Beam.Columnar f0 Core.Coin)
-forOrder t@TxOutputT{..} = (getTxIdfromOutput t, _outputTableIndex, _outputTableAddress, _outputTableCoin)
+forOrder TxOutputT{..} = (_outputTableTxId, _outputTableIndex, _outputTableAddress, _outputTableCoin)
 
 instance Eq TxOutput where
     a == b = (forOrder a) == (forOrder b)
@@ -227,21 +233,23 @@ instance Beamable TxOutputT
 
 instance Table TxOutputT where
     data PrimaryKey TxOutputT f = TxOutputPrimKey
-                (Beam.PrimaryKey TxMetaT f)
+                (Beam.Columnar f Txp.TxId)
                 (Beam.Columnar f Word32) deriving Generic
     primaryKey TxOutputT{..} = TxOutputPrimKey _outputTableTxId _outputTableIndex
 
 instance Beamable (PrimaryKey TxOutputT)
 
 -- | Convenient constructor of a list of 'TxInput' from a 'Kernel.TxMeta'.
--- The list returned should ensure the uniqueness of Indexes.
+--   The list returned should ensure the uniqueness of Indexes.
+--   The usage of unsafe constructor NonEmpty.fromList is justified
+--   because [0..] is indeed Nonempty.
 mkOutputs :: Kernel.TxMeta -> NonEmpty TxOutput
 mkOutputs Kernel.TxMeta{..} = toTxOutput <$> NonEmpty.zip _txMetaOutputs (NonEmpty.fromList [0..])
     where
         toTxOutput :: ((Core.Address, Core.Coin), Word32) -> TxOutput
         toTxOutput ((addr, coin), index) =
             TxOutputT {
-              _outputTableTxId = TxIdPrimKey _txMetaId
+              _outputTableTxId = _txMetaId
             , _outputTableIndex = index
             , _outputTableAddress = addr
             , _outputTableCoin = coin
@@ -253,11 +261,6 @@ fromOutputs :: NonEmpty TxOutput -> NonEmpty (Core.Address, Core.Coin)
 fromOutputs ls = go <$> NonEmpty.sort ls
   where
     go TxOutputT {..} = (_outputTableAddress, _outputTableCoin)
-
-getTxIdfromOutput :: (TxOutputT f) -> Beam.Columnar f Txp.TxId
-getTxIdfromOutput out =
-    let TxIdPrimKey txid = _outputTableTxId out
-    in txid
 
 -- Orphans & other boilerplate
 
@@ -356,7 +359,7 @@ accountixDT = DataType intType
 initialMigration :: () -> Migration SqliteCommandSyntax (CheckedDatabaseSettings Sqlite MetaDB)
 initialMigration () = do
     MetaDB <$> createTable "tx_metas"
-                 (TxMeta (field "meta_id" txIdDT notNull unique)
+                 (TxMeta (field "meta_id" txIdDT notNull)
                          (field "meta_amount" coinDT notNull)
                          (field "meta_created_at" timestampDT notNull)
                          (field "meta_is_local" boolean notNull)
@@ -364,18 +367,17 @@ initialMigration () = do
                          (field "meta_wallet_id" walletidDT notNull)
                          (field "meta_account_ix" accountixDT notNull))
            <*> createTable "tx_metas_inputs"
-                 (TxInputT (TxIdPrimKey (field "meta_id" txIdDT notNull))
-                                                   (field "input_address" addressDT notNull)
-                                                   (field "input_coin" coinDT notNull)
-                                                   (field "input_foreign_id" txIdDT notNull)
-                                                   (field "input_foreign_index" outputIndexDT notNull)
+                 (TxInputT (field "meta_id" txIdDT notNull)
+                           (field "input_foreign_id" txIdDT notNull)
+                           (field "input_foreign_index" outputIndexDT notNull)
+                           (field "input_address" addressDT notNull)
+                           (field "input_coin" coinDT notNull)
                           )
            <*> createTable "tx_metas_outputs"
-                 (TxOutputT (TxIdPrimKey (field "meta_id" txIdDT notNull))
-                                                    (field "output_index" outputIndexDT notNull)
-                                                    (field "output_address" addressDT notNull)
-                                                    (field "output_coin" coinDT notNull)
-
+                 (TxOutputT (field "meta_id" txIdDT notNull)
+                            (field "output_index" outputIndexDT notNull)
+                            (field "output_address" addressDT notNull)
+                            (field "output_coin" coinDT notNull)
                            )
 
 --- | The full list of migrations available for this 'MetaDB'.
@@ -387,6 +389,7 @@ migrateMetaDB = migrationStep "Initial migration" initialMigration
 -- TODO(adinapoli): Make it safe.
 unsafeMigrateMetaDB :: Sqlite.Connection -> IO ()
 unsafeMigrateMetaDB conn = do
+    -- Sqlite.setTrace conn (Just putStrLn)
     void $ runMigrationSteps 0 Nothing migrateMetaDB (\_ _ -> executeMigration (Sqlite.execute_ conn . newSqlQuery))
     -- We don`t add Indexes on tx_metas (meta_id) because it`s unecessary for the PrimaryKey.
     Sqlite.execute_ conn "CREATE INDEX meta_created_at ON tx_metas (meta_created_at)"
@@ -411,63 +414,65 @@ newConnection path = Sqlite.open path
 closeMetaDB :: Sqlite.Connection -> IO ()
 closeMetaDB = Sqlite.close
 
+putTxMeta :: Sqlite.Connection -> Kernel.TxMeta -> IO ()
+putTxMeta conn txMeta = const () <$> putTxMetaT conn txMeta
+
 -- | Inserts a new 'Kernel.TxMeta' in the database, given its opaque
 -- 'MetaDBHandle'.
-putTxMeta :: Sqlite.Connection -> Kernel.TxMeta -> IO ()
-putTxMeta conn txMeta =
+putTxMetaT :: Sqlite.Connection -> Kernel.TxMeta -> IO Kernel.PutReturn
+putTxMetaT conn txMeta =
     let tMeta   = mkTxMeta txMeta
         inputs  = mkInputs txMeta
         outputs = mkOutputs txMeta
+        txId    = _txMetaTableId tMeta
+        accountIx = _txMetaTableAccountIx tMeta
+        walletId = _txMetaTableWalletId tMeta
     in do
-        res <- Sqlite.withTransaction conn $ Sqlite.runDBAction $ runBeamSqlite conn $ do
+        res1 <- Sqlite.runDBAction $ runBeamSqlite conn $ do
+            -- The order here is important. If Outputs succeed everything else should also succeed.
+            SQL.runInsert $ SQL.insert (_mDbOutputs metaDB) $ SQL.insertValues (NonEmpty.toList outputs)
             SQL.runInsert $ SQL.insert (_mDbMeta metaDB)    $ SQL.insertValues [tMeta]
             SQL.runInsert $ SQL.insert (_mDbInputs metaDB)  $ SQL.insertValues (NonEmpty.toList inputs)
-            SQL.runInsert $ SQL.insert (_mDbOutputs metaDB) $ SQL.insertValues (NonEmpty.toList outputs)
-        case res of
-             Left e   -> handleResponse e
-             Right () -> return ()
-    where
-        -- Handle the 'SQLiteResponse', rethrowing the exception or turning
-        -- \"controlled failures\" (like the presence of a duplicated
-        -- transaction) in a no-op.
-        handleResponse :: Sqlite.SQLiteResponse -> IO ()
-        handleResponse e =
-            let txid  = txMeta ^. Kernel.txMetaId
-            in case e of
-                -- NOTE(adinapoli): It's probably possible to make this match the
-                -- Beam schema by using something like 'IsDatabaseEntity' from
-                -- 'Database.Beam.Schema.Tables', but we have a test to catch
-                -- regression in this area.
-                (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas_inputs.meta_id, tx_metas_inputs.input_foreign_id, tx_metas_inputs.input_foreign_index") -> do
-                   let err = Kernel.DuplicatedInputIn txid
-                   throwIO $ Kernel.InvariantViolated err
-
-                (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas_outputs.meta_id, tx_metas_outputs.output_index") -> do
-                   let err = Kernel.DuplicatedOutputIn txid
-                   throwIO $ Kernel.InvariantViolated err
-
-                (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas.meta_id") -> do
-                    -- Check if the 'TxMeta' already present is a @different@
-                    -- one, in which case this is a proper bug there is no
-                    -- recover from. If the 'TxMeta' is the same, this is effectively
-                    -- a no-op.
-                    -- NOTE: We use a shallow equality check here because if the
-                    -- input 'TxMeta' has the same inputs & outputs but in a different
-                    -- order, the 'consistencyCheck' would yield 'False', when in
-                    -- reality should be virtually considered the same 'TxMeta'.
-                    consistencyCheck <- fmap (Kernel.isomorphicTo txMeta) <$> getTxMeta conn txid
-                    case consistencyCheck of
-                         Nothing    ->
-                             throwIO $ Kernel.InvariantViolated (Kernel.UndisputableLookupFailed "consistencyCheck" txid)
-                         Just False ->
-                             throwIO $ Kernel.InvariantViolated (Kernel.DuplicatedTransactionWithDifferentHash txid)
-                         Just True  ->
-                             -- both "hashes" matched, this is genuinely the
-                             -- same 'Tx' being inserted twice, probably as
-                             -- part of a rollback.
-                             return ()
-
-                _ -> throwIO $ Kernel.StorageFailure (toException e)
+        case res1 of
+            Right _ -> return Kernel.Tx --all succeeded. We have a new Tx in db.
+            Left (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas_outputs.meta_id, tx_metas_outputs.output_index") -> do
+                -- This is the only acceptable exception here. If anything else is thrown, that`s an error.
+                t <- getTxMetasById conn txId
+                case (Kernel.txIdIsomorphic txMeta <$> t) of
+                    Nothing   ->
+                        -- Output is there but not TxMeta. This should never happen.
+                        -- This could be improved with foregn keys, which indicate
+                        -- the existence of a least one Output for each Meta.
+                        throwIO $ Kernel.InvariantViolated (Kernel.UndisputableLookupFailed "txId")
+                    Just False ->
+                        -- This violation means the Tx has same TxId but different
+                        -- Inputs (as set) or Outputs (ordered).
+                        throwIO $ Kernel.InvariantViolated (Kernel.TxIdInvariantViolated txId)
+                    Just True  -> do
+                        -- If there not a  TxId violation, we can try to insert TxMeta.
+                        res2 <- Sqlite.runDBAction $ runBeamSqlite conn $
+                                    SQL.runInsert $ SQL.insert (_mDbMeta metaDB) $ SQL.insertValues [tMeta]
+                        case res2 of
+                            Right _ -> return Kernel.Meta -- all good. We managed to inset new TxMeta.
+                            Left (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas.meta_id, tx_metas.meta_wallet_id, tx_metas.meta_account_ix") -> do
+                                res3 <- fmap (Kernel.txIdIsomorphic txMeta) <$> getTxMeta conn txId walletId accountIx
+                                case res3 of
+                                    Nothing ->
+                                        -- We couldn`t insert, but there is nothing here.
+                                        -- This should never happen.
+                                        throwIO $ Kernel.InvariantViolated (Kernel.UndisputableLookupFailed "TxMeta")
+                                    Just True ->
+                                        -- all good. TxMeta is also there. This is most probably the reult
+                                        -- of a rollback, where we try to insert the same Tx two times.
+                                        -- Nothing new is inserted n db.
+                                        return Kernel.No
+                                    Just False ->
+                                        -- This violation means the Tx has same TxId but different
+                                        -- Inputs (as set) or Outputs (ordered).
+                                        throwIO $ Kernel.InvariantViolated (Kernel.TxIdInvariantViolated txId)
+                            Left e ->
+                                throwIO $ Kernel.StorageFailure (toException e)
+            Left e -> throwIO $ Kernel.StorageFailure (toException e)
 
 -- | Converts a database-fetched 'TxMeta' into a domain-specific 'Kernel.TxMeta'.
 toTxMeta :: TxMeta -> NonEmpty TxInput -> NonEmpty TxOutput -> Kernel.TxMeta
@@ -484,8 +489,8 @@ toTxMeta TxMeta{..} inputs outputs = Kernel.TxMeta {
     }
 
 -- | Fetches a 'Kernel.TxMeta' from the database, given its 'Txp.TxId'.
-getTxMeta :: Sqlite.Connection -> Txp.TxId -> IO (Maybe Kernel.TxMeta)
-getTxMeta conn txid = do
+getTxMeta :: Sqlite.Connection -> Txp.TxId -> Core.Address -> Word32 -> IO (Maybe Kernel.TxMeta)
+getTxMeta conn txid walletId accountIx = do
     res <- Sqlite.runDBAction $ runBeamSqlite conn $ do
         metas <- SQL.runSelectReturningList txMetaById
         case metas of
@@ -498,15 +503,23 @@ getTxMeta conn txid = do
          Left e  -> throwIO $ Kernel.StorageFailure (toException e)
          Right r -> return r
     where
-        txMetaById = SQL.lookup_ (_mDbMeta metaDB) (TxIdPrimKey txid)
+        txMetaById = SQL.lookup_ (_mDbMeta metaDB) (TxPrimKey txid walletId accountIx)
         getInputs  = SQL.select $ do
             txInput <- SQL.all_ (_mDbInputs metaDB)
-            SQL.guard_ ((_inputTableTxId txInput) ==. (SQL.val_ $ TxIdPrimKey txid))
+            SQL.guard_ ((_inputTableTxId txInput) ==. (SQL.val_ txid))
             pure txInput
         getOutputs = SQL.select $ do
             txOutput <- SQL.all_ (_mDbOutputs metaDB)
-            SQL.guard_ ((_outputTableTxId txOutput) ==. (SQL.val_ $ TxIdPrimKey txid))
+            SQL.guard_ ((_outputTableTxId txOutput) ==. (SQL.val_ txid))
             pure txOutput
+
+getTxMetasById :: Sqlite.Connection -> Txp.TxId -> IO (Maybe Kernel.TxMeta)
+getTxMetasById conn txId = safeHead . fst <$> getTxMetas conn (Offset 0)
+    (Limit 10) Everything Nothing (FilterByIndex txId) NoFilterOp Nothing
+
+getAllTxMetas :: Sqlite.Connection -> IO [Kernel.TxMeta]
+getAllTxMetas conn =  fst <$> getTxMetas conn (Offset 0)
+    (Limit $ fromIntegral (maxBound :: Int)) Everything Nothing NoFilterOp NoFilterOp Nothing
 
 getTxMetas :: Sqlite.Connection
            -> Offset
@@ -538,12 +551,12 @@ getTxMetas conn (Offset offset) (Limit limit) accountFops mbAddress fopTxId fopT
         let txids = map (SQL.val_ . _txMetaTableId) meta
         input <- SQL.runSelectReturningList $ SQL.select $ do
                 input <- SQL.all_ $ _mDbInputs metaDB
-                let txid = getTxIdfromInput input
+                let txid = _inputTableTxId input
                 SQL.guard_ $ in_ txid txids
                 pure input
         output <- SQL.runSelectReturningList $ SQL.select $ do
                 output <- SQL.all_ $ _mDbOutputs metaDB
-                let txid = getTxIdfromOutput output
+                let txid = _outputTableTxId output
                 SQL.guard_ $ in_ txid txids
                 pure output
         return $ do
@@ -560,8 +573,8 @@ getTxMetas conn (Offset offset) (Limit limit) accountFops mbAddress fopTxId fopT
                 case mbAddress of
                     Nothing   -> SQL.runSelectReturningOne $ SQL.select metaQueryC
                     Just addr -> SQL.runSelectReturningOne $ SQL.select $ metaQueryWithAddrC addr
-            let mapWithInputs  = transform $ map (\inp -> (getTxIdfromInput inp, inp)) inputs
-            let mapWithOutputs = transform $ map (\out -> (getTxIdfromOutput out, out)) outputs
+            let mapWithInputs  = transform $ map (\inp -> (_inputTableTxId inp, inp)) inputs
+            let mapWithOutputs = transform $ map (\out -> (_outputTableTxId out, out)) outputs
             let txMeta = toValidKernelTxMeta mapWithInputs mapWithOutputs $ NonEmpty.toList meta
                 count = case eiCount of
                     Left _  -> Nothing
@@ -616,7 +629,7 @@ getTxMetas conn (Offset offset) (Limit limit) accountFops mbAddress fopTxId fopT
                 -- union removes txId duplicates.
                 txid <- SQL.union_ input output
                 meta <- SQL.join_ (_mDbMeta metaDB)
-                        (\ mt -> ((TxIdPrimKey $ _txMetaTableId mt) ==. txid))
+                        (\ mt -> ((_txMetaTableId mt) ==. txid))
                 pure meta
 
         metaQueryWithAddr addr = do

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Sqlite.hs
@@ -54,6 +54,7 @@ import qualified Database.SQLite.SimpleErrors as Sqlite
 import qualified Database.SQLite.SimpleErrors.Types as Sqlite
 
 import           Control.Exception (throwIO, toException)
+import           Control.Monad (void)
 import qualified Data.Foldable as Foldable
 import           Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
@@ -415,7 +416,7 @@ closeMetaDB :: Sqlite.Connection -> IO ()
 closeMetaDB = Sqlite.close
 
 putTxMeta :: Sqlite.Connection -> Kernel.TxMeta -> IO ()
-putTxMeta conn txMeta = const () <$> putTxMetaT conn txMeta
+putTxMeta conn txMeta = void $ putTxMetaT conn txMeta
 
 -- | Inserts a new 'Kernel.TxMeta' in the database, given its opaque
 -- 'MetaDBHandle'.

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
@@ -21,5 +21,7 @@ openMetaDB fp = do
         , migrateMetaDB = ConcreteStorage.unsafeMigrateMetaDB conn
         , getTxMeta     = ConcreteStorage.getTxMeta conn
         , putTxMeta     = ConcreteStorage.putTxMeta conn
+        , putTxMetaT    = ConcreteStorage.putTxMetaT conn
+        , getAllTxMetas = ConcreteStorage.getAllTxMetas conn
         , getTxMetas    = ConcreteStorage.getTxMetas conn
         }

--- a/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Types.hs
@@ -34,7 +34,6 @@ import qualified Formatting as F
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Resolved
--- import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import qualified Cardano.Wallet.Kernel.Util.Core as Core
 
 {-------------------------------------------------------------------------------

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -135,8 +135,8 @@ metaToTx db slotCount current TxMeta{..} = do
             hdRootId    = HD.HdRootId $ InDb _txMetaWalletId
             hdAccountId = HD.HdAccountId hdRootId (HD.HdAccountIx _txMetaAccountIx)
 
-            inputsToPayDistr :: (Address, Coin, a , b) -> V1.PaymentDistribution
-            inputsToPayDistr (addr, c, _, _) = V1.PaymentDistribution (V1 addr) (V1 c)
+            inputsToPayDistr :: (a , b, Address, Coin) -> V1.PaymentDistribution
+            inputsToPayDistr (_, _, addr, c) = V1.PaymentDistribution (V1 addr) (V1 c)
 
             outputsToPayDistr :: (Address, Coin) -> V1.PaymentDistribution
             outputsToPayDistr (addr, c) = V1.PaymentDistribution (V1 addr) (V1 c)

--- a/wallet-new/test/unit/Test/Spec/TxMetaScenarios.hs
+++ b/wallet-new/test/unit/Test/Spec/TxMetaScenarios.hs
@@ -1,0 +1,133 @@
+module Test.Spec.TxMetaScenarios (
+      txMetaScenarioA
+    , txMetaScenarioB
+    , txMetaScenarioC
+    , txMetaScenarioD
+    ) where
+
+import           Universum
+
+import qualified Data.Set as Set
+
+import qualified Cardano.Wallet.Kernel as Kernel
+import           Cardano.Wallet.Kernel.DB.TxMeta.Types
+import           Cardano.Wallet.Kernel.Internal
+
+import           Pos.Core.Chrono
+
+import           Test.Hspec
+import           Test.Infrastructure.Genesis
+import           UTxO.Context
+import           UTxO.DSL
+import           Wallet.Inductive
+
+-- | A Payment from P0 to P1 with change returned to P0
+paymentWithChangeFromP0ToP1 :: forall h. Hash h Addr
+                            => GenesisValues h Addr -> Transaction h Addr
+paymentWithChangeFromP0ToP1 GenesisValues{..} = Transaction {
+         trFresh = 0
+       , trIns   = Set.fromList [ fst initUtxoP0 ]
+       , trOuts  = [ Output p1 1000
+                   , Output p0 (initBalP0 - 1 * (1000 + fee)) -- change
+                   ]
+       , trFee   = fee
+       , trHash  = 1
+       , trExtra = []
+       }
+  where
+    fee = overestimate txFee 1 2
+
+-- | Scenario A
+-- Empty case
+txMetaScenarioA :: GenesisValues h Addr
+                   -> (Inductive h Addr, (PassiveWallet -> IO ()))
+txMetaScenarioA GenesisValues{..} = (ind, lengthCheck 0)
+  where
+    ind = Inductive {
+          inductiveBoot   = boot
+        , inductiveOurs   = Set.singleton p0 -- define the owner of the wallet: Poor actor 0
+        , inductiveEvents = OldestFirst [
+            ]
+        }
+
+-- | Scenario B
+-- A single pending payment.
+txMetaScenarioB :: forall h. Hash h Addr
+                   => GenesisValues h Addr
+                   -> (Inductive h Addr, PassiveWallet -> IO ())
+txMetaScenarioB genVals@GenesisValues{..} = (ind, lengthCheck 1)
+  where
+    t0 = paymentWithChangeFromP0ToP1 genVals
+    ind = Inductive {
+          inductiveBoot   = boot
+        , inductiveOurs   = Set.singleton p0 -- define the owner of the wallet: Poor actor 0
+        , inductiveEvents = OldestFirst [
+                NewPending t0
+            ]
+        }
+
+-- | Scenario C
+-- A single pending payment and then confirmation.
+txMetaScenarioC :: forall h. Hash h Addr
+                   => GenesisValues h Addr
+                   -> (Inductive h Addr, PassiveWallet -> IO ())
+txMetaScenarioC genVals@GenesisValues{..} = (ind, lengthCheck 1)
+  where
+    t0 = paymentWithChangeFromP0ToP1 genVals
+    ind = Inductive {
+          inductiveBoot   = boot
+        , inductiveOurs   = Set.singleton p0 -- define the owner of the wallet: Poor actor 0
+        , inductiveEvents = OldestFirst [
+              NewPending t0
+            , ApplyBlock $ OldestFirst [t0] -- confirms t0 and updates block metadata
+            ]
+        }
+
+-- | Scenario D
+-- Two confirmed payments from P0 to P1, using `change` addresses P0 and P0b respectively
+txMetaScenarioD :: forall h. Hash h Addr
+                   => GenesisValues h Addr
+                   -> (Inductive h Addr, PassiveWallet -> IO ())
+txMetaScenarioD genVals@GenesisValues{..} = (ind, lengthCheck 2)
+  where
+    (t0,t1) = repeatPaymentWithChangeFromP0ToP1 genVals p0b
+    ind = Inductive {
+          inductiveBoot   = boot
+        , inductiveOurs   = Set.fromList [p0,p0b] -- define the owner of the wallet: Poor actor 0
+        , inductiveEvents = OldestFirst [
+              NewPending t0
+            , ApplyBlock $ OldestFirst [t0] -- confirms t0 and updates block metadata
+            , ApplyBlock $ OldestFirst [t1] -- confirms t1 and updates block metadata
+            ]
+        }
+
+-- | Two payments from P0 to P1 with change returned to P0.
+--   (t0 uses change address p0 and t1 uses p0b)
+--   The second payment spends the change of the first payment.
+repeatPaymentWithChangeFromP0ToP1 :: forall h. Hash h Addr
+                                  => GenesisValues h Addr
+                                  -> Addr
+                                  -> (Transaction h Addr, Transaction h Addr)
+repeatPaymentWithChangeFromP0ToP1 genVals@GenesisValues{..} changeAddr =
+    (t0,t1)
+  where
+    fee = overestimate txFee 1 2
+
+    t0 = paymentWithChangeFromP0ToP1 genVals
+    t1 = Transaction {
+            trFresh = 0
+          , trIns   = Set.fromList [ Input (hash t0) 1 ]
+          , trOuts  = [ Output p1 1000
+                      , Output changeAddr (initBalP0 - 1 * (1000 + fee)) -- change
+                      ]
+          , trFee   = fee
+          , trHash  = 2
+          , trExtra = []
+          }
+
+-- TODO(kde) more complicated tests, that involved creating a Tx from the Meta failed
+lengthCheck :: Int -> PassiveWallet -> IO ()
+lengthCheck n pw = do
+    let db = pw ^. Kernel.walletMeta
+    meta <- getAllTxMetas db
+    length meta `shouldBe` n

--- a/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
@@ -34,6 +34,8 @@ import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import qualified Cardano.Wallet.Kernel.Pending as Kernel
 import           Cardano.Wallet.Kernel.PrefilterTx (prefilterUtxo)
 import qualified Cardano.Wallet.Kernel.Read as Kernel
+import           Cardano.Wallet.Kernel.Transactions (toMeta)
+import           Cardano.Wallet.Kernel.Util.Core (getSomeTimestamp)
 
 import           Util.Buildable
 import           Util.Validated
@@ -266,9 +268,9 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
                       -> RawResolvedTx
                       -> TranslateT EquivalenceViolation m ()
     walletNewPendingT ctxt accountId tx = do
-        -- meta <- liftIO $ Kernel.toMeta accountId tx
+        meta <- toMeta getSomeTimestamp accountId tx
         -- TODO: should meta history be tested here?
-        _ <- liftIO $ Kernel.newPending activeWallet accountId (rawResolvedTx tx) Nothing
+        _ <- liftIO $ Kernel.newPending activeWallet accountId (rawResolvedTx tx) (rightToMaybe meta)
         checkWalletState ctxt accountId
 
     walletRollbackT :: InductiveCtxt h


### PR DESCRIPTION
## Description

This PR:
- adds the possibility for multiple Accounts to insert the same Tx. This is achieved by using a Compound Primary Key (TxId, AccountId).
- Inserts Incoming Txs in meta db
- fixes stray comments and strange leftovers from previous PRs.
- adds tests for sqlite and general tests using the Interpeter.
TODO: creating the V1.Transaction in some tests failed, so for now they just create the TxMeta.

## Linked issue

CBR-375

## Type of change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

## Screenshots (if available)
