### PR TITLE
[release/1.3.1] [CO-354] Introduce `NetworkMagic` 

### DIFF
--- a/auxx/src/Mode.hs
+++ b/auxx/src/Mode.hs
@@ -43,6 +43,7 @@ import           Pos.Context (HasNodeContext (..))
 import           Pos.Core (Address, HasConfiguration, HasPrimaryKey (..), IsBootstrapEraAddr (..),
                            deriveFirstHDAddress, largestPubKeyAddressBoot,
                            largestPubKeyAddressSingleKey, makePubKeyAddress, siEpoch)
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, PublicKey, emptyPassphrase)
 import           Pos.DB (DBSum (..), MonadGState (..), NodeDBs, gsIsBootstrapEra)
 import           Pos.DB.Class (MonadDB (..), MonadDBRead (..))
@@ -211,11 +212,11 @@ instance (HasConfigurations, HasCompileInfo) =>
          MonadAddresses AuxxMode where
     type AddrData AuxxMode = PublicKey
     getNewAddress = makePubKeyAddressAuxx
-    getFakeChangeAddress = do
+    getFakeChangeAddress nm = do
         epochIndex <- siEpoch <$> getCurrentSlotInaccurate
         gsIsBootstrapEra epochIndex <&> \case
-            False -> largestPubKeyAddressBoot
-            True -> largestPubKeyAddressSingleKey
+            False -> largestPubKeyAddressBoot nm
+            True -> largestPubKeyAddressSingleKey nm
 
 instance MonadKeysRead AuxxMode where
     getSecret = getSecretDefault
@@ -242,20 +243,22 @@ instance (HasConfigurations) =>
 -- whether we are currently in bootstrap era.
 makePubKeyAddressAuxx ::
        MonadAuxxMode m
-    => PublicKey
+    => NetworkMagic
+    -> PublicKey
     -> m Address
-makePubKeyAddressAuxx pk = do
+makePubKeyAddressAuxx nm pk = do
     epochIndex <- siEpoch <$> getCurrentSlotInaccurate
     ibea <- IsBootstrapEraAddr <$> gsIsBootstrapEra epochIndex
-    pure $ makePubKeyAddress ibea pk
+    pure $ makePubKeyAddress nm ibea pk
 
 -- | Similar to @makePubKeyAddressAuxx@ but create HD address.
 deriveHDAddressAuxx ::
        MonadAuxxMode m
-    => EncryptedSecretKey
+    => NetworkMagic
+    -> EncryptedSecretKey
     -> m Address
-deriveHDAddressAuxx hdwSk = do
+deriveHDAddressAuxx nm hdwSk = do
     epochIndex <- siEpoch <$> getCurrentSlotInaccurate
     ibea <- IsBootstrapEraAddr <$> gsIsBootstrapEra epochIndex
     pure $ fst $ fromMaybe (error "makePubKeyHDAddressAuxx: pass mismatch") $
-        deriveFirstHDAddress ibea emptyPassphrase hdwSk
+        deriveFirstHDAddress nm ibea emptyPassphrase hdwSk

--- a/client/src/Pos/Client/Txp/Addresses.hs
+++ b/client/src/Pos/Client/Txp/Addresses.hs
@@ -7,6 +7,7 @@ module Pos.Client.Txp.Addresses
 import           Universum
 
 import           Pos.Core (Address)
+import           Pos.Core.NetworkMagic (NetworkMagic)
 
 -- | A class which have the method to generate a new address
 class Monad m => MonadAddresses m where
@@ -14,9 +15,9 @@ class Monad m => MonadAddresses m where
 
     -- | Generate new address using given 'AddrData' (e.g. password +
     -- account id).
-    getNewAddress :: AddrData m -> m Address
+    getNewAddress :: NetworkMagic -> AddrData m -> m Address
 
     -- | Generate a “fake” change address. Its size must be greater
     -- than or equal to the maximal possible size of address generated
     -- by 'getNewAddress'.
-    getFakeChangeAddress :: m Address
+    getFakeChangeAddress :: NetworkMagic -> m Address

