### PR TITLE
[CBR-211] log rotation checks for size and age of files

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17323,6 +17323,7 @@ license = stdenv.lib.licenses.mit;
   mkDerivation
 , aeson
 , async
+, auto-update
 , base
 , bytestring
 , canonical-json
@@ -17385,6 +17386,7 @@ configureFlags = [
 ];
 libraryHaskellDepends = [
 aeson
+auto-update
 base
 canonical-json
 cborg

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -56,8 +56,10 @@ library
   other-modules:
                        Pos.Util.CompileInfoGit
                        Pos.Util.Log.Scribes
+                       Pos.Util.Log.Rotator
 
   build-depends:       aeson
+                     , auto-update
                      , base
                      , canonical-json
                      , cborg

--- a/util/src/Pos/Util/Log/Rotator.hs
+++ b/util/src/Pos/Util/Log/Rotator.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | monitor log files for max age and max size
+
+module Pos.Util.Log.Rotator
+       ( cleanupRotator
+       , evalRotator
+       , initializeRotator
+       ) where
+
+import           Universum
+
+import           Control.Exception.Safe (Exception (..), catchIO)
+
+import qualified Data.List.NonEmpty as NE
+import           Data.Time (UTCTime, addUTCTime, diffUTCTime, getCurrentTime,
+                     parseTimeM)
+import           Data.Time.Format (defaultTimeLocale, formatTime)
+
+import           Pos.Util.Log.Internal (FileDescription (..))
+import           Pos.Util.Log.LoggerConfig
+
+import           System.Directory (listDirectory, removeFile)
+import           System.FilePath ((</>))
+import           System.IO (BufferMode (LineBuffering), Handle,
+                     IOMode (WriteMode), hFileSize, hSetBuffering, stdout)
+
+
+-- | format of a timestamp
+tsformat :: String
+tsformat = "%Y%m%d%H%M%S"
+
+-- | get file path to a log file with current time
+nameLogFile :: FileDescription -> IO FilePath
+nameLogFile FileDescription{..} = do
+    now <- getCurrentTime
+    let tsnow = formatTime defaultTimeLocale tsformat now
+    return $ prefixpath </> filename ++ "-" ++ tsnow
+
+-- | open a new log file
+evalRotator :: RotationParameters -> FileDescription -> IO (Handle, Integer, UTCTime)
+evalRotator rotation fdesc = do
+    let maxAge   = toInteger $ rotation ^. rpMaxAgeHours
+        maxSize  = toInteger $ rotation ^. rpLogLimitBytes
+
+    -- open new log file
+    fpath <- nameLogFile fdesc
+    hdl <- catchIO (openFile fpath WriteMode) $
+               \e -> do
+                   prtoutException fpath e
+                   return stdout    -- fallback to standard output in case of exception
+    hSetBuffering hdl LineBuffering
+
+    -- compute next rotation time
+    now <- getCurrentTime
+    let rottime = addUTCTime (fromInteger $ maxAge * 3600) now
+
+    return (hdl, maxSize, rottime)
+
+prtoutException :: Exception e => FilePath -> e -> IO ()
+prtoutException fp e = do
+    putStrLn $ "error while opening log @ " ++ fp
+    putStrLn $ "exception: " ++ displayException e
+
+-- | list filenames in prefix dir which match 'filename'
+listLogFiles :: FileDescription -> IO (Maybe (NonEmpty FilePath))
+listLogFiles FileDescription{..} = do
+    -- find files in bp which begin with fp
+    files <- listDirectory $ prefixpath
+    return $ nonEmpty $ sort $ filter fpredicate files
+  where
+    tslen = 14  -- length of a timestamp
+    fplen = length filename
+    fpredicate path = take fplen path == filename
+                      && take 1 (drop fplen path) == "-"
+                      && length (drop (fplen + 1) path) == tslen
+
+-- | latest log file in prefix dir which matches 'filename'
+latestLogFile :: FileDescription -> IO (Maybe FilePath)
+latestLogFile fdesc =
+    listLogFiles fdesc >>= \fs -> return $ latestLogFile' fs
+  where
+    latestLogFile' :: Maybe (NonEmpty FilePath) -> Maybe FilePath
+    latestLogFile' Nothing      = Nothing
+    latestLogFile' (Just flist) = Just $ last flist
+
+-- | initialize log file at startup
+--   may append to existing file
+initializeRotator :: RotationParameters -> FileDescription -> IO (Handle, Integer, UTCTime)
+initializeRotator rotation fdesc = do
+    let maxAge   = toInteger $ rotation ^. rpMaxAgeHours
+        maxSize  = toInteger $ rotation ^. rpLogLimitBytes
+
+    latest <- latestLogFile fdesc
+    case latest of
+        Nothing -> -- no file to append, return new
+            evalRotator rotation fdesc
+        Just fname -> do
+            -- check date
+            now <- getCurrentTime
+            tsfp <- parseTimeM True defaultTimeLocale tsformat $ drop (fplen + 1) fname
+            if (round $ diffUTCTime now tsfp) > (3600 * maxAge)
+               then do  -- file is too old, return new
+                  evalRotator rotation fdesc
+               else do
+                  hdl <- catchIO (openFile (prefixpath fdesc </> fname) AppendMode) $
+                             \e -> do
+                                 prtoutException fname e
+                                 return stdout    -- fallback to standard output in case of exception
+                  hSetBuffering hdl LineBuffering
+                  cursize <- hFileSize hdl
+                  let rottime = addUTCTime (fromInteger $ maxAge * 3600) now
+                  return (hdl, (maxSize - cursize), rottime)
+  where
+    fplen = length $ filename fdesc
+
+-- | remove old files; count them and only keep n (from config)
+cleanupRotator :: RotationParameters -> FileDescription -> IO ()
+cleanupRotator rotation fdesc = do
+    let keepN0 = fromIntegral (rotation ^. rpKeepFilesNum) :: Int
+        keepN = max 1 $ min keepN0 99
+    listLogFiles fdesc >>= removeOldFiles keepN
+  where
+    removeOldFiles :: Int -> Maybe (NonEmpty FilePath) -> IO ()
+    removeOldFiles _ Nothing = return ()
+    removeOldFiles n (Just flist) = do
+        putStrLn $ "dropping " ++ (show n) ++ " from " ++ (show flist)
+        removeFiles $ reverse $ NE.drop n $ NE.reverse flist
+    removeFiles [] = return ()
+    removeFiles (fp : fps) = do
+        let bp = prefixpath fdesc
+            filepath = bp </> fp
+        putStrLn $ "removing file " ++ filepath
+        removeFile filepath   -- destructive
+        removeFiles fps
+
+{-
+
+  testing:
+
+  lc0 <- parseLoggerConfig "../log-configs/testing.yaml"
+  lc <- setLogPrefix (Just "/tmp/testlog/") lc0
+  lh <- setupLogging lc
+
+  usingLoggerName lh "testing" $ do { forM_ [1..299] (\n -> logDebug $ T.pack $ "hello world " ++ (show n)) }
+-}


### PR DESCRIPTION
## Description

log rotation for 'katip'
* log files are named with "iso" date appended to filename: `logs/node.log-20180829201517`
* configuration (`--log-config`) defines rotation parameters:
** write to new file if max size is reached (currently 5 MB)
** write to new file if current log file was created more than ''t'' (default: 24) hours ago
** remove oldest files and only keep ''n'' files (currently 20) 
   (since IO is quite expensive, the removal of files from the filesystem is only done at most every 10 seconds)

## Linked issue

CBR-211
CBR-97 (user story)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

the file `util/Pos/Util/Log/Rotator.hs` contains some commands at the end which can be entered in `GHCi` for testing.

```
$ stack ghci util/Pos/Util/Log.hs
```
