### PR TITLE
[CBR-382] Refactor the `.Read` modules

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
@@ -1,174 +1,155 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+
 -- | READ queries on the HD wallet
 --
 -- NOTE: These are pure functions, which are intended to work on a snapshot
 -- of the database. They are intended to support the V1 wallet API.
 module Cardano.Wallet.Kernel.DB.HdWallet.Read (
-    -- | * Infrastructure
-    HdQuery
-  , HdQueryErr
-    -- | * Derived balance
-  , hdRootBalance
-  , hdAccountBalance
-    -- | Accumulate all accounts/addresses
-  , readAllHdRoots
-  , readAllHdAccounts
-  , readAllHdAddresses
-    -- | All wallets/accounts/addresses
-  , readAccountsByRootId
-  , readAddressesByRootId
-  , readAddressesByAccountId
-    -- | Single wallets/accounts/addresses
-  , readHdRoot
-  , readHdAccount
-  , readHdAccountCurrentCheckpoint
-  , readHdAddress
-  , readHdAddressByCardanoAddress
+    -- | Summarize
+    accountsByRootId
+  , addressesByRootId
+  , addressesByAccountId
+    -- | Simple lookups
+  , lookupHdRootId
+  , lookupHdAccountId
+  , lookupHdAddressId
+  , lookupCardanoAddress
+    -- | Properties of an entire root
+  , rootAssuranceLevel
+  , rootTotalBalance
+    -- | Queries on an account's current checkpoint
+  , currentUtxo
+  , currentAvailableUtxo
+  , currentTotalBalance
+  , currentAvailableBalance
+  , currentAddressMeta
+  , currentTxSlotId
+  , currentTxIsPending
   ) where
 
 import           Universum hiding (toList)
 
-import           Control.Lens (at)
-import           Data.Foldable (toList)
+import           Pos.Chain.Txp (TxId, Utxo)
+import           Pos.Core (Address, Coin, SlotId, mkCoin, unsafeAddCoin)
 