--- a/client/src/Pos/Client/Txp/Balances.hs
+++ b/client/src/Pos/Client/Txp/Balances.hs
@@ -14,6 +14,7 @@ import           Control.Monad.Trans (MonadTrans)
 
 import           Pos.Core (Address (..), Coin, HasConfiguration, IsBootstrapEraAddr (..),
                            makePubKeyAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (PublicKey)
 import           Pos.Txp (Utxo, filterUtxoByAddrs, genesisUtxo, unGenesisUtxo)
 import           Pos.Txp.Toil.Utxo (getTotalCoinsInUtxo)
@@ -47,9 +48,10 @@ getOwnUtxo = getOwnUtxos . one
 -- from an address. And we can't enumerate all possible addresses for
 -- a public key. So we only consider two addresses: one with bootstrap
 -- era distribution and another one with single key distribution.
-getOwnUtxoForPk :: MonadBalances m => PublicKey -> m Utxo
-getOwnUtxoForPk ourPk = getOwnUtxos ourAddresses
+getOwnUtxoForPk :: MonadBalances m
+                => NetworkMagic -> PublicKey -> m Utxo
+getOwnUtxoForPk nm ourPk = getOwnUtxos ourAddresses
   where
     ourAddresses :: [Address]
     ourAddresses =
-        map (flip makePubKeyAddress ourPk . IsBootstrapEraAddr) [False, True]
+        map (flip (makePubKeyAddress nm) ourPk . IsBootstrapEraAddr) [False, True]

--- a/client/src/Pos/Client/Txp/Network.hs
+++ b/client/src/Pos/Client/Txp/Network.hs
@@ -25,6 +25,7 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy, PendingAddresses (..
 import           Pos.Communication.Message ()
 import           Pos.Communication.Types (InvOrDataTK)
 import           Pos.Core (Address, Coin, makeRedeemAddress, mkCoin, unsafeAddCoin)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (TxAux (..), TxId, TxOut (..), TxOutAux (..), txaF)
 import           Pos.Crypto (ProtocolMagic, RedeemSecretKey, SafeSigner, hash, redeemToPublic)
 import           Pos.Infra.Communication.Protocol (OutSpecs)
@@ -67,7 +68,7 @@ prepareRedemptionTx
     -> Address
     -> m (TxAux, Address, Coin)
 prepareRedemptionTx pm rsk output = do
-    let redeemAddress = makeRedeemAddress $ redeemToPublic rsk
+    let redeemAddress = makeRedeemAddress fixedNM $ redeemToPublic rsk
     utxo <- getOwnUtxo redeemAddress
     let addCoin c = unsafeAddCoin c . txOutValue . toaOut
         redeemBalance = foldl' addCoin (mkCoin 0) utxo
@@ -89,3 +90,7 @@ submitTxRaw diffusion txAux@TxAux {..} = do
 
 sendTxOuts :: OutSpecs
 sendTxOuts = createOutSpecs (Proxy :: Proxy (InvOrDataTK TxId TxMsgContents))
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/client/test/Test/Pos/Client/Txp/UtilSpec.hs
+++ b/client/test/Test/Pos/Client/Txp/UtilSpec.hs
@@ -26,6 +26,7 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..), TxError (..), T
 import           Pos.Core (Address, BlockVersionData (..), Coeff (..), TxFeePolicy (..),
                            TxSizeLinear (..), makePubKeyAddressBoot, makeRedeemAddress,
                            unsafeIntegerToCoin)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (RedeemSecretKey, SafeSigner, SecretKey, decodeHash, fakeSigner,
                              redeemToPublic, toPublic)
@@ -410,10 +411,10 @@ generateTxOutAux amount sk =
 
 generateRedeemTxOutAux :: Integer -> RedeemSecretKey -> TxOutAux
 generateRedeemTxOutAux amount rsk =
-    makeTxOutAux amount (makeRedeemAddress $ redeemToPublic rsk)
+    makeTxOutAux amount (makeRedeemAddress fixedNM $ redeemToPublic rsk)
 
 secretKeyToAddress :: SecretKey -> Address
-secretKeyToAddress = makePubKeyAddressBoot . toPublic
+secretKeyToAddress = makePubKeyAddressBoot fixedNM . toPublic
 
 makeSigner :: SecretKey -> (SafeSigner, Address)
 makeSigner sk = (fakeSigner sk, secretKeyToAddress sk)
@@ -424,3 +425,7 @@ withTxFeePolicy a b action = do
     let policy = TxFeePolicyTxSizeLinear $ TxSizeLinear a b
     bvd <- gsAdoptedBVData
     withBVData bvd{ bvdTxFeePolicy = policy } action
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -40,6 +40,8 @@ library
                        Pos.Core.Block.Union
                        Pos.Core.Block.Constructors
 
+                       Pos.Core.NetworkMagic
+
                        Pos.Core.Common
                        Pos.Core.Configuration
                        Pos.Core.Constants
@@ -189,6 +191,7 @@ library
                      , cardano-sl-networking
                      , cardano-sl-util
                      , cborg
+                     , cereal
                      , containers
                      , cryptonite
                      , data-default
@@ -208,6 +211,7 @@ library
                      , random
                      , reflection
                      , safe-exceptions
+                     , safecopy
                      , serokell-util
                      , template-haskell
                      , text

--- a/core/src/Pos/Core/NetworkMagic.hs
+++ b/core/src/Pos/Core/NetworkMagic.hs
@@ -1,0 +1,47 @@
+module Pos.Core.NetworkMagic
+       ( NetworkMagic (..)
+       , makeNetworkMagic
+       ) where
+
+import           Universum
+
+import           Data.SafeCopy (SafeCopy (..), contain, safeGet, safePut)
+import           Data.Serialize (getWord8, putWord8)
+import qualified Data.Text.Buildable as Buildable
+import           Formatting (bprint, build, (%))
+
+import           Pos.Crypto.Configuration (ProtocolMagic (..), RequiresNetworkMagic (..),
+                                           getProtocolMagic)
+import           Pos.Util.Util (cerealError)
+
+
+--------------------------------------------------------------------------------
+-- NetworkMagic
+--------------------------------------------------------------------------------
+
+-- mhueschen: although it makes no sense for an identifier to have a sign, we're
+-- opting to maintain consistency with `ProtocolMagicId`, rather than risk subtle
+-- conversion bugs.
+data NetworkMagic
+    = NMNothing
+    | NMJust !Word32
+    deriving (Show, Eq, Ord, Generic)
+
+instance NFData NetworkMagic
+
+instance Buildable NetworkMagic where
+    build NMNothing  = "NMNothing"
+    build (NMJust n) = bprint ("NMJust ("%build%")") n
+
+instance SafeCopy NetworkMagic where
+    getCopy = contain $ getWord8 >>= \case
+        0 -> pure NMNothing
+        1 -> NMJust <$> safeGet
+        t -> cerealError $ "getCopy@NetworkMagic: couldn't read tag: " <> show t
+    putCopy NMNothing  = contain $ putWord8 0
+    putCopy (NMJust x) = contain $ putWord8 1 >> safePut x
+
+makeNetworkMagic :: ProtocolMagic -> NetworkMagic
+makeNetworkMagic pm = case getRequiresNetworkMagic pm of
+    NMMustBeNothing -> NMNothing
+    NMMustBeJust    -> NMJust (fromIntegral (getProtocolMagic pm))

--- a/core/test/Test/Pos/Core/AddressSpec.hs
+++ b/core/test/Test/Pos/Core/AddressSpec.hs
@@ -18,6 +18,7 @@ import           Pos.Core (Address, IsBootstrapEraAddr (..), deriveLvl2KeyPair,
                            largestHDAddressBoot, largestPubKeyAddressBoot,
                            largestPubKeyAddressSingleKey, makePubKeyAddress, makePubKeyAddressBoot,
                            makePubKeyHdwAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, PublicKey, SecretKey (..),
                              ShouldCheckPassphrase (..), deterministicKeyGen, emptyPassphrase,
                              mkEncSecretUnsafe, noPassEncrypt, toPublic)
@@ -32,14 +33,14 @@ spec = describe "Address" $ do
             pkAndHdwAreShownDifferently
 
     describe "Largest addresses" $ do
-        let genPubKeyAddrBoot = pure . makePubKeyAddressBoot . toPublic
+        let genPubKeyAddrBoot = pure . makePubKeyAddressBoot fixedNM . toPublic
         largestAddressProp "PubKey address with BootstrapEra distribution"
-            genPubKeyAddrBoot largestPubKeyAddressBoot 43
+            genPubKeyAddrBoot (largestPubKeyAddressBoot fixedNM) 43
 
-        let genPubKeyAddrSingleKey = pure . makePubKeyAddress
+        let genPubKeyAddrSingleKey = pure . makePubKeyAddress fixedNM
                 (IsBootstrapEraAddr False) . toPublic
         largestAddressProp "PubKey address with SingleKey distribution"
-            genPubKeyAddrSingleKey largestPubKeyAddressSingleKey 78
+            genPubKeyAddrSingleKey (largestPubKeyAddressSingleKey fixedNM) 78
 
         let genHDAddrBoot :: SecretKey -> Gen Address
             genHDAddrBoot sk = frequency
@@ -50,6 +51,7 @@ spec = describe "Address" $ do
             genHDAddrBoot' :: PassPhrase -> EncryptedSecretKey -> Word32 -> Word32 -> Address
             genHDAddrBoot' passphrase esk accIdx addrIdx =
                 case deriveLvl2KeyPair
+                            fixedNM
                             (IsBootstrapEraAddr True)
                             (ShouldCheckPassphrase False)
                             passphrase
@@ -69,12 +71,12 @@ spec = describe "Address" $ do
                 genHDAddrBoot' passphrase esk <$> arbitrary <*> arbitrary
 
         largestAddressProp "HD address with BootstrapEra distribution"
-            genHDAddrBoot largestHDAddressBoot 76
+            genHDAddrBoot (largestHDAddressBoot fixedNM) 76
 
 pkAndHdwAreShownDifferently :: Bool -> PublicKey -> Bool
 pkAndHdwAreShownDifferently isBootstrap pk =
-    show (makePubKeyAddress (IsBootstrapEraAddr isBootstrap) pk) /=
-    (show @Text (makePubKeyHdwAddress (IsBootstrapEraAddr isBootstrap)
+    show (makePubKeyAddress fixedNM (IsBootstrapEraAddr isBootstrap) pk) /=
+    (show @Text (makePubKeyHdwAddress fixedNM (IsBootstrapEraAddr isBootstrap)
                 (HDAddressPayload "pataq") pk))
 
 largestAddressProp :: Text -> (SecretKey -> Gen Address) -> Address -> Byte -> Spec
@@ -91,3 +93,7 @@ largestAddressProp addressDescription genAddress largestAddress expectedLargestS
                     in counterexample
                            (formatToString (int % " > " %int) generatedSize expectedLargestSize)
                            (generatedSize <= expectedLargestSize)
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/Arbitrary.hs
+++ b/core/test/Test/Pos/Core/Arbitrary.hs
@@ -56,6 +56,7 @@ import           Pos.Core.Configuration (HasGenesisBlockVersionData, HasProtocol
 import           Pos.Core.Constants (sharedSeedLength)
 import           Pos.Core.Delegation (HeavyDlgIndex (..), LightDlgIndices (..))
 import qualified Pos.Core.Genesis as G
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..), VssMaxTTL (..), VssMinTTL (..))
 import           Pos.Crypto (ProtocolMagic, createPsk, toPublic)
 import           Pos.Data.Attributes (Attributes (..), UnparsedFields (..))
@@ -252,6 +253,9 @@ instance Arbitrary AddrStakeDistribution where
                     portion <-
                         CoinPortion <$> choose (1, max 1 (limit - 1))
                     genPortions (n - 1) (portion : res)
+
+instance Arbitrary NetworkMagic where
+    arbitrary = oneof [pure NMNothing, NMJust <$> arbitrary]
 
 instance Arbitrary AddrAttributes where
     arbitrary = genericArbitrary

--- a/core/test/Test/Pos/Core/Arbitrary/Unsafe.hs
+++ b/core/test/Test/Pos/Core/Arbitrary/Unsafe.hs
@@ -10,6 +10,7 @@ import           Pos.Core (AddrAttributes (..), AddrStakeDistribution (..), Addr
                            Address (..), Coin, EpochIndex (..), LocalSlotIndex, SharedSeed (..),
                            SlotId (..), mkCoin)
 import           Pos.Core.Configuration (HasProtocolConstants)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Data.Attributes (mkAttributes)
 
 import           Test.Pos.Core.Arbitrary ()
@@ -32,9 +33,16 @@ instance ArbitraryUnsafe Address where
                 AddrAttributes
                 { aaPkDerivationPath = Nothing
                 , aaStakeDistribution = BootstrapEraDistr
+                , aaNetworkMagic = fixedNM
                 }
         let addrType = ATPubKey
         return Address {..}
 
 instance HasProtocolConstants => ArbitraryUnsafe SlotId where
     arbitraryUnsafe = SlotId <$> arbitraryUnsafe <*> arbitraryUnsafe
+
+instance ArbitraryUnsafe NetworkMagic
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/ExampleHelpers.hs
+++ b/core/test/Test/Pos/Core/ExampleHelpers.hs
@@ -134,6 +134,7 @@ import           Pos.Core.Genesis (FakeAvvmOptions (..), GenesisAvvmBalances (..
                                    GenesisNonAvvmBalances (..), GenesisProtocolConstants (..),
                                    GenesisSpec (..), GenesisVssCertificatesMap (..),
                                    GenesisWStakeholders (..), TestnetBalanceOptions (..))
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.ProtocolConstants (ProtocolConstants, VssMaxTTL (..), VssMinTTL (..))
 import           Pos.Core.Slotting (EpochIndex (..), FlatSlotId, LocalSlotIndex (..), SlotId (..),
                                     Timestamp (..))
@@ -515,7 +516,10 @@ exampleTxInUtxo :: TxIn
 exampleTxInUtxo = TxInUtxo exampleHashTx 47 -- TODO: loop here
 
 exampleTxOut :: TxOut
-exampleTxOut = TxOut (makePubKeyAddress (IsBootstrapEraAddr True) pkey) (Coin 47)
+exampleTxOut = TxOut (makePubKeyAddress NMNothing
+                                        (IsBootstrapEraAddr True)
+                                        pkey)
+                     (Coin 47)
     where
         Right pkey = PublicKey <$> CC.xpub (getBytes 0 64)
 
@@ -688,7 +692,7 @@ exampleLightDlgIndices = LightDlgIndices (EpochIndex 7, EpochIndex 88)
 exampleAddress :: Address
 exampleAddress = makeAddress exampleAddrSpendingData_PubKey attrs
   where
-    attrs = AddrAttributes hap BootstrapEraDistr
+    attrs = AddrAttributes hap BootstrapEraDistr NMNothing
     hap = Just (HDAddressPayload (getBytes 32 32))
 
 exampleAddress1 :: Address
@@ -696,14 +700,14 @@ exampleAddress1 = makeAddress easd attrs
   where
     easd = PubKeyASD pk
     [pk] = examplePublicKeys 24 1
-    attrs = AddrAttributes hap BootstrapEraDistr
+    attrs = AddrAttributes hap BootstrapEraDistr NMNothing
     hap = Nothing
 
 exampleAddress2 :: Address
 exampleAddress2 = makeAddress easd attrs
   where
     easd = RedeemASD exampleRedeemPublicKey
-    attrs = AddrAttributes hap asd
+    attrs = AddrAttributes hap asd NMNothing
     hap = Just (HDAddressPayload (getBytes 15 32))
     asd = SingleKeyDistr exampleStakeholderId
 
@@ -711,14 +715,14 @@ exampleAddress3 :: Address
 exampleAddress3 = makeAddress easd attrs
   where
     easd = ScriptASD exampleScript
-    attrs = AddrAttributes hap exampleMultiKeyDistr
+    attrs = AddrAttributes hap exampleMultiKeyDistr NMNothing
     hap = Just (HDAddressPayload (getBytes 17 32))
 
 exampleAddress4 :: Address
 exampleAddress4 = makeAddress easd attrs
   where
     easd = UnknownASD 7 "test value"
-    attrs = AddrAttributes Nothing (SingleKeyDistr sId)
+    attrs = AddrAttributes Nothing (SingleKeyDistr sId) NMNothing
     [sId] = exampleStakeholderIds 7 1
 
 exampleMultiKeyDistr :: AddrStakeDistribution

--- a/core/test/Test/Pos/Core/ExampleHelpers.hs
+++ b/core/test/Test/Pos/Core/ExampleHelpers.hs
@@ -118,57 +118,49 @@ import qualified Serokell.Util.Base16 as B16
 
 import qualified Cardano.Crypto.Wallet as CC
 import           Pos.Binary.Class (Raw (..), asBinary)
-import           Pos.Data.Attributes (Attributes, mkAttributes)
 import           Pos.Core.Common (AddrAttributes (..), AddrSpendingData (..),
-                     AddrStakeDistribution (..), Address (..), BlockCount (..),
-                     ChainDifficulty (..), Coeff (..), Coin (..),
-                     CoinPortion (..), IsBootstrapEraAddr (..), Script (..),
-                     ScriptVersion, SharedSeed (..), SlotLeaders,
-                     StakeholderId, StakesList, TxFeePolicy (..),
-                     TxSizeLinear (..), addressHash, coinPortionDenominator,
-                     makeAddress, makePubKeyAddress, mkMultiKeyDistr)
+                                  AddrStakeDistribution (..), Address (..), BlockCount (..),
+                                  ChainDifficulty (..), Coeff (..), Coin (..), CoinPortion (..),
+                                  IsBootstrapEraAddr (..), Script (..), ScriptVersion,
+                                  SharedSeed (..), SlotLeaders, StakeholderId, StakesList,
+                                  TxFeePolicy (..), TxSizeLinear (..), addressHash,
+                                  coinPortionDenominator, makeAddress, makePubKeyAddress,
+                                  mkMultiKeyDistr)
 import           Pos.Core.Configuration
-import           Pos.Core.Delegation (HeavyDlgIndex (..), LightDlgIndices (..),
-                     ProxySKBlockInfo, ProxySKHeavy)
-import           Pos.Core.Genesis (FakeAvvmOptions (..),
-                     GenesisAvvmBalances (..), GenesisData (..),
-                     GenesisDelegation (..), GenesisInitializer (..),
-                     GenesisNonAvvmBalances (..),
-                     GenesisProtocolConstants (..), GenesisSpec (..),
-                     GenesisVssCertificatesMap (..), GenesisWStakeholders (..),
-                     TestnetBalanceOptions (..))
-import           Pos.Core.ProtocolConstants (ProtocolConstants, VssMaxTTL (..),
-                     VssMinTTL (..))
-import           Pos.Core.Slotting (EpochIndex (..), FlatSlotId,
-                     LocalSlotIndex (..), SlotId (..), Timestamp (..))
-import           Pos.Core.Ssc (Commitment, CommitmentSignature, CommitmentsMap,
-                     InnerSharesMap, Opening, OpeningsMap, SharesDistribution,
-                     SignedCommitment, SscPayload (..), SscProof (..),
-                     VssCertificate (..), VssCertificatesHash,
-                     VssCertificatesMap (..), mkCommitmentsMap,
-                     mkVssCertificate, mkVssCertificatesMap,
-                     randCommitmentAndOpening)
-import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxIn (..),
-                     TxInWitness (..), TxOut (..), TxPayload (..),
-                     TxProof (..), TxSig, TxSigData (..), TxWitness,
-                     mkTxPayload)
-import           Pos.Core.Update (ApplicationName (..), BlockVersion (..),
-                     BlockVersionData (..), BlockVersionModifier (..),
-                     SoftforkRule (..), SoftwareVersion (..), SystemTag (..),
-                     UpAttributes, UpId, UpdateData (..), UpdatePayload (..),
-                     UpdateProof, UpdateProposal, UpdateProposalToSign (..),
-                     UpdateVote (..), VoteId, mkUpdateProof,
-                     mkUpdateProposalWSign, mkUpdateVoteSafe)
-import           Pos.Crypto (AbstractHash (..), EncShare (..),
-                     HDAddressPayload (..), Hash, RequiresNetworkMagic (..), ProtocolMagic (..), ProtocolMagicId (..),
-                     RedeemPublicKey, RedeemSignature, SafeSigner (..),
-                     Secret (..), SecretKey (..), SecretProof (..),
-                     SignTag (..), VssKeyPair, VssPublicKey (..), abstractHash,
-                     decryptShare, deterministic, deterministicVssKeyGen, hash,
-                     redeemDeterministicKeyGen, redeemSign, safeCreatePsk,
-                     sign, toVssPublicKey)
-import           Pos.Crypto.Signing (ProxyCert (..), ProxySecretKey (..),
-                     PublicKey (..), RedeemPublicKey (..))
+import           Pos.Core.Delegation (HeavyDlgIndex (..), LightDlgIndices (..), ProxySKBlockInfo,
+                                      ProxySKHeavy)
+import           Pos.Core.Genesis (FakeAvvmOptions (..), GenesisAvvmBalances (..), GenesisData (..),
+                                   GenesisDelegation (..), GenesisInitializer (..),
+                                   GenesisNonAvvmBalances (..), GenesisProtocolConstants (..),
+                                   GenesisSpec (..), GenesisVssCertificatesMap (..),
+                                   GenesisWStakeholders (..), TestnetBalanceOptions (..))
+import           Pos.Core.ProtocolConstants (ProtocolConstants, VssMaxTTL (..), VssMinTTL (..))
+import           Pos.Core.Slotting (EpochIndex (..), FlatSlotId, LocalSlotIndex (..), SlotId (..),
+                                    Timestamp (..))
+import           Pos.Core.Ssc (Commitment, CommitmentSignature, CommitmentsMap, InnerSharesMap,
+                               Opening, OpeningsMap, SharesDistribution, SignedCommitment,
+                               SscPayload (..), SscProof (..), VssCertificate (..),
+                               VssCertificatesHash, VssCertificatesMap (..), mkCommitmentsMap,
+                               mkVssCertificate, mkVssCertificatesMap, randCommitmentAndOpening)
+import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxIn (..), TxInWitness (..), TxOut (..),
+                               TxPayload (..), TxProof (..), TxSig, TxSigData (..), TxWitness,
+                               mkTxPayload)
+import           Pos.Core.Update (ApplicationName (..), BlockVersion (..), BlockVersionData (..),
+                                  BlockVersionModifier (..), SoftforkRule (..),
+                                  SoftwareVersion (..), SystemTag (..), UpAttributes, UpId,
+                                  UpdateData (..), UpdatePayload (..), UpdateProof, UpdateProposal,
+                                  UpdateProposalToSign (..), UpdateVote (..), VoteId, mkUpdateProof,
+                                  mkUpdateProposalWSign, mkUpdateVoteSafe)
+import           Pos.Crypto (AbstractHash (..), EncShare (..), HDAddressPayload (..), Hash,
+                             ProtocolMagic (..), ProtocolMagicId (..), RedeemPublicKey,
+                             RedeemSignature, RequiresNetworkMagic (..), SafeSigner (..),
+                             Secret (..), SecretKey (..), SecretProof (..), SignTag (..),
+                             VssKeyPair, VssPublicKey (..), abstractHash, decryptShare,
+                             deterministic, deterministicVssKeyGen, hash, redeemDeterministicKeyGen,
+                             redeemSign, safeCreatePsk, sign, toVssPublicKey)
+import           Pos.Crypto.Signing (ProxyCert (..), ProxySecretKey (..), PublicKey (..),
+                                     RedeemPublicKey (..))
+import           Pos.Data.Attributes (Attributes, mkAttributes)
 import           Pos.Merkle (mkMerkleTree, mtRoot)
 
 import           Test.Pos.Core.Gen (genProtocolConstants)

