### PR TITLE
[CBR-391] launcher: add a workingDir setting to the launcher config (backport from release/1.3.1)

### DIFF
--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -101,6 +101,7 @@ data LauncherOptions = LO
     , loWalletArgs          :: ![Text]
     , loWalletLogging       :: !Bool
     , loWalletLogPath       :: !(Maybe FilePath)
+    , loWorkingDir          :: !FilePath
     , loX509ToolPath        :: !FilePath
     , loUpdaterPath         :: !FilePath
     , loUpdaterArgs         :: ![Text]
@@ -288,6 +289,8 @@ main =
     setEnv "LANG"   "en_GB.UTF-8"
 
     LO {..} <- getLauncherOptions
+
+    Sys.setCurrentDirectory loWorkingDir
 
     -- Launcher logs should be in public directory
     let launcherLogsPrefix = (</> "pub") <$> loLogsPrefix


### PR DESCRIPTION
Backport of [CBR-391](https://iohk.myjetbrains.com/youtrack/issue/CBR-391) from `release/1.3.1` to `develop`.
