### PR TITLE
[DEVOPS-398] explorer frontend: reword Testnet banner (backport from release 1.3.1)

### DIFF
--- a/explorer/frontend/src/Explorer/Util/Config.purs
+++ b/explorer/frontend/src/Explorer/Util/Config.purs
@@ -18,9 +18,6 @@ foreign import versionImpl :: String
 version :: String
 version = versionImpl
 
-testNetVersion :: String
-testNetVersion = "0.5"
-
 foreign import commitHashImpl :: String
 
 commitHash :: String

--- a/explorer/frontend/src/Explorer/View/Common.purs
+++ b/explorer/frontend/src/Explorer/View/Common.purs
@@ -39,7 +39,6 @@ import Explorer.Routes (Route(..), toUrl)
 import Explorer.State (initialState)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (CCurrency(..), PageNumber(..), State)
-import Explorer.Util.Config (testNetVersion)
 import Explorer.Util.DOM (enterKeyPressed)
 import Explorer.Util.Factory (mkCAddress, mkCTxId, mkCoin)
 import Explorer.Util.String (formatADA)
@@ -362,7 +361,7 @@ logoView' mRoute isTestnet =
                 ! S.className "logo__img bg-logo"
                 $ S.div
                     ! S.className ("testnet-icon" <> iconHiddenClazz)
-                    $ S.text ("TN " <> testNetVersion)
+                    $ S.text ("Testnet")
 
 logoView :: Boolean -> P.HTML Action
 logoView isTestnet = logoView' Nothing isTestnet


### PR DESCRIPTION
Backport of [DEVOPS-398](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-398) from `release/1.3.1` to `develop`.