--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -190,6 +190,7 @@ import           Pos.Core.Genesis (FakeAvvmOptions (..), GenesisAvvmBalances (..
                                    GenesisSpec (..), GenesisVssCertificatesMap (..),
                                    GenesisWStakeholders (..), TestnetBalanceOptions (..),
                                    mkGenesisDelegation, mkGenesisSpec)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..), VssMaxTTL (..), VssMinTTL (..))
 import           Pos.Core.Slotting (EpochIndex (..), EpochOrSlot (..), FlatSlotId,
                                     LocalSlotIndex (..), SlotCount (..), SlotId (..), TimeDiff (..),
@@ -341,9 +342,10 @@ genMainToSign pm pc =
 ----------------------------------------------------------------------------
 
 genAddrAttributes :: Gen AddrAttributes
-genAddrAttributes = AddrAttributes <$> hap <*> genAddrStakeDistribution
+genAddrAttributes = AddrAttributes <$> hap <*> genAddrStakeDistribution <*> nm
   where
     hap = Gen.maybe genHDAddressPayload
+    nm = pure fixedNM
 
 genAddress :: Gen Address
 genAddress = makeAddress <$> genAddrSpendingData <*> genAddrAttributes
@@ -1057,3 +1059,7 @@ genWord32 = Gen.word32 Range.constantBounded
 
 genWord8 :: Gen Word8
 genWord8 = Gen.word8 Range.constantBounded
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/Json.hs
+++ b/core/test/Test/Pos/Core/Json.hs
@@ -9,30 +9,29 @@ import           Pos.Aeson.Core ()
 import           Pos.Aeson.Core.Configuration ()
 import           Pos.Aeson.Genesis ()
 
-import           Test.Pos.Core.ExampleHelpers (exampleAddress, exampleAddress1,
-                     exampleAddress2, exampleAddress3, exampleAddress4,
-                     exampleGenesisConfiguration_GCSpec0,
-                     exampleGenesisConfiguration_GCSpec1,
-                     exampleGenesisConfiguration_GCSpec2,
-                     exampleGenesisConfiguration_GCSrc, exampleGenesisData0,
-                     exampleGenesisData1, exampleGenesisData2,
-                     exampleGenesisProtocolConstants0,
-                     exampleGenesisProtocolConstants1,
-                     exampleGenesisProtocolConstants2, feedPM)
-import           Test.Pos.Core.Gen (genAddress, genBlockVersionData, genByte,
-                     genCoin, genCoinPortion, genEpochIndex, genFlatSlotId,
-                     genGenesisAvvmBalances, genGenesisConfiguration,
-                     genGenesisData, genGenesisDelegation,
-                     genGenesisInitializer, genGenesisProtocolConstants,
-                     genSharedSeed, genSoftforkRule, genTxFeePolicy)
+import           Test.Pos.Core.ExampleHelpers (exampleAddress, exampleAddress1, exampleAddress2,
+                                               exampleAddress3, exampleAddress4,
+                                               exampleGenesisConfiguration_GCSpec0,
+                                               exampleGenesisConfiguration_GCSpec1,
+                                               exampleGenesisConfiguration_GCSpec2,
+                                               exampleGenesisConfiguration_GCSrc,
+                                               exampleGenesisData0, exampleGenesisData1,
+                                               exampleGenesisData2,
+                                               exampleGenesisProtocolConstants0,
+                                               exampleGenesisProtocolConstants1,
+                                               exampleGenesisProtocolConstants2, feedPM)
+import           Test.Pos.Core.Gen (genAddress, genBlockVersionData, genByte, genCoin,
+                                    genCoinPortion, genEpochIndex, genFlatSlotId,
+                                    genGenesisAvvmBalances, genGenesisConfiguration, genGenesisData,
+                                    genGenesisDelegation, genGenesisInitializer,
+                                    genGenesisProtocolConstants, genSharedSeed, genSoftforkRule,
+                                    genTxFeePolicy)
 import           Test.Pos.Crypto.Gen (genRedeemPublicKey)
 import           Test.Pos.Util.Gen (genMillisecond)
-import           Test.Pos.Util.Golden (discoverGolden, eachOf,
-                     goldenTestCanonicalJSONDec, goldenTestJSON,
-                     goldenTestJSONDec)
-import           Test.Pos.Util.Tripping (discoverRoundTrip,
-                     roundTripsAesonBuildable, roundTripsAesonShow,
-                     roundTripsCanonicalJSONShow)
+import           Test.Pos.Util.Golden (discoverGolden, eachOf, goldenTestCanonicalJSONDec,
+                                       goldenTestJSON, goldenTestJSONDec)
+import           Test.Pos.Util.Tripping (discoverRoundTrip, roundTripsAesonBuildable,
+                                         roundTripsAesonShow, roundTripsCanonicalJSONShow)
 
 --------------------------------------------------------------------------------
 -- Address

--- a/explorer/src/Pos/Explorer/BListener.hs
+++ b/explorer/src/Pos/Explorer/BListener.hs
@@ -34,6 +34,7 @@ import           Pos.Block.Types (Blund)
 import           Pos.Core (HasConfiguration, HeaderHash, LocalSlotIndex (..), SlotId (..),
                            difficultyL, epochIndexL, getChainDifficulty, headerHash, mainBlockSlot)
 import           Pos.Core.Block (Block, MainBlock, mainBlockTxPayload)
+import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..), toNewestFirst)
 import           Pos.Core.Txp (Tx, txpTxs)
 import           Pos.Crypto (withHash)
 import           Pos.DB.BatchOp (SomeBatchOp (..))
