### PR TITLE
[CBR-207] Edit export list of Pos.Util.Wlog.

### DIFF
--- a/util/src/Pos/Util/Wlog.hs
+++ b/util/src/Pos/Util/Wlog.hs
@@ -1,7 +1,69 @@
 module Pos.Util.Wlog
-        ( module System.Wlog
-        , module System.Wlog.LogHandler
-        , module System.Wlog.Formatter
+        ( -- * CanLog
+          CanLog (..)
+        , WithLogger
+        , dispatchEvents
+          -- * Pure logging manipulation
+        , LogEvent (..)
+        , NamedPureLogger (..)
+        , launchNamedPureLog
+        , runNamedPureLog
+          -- * Logging functions
+        , logDebug
+        , logError
+        , logInfo
+        , logNotice
+        , logWarning
+        , logMessage
+          -- * LoggerName
+        , LoggerName (..)
+        , LoggerNameBox (..)
+        , HasLoggerName (..)
+        , usingLoggerName
+          -- * LoggerConfig
+        , LoggerConfig (..)
+        , lcLogsDirectory
+        , lcTermSeverityOut
+        , lcTree
+        , parseLoggerConfig
+          -- * Hierarchical tree of loggers (with lenses)
+        , HandlerWrap (..)
+        , fromScratch
+        , hwFilePath
+        , ltFiles
+        , ltSeverity
+        , ltSubloggers
+        , zoomLogger
+          -- * Builders for 'LoggerConfig'
+        , consoleActionB
+        , maybeLogsDirB
+        , showTidB
+        , productionB
+        , termSeveritiesOutB
+          -- * Severity
+        , Severity (..)
+        , debugPlus
+        , errorPlus
+        , infoPlus
+        , noticePlus
+        , warningPlus
+          -- * Saving Changes
+        , retrieveLogContent
+        , updateGlobalLogger
+          -- * LogHandler
+        , defaultHandleAction
+          -- * Logging messages with a condition
+        , logMCond
+          -- * Utility functions
+        , removeAllHandlers
+          -- * Modifying Loggers
+        , setLevel
+          -- * Launcher
+        , setupLogging
+          -- * Formatter
+        , centiUtcTimeF
+          -- * LogHandler
+        , LogHandlerTag (HandlerFilelike)
         ) where
 
 import           System.Wlog (CanLog (..), HandlerWrap (..), HasLoggerName (..),

--- a/util/src/Pos/Util/Wlog.hs
+++ b/util/src/Pos/Util/Wlog.hs
@@ -1,69 +1,69 @@
+-- | an interface to 'log-warper'
+
 module Pos.Util.Wlog
         ( -- * CanLog
           CanLog (..)
         , WithLogger
-        , dispatchEvents
-          -- * Pure logging manipulation
-        , LogEvent (..)
+          -- * Pure logging
+        , dispatchEvents        -- call sites: 1 chain/src/Pos/Chain/Ssc/Toss/Pure.hs
+        , LogEvent (..)         -- call sites: 3 chain/src/Pos/Chain/Ssc/Toss/Pure.hs,db/src/Pos/DB/Update/Poll/Pure.hs,wallet-new/test/unit/UTxO/Verify.hs
         , NamedPureLogger (..)
-        , launchNamedPureLog
-        , runNamedPureLog
+        , launchNamedPureLog    -- call sites: 8   chain,db,explorer
+        , runNamedPureLog       -- call sites: 2   chain,db
+          -- * Setup
+        , setupLogging          -- call sites: 7 generator,lib,networking(bench),tools:keygen|launcher
           -- * Logging functions
         , logDebug
         , logError
         , logInfo
         , logNotice
         , logWarning
-        , logMessage
+        , logMessage            -- call sites: 3  infra,wallet-new
           -- * LoggerName
         , LoggerName (..)
-        , LoggerNameBox (..)
+        , LoggerNameBox (..)    -- call sites: 9  core,db,infra,lib,tools,util
         , HasLoggerName (..)
-        , usingLoggerName
+        , usingLoggerName       -- call sites: 22 db,explorer,infra,lib,networking,node-ipc,tools,wallet,wallet-new
           -- * LoggerConfig
-        , LoggerConfig (..)
-        , lcLogsDirectory
-        , lcTermSeverityOut
-        , lcTree
-        , parseLoggerConfig
+        , LoggerConfig (..)     -- call sites: 13  (mostly together with 'setupLogging')
+        , lcLogsDirectory       -- call sites: 1 tools/src/launcher/Main.hs
+        , lcTermSeverityOut     -- call sites: 1 tools/src/launcher/Main.hs
+        , lcTree                -- call sites: 4 infra,lib,networking,tools
+        , parseLoggerConfig     -- call sites: 2 lib,networking
           -- * Hierarchical tree of loggers (with lenses)
-        , HandlerWrap (..)
-        , fromScratch
-        , hwFilePath
-        , ltFiles
-        , ltSeverity
-        , ltSubloggers
-        , zoomLogger
+        , HandlerWrap (..)      -- call sites: 1 tools/src/launcher/Main.hs
+        , fromScratch           -- call sites: 1 networking/src/Bench/Network/Commons.hs
+        , hwFilePath            -- call sites: 1 infra/src/Pos/Infra/Reporting/Wlog.hs
+        , ltFiles               -- call sites: 2 infra/.../Reporting/Wlog.hs,tools/src/launcher/Main.hs
+        , ltSeverity            -- call sites: 5 networking/src/Bench/Network/Commons.hs,tools/src/launcher/Main.hs
+        , zoomLogger            -- call sites: 3 networking/src/Bench/Network/Commons.hs
+        , ltSubloggers          -- call sites: 1 infra/src/Pos/Infra/Reporting/Wlog.hs
           -- * Builders for 'LoggerConfig'
-        , consoleActionB
-        , maybeLogsDirB
-        , showTidB
-        , productionB
-        , termSeveritiesOutB
+        , consoleActionB        -- call sites: 3 generator/app/VerificationBench.hs,lib/src/Pos/Launcher/Resource.hs
+        , maybeLogsDirB         -- call sites: 2 lib/src/Pos/Launcher/Resource.hs,networking/src/Bench/Network/Commons.hs
+        , showTidB              -- call sites: 1 lib/src/Pos/Launcher/Resource.hs
+        , productionB           -- call sites: 6 lib,networking,tools
+        , termSeveritiesOutB    -- call sites: 2 generator/app/VerificationBench.hs,tools/src/keygen/Main.hs
           -- * Severity
         , Severity (..)
-        , debugPlus
-        , errorPlus
-        , infoPlus
-        , noticePlus
-        , warningPlus
+        , debugPlus             -- call sites: 4 generator/app/VerificationBench.hs,tools:keygen|launcher
+        , errorPlus             -- call sites: 1 networking/src/Bench/Network/Commons.hs
+        , infoPlus              -- call sites: 2 networking/src/Bench/Network/Commons.hs
+        , noticePlus            -- call sites: 1 networking/src/Network/Broadcast/OutboundQueue/Demo.hs
+        , warningPlus           -- call sites: 1 networking/src/Bench/Network/Commons.hs
           -- * Saving Changes
-        , retrieveLogContent
-        , updateGlobalLogger
+        , retrieveLogContent    -- call sites: 1 infra/src/Pos/Infra/Reporting/Wlog.hs
+        , updateGlobalLogger    -- call sites: 1 networking/src/Network/Broadcast/OutboundQueue/Demo.hs
           -- * LogHandler
-        , defaultHandleAction
+        , defaultHandleAction   -- call sites: 2 generator/app/VerificationBench.hs,lib/src/Pos/Launcher/Resource.hs
           -- * Logging messages with a condition
-        , logMCond
-          -- * Utility functions
-        , removeAllHandlers
-          -- * Modifying Loggers
-        , setLevel
-          -- * Launcher
-        , setupLogging
-          -- * Formatter
-        , centiUtcTimeF
+        , logMCond              -- call sites: 1 core/src/Pos/Core/Util/LogSafe.hs
           -- * LogHandler
-        , LogHandlerTag (HandlerFilelike)
+        , LogHandlerTag (HandlerFilelike)  -- call sites: 1 core/src/Pos/Core/Util/LogSafe.hs
+          -- * Utility functions
+        , removeAllHandlers     -- call sites: 2 lib/src/Pos/Launcher/Resource.hs,networking/test/Test/Network/Broadcast/OutboundQueueSpec.hs
+        , centiUtcTimeF         -- call sites: 1 networking/bench/LogReader/Main.hs
+        , setLevel              -- call sites: 1 networking/src/Network/Broadcast/OutboundQueue/Demo.hs
         ) where
 
 import           System.Wlog (CanLog (..), HandlerWrap (..), HasLoggerName (..),
@@ -83,3 +83,4 @@ import           System.Wlog (CanLog (..), HandlerWrap (..), HasLoggerName (..),
                      zoomLogger)
 import           System.Wlog.Formatter (centiUtcTimeF)
 import           System.Wlog.LogHandler (LogHandlerTag (HandlerFilelike))
+


### PR DESCRIPTION
## Description
Changed export list of Pos.Util.Wlog to contain the names of the functions and the data structures and not just the modules being exported.

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

CBR-207

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
