### PR TITLE
[DEVOPS-999] explorer frontend: Replace @gitrev@ with actual rev

### DIFF
--- a/explorer/frontend/default.nix
+++ b/explorer/frontend/default.nix
@@ -46,6 +46,12 @@ let
     nodejs = pkgs.nodejs-6_x;
   };
 
+  regen-script = pkgs.writeScriptBin "regen" ''
+    export PATH=${makeBinPath [oldHaskellPackages.purescript-derive-lenses cardano-sl-explorer]}:$PATH
+    cardano-explorer-hs2purs --bridge-path src/Generated/
+    scripts/generate-explorer-lenses.sh
+  '';
+
   frontend = { stdenv, python, purescript, mkYarnPackage }:
     mkYarnPackage {
       name = "cardano-explorer-frontend";
@@ -56,14 +62,14 @@ let
         oldHaskellPackages.purescript-derive-lenses
         cardano-sl-explorer
         purescript
+        regen-script
       ];
       passthru = { inherit bowerComponents; };
       postConfigure = ''
         rm -rf .psci_modules .pulp-cache bower_components output result
 
         # Purescript code generation
-        cardano-explorer-hs2purs --bridge-path src/Generated/
-        scripts/generate-explorer-lenses.sh
+        regen
 
         # Frontend dependencies
         ln -s ${bowerComponents}/bower_components .

--- a/explorer/frontend/shell.nix
+++ b/explorer/frontend/shell.nix
@@ -1,0 +1,29 @@
+{ ... }@args:
+
+let
+  cardanoPkgs = import ../.. args;
+  frontend = cardanoPkgs.cardano-sl-explorer-frontend;
+
+in
+  # fixme: cardano-sl-explorer source is not filtered enough, so
+  # generating files in frontend will cause a rebuild of explorer
+  # backend. You will just have to wait a little wait to get a shell.
+
+  frontend.overrideAttrs (oldAttrs: {
+
+    shellHook = ''
+      help() {
+        echo "*** To regenerate purescript code, run \`regen'."
+        echo
+        echo "*** To build, run \`yarn build:prod'."
+        echo "*** For dev, run \`yarn server:dev'."
+        echo
+        echo "*** To see this message again, run \`help'."
+      }
+
+      echo; echo; help
+
+      export PATH=$(pwd)/node_modules/.bin:$PATH
+    '';
+
+  })


### PR DESCRIPTION
## Description

Git revision stamping in explorer frontend got broken by the build caching improvements. This fixes it. It is done in a way that avoids a webpack rebuild every time the git revision changes.

This means that when you do a deploy it will download a prebuilt explorer frontend rather than rebuilding just because the git revision is different. It also means that explorer doesn't need to be rebuilt in CI for every single commit.

See also: the release branch fix in #3386.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-999

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing checklist and QA Steps

Same as #3386.