@@ -43,7 +44,6 @@ import           Pos.Explorer.DB (Epoch, EpochPagedBlocksKey, Page, defaultPageS
 import qualified Pos.Explorer.DB as DB
 import           Pos.Txp (topsortTxs)
 import           Pos.Util.AssertMode (inAssertMode)
-import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..), toNewestFirst)
 
 
 ----------------------------------------------------------------------------
@@ -76,8 +76,8 @@ instance ( MonadDBRead m
          , HasConfiguration
          )
          => MonadBListener (ExplorerBListener m) where
-    onApplyBlocks     blunds = onApplyCallGeneral blunds
-    onRollbackBlocks  blunds = onRollbackCallGeneral blunds
+    onApplyBlocks    _nm blunds = onApplyCallGeneral blunds
+    onRollbackBlocks _nm blunds = onRollbackCallGeneral blunds
 
 
 ----------------------------------------------------------------------------

--- a/explorer/src/Pos/Explorer/TestUtil.hs
+++ b/explorer/src/Pos/Explorer/TestUtil.hs
@@ -39,6 +39,7 @@ import           Pos.Core (Address, BlockCount (..), ChainDifficulty (..), Epoch
                            headerHash, makePubKeyAddressBoot)
 import           Pos.Core.Block (Block, BlockHeader, GenesisBlock, MainBlock, getBlockHeader)
 import           Pos.Core.Block.Constructors (mkGenesisBlock)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Ssc (SscPayload)
 import           Pos.Core.Txp (TxAux)
 import           Pos.Core.Update (UpdatePayload (..))
@@ -399,4 +400,8 @@ produceSecretKeys blocksNumber = liftIO $ secretKeys
 -- | Friendly borrowed from `Test.Pos.Client.Txp.UtilSpec`
 -- | TODO: Remove it as soon as ^ is exposed
 secretKeyToAddress :: SecretKey -> Address