-import           Pos.Core (Address, Coin, sumCoins)
-
+import           Cardano.Wallet.Kernel.DB.BlockMeta (AddressMeta)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import           Cardano.Wallet.Kernel.DB.InDb
-import           Cardano.Wallet.Kernel.DB.Spec
-import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed, IxSet,
-                     ixedIndexed)
+import           Cardano.Wallet.Kernel.DB.Spec (IsCheckpoint (..),
+                     cpAddressMeta)
+import           Cardano.Wallet.Kernel.DB.Spec.Read
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
+import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed, IxSet)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 
-{-# ANN module ("HLint: ignore Unnecessary hiding" :: Text) #-}
-
 {-------------------------------------------------------------------------------
-  Infrastructure
--------------------------------------------------------------------------------}
-
--- | Query on a HD wallet
-type HdQuery a = HdWallets -> a
-
--- | Like 'HdQuery', but with the possibility of errors
-type HdQueryErr e a = HdQuery (Either e a)
-
--- | Like '(>>=)' for queries
-using :: HdQueryErr e a -> (a -> HdQueryErr e b) -> HdQueryErr e b
-using f g wallets =
-    case f wallets of
-      Left  e -> Left e
-      Right a -> g a wallets
-
--- | Variation on 'using' where the second query cannot throw errors
-using' :: HdQueryErr e a -> (a -> HdQuery b) -> HdQueryErr e b
-using' f g = using f ((Right .) . g)
-
--- | Variation on 'using'' where the result of the first query is ignored
---
--- Useful when the first query is merely a sanity check.
-check :: HdQueryErr e a -> HdQuery b -> HdQueryErr e b
-check f g = using' f (const g)
-
-{-------------------------------------------------------------------------------
-  Computed balances information
--------------------------------------------------------------------------------}
-
-hdRootBalance :: HdRootId -> HdQuery Integer
-hdRootBalance rootId = sumCoins
-                     . map hdAccountBalance
-                     . Data.Foldable.toList
-                     . IxSet.getEQ rootId
-                     . view hdWalletsAccounts
-
--- | Current balance of an account
-hdAccountBalance :: HdAccount -> Coin
-hdAccountBalance = view $ hdAccountState
-                        . hdAccountStateCurrent
-                        . pcheckpointUtxoBalance
-                        . fromDb
-
-{-------------------------------------------------------------------------------
-  Accumulate across wallets/accounts
--------------------------------------------------------------------------------}
-
--- | Meta-information of /all wallets
-readAllHdRoots :: HdQuery (IxSet HdRoot)
-readAllHdRoots = view hdWalletsRoots
-
--- | Meta-information of /all/ accounts
-readAllHdAccounts :: HdQuery (IxSet HdAccount)
-readAllHdAccounts = view hdWalletsAccounts
-
--- | Meta-information and total balance of /all/ addresses
-readAllHdAddresses :: HdQuery (IxSet (Indexed HdAddress))
-readAllHdAddresses = view hdWalletsAddresses
-
-{-------------------------------------------------------------------------------
-  Information about all wallets/accounts/addresses
+  Summarize
 -------------------------------------------------------------------------------}
 
 -- | All accounts in the given wallet
-readAccountsByRootId :: HdRootId  -> HdQueryErr UnknownHdRoot (IxSet HdAccount)
-readAccountsByRootId rootId =
-      check (readHdRoot rootId)
-    $ IxSet.getEQ rootId . readAllHdAccounts
+--
+-- NOTE: Does not check that the root exists.
+accountsByRootId :: HdRootId -> Query' HdWallets e (IxSet HdAccount)
+accountsByRootId rootId = do
+    asks $ IxSet.getEQ rootId . view hdWalletsAccounts
 
 -- | All addresses in the given wallet
-readAddressesByRootId :: HdRootId
-                      -> HdQueryErr UnknownHdRoot (IxSet (Indexed HdAddress))
-readAddressesByRootId rootId =
-      check (readHdRoot rootId)
-    $ IxSet.getEQ rootId . readAllHdAddresses
+--
+-- NOTE: Does not check that the root exists.
+addressesByRootId :: HdRootId -> Query' HdWallets e (IxSet (Indexed HdAddress))
+addressesByRootId rootId =
+    asks $ IxSet.getEQ rootId . view hdWalletsAddresses
 
 -- | All addresses in the given account
-readAddressesByAccountId :: HdAccountId
-                         -> HdQueryErr UnknownHdAccount (IxSet (Indexed HdAddress))
-readAddressesByAccountId accId =
-      check (readHdAccount accId)
-    $ IxSet.getEQ accId . readAllHdAddresses
+--
+-- NOTE: Does not check that the account exists.
+addressesByAccountId :: HdAccountId -> Query' HdWallets e (IxSet (Indexed HdAddress))
+addressesByAccountId accId =
+    asks $ IxSet.getEQ accId . view hdWalletsAddresses
 
 {-------------------------------------------------------------------------------
-  Information about a single wallet/address/account
+  Simple lookups
 -------------------------------------------------------------------------------}
 
--- | Look up the specified wallet
-readHdRoot :: HdRootId -> HdQueryErr UnknownHdRoot HdRoot
-readHdRoot rootId = aux . view (at rootId) . readAllHdRoots
+lookupHdRootId :: HdRootId -> Query' HdWallets UnknownHdRoot HdRoot
+lookupHdRootId rootId = zoomHdRootId identity rootId $ ask
+
+lookupHdAccountId :: HdAccountId -> Query' HdWallets UnknownHdAccount HdAccount
+lookupHdAccountId accId = zoomHdAccountId identity accId $ ask
+
+lookupHdAddressId :: HdAddressId -> Query' HdWallets UnknownHdAddress HdAddress
+lookupHdAddressId addrId = zoomHdAddressId identity addrId $ ask
+
+lookupCardanoAddress :: Address -> Query' HdWallets UnknownHdAddress HdAddress
+lookupCardanoAddress addr = zoomHdCardanoAddress identity addr $ ask
+
+{-------------------------------------------------------------------------------
+  Properties of an entire HdRoot
+-------------------------------------------------------------------------------}
+
+rootAssuranceLevel :: HdRootId -> Query' HdWallets UnknownHdRoot AssuranceLevel
+rootAssuranceLevel rootId =
+    zoomHdRootId identity rootId $
+      view hdRootAssurance
+
+-- | Total balance for all accounts in the given root
+--
+-- NOTE: Does not check that the root exists.
+rootTotalBalance :: HdRootId -> Query' HdWallets e Coin
+rootTotalBalance rootId = do
+    accounts <- IxSet.getEQ rootId <$> view hdWalletsAccounts
+    sumTotals <$> mapM currentTotalBalance' (IxSet.toList accounts)
   where
-    aux :: Maybe a -> Either UnknownHdRoot a
-    aux = maybe (Left (UnknownHdRoot rootId)) Right
+    sumTotals :: [Coin] -> Coin
+    sumTotals = foldl' unsafeAddCoin (mkCoin 0)
 
--- | Look up the specified account
-readHdAccount :: HdAccountId -> HdQueryErr UnknownHdAccount HdAccount
-readHdAccount accId = do
-    res <- view (at accId) . readAllHdAccounts
-    case res of
-         Just account -> return (Right account)
-         Nothing -> do
-             let rootId = accId ^. hdAccountIdParent
-             -- Offer a better diagnostic on what went wrong.
-             either (\_ -> Left (UnknownHdAccountRoot rootId))
-                    (\_ -> Left (UnknownHdAccount accId))
-                   <$> readHdRoot rootId
+{-------------------------------------------------------------------------------
+  Functions on the most recent checkpoint
+-------------------------------------------------------------------------------}
 
--- | Look up the specified account and return the current checkpoint
-readHdAccountCurrentCheckpoint :: HdAccountId
-                               -> HdQueryErr UnknownHdAccount PartialCheckpoint
-readHdAccountCurrentCheckpoint accId db =
-    view (hdAccountState . hdAccountStateCurrent) <$> readHdAccount accId db
+-- | Internal: lift a function on the current checkpoint
+liftCP :: (forall c. IsCheckpoint c => c -> a)
+       -> HdAccountId -> Query' HdWallets UnknownHdAccount a
+liftCP f accId =
+    zoomHdAccountId identity accId $
+      zoomHdAccountCurrent $
+        asks f
 
--- | Look up the specified address
-readHdAddress :: HdAddressId -> HdQueryErr UnknownHdAddress HdAddress
-readHdAddress addrId = aux . view (at addrId) . readAllHdAddresses
+currentUtxo :: HdAccountId -> Query' HdWallets UnknownHdAccount Utxo
+currentUtxo = liftCP (view cpUtxo)
+
+currentAvailableUtxo :: HdAccountId -> Query' HdWallets UnknownHdAccount Utxo
+currentAvailableUtxo = liftCP cpAvailableUtxo
+
+currentTxSlotId :: TxId -> HdAccountId -> Query' HdWallets UnknownHdAccount (Maybe SlotId)
+currentTxSlotId txId = liftCP $ cpTxSlotId txId
+
+currentTxIsPending :: TxId -> HdAccountId -> Query' HdWallets UnknownHdAccount Bool
+currentTxIsPending txId = liftCP $ cpTxIsPending txId
+
+currentAvailableBalance :: HdAccountId -> Query' HdWallets UnknownHdAccount Coin
+currentAvailableBalance = liftCP cpAvailableBalance
+
+currentAddressMeta :: HdAddress -> Query' HdWallets UnknownHdAccount AddressMeta
+currentAddressMeta = withAddr $ \addr ->
+    liftCP $ view (cpAddressMeta (addr ^. hdAddressAddress . fromDb))
   where
-    aux :: Maybe (Indexed a) -> Either UnknownHdAddress a
-    aux = maybe (Left (UnknownHdAddress addrId)) (Right . view ixedIndexed)
+    withAddr :: (HdAddress -> HdAccountId -> Query' st e a)
+             -> (HdAddress -> Query' st e a)
+    withAddr f addr = f addr (addr ^. hdAddressId . hdAddressIdParent)
 
--- | Look up the specified address by its associated Cardano's 'Address'.
-readHdAddressByCardanoAddress :: Address -> HdQueryErr UnknownHdAddress HdAddress
-readHdAddressByCardanoAddress cardanoAddr = do
-    aux . IxSet.getEQ cardanoAddr . readAllHdAddresses
+currentTotalBalance :: HdAccountId -> Query' HdWallets UnknownHdAccount Coin
+currentTotalBalance accId =
+    zoomHdAccountId identity accId ask >>= currentTotalBalance'
+
+-- Internal helper generalization
+--
+-- Total balance breaks the pattern because we need the set of addresses that
+-- belong to the account, but for that we need 'HdWallets'.
+currentTotalBalance' :: HdAccount -> Query' HdWallets e Coin
+currentTotalBalance' acc = do
+    ourAddrs <- IxSet.getEQ (acc ^. hdAccountId) <$> view hdWalletsAddresses
+    return $ cpTotalBalance ourAddrs cp
   where
-    aux :: IxSet (Indexed HdAddress) -> Either UnknownHdAddress HdAddress
-    aux ixset = case IxSet.getOne ixset of
-                     Just x  -> Right (view ixedIndexed x)
-                     Nothing -> Left (UnknownHdCardanoAddress cardanoAddr)
+    cp = acc ^. hdAccountState . hdAccountStateCurrent

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet.Read (
   , currentTxIsPending
   ) where
 
-import           Universum hiding (toList)
+import           Universum
 
 import           Pos.Chain.Txp (TxId, Utxo)
 import           Pos.Core (Address, Coin, SlotId, mkCoin, unsafeAddCoin)

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
@@ -32,10 +32,10 @@ import           Cardano.Wallet.Kernel.DB.AcidState (DB, dbHdWallets)
 import           Cardano.Wallet.Kernel.DB.BlockMeta (AddressMeta)
 import           Cardano.Wallet.Kernel.DB.HdWallet
 import qualified Cardano.Wallet.Kernel.DB.HdWallet.Read as HD
-import           Cardano.Wallet.Kernel.DB.Util.IxSet (IxSet, Indexed)
+import           Cardano.Wallet.Kernel.DB.Util.AcidState
+import           Cardano.Wallet.Kernel.DB.Util.IxSet (Indexed, IxSet)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import           Cardano.Wallet.Kernel.Types (WalletId (..))
-import           Cardano.Wallet.Kernel.DB.Util.AcidState
 
 {-------------------------------------------------------------------------------
   Getters across the entire kernel

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Addresses.hs
@@ -156,7 +156,7 @@ takeIndexed db n acc (currentIndex, (a:as))
     toV1 :: HD.HdAccount -> Indexed HD.HdAddress -> V1.WalletAddress
     toV1 hdAccount ixed = toAddress hdAccount (ixed ^. ixedIndexed)
 
-readAddresses :: HasCallStack => Kernel.DB -> HD.HdAccount -> IxSet (Indexed HD.HdAddress)
+readAddresses :: Kernel.DB -> HD.HdAccount -> IxSet (Indexed HD.HdAddress)
 readAddresses db hdAccount = Kernel.addressesByAccountId db (hdAccount ^. HD.hdAccountId)
 
 -- | Validate an address

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Transactions.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Wallet.Kernel.DB.TxMeta as TxMeta
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import qualified Cardano.Wallet.Kernel.Read as Kernel
+import           Cardano.Wallet.Kernel.Util (exceptT)
 import           Cardano.Wallet.WalletLayer (GetTxError (..))
 
 getTransactions :: MonadIO m
@@ -54,18 +55,19 @@ getTransactions wallet mbWalletId mbAccountIndex mbAddress params fop sop = lift
         (castFiltering $ mapIx unV1 <$> F.findMatchingFilterOp fop)
         (castFiltering $ mapIx unV1 <$> F.findMatchingFilterOp fop)
         mbSorting
-    let txs = map (metaToTx db sc currentSlot) meta
+    txs <- withExceptT GetTxUnknownHdAccount $
+             mapM (metaToTx db sc currentSlot) meta
     return $ respond params txs mbTotalEntries
 
 toTransaction :: MonadIO m
               => Kernel.PassiveWallet
               -> TxMeta
-              -> m V1.Transaction
+              -> m (Either HD.UnknownHdAccount V1.Transaction)
 toTransaction wallet meta = liftIO $ do
     db <- liftIO $ Kernel.getWalletSnapshot wallet
     sc <- liftIO $ Node.getSlotCount (wallet ^. Kernel.walletNode)
     currentSlot <- Node.getTipSlotId (wallet ^. Kernel.walletNode)
-    return $ metaToTx db sc currentSlot meta
+    return $ runExcept $ metaToTx db sc currentSlot meta
 
 -- | Type Casting for Account filtering from V1 to MetaData Types.
 castAccountFiltering :: Monad m => Maybe V1.WalletId -> Maybe V1.AccountIndex -> ExceptT GetTxError m TxMeta.AccountFops
@@ -109,9 +111,16 @@ castFilterOrd pr = case pr of
     F.LesserThan       -> TxMeta.LesserThan
     F.LesserThanEqual  -> TxMeta.LesserThanEqual
 
-metaToTx :: Kernel.DB -> SlotCount -> SlotId -> TxMeta -> V1.Transaction
-metaToTx db slotCount current TxMeta{..} =
-    V1.Transaction {
+metaToTx :: Monad m => Kernel.DB -> SlotCount -> SlotId -> TxMeta -> ExceptT HD.UnknownHdAccount m V1.Transaction
+metaToTx db slotCount current TxMeta{..} = do
+    mSlot          <- withExceptT identity $ exceptT $
+                        Kernel.currentTxSlotId db _txMetaId hdAccountId
+    isPending      <- withExceptT identity $ exceptT $
+                        Kernel.currentTxIsPending db _txMetaId hdAccountId
+    assuranceLevel <- withExceptT HD.embedUnknownHdRoot $ exceptT $
+                        Kernel.rootAssuranceLevel db hdRootId
+    let (status, confirmations) = buildDynamicTxMeta assuranceLevel slotCount mSlot current isPending
+    return V1.Transaction {
         txId = V1 _txMetaId,
         txConfirmations = fromIntegral confirmations,
         txAmount = V1 _txMetaAmount,
@@ -122,7 +131,6 @@ metaToTx db slotCount current TxMeta{..} =
         txCreationTime = V1 _txMetaCreationAt,
         txStatus = status
     }
-
         where
             hdRootId    = HD.HdRootId $ InDb _txMetaWalletId
             hdAccountId = HD.HdAccountId hdRootId (HD.HdAccountIx _txMetaAccountIx)
@@ -132,12 +140,6 @@ metaToTx db slotCount current TxMeta{..} =
 
             outputsToPayDistr :: (Address, Coin) -> V1.PaymentDistribution
             outputsToPayDistr (addr, c) = V1.PaymentDistribution (V1 addr) (V1 c)
-
-            mSlot = Kernel.accountTxSlot db hdAccountId _txMetaId
-            isPending = Kernel.accountIsTxPending db hdAccountId _txMetaId
-
-            assuranceLevel = Kernel.walletAssuranceLevel db hdRootId
-            (status, confirmations) = buildDynamicTxMeta assuranceLevel slotCount mSlot current isPending
 
 buildDynamicTxMeta :: HD.AssuranceLevel -> SlotCount -> Maybe SlotId -> SlotId -> Bool -> (V1.TransactionStatus, Word64)
 buildDynamicTxMeta assuranceLevel slotCount mSlot currentSlot isPending = case isPending of

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -18,11 +18,9 @@ import           Pos.Crypto.Signing
 import           Cardano.Wallet.API.V1.Types (V1 (..))
 import qualified Cardano.Wallet.API.V1.Types as V1
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
+import           Cardano.Wallet.Kernel.DB.AcidState (dbHdWallets)
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
-import           Cardano.Wallet.Kernel.DB.HdWallet.Read (readAllHdRoots,
-                     readHdRoot)
 import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
-import           Cardano.Wallet.Kernel.DB.Read (hdWallets)
 import           Cardano.Wallet.Kernel.DB.Util.IxSet (IxSet)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
@@ -140,7 +138,7 @@ getWallet wId db = runExcept $ do
     rootId <- withExceptT GetWalletWalletIdDecodingFailed $ fromRootId wId
     fmap (toWallet db) $
       withExceptT (GetWalletError . V1) $ exceptT $
-        readHdRoot rootId (hdWallets db)
+        Kernel.lookupHdRootId db rootId
 
 -- | Gets all the wallets known to this edge node.
 --
@@ -148,4 +146,4 @@ getWallet wId db = runExcept $ do
 getWallets :: Kernel.DB -> IxSet V1.Wallet
 getWallets db = IxSet.fromList . map (toWallet db) . IxSet.toList $ allRoots
   where
-    allRoots = readAllHdRoots (hdWallets db)
+    allRoots = db ^. dbHdWallets . HD.hdWalletsRoots

--- a/wallet-new/test/unit/Test/Spec/BlockMetaScenarios.hs
+++ b/wallet-new/test/unit/Test/Spec/BlockMetaScenarios.hs
@@ -20,8 +20,7 @@ import           Cardano.Wallet.Kernel.DB.AcidState (DB, dbHdWallets)
 import           Cardano.Wallet.Kernel.DB.BlockMeta (AddressMeta (..),
                      BlockMeta (..))
 import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountState (..),
-                     hdAccountState, hdUpToDateCheckpoints)
-import           Cardano.Wallet.Kernel.DB.HdWallet.Read (readAllHdAccounts)
+                     hdAccountState, hdUpToDateCheckpoints, hdWalletsAccounts)
 import           Cardano.Wallet.Kernel.DB.Spec (checkpointBlockMeta,
                      currentCheckpoint)
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
@@ -54,7 +53,7 @@ actualBlockMeta snapshot' =
             error "actualBlockMeta: Expected HdAccountStateUpToDate"
     where
         getOne' ix = fromMaybe (error "Expected a singleton") (IxSet.getOne ix)
-        theAccount = getOne' (readAllHdAccounts $ snapshot' ^. dbHdWallets)
+        theAccount = getOne' (snapshot' ^. dbHdWallets . hdWalletsAccounts)
 
 -- | A Payment from P0 to P1 with change returned to P0
 paymentWithChangeFromP0ToP1 :: forall h. Hash h Addr

--- a/wallet-new/test/unit/Test/Spec/GetTransactions.hs
+++ b/wallet-new/test/unit/Test/Spec/GetTransactions.hs
@@ -126,10 +126,11 @@ spec =
                                 accIdx = hdAccountId ^. hdAccountIdIx . to getHdAccountIx
                                 hdl = (pw ^. Kernel.walletMeta)
                             db <- Kernel.getWalletSnapshot pw
-                            let isPending = Kernel.accountIsTxPending db hdAccountId txid
+                            let isPending = Kernel.currentTxIsPending db txid hdAccountId
                             _ <- case isPending of
-                                False -> expectationFailure "txid not found in Acid State from Kernel"
-                                True -> pure ()
+                                Left _err -> expectationFailure "hdAccountId not found in Acid State from Kernel"
+                                Right False -> expectationFailure "txid not found in Acid State from Kernel"
+                                Right True -> pure ()
                             _ <- liftIO ((WalletLayer._pwlCreateAddress layer) (V1.NewAddress Nothing accIdx (V1.WalletId wId)))
                             (result, mbCount) <- (getTxMetas hdl) (Offset 0) (Limit 10) Everything Nothing NoFilterOp NoFilterOp Nothing
                             map Isomorphic result `shouldMatchList` [Isomorphic meta]


### PR DESCRIPTION
## Description

There was a lot of duplication, inconsistent naming, and dead code. Most
importantly, a lot of pure errors were silently thrown as pure exceptions by a
blanket wrapper. This wrapper is now completely gone, the naming is entirely
consistent, (most) duplication is gone, and the dead code is removed.

The split into modules is now also consistent:

* The `Spec.Read` module works on a checkpoint
* The `HdWallet.Read` module works on a HdWallet
* The `DB.Read` lifts this to the entire acid-state DB

This takes advantage of the new Query' infrastructure introduced previously.

Renamed functions:

```
  queryAccountTotalBalannce      currentTotalBalance
  queryAccountUtxo               currentUtxo
  queryAccountAvailableUtxo      currentAvailableUtxo
  queryAccountAvailableBalance   currentAvailableBalance

  accountAddresses               addressesByAccountId
  walletAccounts                 accountsByRootId

  accountAvailableBalance        currentAvailableBalance
  accountAvailableUtxo           currentAvailableUtxo
  accountIsTxPending             currentTxIsPending
  accountTotalBalance            currentTotalBalance
  accountTxSlot                  currentTxSlotId
  accountUtxo                    currentUtxo
  readAddressMeta                currentAddressMeta

  walletAssuranceLevel           rootAssuranceLevel
  walletTotalBalance             rootTotalBalance

  readAccountsByRootId           accountsByRootId
  readAddressesByRootId          addressesByRootId
  readAddressesByAccountId       addressesByAccountId
  readHdAddressByCardanoAddress  lookupCardanoAddress

  readHdRoot     lookupHdRootId
  readHdAccount  lookupHdAccountId
  readHdAddress  lookupHdAddressId
```

Replaced by new zoom combinators:

```
  readHdAccountCurrentCheckpoint  zoomHdAccountCurrent
```

New (or newly exported) functions on checkpoints:

```
  cpChanged
  cpTotalBalance
  cpTxSlotId
  cpTxIsPending
```

Deleted (these were simple aliases for existing lenses):

```
  hdWallets            dbHdWallets
  readAllHdRoots       hdWalletsRoots
  readAllHdAccounts    hdWalletsAccounts
  readAllHdAddresses   hdWalletsAddresses
```

Deleted (dead code):

```
  hdRootBalance
  hdAccountBalance
```

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-382

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
