### PR TITLE
Disable the 'runActionCheck' wallet integration test

### DIFF
--- a/wallet-new/integration/Main.hs
+++ b/wallet-new/integration/Main.hs
@@ -63,15 +63,17 @@ main = do
         printT "Starting deterministic tests."
         hspec $ deterministicTests wRef walletClient manager
 
-        walletState <- initialWalletState walletClient
+        printT $ "The 'runActionCheck' tests were disabled because they were highly un-reliable."
+        when False $ do
+            walletState <- initialWalletState walletClient
 
-        printT $ "Initial wallet state: " <> show walletState
+            printT $ "Initial wallet state: " <> show walletState
 
-        -- some monadic fold or smth similar
-        void $ runActionCheck
-          walletClient
-          walletState
-          actionDistribution
+            -- some monadic fold or smth similar
+            void $ runActionCheck
+                walletClient
+                walletState
+                actionDistribution
   where
     orFail :: MonadFail m => Either String a -> m a
     orFail =


### PR DESCRIPTION
This test was highly un-reliable, failing in CI for no good reason
about 50% of the time. This test will be replaced.