-secretKeyToAddress = makePubKeyAddressBoot . toPublic
+secretKeyToAddress = makePubKeyAddressBoot fixedNM . toPublic
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/explorer/src/Pos/Explorer/Web/Transform.hs
+++ b/explorer/src/Pos/Explorer/Web/Transform.hs
@@ -25,6 +25,7 @@ import           Servant.Server (Handler, hoistServer)
 import           Pos.Block.Configuration (HasBlockConfiguration)
 import           Pos.Configuration (HasNodeConfiguration)
 import           Pos.Core (HasConfiguration)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Infra.Diffusion.Types (Diffusion)
 import           Pos.Infra.Reporting (MonadReporting (..))
 import           Pos.Recovery ()
@@ -103,7 +104,7 @@ explorerServeWebReal
     -> ExplorerProd ()
 explorerServeWebReal diffusion port = do
     rctx <- ask
-    let handlers = explorerHandlers diffusion
+    let handlers = explorerHandlers fixedNM diffusion
         server = hoistServer explorerApi (convertHandler rctx) handlers
         app = explorerApp (pure server)
     explorerServeImpl app port
@@ -125,3 +126,7 @@ convertHandler rctx handler =
 
     excHandlers = [E.Handler catchServant]
     catchServant = throwError
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/generator/src/Pos/Generator/Block/Mode.hs
+++ b/generator/src/Pos/Generator/Block/Mode.hs
@@ -52,10 +52,9 @@ import           Pos.Generator.Block.Param (BlockGenParams (..), HasBlockGenPara
                                             HasTxGenParams (..))
 import qualified Pos.GState as GS
 import           Pos.Infra.Network.Types (HasNodeType (..), NodeType (..))
-import           Pos.Infra.Reporting (MonadReporting (..),
-                                      HasMisbehaviorMetrics (..))
-import           Pos.Infra.Slotting (HasSlottingVar (..), MonadSlots (..),
-                                     MonadSlotsData, currentTimeSlottingSimple)
+import           Pos.Infra.Reporting (HasMisbehaviorMetrics (..), MonadReporting (..))
+import           Pos.Infra.Slotting (HasSlottingVar (..), MonadSlots (..), MonadSlotsData,
+                                     currentTimeSlottingSimple)
 import           Pos.Infra.Slotting.Types (SlottingData)
 import           Pos.Lrc (HasLrcContext, LrcContext (..))
 import           Pos.Ssc (HasSscConfiguration, SscMemTag, SscState, mkSscState)
@@ -331,19 +330,19 @@ instance MonadBlockGenBase m => DB.MonadGState (BlockGenMode ext m) where
     gsAdoptedBVData = gsAdoptedBVDataDefault
 
 instance MonadBListener m => MonadBListener (BlockGenMode ext m) where
-    onApplyBlocks = lift . onApplyBlocks
-    onRollbackBlocks = lift . onRollbackBlocks
+    onApplyBlocks nm = lift . onApplyBlocks nm
+    onRollbackBlocks nm = lift . onRollbackBlocks nm
 
 
 instance Monad m => MonadAddresses (BlockGenMode ext m) where
     type AddrData (BlockGenMode ext m) = Address
-    getNewAddress = pure
+    getNewAddress _ = pure
     -- It must be consistent with the way we construct address in
     -- block-gen. If it's changed, tests will fail, so we will notice
     -- it.
     -- N.B. Currently block-gen uses only PubKey addresses with BootstrapEra
     -- distribution.
-    getFakeChangeAddress = pure largestPubKeyAddressBoot
+    getFakeChangeAddress nm = pure (largestPubKeyAddressBoot nm)
 
 type instance MempoolExt (BlockGenMode ext m) = ext
 

--- a/lib/src/Pos/AllSecrets.hs
+++ b/lib/src/Pos/AllSecrets.hs
@@ -27,6 +27,7 @@ import           Pos.Binary.Core ()
 import           Pos.Core (AddrSpendingData (..), Address, IsBootstrapEraAddr (..), StakeholderId,
                            addressHash, checkAddrSpendingData, makePubKeyAddress,
                            makePubKeyAddressBoot)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (PublicKey, SecretKey, toPublic)
 
 -- | This map effectively provides inverse of 'hash' and
@@ -91,12 +92,17 @@ mkAllSecretsSimple sks =
     , _asSpendingData = invAddrSpendingData
     }
   where
+    nm = fixedNM
     pks :: [PublicKey]
     pks = map toPublic sks
     spendingDataList = map PubKeyASD pks
-    addressesNonBoot = map (makePubKeyAddress (IsBootstrapEraAddr False)) pks
-    addressesBoot = map makePubKeyAddressBoot pks
+    addressesNonBoot = map (makePubKeyAddress nm (IsBootstrapEraAddr False)) pks
+    addressesBoot = map (makePubKeyAddressBoot nm) pks
     invAddrSpendingData =
         mkInvAddrSpendingData $
         zip addressesNonBoot spendingDataList <>
         zip addressesBoot spendingDataList
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/lib/src/Pos/Util/UserSecret.hs
+++ b/lib/src/Pos/Util/UserSecret.hs
@@ -53,7 +53,7 @@ import           System.FileLock (FileLock, SharedExclusive (..), lockFile, unlo
 import           System.FilePath (takeDirectory, takeFileName)
 import           System.IO (hClose, openBinaryTempFile)
 #ifdef POSIX
-import           System.Wlog (WithLogger, logWarning, logInfo)
+import           System.Wlog (WithLogger, logInfo, logWarning)
 #else
 import           System.Wlog (WithLogger, logInfo)
 #endif
@@ -64,6 +64,7 @@ import           Pos.Binary.Class (Bi (..), Cons (..), Field (..), decodeFull', 
                                    encodeListLen, enforceSize, serialize')
 import           Pos.Core (Address, accountGenesisIndex, addressF, makeRootPubKeyAddress,
                            wAddressGenesisIndex)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (EncryptedSecretKey, SecretKey, VssKeyPair, encToPublic)
 
 import           Test.Pos.Crypto.Arbitrary ()
@@ -93,11 +94,17 @@ instance Arbitrary WalletUserSecret where
 
 makeLenses ''WalletUserSecret
 
+fixedNM :: NetworkMagic
+fixedNM = NMNothing
+
 instance Buildable WalletUserSecret where
     build WalletUserSecret{..} =
         bprint ("{ root = "%addressF%", set name = "%build%
                 ", wallets = "%pairsF%", accounts = "%pairsF%" }")
-        (makeRootPubKeyAddress $ encToPublic _wusRootKey)
+        -- TODO mhueschen |
+        -- TODO @intricate: Will probably have to add NetworkMagic to WalletUserSecret
+        -- instead of using NMNothing here :/
+        (makeRootPubKeyAddress fixedNM $ encToPublic _wusRootKey)
         _wusWalletName
         _wusAccounts
         _wusAddrs

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15646,6 +15646,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-util
 , cardano-sl-util-test
 , cborg
+, cereal
 , containers
 , cpphs
 , cryptonite
@@ -15673,6 +15674,7 @@ license = stdenv.lib.licenses.mit;
 , random
 , reflection
 , safe-exceptions
+, safecopy
 , serokell-util
 , stdenv
 , template-haskell
@@ -15707,6 +15709,7 @@ cardano-sl-crypto
 cardano-sl-networking
 cardano-sl-util
 cborg
+cereal
 containers
 cryptonite
 data-default
@@ -15726,6 +15729,7 @@ plutus-prototype
 random
 reflection
 safe-exceptions
+safecopy
 serokell-util
 template-haskell
 text

--- a/tools/src/addr-convert/Main.hs
+++ b/tools/src/addr-convert/Main.hs
@@ -14,6 +14,7 @@ import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import           Paths_cardano_sl (version)
 import           Pos.Core (makeRedeemAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto.Signing (fromAvvmPk)
 import           Pos.Util.Util (eitherToThrow)
 
@@ -59,7 +60,7 @@ In this case each entered vending address is echoed with a testnet address.|]
 
 convertAddr :: Text -> IO Text
 convertAddr addr =
-    pretty . makeRedeemAddress <$>
+    pretty . makeRedeemAddress fixedNM <$>
     (eitherToThrow . fromAvvmPk) (toText addr)
 
 main :: IO ()
@@ -68,3 +69,7 @@ main = do
     case address of
         Just addr -> convertAddr addr >>= putText
         Nothing   -> forever (getLine >>= convertAddr >>= putText)
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/txp/src/Pos/Txp/GenesisUtxo.hs
+++ b/txp/src/Pos/Txp/GenesisUtxo.hs
@@ -12,9 +12,9 @@ import           Universum
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 
-import           Pos.Core (Address, Coin, GenesisData (..), StakesMap, HasGenesisData,
-                           genesisData, getGenesisAvvmBalances, getGenesisNonAvvmBalances,
-                           makeRedeemAddress)
+import           Pos.Core (Address, Coin, GenesisData (..), HasGenesisData, StakesMap, genesisData,
+                           getGenesisAvvmBalances, getGenesisNonAvvmBalances, makeRedeemAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (unsafeHash)
 import           Pos.Txp.Toil (GenesisUtxo (..), utxoToStakes)
@@ -29,8 +29,11 @@ genesisUtxo =
                    , gdAvvmDistr
                    } = genesisData
 
+        networkMagic :: NetworkMagic
+        networkMagic = fixedNM
+
         preUtxo :: [(Address, Coin)]
-        preUtxo = (first makeRedeemAddress <$> HM.toList (getGenesisAvvmBalances gdAvvmDistr))
+        preUtxo = (first (makeRedeemAddress networkMagic) <$> HM.toList (getGenesisAvvmBalances gdAvvmDistr))
                                   <> (HM.toList $ getGenesisNonAvvmBalances gdNonAvvmBalances)
 
         utxoEntry :: (Address, Coin) -> (TxIn, TxOutAux)
@@ -40,3 +43,7 @@ genesisUtxo =
                  )
 
      in GenesisUtxo . Map.fromList $ utxoEntry <$> preUtxo
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/txp/src/Pos/Txp/Toil/Failure.hs
+++ b/txp/src/Pos/Txp/Toil/Failure.hs
@@ -17,8 +17,8 @@ import           GHC.TypeLits (TypeError)
 import           Serokell.Data.Memory.Units (Byte, memory)
 import           Serokell.Util (listJson)
 
-import           Pos.Core (Address, HeaderHash, ScriptVersion, TxFeePolicy, addressF,
-                           addressDetailedF)
+import           Pos.Core (Address, HeaderHash, ScriptVersion, TxFeePolicy, addressDetailedF,
+                           addressF)
 import           Pos.Core.Txp (TxIn, TxInWitness, TxOut (..))
 import           Pos.Data.Attributes (UnparsedFields)
 import           Pos.Script (PlutusError)
@@ -174,7 +174,9 @@ data TxOutVerFailure
     | TxOutUnknownAddressType Address
     -- | Can't send to a redeem address
     | TxOutRedeemAddressProhibited Address
-    deriving (Show, Eq, Generic, NFData)
+    -- | NetworkMagic's must match
+    | TxOutAddressBadNetworkMagic Address
+     deriving (Show, Eq, Generic, NFData)
 
 instance Buildable TxOutVerFailure where
     build (TxOutUnknownAttributes addr) =
@@ -185,3 +187,7 @@ instance Buildable TxOutVerFailure where
     build (TxOutRedeemAddressProhibited addr) =
         bprint ("sends money to a redeem address ("
                 %addressF%"), this is prohibited") addr
+    build (TxOutAddressBadNetworkMagic addr) =
+        bprint ("sends money to an address with mismatched \
+                \NetworkMagic ("%addressF%"), this is prohibited")
+               addr

--- a/txp/src/Pos/Txp/Toil/Logic.hs
+++ b/txp/src/Pos/Txp/Toil/Logic.hs
@@ -25,6 +25,7 @@ import           Pos.Core (AddrAttributes (..), AddrStakeDistribution (..), Addr
                            addrAttributesUnwrapped, isBootstrapEraBVD, isRedeemAddress)
 import           Pos.Core.Common (integerToCoin)
 import qualified Pos.Core.Common as Fee (TxFeePolicy (..), calculateTxSizeLinear)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxOut (..), TxUndo, TxpUndo, checkTxAux,
                                toaOut, txOutAddress)
 import           Pos.Crypto (WithHash (..), hash)
