### PR TITLE
[CBR-348] log-config defines Loggername - Severity mapping

### DIFF
--- a/util/src/Pos/Util/Log/LoggerName.hs
+++ b/util/src/Pos/Util/Log/LoggerName.hs
@@ -7,7 +7,7 @@ module Pos.Util.Log.LoggerName
 
 import           Universum
 
-import           Pos.Util.Log (LoggerName)
+type LoggerName = Text
 
 class HasLoggerName' ctx where
     loggerName :: Lens' ctx LoggerName

--- a/util/src/Pos/Util/Log/Scribes.hs
+++ b/util/src/Pos/Util/Log/Scribes.hs
@@ -18,6 +18,7 @@ import           Control.AutoUpdate (UpdateSettings (..), defaultUpdateSettings,
 import           Control.Concurrent.MVar (modifyMVar_)
 
 import           Data.Aeson.Text (encodeToLazyText)
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import           Data.Text.Lazy.Builder
 import qualified Data.Text.Lazy.IO as TIO
@@ -27,28 +28,31 @@ import           Katip.Core
 import           Katip.Scribes.Handle (brackets)
 
 import qualified Pos.Util.Log.Internal as Internal
-import           Pos.Util.Log.LoggerConfig (RotationParameters (..))
+import           Pos.Util.Log.LoggerConfig (NamedSeverity,
+                     RotationParameters (..))
+import           Pos.Util.Log.LoggerName (LoggerName)
 import           Pos.Util.Log.Rotator (cleanupRotator, evalRotator,
                      initializeRotator)
+import qualified Pos.Util.Log.Severity as Log (Severity (..))
 
 import           System.IO (BufferMode (LineBuffering), Handle,
                      IOMode (WriteMode), hClose, hSetBuffering, stderr, stdout)
 
 -- | create a katip scribe for logging to a file in JSON representation
-mkJsonFileScribe :: RotationParameters -> Internal.FileDescription -> Severity -> Verbosity -> IO Scribe
-mkJsonFileScribe rot fdesc s v = do
-    mkFileScribe rot fdesc formatter False s v
+mkJsonFileScribe :: RotationParameters -> NamedSeverity -> Internal.FileDescription -> Log.Severity -> Verbosity -> IO Scribe
+mkJsonFileScribe rot sevfilter fdesc s v = do
+    mkFileScribe rot sevfilter fdesc formatter False s v
   where
-    formatter :: LogItem a => Handle -> Bool -> Verbosity -> Item a -> IO Int
+    formatter :: (LogItem a) => Handle -> Bool -> Verbosity -> Item a -> IO Int
     formatter hdl _ v' item = do
         let tmsg = encodeToLazyText $ itemJson v' item
         TIO.hPutStrLn hdl tmsg
         return $ length tmsg
 
 -- | create a katip scribe for logging to a file in textual representation
-mkTextFileScribe :: RotationParameters -> Internal.FileDescription -> Bool -> Severity -> Verbosity -> IO Scribe
-mkTextFileScribe rot fdesc colorize s v = do
-    mkFileScribe rot fdesc formatter colorize s v
+mkTextFileScribe :: RotationParameters -> NamedSeverity -> Internal.FileDescription -> Bool -> Log.Severity -> Verbosity -> IO Scribe
+mkTextFileScribe rot sevfilter fdesc colorize s v = do
+    mkFileScribe rot sevfilter fdesc formatter colorize s v
   where
     formatter :: Handle -> Bool -> Verbosity -> Item a -> IO Int
     formatter hdl colorize' v' item = do
@@ -60,12 +64,13 @@ mkTextFileScribe rot fdesc colorize s v = do
 --   and handle file rotation within the katip-invoked logging function
 mkFileScribe
     :: RotationParameters
+    -> NamedSeverity
     -> Internal.FileDescription
     -> (forall a . LogItem a => Handle -> Bool -> Verbosity -> Item a -> IO Int)      -- format and output function, returns written bytes
     -> Bool                              -- whether the output is colourized
-    -> Severity -> Verbosity
+    -> Log.Severity -> Verbosity
     -> IO Scribe
-mkFileScribe rot fdesc formatter colorize s v = do
+mkFileScribe rot sevfilter fdesc formatter colorize s v = do
     trp <- initializeRotator rot fdesc
     scribestate <- newMVar trp    -- triple of (handle), (bytes remaining), (rotate time)
     -- sporadically remove old log files - every 10 seconds
@@ -77,7 +82,7 @@ mkFileScribe rot fdesc formatter colorize s v = do
                 return (hdl, b, t)
     let logger :: forall a. LogItem a => Item a -> IO ()
         logger item =
-          when (permitItem s item) $
+          when (checkItem s sevfilter item) $
               modifyMVar_ scribestate $ \(hdl, bytes, rottime) -> do
                   byteswritten <- formatter hdl colorize v item
                   -- remove old files
@@ -97,38 +102,47 @@ mkFileScribe rot fdesc formatter colorize s v = do
     return $ Scribe logger finalizer
 
 -- | create a katip scribe for logging to a file
-mkFileScribeH :: Handle -> Bool -> Severity -> Verbosity -> IO Scribe
-mkFileScribeH h colorize s v = do
+mkFileScribeH :: Handle -> Bool -> NamedSeverity -> Log.Severity -> Verbosity -> IO Scribe
+mkFileScribeH h colorize sevfilter s v = do
     hSetBuffering h LineBuffering
     locklocal <- newMVar ()
-    let logger :: forall a. Item a -> IO ()
-        logger item = when (permitItem s item) $
+    let logger :: Item a -> IO ()
+        logger item = when (checkItem s sevfilter item) $
             bracket_ (takeMVar locklocal) (putMVar locklocal ()) $
                 TIO.hPutStrLn h $! toLazyText $ formatItem colorize v item
     pure $ Scribe logger (hClose h)
 
 -- | create a katip scribe for logging to the console
-mkStdoutScribe :: Severity -> Verbosity -> IO Scribe
+mkStdoutScribe :: NamedSeverity -> Log.Severity -> Verbosity -> IO Scribe
 mkStdoutScribe = mkFileScribeH stdout True
 
 -- | create a katip scribe for logging to stderr
-mkStderrScribe :: Severity -> Verbosity -> IO Scribe
+mkStderrScribe :: NamedSeverity -> Log.Severity -> Verbosity -> IO Scribe
 mkStderrScribe = mkFileScribeH stderr True
 
 -- | @Scribe@ that outputs to '/dev/null' without locking
-mkDevNullScribe :: Internal.LoggingHandler -> Severity -> Verbosity -> IO Scribe
-mkDevNullScribe lh s v = do
+mkDevNullScribe :: Internal.LoggingHandler -> NamedSeverity -> Log.Severity -> Verbosity -> IO Scribe
+mkDevNullScribe lh sevfilter s v = do
     h <- openFile "/dev/null" WriteMode
     let colorize = False
     hSetBuffering h LineBuffering
-    let logger :: forall a. Item a -> IO ()
-        logger item = when (permitItem s item) $
+    let logger :: Item a -> IO ()
+        logger item = when (checkItem s sevfilter item) $
             Internal.incrementLinesLogged lh
               >> (TIO.hPutStrLn h $! toLazyText $ formatItem colorize v item)
     pure $ Scribe logger (hClose h)
 
+-- | check if item passes severity filter
+checkItem :: Log.Severity -> NamedSeverity -> Item a -> Bool
+checkItem s sevfilter item@Item{..} =
+    permitItem (Internal.sev2klog severity) item
+  where
+    severity :: Log.Severity
+    severity = fromMaybe s $ HM.lookup namedcontext sevfilter
+    namedcontext :: LoggerName
+    namedcontext = mconcat $ intercalateNs _itemNamespace
 
--- | format a @LogItem@ with subsecond precision (ISO 8601)
+-- | format a @Item@
 formatItem :: Bool -> Verbosity -> Item a -> Builder
 formatItem withColor _verb Item{..} =
     fromText header <>


### PR DESCRIPTION
## Description

provide a mapping of LoggerName -> Severity, and apply it in filtering messages in katip's scribes
* log-config defines minimum severity for a named logging context
turning off specific logging messages has been done in the current log configuration to prevent massive log creation.
with these changes for the new "structured logging" we provide the same functionality. 

## Linked issue(s)

CBR-97 (user story)
CBR-348
CBR-402
RCD-32

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

see test at the end of the file `util/src/Pos/Util/Log.hs`
and the new test in `util/test/Test/Pos/Util/LogSpec.hs`
