### PR TITLE
[DEVOPS-1032] nix: Add flag to build with optimization disabled

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -4,9 +4,11 @@ in
   { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
   , scrubJobs ? true
   , cardano ? { outPath = ./.; rev = "abcdef"; }
+  , fasterBuild ? false
   , nixpkgsArgs ? {
       config = { allowUnfree = false; inHydra = true; };
       gitrev = cardano.rev;
+      inherit fasterBuild;
     }
   }:
 


### PR DESCRIPTION
## Description

Adds a `fasterBuild` argument to the nix build. This will result in `-O0` being passed to GHC. This can be enabled for PR builds (see input-output-hk/iohk-ops#418) to get quicker turnaround.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1032