@@ -137,12 +138,11 @@ verifyAndApplyTx ::
     -> ExceptT ToilVerFailure UtxoM TxUndo
 verifyAndApplyTx pm adoptedBVD lockedAssets curEpoch verifyVersions tx@(_, txAux) = do
     whenLeft (checkTxAux txAux) (throwError . ToilInconsistentTxAux)
+    let ctx = Utxo.VTxContext verifyVersions fixedNM
     vtur@VerifyTxUtxoRes {..} <- Utxo.verifyTxUtxo pm ctx lockedAssets txAux
     liftEither $ verifyGState adoptedBVD curEpoch txAux vtur
     lift $ applyTxToUtxo' tx
     pure vturUndo
-  where
-    ctx = Utxo.VTxContext verifyVersions
 
 isRedeemTx :: TxUndo -> Bool
 isRedeemTx resolvedOuts = all isRedeemAddress inputAddresses
@@ -230,3 +230,7 @@ withTxId aux = (hash (taTx aux), aux)
 
 applyTxToUtxo' :: (TxId, TxAux) -> UtxoM ()
 applyTxToUtxo' (i, TxAux tx _) = Utxo.applyTxToUtxo (WithHash tx i)
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/txp/test/Test/Pos/Txp/Arbitrary.hs
+++ b/txp/test/Test/Pos/Txp/Arbitrary.hs
@@ -31,6 +31,7 @@ import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShr
 import           Pos.Binary.Class (Raw)
 import           Pos.Binary.Core ()
 import           Pos.Core.Common (Coin, IsBootstrapEraAddr (..), makePubKeyAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxIn (..), TxInWitness (..), TxOut (..),
                                TxOutAux (..), TxPayload (..), TxProof (..), TxSigData (..),
                                mkTxPayload)
@@ -149,7 +150,7 @@ buildProperTx pm inputList (inCoin, outCoin) =
         , twSig = sign pm SignTx fromSk TxSigData {
                       txSigTxHash = newTxHash } }
     makeTxOutput s c =
-        TxOut (makePubKeyAddress (IsBootstrapEraAddr True) $ toPublic s) c
+        TxOut (makePubKeyAddress fixedNM (IsBootstrapEraAddr True) $ toPublic s) c
 
 -- | Well-formed transaction 'Tx'.
 --
@@ -235,3 +236,7 @@ genTxPayload pm = mkTxPayload <$> genTxOutDist pm
 instance Arbitrary TxPayload where
     arbitrary = genTxPayload dummyProtocolMagic
     shrink = genericShrink
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/txp/test/Test/Pos/Txp/Toil/UtxoSpec.hs
+++ b/txp/test/Test/Pos/Txp/Toil/UtxoSpec.hs
@@ -21,6 +21,7 @@ import           Test.QuickCheck (Property, arbitrary, counterexample, (==>))
 import           Pos.Core (HasConfiguration, addressHash, checkPubKeyAddress,
                            defaultCoreConfiguration, makePubKeyAddressBoot, makeScriptAddress,
                            mkCoin, sumCoins, withGenesisSpec)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxIn (..), TxInWitness (..), TxOut (..),
                                TxOutAux (..), TxSigData (..), TxWitness, isTxInUnknown)
 import           Pos.Crypto (ProtocolMagic, SignTag (SignTx), checkSig, fakeSigner, hash, toPublic,
@@ -103,7 +104,7 @@ verifyTxInUtxo pm (SmallGenerator (GoodTx ls)) =
             let id = hash tx
             (idx, out) <- zip [0..] (toList _txOutputs)
             pure ((TxInUtxo id idx), TxOutAux out)
-        vtxContext = VTxContext False
+        vtxContext = VTxContext False fixedNM
         txAux = TxAux newTx witness
     in counterexample ("\n"+|nameF "txs" (blockListF' "-" genericF txs)|+""
                            +|nameF "transaction" (B.build txAux)|+"") $
@@ -113,7 +114,7 @@ badSigsTx :: ProtocolMagic -> SmallGenerator BadSigsTx -> Property
 badSigsTx pm (SmallGenerator (getBadSigsTx -> ls)) =
     let (tx@UnsafeTx {..}, utxo, extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False
+        ctx = VTxContext False fixedNM
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         notAllSignaturesAreValid =
@@ -126,7 +127,7 @@ doubleInputTx :: ProtocolMagic -> SmallGenerator DoubleInputTx -> Property
 doubleInputTx pm (SmallGenerator (getDoubleInputTx -> ls)) =
     let ((tx@UnsafeTx {..}), utxo, _extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False
+        ctx = VTxContext False fixedNM
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         someInputsAreDuplicated =
@@ -136,7 +137,7 @@ doubleInputTx pm (SmallGenerator (getDoubleInputTx -> ls)) =
 validateGoodTx :: ProtocolMagic -> SmallGenerator GoodTx -> Property
 validateGoodTx pm (SmallGenerator (getGoodTx -> ls)) =
     let quadruple@(tx, utxo, _, txWits) = getTxFromGoodTx ls
-        ctx = VTxContext False
+        ctx = VTxContext False fixedNM
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         transactionReallyIsGood = individualTxPropertyVerifier pm quadruple
@@ -416,7 +417,7 @@ scriptTxSpec pm = describe "script transactions" $ do
     -- Some random stuff we're going to use when building transactions
     randomPkOutput = runGen $ do
         key <- arbitrary
-        return (TxOut (makePubKeyAddressBoot key) (mkCoin 1))
+        return (TxOut (makePubKeyAddressBoot fixedNM key) (mkCoin 1))
     -- Make utxo with a single output; return utxo, the output, and an
     -- input that can be used to spend that output
     mkUtxo :: TxOut -> (TxIn, TxOut, Utxo)
@@ -425,7 +426,7 @@ scriptTxSpec pm = describe "script transactions" $ do
         in  (TxInUtxo txid 0, outp, one ((TxInUtxo txid 0), (TxOutAux outp)))
 
     -- Do not verify versions
-    vtxContext = VTxContext False
+    vtxContext = VTxContext False fixedNM
 
     -- Try to apply a transaction (with given utxo as context) and say
     -- whether it applied successfully
@@ -442,7 +443,7 @@ scriptTxSpec pm = describe "script transactions" $ do
                   -> Either ToilVerFailure ()
     checkScriptTx val mkWit =
         let (inp, _, utxo) = mkUtxo $
-                TxOut (makeScriptAddress Nothing val) (mkCoin 1)
+                TxOut (makeScriptAddress fixedNM Nothing val) (mkCoin 1)
             tx = UnsafeTx (one inp) (one randomPkOutput) $ mkAttributes ()
             txSigData = TxSigData { txSigTxHash = hash tx }
             txAux = TxAux tx (one (mkWit txSigData))
@@ -476,3 +477,7 @@ txShouldFailWithPlutus res err = case res of
     other -> expectationFailure $
         "expected: Left ...: " <> show (WitnessScriptError err) <> "\n" <>
         " but got: " <> show other
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -16,6 +16,7 @@ import           Test.QuickCheck (Arbitrary (..), oneof)
 
 import qualified Pos.Client.Txp.Util as TxError
 import qualified Pos.Core as Core
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto.Hashing as Crypto
 import qualified Pos.Data.Attributes as Core
 
@@ -137,7 +138,7 @@ sampleAddress = V1 $ Core.Address
     { Core.addrRoot =
         Crypto.unsafeAbstractHash ("asdfasdf" :: String)
     , Core.addrAttributes =
-        Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr
+        Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr fixedNM
     , Core.addrType =
         Core.ATPubKey
     }
@@ -244,3 +245,7 @@ applicationJson :: HTTP.Header
 applicationJson =
     let [hdr] = getHeaders (addHeader "application/json" mempty :: (Headers '[Header "Content-Type" String] String))
     in hdr
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -17,6 +17,7 @@ import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 
 import qualified Data.Map.Strict as Map
 import qualified Pos.Core.Common as Core
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto.Signing as Core
 
 
@@ -64,6 +65,7 @@ instance Example (V1 Address) where
                     [ pure Core.BootstrapEraDistr
                     , Core.SingleKeyDistr <$> arbitrary
                     ]
+                <*> pure fixedNM
 
 instance Example BackupPhrase where
     example = pure def
@@ -143,3 +145,7 @@ instance Example WalletStateSnapshot
 -- TODO: We should probably add this as a part of our swagger CI script and fail swagger if we find some of them - with instruction to the developer above what is said above.
 --
 -- Most of it comes to removing Nothing from `Arbitrary (Maybe a)` instance and removing empty list from `Arbitrary [a]` instance. It could be done automatically with some quickcheck hacks but I think it would be an overkill.
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Mode.hs
@@ -88,8 +88,8 @@ walletRollbackBlocks _w _bs = do
     return mempty
 
 instance MonadBListener WalletMode where
-  onApplyBlocks    bs = getWallet >>= (`walletApplyBlocks`    bs)
-  onRollbackBlocks bs = getWallet >>= (`walletRollbackBlocks` bs)
+  onApplyBlocks    _nm bs = getWallet >>= (`walletApplyBlocks`    bs)
+  onRollbackBlocks _nm bs = getWallet >>= (`walletRollbackBlocks` bs)
 
 {-------------------------------------------------------------------------------
   Run the wallet

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -45,6 +45,7 @@ import           Serokell.Util.Base16 (base16F)
 import           Universum
 
 import           Pos.Core
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto
 import           Pos.Lrc.Genesis
 import           Pos.Txp
@@ -289,7 +290,7 @@ initActors CardanoContext{..} = Actors{..}
         richKey = regularKeyPair richSec
 
         richAddr :: Address
-        richAddr = makePubKeyAddressBoot (toPublic richSec)
+        richAddr = makePubKeyAddressBoot fixedNM (toPublic richSec)
 
     mkPoor :: PoorSecret -> (PublicKey, Poor)
     mkPoor (PoorSecret _) = error err
@@ -306,6 +307,7 @@ initActors CardanoContext{..} = Actors{..}
 
         poorAddrs :: [(EncKeyPair, Address)]
         poorAddrs = [ case deriveFirstHDAddress
+                             fixedNM
                              (IsBootstrapEraAddr True)
                              emptyPassphrase
                              poorSec of
@@ -341,7 +343,7 @@ initActors CardanoContext{..} = Actors{..}
         avvmKey = RedeemKeyPair{..}
 
         avvmAddr :: Address
-        avvmAddr = makeRedeemAddress redKpPub
+        avvmAddr = makeRedeemAddress fixedNM redKpPub
 
         Just (redKpPub, redKpSec) = redeemDeterministicKeyGen avvmSeed
 
@@ -647,3 +649,7 @@ instance Buildable TransCtxt where
       tcCardano
       tcActors
       tcAddrMap
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet/src/Pos/Wallet/Web/Account.hs
+++ b/wallet/src/Pos/Wallet/Web/Account.hs
@@ -26,6 +26,7 @@ import           Universum
 import           Pos.Client.KeyStorage (AllUserSecrets (..), MonadKeys, MonadKeysRead, addSecretKey,
                                         getSecretKeys, getSecretKeysPlain)
 import           Pos.Core (Address (..), IsBootstrapEraAddr (..), deriveLvl2KeyPair)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ShouldCheckPassphrase (..),
                              firstHardened)
 import           Pos.Util (eitherToThrow)
@@ -188,6 +189,7 @@ deriveAddressSKPure secrets scp passphrase AccountId {..} addressIndex = do
     key <- getSKByIdPure secrets aiWId
     maybe (throwError badPass) pure $
         deriveLvl2KeyPair
+            fixedNM
             (IsBootstrapEraAddr True) -- TODO: make it context-dependent!
             scp
             passphrase
@@ -219,3 +221,9 @@ instance AccountMode ctx m => MonadKeySearch AccountId m where
 
 instance AccountMode ctx m => MonadKeySearch WAddressMeta m where
     findKey = findKey . _wamWalletId
+
+
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -20,6 +20,7 @@ import           Formatting (build, sformat)
 import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Core (Address, ChainDifficulty, decodeTextAddress, makePubKeyAddressBoot,
                            sumCoins, unsafeAddCoin, unsafeIntegerToCoin)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxOut (..), txOutAddress, txOutValue)
 import           Pos.Core.Update (BlockVersionData (..), BlockVersionModifier (..),
                                   UpdateProposal (..))
@@ -48,7 +49,7 @@ cIdToAddress (CId (CHash h)) = decodeTextAddress h
 -- distribution based on this information. Currently it's always
 -- bootstrap era distribution.
 encToCId :: EncryptedSecretKey -> CId w
-encToCId = encodeCType . makePubKeyAddressBoot . encToPublic
+encToCId = encodeCType . makePubKeyAddressBoot fixedNM . encToPublic
 
 mergeTxOuts :: [TxOut] -> [TxOut]
 mergeTxOuts = map stick . NE.groupWith txOutAddress
@@ -127,3 +128,7 @@ toCUpdateInfo bvd ConfirmedProposalState {..} =
         cuiPositiveStake    = encodeCType cpsPositiveStake
         cuiNegativeStake    = encodeCType cpsNegativeStake
     in CUpdateInfo {..}
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -53,19 +53,15 @@ import           Pos.DB.Rocks (dbDeleteDefault, dbGetDefault, dbIterSourceDefaul
                                dbWriteBatchDefault)
 import           Pos.Infra.Network.Types (HasNodeType (..))
 import           Pos.Infra.Recovery.Info (MonadRecoveryInfo)
-import           Pos.Infra.Reporting (MonadReporting (..),
-                                      HasMisbehaviorMetrics (..),
+import           Pos.Infra.Reporting (HasMisbehaviorMetrics (..), MonadReporting (..),
                                       Reporter (..))
 import           Pos.Infra.Shutdown (HasShutdownContext (..))
 import           Pos.Infra.Slotting.Class (MonadSlots (..))
-import           Pos.Infra.Slotting.Impl (currentTimeSlottingSimple,
-                                          getCurrentSlotBlockingSimple,
-                                          getCurrentSlotInaccurateSimple,
-                                          getCurrentSlotSimple)
+import           Pos.Infra.Slotting.Impl (currentTimeSlottingSimple, getCurrentSlotBlockingSimple,
+                                          getCurrentSlotInaccurateSimple, getCurrentSlotSimple)
 import           Pos.Infra.Slotting.MemState (HasSlottingVar (..), MonadSlotsData)
 import           Pos.Infra.StateLock (StateLock)
-import           Pos.Infra.Util.JsonLog.Events (HasJsonLogConfig (..),
-                                                jsonLogDefault)
+import           Pos.Infra.Util.JsonLog.Events (HasJsonLogConfig (..), jsonLogDefault)
 import           Pos.Infra.Util.TimeWarp (CanJsonLog (..))
 import           Pos.Launcher (HasConfigurations)
 import           Pos.Recovery ()
@@ -93,8 +89,8 @@ import           Pos.Wallet.Web.ClientTypes (AccountId)
 import           Pos.Wallet.Web.Methods.Logic (MonadWalletLogic, newAddress_)
 import           Pos.Wallet.Web.Sockets.Connection (MonadWalletWebSockets)
 import           Pos.Wallet.Web.Sockets.ConnSet (ConnectionsVar)
-import           Pos.Wallet.Web.State (WalletDB, WalletDbReader, getWalletBalancesAndUtxo,
-                                       getWalletUtxo, askWalletSnapshot, wamAddress)
+import           Pos.Wallet.Web.State (WalletDB, WalletDbReader, askWalletSnapshot,
+                                       getWalletBalancesAndUtxo, getWalletUtxo, wamAddress)
 import           Pos.Wallet.Web.Tracking (MonadBListener (..), onApplyBlocksWebWallet,
                                           onRollbackBlocksWebWallet)
 
@@ -265,8 +261,8 @@ instance HasConfiguration => MonadGState WalletWebMode where
 
 instance (HasConfiguration)
        => MonadBListener WalletWebMode where
-    onApplyBlocks = onApplyBlocksWebWallet
-    onRollbackBlocks = onRollbackBlocksWebWallet
+    onApplyBlocks _nm = onApplyBlocksWebWallet
+    onRollbackBlocks _nm = onRollbackBlocksWebWallet
 
 instance MonadUpdates WalletWebMode where
     waitForUpdate = waitForUpdateWebWallet
@@ -352,5 +348,5 @@ instance (HasConfigurations)
     type AddrData Pos.Wallet.Web.Mode.WalletWebMode = (AccountId, PassPhrase)
     -- We rely on the fact that Daedalus always uses HD addresses with
     -- BootstrapEra distribution.
-    getFakeChangeAddress = pure largestHDAddressBoot
-    getNewAddress = getNewAddressWebWallet
+    getFakeChangeAddress nm = pure (largestHDAddressBoot nm)
+    getNewAddress _nm = getNewAddressWebWallet

--- a/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
@@ -22,13 +22,14 @@ import           Serokell.Util (enumerate)
 import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Core (Address (..), ChainDifficulty, Timestamp, aaPkDerivationPath,
                            addrAttributesUnwrapped, makeRootPubKeyAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (Tx (..), TxIn (..), TxOut, TxOutAux (..), TxUndo, toaOut,
                                txOutAddress)
 import           Pos.Crypto (EncryptedSecretKey, HDPassphrase, WithHash (..), deriveHDPassphrase,
                              encToPublic, unpackHDAddressAttr)
 import           Pos.Util.Servant (encodeCType)
 import           Pos.Wallet.Web.ClientTypes (CId, Wal)
-import           Pos.Wallet.Web.State (WAddressMeta(..))
+import           Pos.Wallet.Web.State (WAddressMeta (..))
 
 type OwnTxInOuts = [((TxIn, TxOutAux), WAddressMeta)]
 
@@ -78,7 +79,7 @@ eskToWalletDecrCredentials :: EncryptedSecretKey -> WalletDecrCredentials
 eskToWalletDecrCredentials encSK = do
     let pubKey = encToPublic encSK
     let hdPass = deriveHDPassphrase pubKey
-    let wCId = encodeCType $ makeRootPubKeyAddress pubKey
+    let wCId = encodeCType $ makeRootPubKeyAddress fixedNM pubKey
     (hdPass, wCId)
 
 selectOwnAddresses
@@ -95,3 +96,7 @@ decryptAddress (hdPass, wCId) addr = do
     derPath <- unpackHDAddressAttr hdPass hdPayload
     guard $ length derPath == 2
     pure $ WAddressMeta wCId (derPath !! 0) (derPath !! 1) addr
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet/test/Test/Pos/Wallet/Web/AddressSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/AddressSpec.hs
@@ -18,6 +18,7 @@ import           Test.QuickCheck.Monadic (pick, stop)
 import           Pos.Binary (biSize)
 import           Pos.Client.Txp.Addresses (getFakeChangeAddress, getNewAddress)
 import           Pos.Core.Common (Address)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (PassPhrase)
 import           Pos.Launcher (HasConfigurations)
 
@@ -54,7 +55,7 @@ fakeAddressHasMaxSizeTest generator accSeed = do
          =<< newAccount (DeterminedSeed accSeed) passphrase (CAccountInit def wid)
     address <- generator accId passphrase
 
-    largeAddress <- lift getFakeChangeAddress
+    largeAddress <- lift (getFakeChangeAddress fixedNM)
 
     assertProperty
         (biSize largeAddress >= biSize address)
@@ -64,7 +65,7 @@ fakeAddressHasMaxSizeTest generator accSeed = do
 -- Unfortunatelly, its randomness doesn't depend on QuickCheck seed,
 -- so another proper generator is helpful.
 changeAddressGenerator :: HasConfigurations => AddressGenerator
-changeAddressGenerator accId passphrase = lift $ getNewAddress (accId, passphrase)
+changeAddressGenerator accId passphrase = lift $ getNewAddress fixedNM (accId, passphrase)
 
 -- | Generator which is directly used in endpoints.
 commonAddressGenerator :: AddressGenerator
@@ -80,3 +81,7 @@ commonAddressGenerator accId passphrase = do
     seedBusyHandler (InternalError "address generation: this index is already taken")
                       = pure Nothing
     seedBusyHandler e = throwM e
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -370,8 +370,8 @@ instance HasLens (StateLockMetrics MemPoolModifyReason) WalletTestContext (State
 
 instance HasConfigurations => MonadAddresses WalletTestMode where
     type AddrData WalletTestMode = (AccountId, PassPhrase)
-    getNewAddress = getNewAddressWebWallet
-    getFakeChangeAddress = pure largestHDAddressBoot
+    getNewAddress _nm = getNewAddressWebWallet
+    getFakeChangeAddress nm = pure (largestHDAddressBoot nm)
 
 instance MonadKeysRead WalletTestMode where
     getSecret = getSecretDefault
@@ -393,8 +393,8 @@ instance MonadUpdates WalletTestMode where
     applyLastUpdate = applyLastUpdateWebWallet
 
 instance (HasConfigurations) => MonadBListener WalletTestMode where
-    onApplyBlocks = onApplyBlocksWebWallet
-    onRollbackBlocks = onRollbackBlocksWebWallet
+    onApplyBlocks _nm = onApplyBlocksWebWallet
+    onRollbackBlocks _nm = onRollbackBlocksWebWallet
 
 instance HasConfiguration => MonadBlockchainInfo WalletTestMode where
     networkChainDifficulty = networkChainDifficultyWebWallet

--- a/wallet/test/Test/Pos/Wallet/Web/Util.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Util.hs
@@ -44,6 +44,7 @@ import           Pos.Core.Block (blockHeader)
 import           Pos.Core.Chrono (OldestFirst (..))
 import           Pos.Core.Common (IsBootstrapEraAddr (..), deriveLvl2KeyPair)
 import           Pos.Core.Genesis (poorSecretToEncKey)
+import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Core.Txp (TxIn, TxOut (..), TxOutAux (..))
 import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ProtocolMagic,
                              ShouldCheckPassphrase (..), emptyPassphrase, firstHardened)
@@ -171,6 +172,7 @@ genWalletLvl2KeyPair sk psw = do
     accountIdx <- getDerivingIndex <$> arbitrary
     addressIdx <- getDerivingIndex <$> arbitrary
     pure $ deriveLvl2KeyPair
+        fixedNM
         (IsBootstrapEraAddr True)
         (ShouldCheckPassphrase False)
         psw sk accountIdx addressIdx
@@ -229,3 +231,7 @@ newtype DerivingIndex = DerivingIndex
 
 instance Arbitrary DerivingIndex where
     arbitrary = DerivingIndex <$> choose (firstHardened, firstHardened + (firstHardened - 1))
+
+
+fixedNM :: NetworkMagic
+fixedNM = NMNothing


### PR DESCRIPTION
## Description

Building on the previous commit, we add the `NetworkMagic` datatype,
which allows us to discriminate addresses originating from different
networks.

In order to make this commit as simple and easy-to-review as possible,
I stub out the added arguments of type `NetworkMagic` with a dummy
variable: `fixedNM`. This puts off the (fairly involved) work of
threading `NetworkMagic` values from the nearest occurrence of
`ProtocolMagic` to where said values are needed.

The remainder of the work will come in a separate commit.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-354

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.
^ there is no 1.3.1 section in the CHANGELOG, and this is dev work on a release branch, so I'm skipping this.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
^ no tests were added because these changes introduce new capabilities which are not used yet. Thus the behavior is the same, and the existing tests should be adequate.