### PR TITLE
[release/1.3.1] [CO-354] Split test-suites for NMNothing/NMJust

### DIFF
--- a/client/test/Test/Pos/Client/Txp/UtilSpec.hs
+++ b/client/test/Test/Pos/Client/Txp/UtilSpec.hs
@@ -14,9 +14,9 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import qualified Data.Set as S
 import           Formatting (build, hex, left, sformat, shown, (%), (%.))
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (prop)
-import           Test.QuickCheck (Discard (..), Gen, Testable, arbitrary, choose)
+import           Test.QuickCheck (Discard (..), Gen, Testable, arbitrary, choose, generate)
 import           Test.QuickCheck.Monadic (forAllM, stop)
 
 import           Pos.Client.Txp.Addresses (MonadAddresses (..))
@@ -26,18 +26,18 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..), TxError (..), T
 import           Pos.Core (Address, BlockVersionData (..), Coeff (..), TxFeePolicy (..),
                            TxSizeLinear (..), makePubKeyAddressBoot, makeRedeemAddress,
                            unsafeIntegerToCoin)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxId, TxIn (..), TxOut (..), TxOutAux (..))
-import           Pos.Crypto (RedeemSecretKey, SafeSigner, SecretKey, decodeHash, fakeSigner,
-                             redeemToPublic, toPublic)
+import           Pos.Crypto (ProtocolMagic (..), RedeemSecretKey, RequiresNetworkMagic (..),
+                             SafeSigner, SecretKey, decodeHash, fakeSigner, redeemToPublic,
+                             toPublic)
 import           Pos.DB (gsAdoptedBVData)
 import           Pos.Txp (Utxo)
 import           Pos.Util.Util (leftToPanic)
 
 import           Test.Pos.Client.Txp.Mode (HasTxpConfigurations, TxpTestMode, TxpTestProperty,
                                            withBVData)
-import           Test.Pos.Configuration (withDefConfigurations)
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Arbitrary (nonrepeating)
 import           Test.Pos.Util.QuickCheck.Property (stopProperty)
 
@@ -46,7 +46,18 @@ import           Test.Pos.Util.QuickCheck.Property (stopProperty)
 ----------------------------------------------------------------------------
 
 spec :: Spec
-spec = withDefConfigurations $ \_ _ ->
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $
     describe "Client.Txp.Util" $ do
         describe "createMTx" $ createMTxSpec
 
@@ -114,7 +125,7 @@ testCreateMTx
     => CreateMTxParams
     -> TxpTestProperty (Either TxError (TxAux, NonEmpty TxOut))
 testCreateMTx CreateMTxParams{..} = lift $
-    createMTx dummyProtocolMagic mempty cmpInputSelectionPolicy cmpUtxo (getSignerFromList cmpSigners)
+    createMTx cmpProtocolMagic mempty cmpInputSelectionPolicy cmpUtxo (getSignerFromList cmpSigners)
     cmpOutputs cmpAddrData
 
 createMTxWorksWhenWeAreRichSpec
@@ -202,7 +213,7 @@ manyAddressesToManySpec inputSelectionPolicy = do
 redemptionSpec :: HasTxpConfigurations => TxpTestProperty ()
 redemptionSpec = do
     forAllM genParams $ \(CreateRedemptionTxParams {..}) -> do
-        txOrError <- createRedemptionTx dummyProtocolMagic crpUtxo crpRsk crpOutputs
+        txOrError <- createRedemptionTx crpProtocolMagic crpUtxo crpRsk crpOutputs
         case txOrError of
             Left err -> stopProperty $ pretty err
             Right _  -> return ()
@@ -210,9 +221,11 @@ redemptionSpec = do
     genParams = do
         crpRsk <- arbitrary
         skTo   <- arbitrary
+        crpProtocolMagic <- arbitrary
 
-        let txOutAuxInput = generateRedeemTxOutAux 1 crpRsk
-            txOutAuxOutput = generateTxOutAux 1 skTo
+        let nm = makeNetworkMagic crpProtocolMagic
+            txOutAuxInput = generateRedeemTxOutAux nm 1 crpRsk
+            txOutAuxOutput = generateTxOutAux nm 1 skTo
             crpUtxo = one (TxInUtxo (unsafeIntegerToTxId 0) 0, txOutAuxInput)
             crpOutputs = one txOutAuxOutput
 
@@ -225,7 +238,7 @@ txWithRedeemOutputFailsSpec
 txWithRedeemOutputFailsSpec inputSelectionPolicy = do
     forAllM genParams $ \(CreateMTxParams {..}) -> do
         txOrError <-
-            createMTx dummyProtocolMagic mempty cmpInputSelectionPolicy cmpUtxo
+            createMTx cmpProtocolMagic mempty cmpInputSelectionPolicy cmpUtxo
                       (getSignerFromList cmpSigners)
                       cmpOutputs cmpAddrData
         case txOrError of
@@ -235,8 +248,9 @@ txWithRedeemOutputFailsSpec inputSelectionPolicy = do
                 sformat ("Transaction to a redeem address was created")
   where
     genParams = do
-        txOutAuxOutput <- generateRedeemTxOutAux 1 <$> arbitrary
         params <- makeManyAddressesToManyParams inputSelectionPolicy 1 1000000 1 1
+        let nm = makeNetworkMagic (cmpProtocolMagic params)
+        txOutAuxOutput <- generateRedeemTxOutAux nm 1 <$> arbitrary
         pure params{ cmpOutputs = one txOutAuxOutput }
 
 feeForManyAddressesSpec
@@ -324,14 +338,16 @@ data CreateMTxParams = CreateMTxParams
     , cmpAddrData             :: !(AddrData TxpTestMode)
     -- ^ Data that is normally used for creation of change addresses.
     -- In tests, it is always `()`.
+    , cmpProtocolMagic        :: !ProtocolMagic
     } deriving Show
 
 -- | Container for parameters of `createRedemptionTx`.
 -- The parameters mirror those of `createMTx` almost perfectly.
 data CreateRedemptionTxParams = CreateRedemptionTxParams
-    { crpUtxo    :: !Utxo
-    , crpRsk     :: !RedeemSecretKey
-    , crpOutputs :: !TxOutputs
+    { crpUtxo          :: !Utxo
+    , crpRsk           :: !RedeemSecretKey
+    , crpOutputs       :: !TxOutputs
+    , crpProtocolMagic :: !ProtocolMagic
     } deriving Show
 
 getSignerFromList :: NonEmpty (SafeSigner, Address) -> Address -> Maybe SafeSigner
@@ -341,13 +357,15 @@ getSignerFromList (HM.fromList . map swap . toList -> hm) =
 makeManyUtxoTo1Params :: InputSelectionPolicy -> Int -> Integer -> Integer -> Gen CreateMTxParams
 makeManyUtxoTo1Params inputSelectionPolicy numFrom amountEachFrom amountTo = do
     ~[skFrom, skTo] <- nonrepeating 2
-    let txOutAuxInput  = generateTxOutAux amountEachFrom skFrom
-        txOutAuxOutput = generateTxOutAux amountTo skTo
+    cmpProtocolMagic <- arbitrary
+    let nm = makeNetworkMagic cmpProtocolMagic
+    let txOutAuxInput  = generateTxOutAux nm amountEachFrom skFrom
+        txOutAuxOutput = generateTxOutAux nm amountTo skTo
         cmpInputSelectionPolicy = inputSelectionPolicy
         cmpUtxo = M.fromList
             [(TxInUtxo (unsafeIntegerToTxId 0) (fromIntegral k), txOutAuxInput) |
                 k <- [0..numFrom-1]]
-        cmpSigners = one $ makeSigner skFrom
+        cmpSigners = one $ makeSigner nm skFrom
         cmpOutputs = one txOutAuxOutput
         cmpAddrData = ()
 
@@ -362,12 +380,14 @@ makeManyAddressesToManyParams
     -> Gen CreateMTxParams
 makeManyAddressesToManyParams inputSelectionPolicy numFrom amountEachFrom numTo amountEachTo = do
     sks <- nonrepeating (numFrom + numTo)
+    cmpProtocolMagic <- arbitrary
+    let nm = makeNetworkMagic cmpProtocolMagic
 
     let (sksFrom, sksTo) = splitAt numFrom sks
-        cmpSignersList = map makeSigner sksFrom
+        cmpSignersList = map (makeSigner nm) sksFrom
         cmpSigners = NE.fromList cmpSignersList
-        txOutAuxInputs = map (generateTxOutAux amountEachFrom) sksFrom
-        txOutAuxOutputs = map (generateTxOutAux amountEachTo) sksTo
+        txOutAuxInputs = map (generateTxOutAux nm amountEachFrom) sksFrom
+        txOutAuxOutputs = map (generateTxOutAux nm amountEachTo) sksTo
         cmpInputSelectionPolicy = inputSelectionPolicy
         cmpUtxo = M.fromList
             [(TxInUtxo (unsafeIntegerToTxId $ fromIntegral k) 0, txOutAux) |
@@ -405,19 +425,19 @@ makeTxOutAux amount addr =
         txOut = TxOut addr coin
     in TxOutAux txOut
 
-generateTxOutAux :: Integer -> SecretKey -> TxOutAux
-generateTxOutAux amount sk =
-    makeTxOutAux amount (secretKeyToAddress sk)
+generateTxOutAux :: NetworkMagic -> Integer -> SecretKey -> TxOutAux
+generateTxOutAux nm amount sk =
+    makeTxOutAux amount (secretKeyToAddress nm sk)
 
-generateRedeemTxOutAux :: Integer -> RedeemSecretKey -> TxOutAux
-generateRedeemTxOutAux amount rsk =
-    makeTxOutAux amount (makeRedeemAddress fixedNM $ redeemToPublic rsk)
+generateRedeemTxOutAux :: NetworkMagic -> Integer -> RedeemSecretKey -> TxOutAux
+generateRedeemTxOutAux nm amount rsk =
+    makeTxOutAux amount (makeRedeemAddress nm $ redeemToPublic rsk)
 
-secretKeyToAddress :: SecretKey -> Address
-secretKeyToAddress = makePubKeyAddressBoot fixedNM . toPublic
+secretKeyToAddress :: NetworkMagic -> SecretKey -> Address
+secretKeyToAddress nm = makePubKeyAddressBoot nm . toPublic
 
-makeSigner :: SecretKey -> (SafeSigner, Address)
-makeSigner sk = (fakeSigner sk, secretKeyToAddress sk)
+makeSigner :: NetworkMagic -> SecretKey -> (SafeSigner, Address)
+makeSigner nm sk = (fakeSigner sk, secretKeyToAddress nm sk)
 
 withTxFeePolicy
   :: Coeff -> Coeff -> TxpTestProperty () -> TxpTestProperty ()
@@ -425,7 +445,3 @@ withTxFeePolicy a b action = do
     let policy = TxFeePolicyTxSizeLinear $ TxSizeLinear a b
     bvd <- gsAdoptedBVData
     withBVData bvd{ bvdTxFeePolicy = policy } action
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/AddressSpec.hs
+++ b/core/test/Test/Pos/Core/AddressSpec.hs
@@ -9,38 +9,56 @@ import           Universum
 import qualified Data.ByteString as BS
 import           Formatting (formatToString, int, (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
-import           Test.Hspec (Spec, describe, it, shouldBe)
+import           Test.Hspec (Spec, describe, it, runIO, shouldBe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Gen, arbitrary, counterexample, forAll, frequency, vectorOf)
+import           Test.QuickCheck (Gen, arbitrary, counterexample, forAll, frequency, generate,
+                                  vectorOf)
 
 import           Pos.Binary.Class (biSize)
 import           Pos.Core (Address, IsBootstrapEraAddr (..), deriveLvl2KeyPair,
                            largestHDAddressBoot, largestPubKeyAddressBoot,
                            largestPubKeyAddressSingleKey, makePubKeyAddress, makePubKeyAddressBoot,
                            makePubKeyHdwAddress)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
-import           Pos.Crypto (EncryptedSecretKey, PassPhrase, PublicKey, SecretKey (..),
-                             ShouldCheckPassphrase (..), deterministicKeyGen, emptyPassphrase,
-                             mkEncSecretUnsafe, noPassEncrypt, toPublic)
+import           Pos.Core.NetworkMagic (NetworkMagic (..), makeNetworkMagic)
+import           Pos.Crypto (EncryptedSecretKey, PassPhrase, ProtocolMagic (..), PublicKey,
+                             RequiresNetworkMagic (..), SecretKey (..), ShouldCheckPassphrase (..),
+                             deterministicKeyGen, emptyPassphrase, mkEncSecretUnsafe, noPassEncrypt,
+                             toPublic)
 import           Pos.Crypto.HD (HDAddressPayload (..))
 
 import           Test.Pos.Core.Arbitrary ()
 
 spec :: Spec
-spec = describe "Address" $ do
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+-- An attempt to avoid rightward creep
+specBody :: ProtocolMagic -> Spec
+specBody pm = do
+    let nm = makeNetworkMagic pm
+
     modifyMaxSuccess (min 10) $ do
         prop "PK and HDW addresses with same public key are shown differently"
-            pkAndHdwAreShownDifferently
+            (pkAndHdwAreShownDifferently nm)
 
     describe "Largest addresses" $ do
-        let genPubKeyAddrBoot = pure . makePubKeyAddressBoot fixedNM . toPublic
+        let genPubKeyAddrBoot = pure . makePubKeyAddressBoot nm . toPublic
+            pubKeyAddrBootSize = 43 + networkMagicExtraBytes pm
         largestAddressProp "PubKey address with BootstrapEra distribution"
-            genPubKeyAddrBoot (largestPubKeyAddressBoot fixedNM) 43
+            genPubKeyAddrBoot (largestPubKeyAddressBoot nm) pubKeyAddrBootSize
 
-        let genPubKeyAddrSingleKey = pure . makePubKeyAddress fixedNM
+        let genPubKeyAddrSingleKey = pure . makePubKeyAddress nm
                 (IsBootstrapEraAddr False) . toPublic
+            pubKeyAddrSingleKeySize = 78 + networkMagicExtraBytes pm
         largestAddressProp "PubKey address with SingleKey distribution"
-            genPubKeyAddrSingleKey (largestPubKeyAddressSingleKey fixedNM) 78
+            genPubKeyAddrSingleKey (largestPubKeyAddressSingleKey nm) pubKeyAddrSingleKeySize
 
         let genHDAddrBoot :: SecretKey -> Gen Address
             genHDAddrBoot sk = frequency
@@ -51,7 +69,7 @@ spec = describe "Address" $ do
             genHDAddrBoot' :: PassPhrase -> EncryptedSecretKey -> Word32 -> Word32 -> Address
             genHDAddrBoot' passphrase esk accIdx addrIdx =
                 case deriveLvl2KeyPair
-                            fixedNM
+                            nm
                             (IsBootstrapEraAddr True)
                             (ShouldCheckPassphrase False)
                             passphrase
@@ -70,13 +88,22 @@ spec = describe "Address" $ do
                 esk <- mkEncSecretUnsafe passphrase sk
                 genHDAddrBoot' passphrase esk <$> arbitrary <*> arbitrary
 
+        let hdAddrBootSize = 76 + networkMagicExtraBytes pm
         largestAddressProp "HD address with BootstrapEra distribution"
-            genHDAddrBoot (largestHDAddressBoot fixedNM) 76
+            genHDAddrBoot (largestHDAddressBoot nm) hdAddrBootSize
 
-pkAndHdwAreShownDifferently :: Bool -> PublicKey -> Bool
-pkAndHdwAreShownDifferently isBootstrap pk =
-    show (makePubKeyAddress fixedNM (IsBootstrapEraAddr isBootstrap) pk) /=
-    (show @Text (makePubKeyHdwAddress fixedNM (IsBootstrapEraAddr isBootstrap)
+networkMagicExtraBytes :: ProtocolMagic -> Byte
+networkMagicExtraBytes pm = case makeNetworkMagic pm of
+    NMNothing -> 0
+    -- Encoding size:
+    -- Map key: 2 bytes (1 for header, 1 for Word8)
+    -- Map val: 1-5 bytes (1 for header, 0-4 for Int32)
+    NMJust v  -> 2 + biSize v
+
+pkAndHdwAreShownDifferently :: NetworkMagic -> Bool -> PublicKey -> Bool
+pkAndHdwAreShownDifferently nm isBootstrap pk =
+    show (makePubKeyAddress nm (IsBootstrapEraAddr isBootstrap) pk) /=
+    (show @Text (makePubKeyHdwAddress nm (IsBootstrapEraAddr isBootstrap)
                 (HDAddressPayload "pataq") pk))
 
 largestAddressProp :: Text -> (SecretKey -> Gen Address) -> Address -> Byte -> Spec
@@ -93,7 +120,3 @@ largestAddressProp addressDescription genAddress largestAddress expectedLargestS
                     in counterexample
                            (formatToString (int % " > " %int) generatedSize expectedLargestSize)
                            (generatedSize <= expectedLargestSize)
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/CborSpec.hs
+++ b/core/test/Test/Pos/Core/CborSpec.hs
@@ -13,6 +13,7 @@ module Test.Pos.Core.CborSpec
 import           Universum
 
 import           Test.Hspec (Spec, describe, runIO)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 import           Test.QuickCheck (Arbitrary (..), generate)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
@@ -29,7 +30,7 @@ import           Pos.Merkle (MerkleTree)
 import           Test.Pos.Binary.Helpers (binaryTest)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Core.Chrono ()
-import           Test.Pos.Crypto.Arbitrary ()
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 
 
 data MyScript = MyScript
@@ -77,6 +78,11 @@ instance Bi (Attributes X2) where
 
 ----------------------------------------
 
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -84,43 +90,44 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        withGenesisSpec 0 (defaultCoreConfiguration pm) $ \_ ->
-            describe "Cbor Bi instances" $ do
-                describe "Core.Address" $ do
-                    binaryTest @Address
-                    binaryTest @Address'
-                    binaryTest @AddrType
-                    binaryTest @AddrStakeDistribution
-                    binaryTest @AddrSpendingData
-                describe "Core.Types" $ do
-                    binaryTest @Timestamp
-                    binaryTest @TimeDiff
-                    binaryTest @EpochIndex
-                    binaryTest @Coin
-                    binaryTest @CoinPortion
-                    binaryTest @LocalSlotIndex
-                    binaryTest @SlotId
-                    binaryTest @EpochOrSlot
-                    binaryTest @SharedSeed
-                    binaryTest @ChainDifficulty
-                    binaryTest @SoftforkRule
-                    binaryTest @BlockVersionData
-                    binaryTest @(Attributes ())
-                    binaryTest @(Attributes AddrAttributes)
-                describe "Core.Fee" $ do
-                    binaryTest @Coeff
-                    binaryTest @TxSizeLinear
-                    binaryTest @TxFeePolicy
-                describe "Core.Script" $ do
-                    binaryTest @Script
-                describe "Core.Vss" $ do
-                    binaryTest @VssCertificate
-                describe "Core.Version" $ do
-                    binaryTest @ApplicationName
-                    binaryTest @SoftwareVersion
-                    binaryTest @BlockVersion
-                describe "Merkle" $ do
-                    binaryTest @(MerkleTree Int32)
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            withGenesisSpec 0 (defaultCoreConfiguration pm) $ \_ ->
+                describe "Cbor Bi instances" $ do
+                    describe "Core.Address" $ do
+                        binaryTest @Address
+                        binaryTest @Address'
+                        binaryTest @AddrType
+                        binaryTest @AddrStakeDistribution
+                        binaryTest @AddrSpendingData
+                    describe "Core.Types" $ do
+                        binaryTest @Timestamp
+                        binaryTest @TimeDiff
+                        binaryTest @EpochIndex
+                        binaryTest @Coin
+                        binaryTest @CoinPortion
+                        binaryTest @LocalSlotIndex
+                        binaryTest @SlotId
+                        binaryTest @EpochOrSlot
+                        binaryTest @SharedSeed
+                        binaryTest @ChainDifficulty
+                        binaryTest @SoftforkRule
+                        binaryTest @BlockVersionData
+                        binaryTest @(Attributes ())
+                        binaryTest @(Attributes AddrAttributes)
+                    describe "Core.Fee" $ do
+                        binaryTest @Coeff
+                        binaryTest @TxSizeLinear
+                        binaryTest @TxFeePolicy
+                    describe "Core.Script" $ do
+                        binaryTest @Script
+                    describe "Core.Vss" $ do
+                        binaryTest @VssCertificate
+                    describe "Core.Version" $ do
+                        binaryTest @ApplicationName
+                        binaryTest @SoftwareVersion
+                        binaryTest @BlockVersion
+                    describe "Merkle" $ do
+                        binaryTest @(MerkleTree Int32)

--- a/crypto/test/Test/Pos/Crypto/Arbitrary.hs
+++ b/crypto/test/Test/Pos/Crypto/Arbitrary.hs
@@ -9,6 +9,7 @@ module Test.Pos.Crypto.Arbitrary
        , genSignature
        , genSignatureEncoded
        , genRedeemSignature
+       , genProtocolMagicUniformWithRNM
        ) where
 
 import           Universum hiding (keys)
@@ -16,7 +17,7 @@ import           Universum hiding (keys)
 import           Control.Monad (zipWithM)
 import qualified Data.ByteArray as ByteArray
 import           Data.List.NonEmpty (fromList)
-import           Test.QuickCheck (Arbitrary (..), Gen, elements, oneof, vector)
+import           Test.QuickCheck (Arbitrary (..), Gen, choose, elements, oneof, vector)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
 import           Pos.Binary.Class (AsBinary (..), AsBinaryClass (..), Bi, Raw)
@@ -53,6 +54,12 @@ instance Arbitrary ProtocolMagicId where
 
 instance Arbitrary RequiresNetworkMagic where
     arbitrary = elements [NMMustBeNothing, NMMustBeJust]
+
+genProtocolMagicUniformWithRNM :: RequiresNetworkMagic -> Gen ProtocolMagic
+genProtocolMagicUniformWithRNM rnm =
+    (\ident -> ProtocolMagic (ProtocolMagicId ident) rnm)
+    <$>
+    choose (minBound, maxBound)
 
 {- A note on 'Arbitrary' instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -356,6 +356,7 @@ test-suite cardano-explorer-test
                      , cardano-sl-block-test
                      , cardano-sl-core
                      , cardano-sl-crypto
+                     , cardano-sl-crypto-test
                      , cardano-sl-explorer
                      , cardano-sl-txp
                      , cardano-sl-util

--- a/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
@@ -15,24 +15,24 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import           Network.EngineIO (SocketId)
 
-import           Test.Hspec (Spec, anyException, describe, it, shouldBe, shouldThrow)
+import           Test.Hspec (Spec, anyException, describe, it, runIO, shouldBe, shouldThrow)
 import           Test.Hspec.QuickCheck (modifyMaxSize, prop)
-import           Test.QuickCheck (Property, arbitrary, forAll)
+import           Test.QuickCheck (Property, arbitrary, forAll, generate)
 import           Test.QuickCheck.Monadic (assert, monadicIO, run)
 
-import           Pos.Crypto (SecretKey)
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..), SecretKey)
 import           Pos.Explorer.ExplorerMode (runSubTestMode)
-import           Pos.Explorer.Socket.Holder (ConnectionsState, ExplorerSocket(..),
+import           Pos.Explorer.Socket.Holder (ConnectionsState, ExplorerSocket (..),
                                              csAddressSubscribers, csBlocksPageSubscribers,
-                                             csEpochsLastPageSubscribers, csTxsSubscribers,
-                                             csClients, mkClientContext, mkConnectionsState)
-import           Pos.Explorer.Socket.Methods (addrSubParam, addressSetByTxs,
-                                              blockPageSubParam, fromCAddressOrThrow,
-                                              spSessId, subscribeAddr, subscribeBlocksLastPage,
-                                              subscribeEpochsLastPage, subscribeTxs,
-                                              txsSubParam, unsubscribeAddr, unsubscribeBlocksLastPage,
-                                              unsubscribeEpochsLastPage, unsubscribeFully,
-                                              unsubscribeTxs)
+                                             csClients, csEpochsLastPageSubscribers,
+                                             csTxsSubscribers, mkClientContext, mkConnectionsState)
+import           Pos.Explorer.Socket.Methods (addrSubParam, addressSetByTxs, blockPageSubParam,
+                                              fromCAddressOrThrow, spSessId, subscribeAddr,
+                                              subscribeBlocksLastPage, subscribeEpochsLastPage,
+                                              subscribeTxs, txsSubParam, unsubscribeAddr,
+                                              unsubscribeBlocksLastPage, unsubscribeEpochsLastPage,
+                                              unsubscribeFully, unsubscribeTxs)
 import           Pos.Explorer.TestUtil (secretKeyToAddress)
 import           Pos.Explorer.Web.ClientTypes (CAddress (..), toCAddress)
 
@@ -46,7 +46,18 @@ import           Test.Pos.Explorer.MockFactory (mkTxOut)
 -- stack test cardano-sl-explorer --fast --test-arguments "-m Test.Pos.Explorer.Socket"
 
 spec :: Spec
-spec =
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody (makeNetworkMagic pm)
+
+specBody :: NetworkMagic -> Spec
+specBody nm =
     describe "Methods" $ do
         describe "fromCAddressOrThrow" $
             it "throws an exception if a given CAddress is invalid" $
@@ -54,7 +65,7 @@ spec =
         describe "addressSetByTxs" $
             modifyMaxSize (const 200) $
                 prop "creates a Set of Addresses by given txs"
-                    addressSetByTxsProp
+                    (addressSetByTxsProp nm)
         describe "addrSubParam" $
             it "stores a given SocketId into SubscriptionParam of address subscribers" $ do
                 let socketId = BS.pack "any-id" -- SocketId
@@ -108,8 +119,8 @@ spec =
                     unsubscribeFullyProp
 
 
-addressSetByTxsProp :: SecretKey -> Bool
-addressSetByTxsProp key =
+addressSetByTxsProp :: NetworkMagic -> SecretKey -> Bool
+addressSetByTxsProp _nm key =
     let
         addrA = secretKeyToAddress key
         addrB = secretKeyToAddress key

--- a/explorer/test/Test/Pos/Explorer/Web/ServerSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Web/ServerSpec.hs
@@ -8,13 +8,14 @@ module Test.Pos.Explorer.Web.ServerSpec
 
 import           Universum
 
-import           Test.Hspec (Spec, describe, shouldBe)
+import           Test.Hspec (Spec, describe, runIO, shouldBe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (arbitrary, counterexample, forAll, (==>))
+import           Test.QuickCheck (arbitrary, counterexample, forAll, generate, (==>))
 import           Test.QuickCheck.Monadic (assert, monadicIO, run)
 
 import qualified Pos.Communication ()
 import           Pos.Core (EpochIndex (..))
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Explorer.ExplorerMode (runExplorerTestMode)
 import           Pos.Explorer.ExtraContext (ExtraContext (..), makeExtraCtx, makeMockExtraCtx)
 import           Pos.Explorer.TestUtil (emptyBlk, generateValidBlocksSlotsNumber,
@@ -29,7 +30,7 @@ import           Pos.Util (divRoundUp)
 import           Pos.Util.Mockable ()
 
 import           Test.Pos.Block.Arbitrary ()
-import           Test.Pos.Configuration (withDefConfigurations)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 
 
 ----------------------------------------------------------------
@@ -40,7 +41,18 @@ import           Test.Pos.Configuration (withDefConfigurations)
 
 -- stack test cardano-sl-explorer --fast --test-arguments "-m Pos.Explorer.Web.Server"
 spec :: Spec
-spec = withDefConfigurations $ \_ _ -> do
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ do
     describe "Pos.Explorer.Web.Server" $ do
         blocksTotalSpec
         blocksPagesTotalSpec

--- a/explorer/test/Test/Pos/Explorer/Web/ServerSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Web/ServerSpec.hs
@@ -31,6 +31,7 @@ import           Pos.Util.Mockable ()
 
 import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 
 
 ----------------------------------------------------------------
@@ -40,16 +41,24 @@ import           Test.Pos.Configuration (withProvidedMagicConfig)
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 -- stack test cardano-sl-explorer --fast --test-arguments "-m Pos.Explorer.Web.Server"
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ do

--- a/generator/test/Test/Pos/Binary/CommunicationSpec.hs
+++ b/generator/test/Test/Pos/Binary/CommunicationSpec.hs
@@ -7,8 +7,8 @@ import           Universum
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Default (def)
 import           Test.Hspec (Spec, describe, runIO)
-import           Test.Hspec.QuickCheck (prop)
-import           Test.QuickCheck (arbitrary, generate)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import           Test.QuickCheck (generate)
 import           Test.QuickCheck.Monadic (assert)
 
 import           Pos.Binary.Class (decodeFull, serialize')
@@ -21,6 +21,7 @@ import           Pos.Util.CompileInfo (withCompileInfo)
 import           Test.Pos.Block.Logic.Mode (blockPropertyTestable)
 import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..), bpGenBlock)
 import           Test.Pos.Configuration (HasStaticConfigurations, withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 
 -- |
 -- The binary encoding of `MsgSerializedBlock` using `serializeMsgSerializedBlock`
@@ -63,16 +64,24 @@ deserializeSerilizedMsgSerializedBlockSpec pm = do
     desc = "deserialization of a serialized MsgSerializedBlock message should give back corresponding MsgBlock"
     descNoBlock = "deserialization of a serialized MsgNoSerializedBlock message should give back corresponding MsgNoBlock"
 
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ withCompileInfo def $

--- a/generator/test/Test/Pos/Binary/CommunicationSpec.hs
+++ b/generator/test/Test/Pos/Binary/CommunicationSpec.hs
@@ -20,7 +20,7 @@ import           Pos.Util.CompileInfo (withCompileInfo)
 
 import           Test.Pos.Block.Logic.Mode (blockPropertyTestable)
 import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..), bpGenBlock)
-import           Test.Pos.Configuration (HasStaticConfigurations, withProvidedMagicConfig)
+import           Test.Pos.Configuration (HasStaticConfigurations, withStaticConfigurations)
 import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 
 -- |
@@ -84,7 +84,7 @@ runWithMagic rnm = replicateM_ testMultiple $
             specBody pm
 
 specBody :: ProtocolMagic -> Spec
-specBody pm = withProvidedMagicConfig pm $ withCompileInfo def $
+specBody pm = withStaticConfigurations $ \_ -> withCompileInfo def $
     describe "Pos.Binary.Communication" $ do
         describe "serializeMsgSerializedBlock" (serializeMsgSerializedBlockSpec pm)
         describe "decode is left inverse of serializeMsgSerializedBlock" (deserializeSerilizedMsgSerializedBlockSpec pm)

--- a/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
@@ -31,9 +31,16 @@ import           Pos.Update.Configuration (HasUpdateConfiguration)
 
 import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Configuration (withDefUpdateConfiguration, withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Delegation.Arbitrary (genDlgPayload)
 import           Test.Pos.Txp.Arbitrary (GoodTx, goodTxToTxAux)
 import           Test.Pos.Util.QuickCheck (SmallGenerator (..), makeSmall)
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
 
 spec :: Spec
 spec = do
@@ -41,10 +48,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ withDefUpdateConfiguration $

--- a/generator/test/Test/Pos/Block/Logic/VarSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/VarSpec.hs
@@ -46,7 +46,7 @@ import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..)
                                             bpGenBlocks, bpGoToArbitraryState, getAllSecrets,
                                             satisfySlotCheck)
 import           Test.Pos.Block.Property (blockPropertySpec)
-import           Test.Pos.Configuration (HasStaticConfigurations, withProvidedMagicConfig)
+import           Test.Pos.Configuration (HasStaticConfigurations, withStaticConfigurations)
 import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Property (splitIntoChunks, stopProperty)
 
@@ -73,7 +73,7 @@ runWithMagic rnm = replicateM_ testMultiple $
             specBody pm
 
 specBody :: ProtocolMagic -> Spec
-specBody pm = withProvidedMagicConfig pm $
+specBody pm = withStaticConfigurations $ \_ ->
     describe "Block.Logic.VAR" $ modifyMaxSuccess (min 4) $ do
         describe "verifyBlocksPrefix" (verifyBlocksPrefixSpec pm)
         describe "verifyAndApplyBlocks" (verifyAndApplyBlocksSpec pm)

--- a/generator/test/Test/Pos/Block/Property.hs
+++ b/generator/test/Test/Pos/Block/Property.hs
@@ -12,6 +12,7 @@ import           Test.Hspec (Spec)
 import           Test.Hspec.QuickCheck (prop)
 
 import           Pos.Core (HasConfiguration)
+import           Pos.Crypto (ProtocolMagic)
 import           Pos.Delegation (HasDlgConfiguration)
 
 import           Test.Pos.Block.Logic.Mode (BlockProperty, blockPropertyTestable)
@@ -20,7 +21,8 @@ import           Test.QuickCheck.Property (Testable)
 -- | Specialized version of 'prop' function from 'hspec'.
 blockPropertySpec ::
        (HasDlgConfiguration, Testable a)
-    => String
+    => ProtocolMagic
+    -> String
     -> (HasConfiguration => BlockProperty a)
     -> Spec
-blockPropertySpec description bp = prop description (blockPropertyTestable bp)
+blockPropertySpec pm description bp = prop description (blockPropertyTestable pm bp)

--- a/generator/test/Test/Pos/Generator/Block/LrcSpec.hs
+++ b/generator/test/Test/Pos/Generator/Block/LrcSpec.hs
@@ -41,8 +41,15 @@ import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..)
                                             bpGenBlocks)
 import           Test.Pos.Block.Property (blockPropertySpec)
 import           Test.Pos.Configuration (defaultTestBlockVersionData, withStaticConfigurations)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck (maybeStopProperty, stopProperty)
 
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
 
 spec :: Spec
 spec = do
@@ -50,10 +57,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withStaticConfigurations $ \_ ->

--- a/lib/test/Test/Pos/Block/Identity/SafeCopySpec.hs
+++ b/lib/test/Test/Pos/Block/Identity/SafeCopySpec.hs
@@ -5,7 +5,8 @@ module Test.Pos.Block.Identity.SafeCopySpec
        ) where
 
 import           Test.Hspec (Spec, describe, runIO)
-import           Test.QuickCheck (arbitrary, generate)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess)
+import           Test.QuickCheck (generate)
 import           Universum
 
 import qualified Pos.Core.Block as BT
@@ -15,6 +16,14 @@ import           Pos.SafeCopy ()
 import           Test.Pos.Binary.Helpers (safeCopyTest)
 import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -22,10 +31,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ describe "Block types" $

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -18,9 +18,9 @@ import qualified Cardano.Crypto.Wallet as CC
 import           Crypto.Hash (Blake2b_224, Blake2b_256)
 import           Data.Tagged (Tagged)
 import           System.FileLock (FileLock)
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Arbitrary (..))
+import           Test.QuickCheck (Arbitrary (..), arbitrary, generate)
 
 import           Pos.Arbitrary.Infra ()
 import           Pos.Arbitrary.Slotting ()
@@ -32,11 +32,12 @@ import           Pos.Binary.Core ()
 import           Pos.Binary.Ssc ()
 import qualified Pos.Block.Network as BT
 import qualified Pos.Block.Types as BT
-import           Pos.Core (ProxySKHeavy, StakeholderId, VssCertificate)
 import qualified Pos.Communication as C
 import           Pos.Communication.Limits (mlOpening, mlUpdateVote, mlVssCertificate)
+import           Pos.Core (ProxySKHeavy, StakeholderId, VssCertificate)
 import qualified Pos.Core.Block as BT
 import qualified Pos.Core.Ssc as Ssc
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import qualified Pos.Crypto as Crypto
 import           Pos.Crypto.Signing (EncryptedSecretKey)
 import           Pos.Delegation (DlgPayload, DlgUndo)
@@ -55,7 +56,7 @@ import           Pos.Util.UserSecret (UserSecret, WalletUserSecret)
 import           Test.Pos.Binary.Helpers (U, binaryTest, extensionProperty, msgLenLimitedTest)
 import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Block.Arbitrary.Message ()
-import           Test.Pos.Configuration (withDefConfiguration)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Crypto.Arbitrary ()
 import           Test.Pos.Delegation.Arbitrary ()
@@ -69,7 +70,18 @@ type UpId' = Tagged (U.UpdateProposal, [U.UpdateVote])U.UpId
 ----------------------------------------
 
 spec :: Spec
-spec = withDefConfiguration $ \_ -> do
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ do
     describe "Cbor.Bi instances" $ do
         modifyMaxSuccess (const 1000) $ do
             describe "Lib/core instances" $ do

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -58,7 +58,7 @@ import           Test.Pos.Block.Arbitrary ()
 import           Test.Pos.Block.Arbitrary.Message ()
 import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
-import           Test.Pos.Crypto.Arbitrary ()
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Delegation.Arbitrary ()
 import           Test.Pos.Txp.Arbitrary.Network ()
 import           Test.Pos.Util.QuickCheck (SmallGenerator)
@@ -69,16 +69,24 @@ type UpId' = Tagged (U.UpdateProposal, [U.UpdateVote])U.UpId
 
 ----------------------------------------
 
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ do

--- a/lib/test/Test/Pos/Diffusion/BlockSpec.hs
+++ b/lib/test/Test/Pos/Diffusion/BlockSpec.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes   #-}
 
 module Test.Pos.Diffusion.BlockSpec
     ( spec
@@ -14,7 +14,8 @@ import           Control.DeepSeq (force)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Semigroup ((<>))
-import           Test.Hspec (Spec, describe, it, shouldBe)
+import           Test.Hspec (Spec, describe, it, runIO, shouldBe)
+import           Test.QuickCheck (arbitrary, generate)
 
 import           Data.Bits
 import           Data.List.NonEmpty (NonEmpty ((:|)))
@@ -31,7 +32,7 @@ import           Pos.Binary.Class (serialize')
 import           Pos.Core (Block, BlockHeader, BlockVersion (..), HeaderHash, blockHeaderHash)
 import qualified Pos.Core as Core (getBlockHeader)
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..))
-import           Pos.Crypto (ProtocolMagic (..), ProtocolMagicId (..), RequiresNetworkMagic (..))
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Crypto.Hashing (Hash, unsafeMkAbstractHash)
 import           Pos.DB.Class (Serialized (..), SerializedBlock)
 import           Pos.Diffusion.Full (FullDiffusionConfiguration (..), FullDiffusionInternals (..),
@@ -51,9 +52,6 @@ import           Test.Pos.Block.Arbitrary.Generate (generateMainBlock)
 -- HLint warning disabled since I ran into https://ghc.haskell.org/trac/ghc/ticket/13106
 -- when trying to resolve it.
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
-
-protocolMagic :: ProtocolMagic
-protocolMagic = ProtocolMagic (ProtocolMagicId 0) NMMustBeNothing
 
 protocolConstants :: ProtocolConstants
 protocolConstants = ProtocolConstants
@@ -117,8 +115,8 @@ clientLogic = pureLogic
     { getLcaMainChain = \headers -> pure (NewestFirst [], headers)
     }
 
-withServer :: Transport -> Logic IO -> (NodeId -> IO t) -> IO t
-withServer transport logic k = do
+withServer :: ProtocolMagic -> Transport -> Logic IO -> (NodeId -> IO t) -> IO t
+withServer pm transport logic k = do
     -- Morally, the server shouldn't need an outbound queue, but we have to
     -- give one.
     oq <- liftIO $ OQ.new
@@ -143,7 +141,7 @@ withServer transport logic k = do
     runFullDiffusionInternals runInternals $ \internals -> k (Node.nodeId (fdiNode internals))
   where
     fdconf = FullDiffusionConfiguration
-        { fdcProtocolMagic = protocolMagic
+        { fdcProtocolMagic = pm
         , fdcProtocolConstants = protocolConstants
         -- Just like in production.
         , fdcRecoveryHeadersMessage = 2200
@@ -156,13 +154,14 @@ withServer transport logic k = do
 -- Like 'withServer' but we must set up the outbound queue so that it will
 -- contact the server.
 withClient
-    :: Word32
+    :: ProtocolMagic
+    -> Word32
     -> Transport
     -> Logic IO
     -> NodeId
     -> (Diffusion IO -> IO t)
     -> IO t
-withClient streamWindow transport logic serverAddress@(Node.NodeId _) k = do
+withClient pm streamWindow transport logic serverAddress@(Node.NodeId _) k = do
     -- Morally, the server shouldn't need an outbound queue, but we have to
     -- give one.
     oq <- OQ.new
@@ -189,7 +188,7 @@ withClient streamWindow transport logic serverAddress@(Node.NodeId _) k = do
     runFullDiffusionInternals runInternals $ \_ -> k diffusion
   where
     fdconf = FullDiffusionConfiguration
-        { fdcProtocolMagic = protocolMagic
+        { fdcProtocolMagic = pm
         , fdcProtocolConstants = protocolConstants
         -- Just like in production.
         , fdcRecoveryHeadersMessage = 2200
@@ -225,26 +224,26 @@ blockDownloadStream serverAddress resultIORef streamIORef setStreamIORef ~(block
               loop n (b : recvBlocks) (streamWindow, wqgM, blockChan)
 
 -- Generate a list of n+1 blocks
-generateBlocks :: Int -> NonEmpty Block
-generateBlocks blocks =
+generateBlocks :: ProtocolMagic -> Int -> NonEmpty Block
+generateBlocks pm blocks =
   let root = doGenerateBlock 0 in
   root :| (doGenerateBlocks blocks)
   where
     doGenerateBlock :: Int -> Block
     doGenerateBlock seed =
         let size = 4 in
-        force $ Right (generateMainBlock protocolMagic protocolConstants seed size)
+        force $ Right (generateMainBlock pm protocolConstants seed size)
 
     doGenerateBlocks :: Int -> [Block]
     doGenerateBlocks 0 = []
     doGenerateBlocks x = do
         [doGenerateBlock x] ++ (doGenerateBlocks (x-1))
 
-streamSimple :: Word32 -> Int -> IO Bool
-streamSimple streamWindow blocks = do
+streamSimple :: ProtocolMagic -> Word32 -> Int -> IO Bool
+streamSimple pm streamWindow blocks = do
     streamIORef <- newIORef []
     resultIORef <- newIORef False
-    let arbitraryBlocks = generateBlocks (blocks - 1)
+    let arbitraryBlocks = generateBlocks pm (blocks - 1)
         arbitraryHeaders = NE.map Core.getBlockHeader arbitraryBlocks
         arbitraryHashes = NE.map blockHeaderHash arbitraryHeaders
         !arbitraryBlock = NE.head arbitraryBlocks
@@ -252,45 +251,52 @@ streamSimple streamWindow blocks = do
         checkpoints = [tipHash]
         setStreamIORef = \_ -> writeIORef streamIORef $ NE.tail arbitraryBlocks
     withTransport $ \transport ->
-        withServer transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
-        withClient streamWindow transport clientLogic serverAddress $
+        withServer pm transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
+        withClient pm streamWindow transport clientLogic serverAddress $
             liftIO . blockDownloadStream serverAddress resultIORef streamIORef setStreamIORef
                 (tipHash, checkpoints)
     readIORef resultIORef
 
-batchSimple :: Int -> IO Bool
-batchSimple blocks = do
+batchSimple :: ProtocolMagic -> Int -> IO Bool
+batchSimple pm blocks = do
     streamIORef <- newIORef []
-    let arbitraryBlocks = generateBlocks (blocks - 1)
+    let arbitraryBlocks = generateBlocks pm (blocks - 1)
         arbitraryHeaders = NE.map Core.getBlockHeader arbitraryBlocks
         arbitraryHashes = NE.map blockHeaderHash arbitraryHeaders
         arbitraryBlock = NE.head arbitraryBlocks
         !checkPoints = if blocks == 1 then [someHash]
                                       else [someHash' (blocks + 1) []]
     withTransport $ \transport ->
-        withServer transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
-        withClient 2048 transport clientLogic serverAddress $
+        withServer pm transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
+        withClient pm 2048 transport clientLogic serverAddress $
             liftIO . blockDownloadBatch serverAddress (someHash, checkPoints)
     return True
 
 spec :: Spec
-spec = describe "Blockdownload" $ do
-    it "Stream 4 blocks" $ do
-        r <- streamSimple 2048 4
-        r `shouldBe` True
-    it "Stream 128 blocks" $ do
-        r <- streamSimple 2048 128
-        r `shouldBe` True
-    it "Stream 4096 blocks" $ do
-        r <- streamSimple 128 4096
-        r `shouldBe` True
-    it "Streaming dislabed by client" $ do
-        r <- streamSimple 0 4
-        r `shouldBe` False
-    it "Batch, single block" $ do
-        r <- batchSimple 1
-        r `shouldBe` True
-    it "Batch of blocks" $ do
-        r <- batchSimple 2200
-        r `shouldBe` True
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
 
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        describe "Blockdownload" $ do
+            it "Stream 4 blocks" $ do
+                r <- streamSimple pm 2048 4
+                r `shouldBe` True
+            it "Stream 128 blocks" $ do
+                r <- streamSimple pm 2048 128
+                r `shouldBe` True
+            it "Stream 4096 blocks" $ do
+                r <- streamSimple pm 128 4096
+                r `shouldBe` True
+            it "Streaming dislabed by client" $ do
+                r <- streamSimple pm 0 4
+                r `shouldBe` False
+            it "Batch, single block" $ do
+                r <- batchSimple pm 1
+                r `shouldBe` True
+            it "Batch of blocks" $ do
+                r <- batchSimple pm 2200
+                r `shouldBe` True

--- a/lib/test/Test/Pos/Genesis/CanonicalSpec.hs
+++ b/lib/test/Test/Pos/Genesis/CanonicalSpec.hs
@@ -6,18 +6,31 @@ module Test.Pos.Genesis.CanonicalSpec
 
 import           Universum
 
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
+import           Test.QuickCheck (arbitrary, generate)
 
 import           Pos.Core.Genesis (GenesisAvvmBalances, GenesisData, GenesisDelegation,
                                    GenesisProtocolConstants, GenesisWStakeholders)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 
-import           Test.Pos.Configuration (withDefConfiguration)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Helpers (canonicalJsonTest)
 
 spec :: Spec
-spec = withDefConfiguration $ \_ -> describe "Genesis" $ modifyMaxSuccess (const 10) $ do
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ describe "Genesis" $ modifyMaxSuccess (const 10) $ do
     describe "Canonical encoding" $ do
         canonicalJsonTest @GenesisProtocolConstants
         canonicalJsonTest @GenesisAvvmBalances

--- a/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
+++ b/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
@@ -13,7 +13,7 @@ import qualified Data.HashSet as HS
 import           Data.List.Extra (nubOrdOn)
 import           System.Random (mkStdGen, randomR)
 import           Test.Hspec (Spec, describe, runIO)
-import           Test.Hspec.QuickCheck (prop)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (..), Gen, NonEmptyList (..), Property, arbitrary,
                                   elements, generate, listOf, property, sublistOf, suchThat, vector,
                                   (.&&.), (===), (==>))
@@ -41,7 +41,15 @@ import           Test.Pos.Lrc.Arbitrary (GenesisMpcThd, ValidRichmenStakes (..))
 import           Test.Pos.Util.QuickCheck.Property (qcElem, qcFail, qcIsRight)
 
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -49,10 +57,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ describe "Ssc.Base" $ do

--- a/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
+++ b/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
@@ -12,7 +12,7 @@ import           Data.List.Extra (nubOrdOn)
 import qualified Data.Set as S
 import           Data.Tuple (swap)
 import           Test.Hspec (Spec, describe, runIO)
-import           Test.Hspec.QuickCheck (prop)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, arbitrary, choose, conjoin,
                                   counterexample, generate, suchThat, vectorOf, (.&&.), (==>))
 
@@ -29,8 +29,16 @@ import           Pos.Ssc (SscGlobalState (..), VssCertData (..), delete, empty, 
 
 import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Util.QuickCheck.Property (qcIsJust)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -38,10 +46,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ describe "Ssc.VssCertData" $ do

--- a/lib/test/Test/Pos/Types/BlockSpec.hs
+++ b/lib/test/Test/Pos/Types/BlockSpec.hs
@@ -11,7 +11,7 @@ import           Universum
 import           Serokell.Util (isVerSuccess)
 import           Test.Hspec (Spec, describe, it, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Property, arbitrary, generate, (===), (==>))
+import           Test.QuickCheck (Property, generate, (===), (==>))
 
 import           Pos.Binary (Bi)
 import qualified Pos.Block.Logic.Integrity as T
@@ -25,19 +25,27 @@ import           Pos.Data.Attributes (mkAttributes)
 
 import           Test.Pos.Block.Arbitrary as T
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic, dummyProtocolMagicId)
 
--- This tests are quite slow, hence max success is at most 20.
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $

--- a/lib/test/Test/Pos/Types/Identity/SafeCopySpec.hs
+++ b/lib/test/Test/Pos/Types/Identity/SafeCopySpec.hs
@@ -7,7 +7,8 @@ module Test.Pos.Types.Identity.SafeCopySpec
 import           Universum
 
 import           Test.Hspec (Spec, describe, runIO)
-import           Test.QuickCheck (arbitrary, generate)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess)
+import           Test.QuickCheck (generate)
 
 import qualified Pos.Core as Core
 import qualified Pos.Core.Txp as Txp
@@ -16,8 +17,16 @@ import           Pos.SafeCopy ()
 
 import           Test.Pos.Binary.Helpers (safeCopyTest)
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Txp.Arbitrary ()
 import           Test.Pos.Txp.Arbitrary.Network ()
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -25,10 +34,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ describe "Types" $ do

--- a/lib/test/Test/Pos/Update/PollSpec.hs
+++ b/lib/test/Test/Pos/Update/PollSpec.hs
@@ -26,7 +26,15 @@ import qualified Pos.Util.Modifier as MM
 
 import           Test.Pos.Binary.Helpers ()
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Property (formsMonoid)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
 
 spec :: Spec
 spec = do
@@ -34,10 +42,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ describe "Poll" $ do

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16411,6 +16411,7 @@ cardano-sl-block
 cardano-sl-block-test
 cardano-sl-core
 cardano-sl-crypto
+cardano-sl-crypto-test
 cardano-sl-txp
 cardano-sl-util
 containers
@@ -18305,6 +18306,7 @@ license = stdenv.lib.licenses.mit;
 , cardano-sl-core
 , cardano-sl-core-test
 , cardano-sl-crypto
+, cardano-sl-crypto-test
 , cardano-sl-db
 , cardano-sl-delegation
 , cardano-sl-infra
@@ -18529,6 +18531,7 @@ cardano-sl-block
 cardano-sl-client
 cardano-sl-core
 cardano-sl-crypto
+cardano-sl-crypto-test
 cardano-sl-db
 cardano-sl-delegation
 cardano-sl-lrc

--- a/txp/test/Test/Pos/Txp/Toil/UtxoSpec.hs
+++ b/txp/test/Test/Pos/Txp/Toil/UtxoSpec.hs
@@ -14,18 +14,18 @@ import qualified Data.Text.Buildable as B
 import qualified Data.Vector as V (fromList)
 import           Fmt (blockListF', genericF, nameF, (+|), (|+))
 import           Serokell.Util (allDistinct)
-import           Test.Hspec (Expectation, Spec, describe, expectationFailure, it)
+import           Test.Hspec (Expectation, Spec, describe, expectationFailure, it, runIO)
 import           Test.Hspec.QuickCheck (prop)
-import           Test.QuickCheck (Property, arbitrary, counterexample, (==>))
+import           Test.QuickCheck (Property, arbitrary, counterexample, forAll, generate, (==>))
 
 import           Pos.Core (HasConfiguration, addressHash, checkPubKeyAddress,
                            defaultCoreConfiguration, makePubKeyAddressBoot, makeScriptAddress,
                            mkCoin, sumCoins, withGenesisSpec)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxIn (..), TxInWitness (..), TxOut (..),
                                TxOutAux (..), TxSigData (..), TxWitness, isTxInUnknown)
-import           Pos.Crypto (ProtocolMagic, SignTag (SignTx), checkSig, fakeSigner, hash, toPublic,
-                             unsafeHash, withHash)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..), SignTag (SignTx),
+                             checkSig, fakeSigner, hash, toPublic, unsafeHash, withHash)
 import           Pos.Data.Attributes (mkAttributes)
 import           Pos.Script (PlutusError (..), Script)
 import           Pos.Script.Examples (alwaysSuccessValidator, badIntRedeemer, goodIntRedeemer,
@@ -38,8 +38,8 @@ import           Pos.Txp (ToilVerFailure (..), Utxo, VTxContext (..), VerifyTxUt
                           utxoToLookup, verifyTxUtxo)
 import qualified Pos.Util.Modifier as MM
 
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
-import           Test.Pos.Txp.Arbitrary (BadSigsTx (..), DoubleInputTx (..), GoodTx (..))
+import           Test.Pos.Txp.Arbitrary (BadSigsTx (..), DoubleInputTx (..), GoodTx (..),
+                                         genGoodTxWithMagic)
 import           Test.Pos.Util.QuickCheck.Arbitrary (SmallGenerator (..), nonrepeating, runGen)
 import           Test.Pos.Util.QuickCheck.Property (qcIsLeft, qcIsRight)
 
@@ -48,8 +48,20 @@ import           Test.Pos.Util.QuickCheck.Property (qcIsLeft, qcIsRight)
 ----------------------------------------------------------------------------
 
 spec :: Spec
-spec =
-    withGenesisSpec 0 (defaultCoreConfiguration dummyProtocolMagic)
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pmTop =
+    -- `pmTop` should be equal to `pm`, but this approach avoids shadowing.
+    withGenesisSpec 0 (defaultCoreConfiguration pmTop)
         $ \pm -> describe "Txp.Toil.Utxo" $ do
               describe "utxoGet (no modifier)" $ do
                   it "returns Nothing when given empty Utxo"
@@ -93,8 +105,8 @@ findTxInUtxo key txO utxo =
      in (isJust $ utxoGetSimple newUtxo key) &&
         (isNothing $ utxoGetSimple utxo' key)
 
-verifyTxInUtxo :: ProtocolMagic -> SmallGenerator GoodTx -> Property
-verifyTxInUtxo pm (SmallGenerator (GoodTx ls)) =
+verifyTxInUtxo :: ProtocolMagic -> Property
+verifyTxInUtxo pm = forAll (genGoodTxWithMagic pm) $ \(GoodTx ls) ->
     let txs = fmap (view _1) ls
         witness = V.fromList $ toList $ fmap (view _4) ls
         (ins, outs) = NE.unzip $ map (\(_, tIs, tOs, _) -> (tIs, tOs)) ls
@@ -104,7 +116,7 @@ verifyTxInUtxo pm (SmallGenerator (GoodTx ls)) =
             let id = hash tx
             (idx, out) <- zip [0..] (toList _txOutputs)
             pure ((TxInUtxo id idx), TxOutAux out)
-        vtxContext = VTxContext False fixedNM
+        vtxContext = VTxContext False (makeNetworkMagic pm)
         txAux = TxAux newTx witness
     in counterexample ("\n"+|nameF "txs" (blockListF' "-" genericF txs)|+""
                            +|nameF "transaction" (B.build txAux)|+"") $
@@ -114,7 +126,7 @@ badSigsTx :: ProtocolMagic -> SmallGenerator BadSigsTx -> Property
 badSigsTx pm (SmallGenerator (getBadSigsTx -> ls)) =
     let (tx@UnsafeTx {..}, utxo, extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False fixedNM
+        ctx = VTxContext False (makeNetworkMagic pm)
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         notAllSignaturesAreValid =
@@ -127,17 +139,18 @@ doubleInputTx :: ProtocolMagic -> SmallGenerator DoubleInputTx -> Property
 doubleInputTx pm (SmallGenerator (getDoubleInputTx -> ls)) =
     let ((tx@UnsafeTx {..}), utxo, _extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False fixedNM
+        ctx = VTxContext False (makeNetworkMagic pm)
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         someInputsAreDuplicated =
             not $ allDistinct (toList _txInputs)
     in someInputsAreDuplicated ==> qcIsLeft transactionVerRes
 
-validateGoodTx :: ProtocolMagic -> SmallGenerator GoodTx -> Property
-validateGoodTx pm (SmallGenerator (getGoodTx -> ls)) =
+validateGoodTx :: ProtocolMagic -> Property
+validateGoodTx pm =
+    forAll (genGoodTxWithMagic pm) $ \(GoodTx ls) ->
     let quadruple@(tx, utxo, _, txWits) = getTxFromGoodTx ls
-        ctx = VTxContext False fixedNM
+        ctx = VTxContext False (makeNetworkMagic pm)
         transactionVerRes =
             verifyTxUtxoSimple pm ctx utxo $ TxAux tx txWits
         transactionReallyIsGood = individualTxPropertyVerifier pm quadruple
@@ -414,10 +427,11 @@ scriptTxSpec pm = describe "script transactions" $ do
                 "Out of petrol."
 
   where
+    nm = makeNetworkMagic pm
     -- Some random stuff we're going to use when building transactions
     randomPkOutput = runGen $ do
         key <- arbitrary
-        return (TxOut (makePubKeyAddressBoot fixedNM key) (mkCoin 1))
+        return (TxOut (makePubKeyAddressBoot nm key) (mkCoin 1))
     -- Make utxo with a single output; return utxo, the output, and an
     -- input that can be used to spend that output
     mkUtxo :: TxOut -> (TxIn, TxOut, Utxo)
@@ -426,7 +440,7 @@ scriptTxSpec pm = describe "script transactions" $ do
         in  (TxInUtxo txid 0, outp, one ((TxInUtxo txid 0), (TxOutAux outp)))
 
     -- Do not verify versions
-    vtxContext = VTxContext False fixedNM
+    vtxContext = VTxContext False nm
 
     -- Try to apply a transaction (with given utxo as context) and say
     -- whether it applied successfully
@@ -443,7 +457,7 @@ scriptTxSpec pm = describe "script transactions" $ do
                   -> Either ToilVerFailure ()
     checkScriptTx val mkWit =
         let (inp, _, utxo) = mkUtxo $
-                TxOut (makeScriptAddress fixedNM Nothing val) (mkCoin 1)
+                TxOut (makeScriptAddress nm Nothing val) (mkCoin 1)
             tx = UnsafeTx (one inp) (one randomPkOutput) $ mkAttributes ()
             txSigData = TxSigData { txSigTxHash = hash tx }
             txAux = TxAux tx (one (mkWit txSigData))
@@ -477,7 +491,3 @@ txShouldFailWithPlutus res err = case res of
     other -> expectationFailure $
         "expected: Left ...: " <> show (WitnessScriptError err) <> "\n" <>
         " but got: " <> show other
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -419,6 +419,7 @@ test-suite wallet-unit-tests
                     , cardano-sl-client
                     , cardano-sl-core
                     , cardano-sl-crypto
+                    , cardano-sl-crypto-test
                     , cardano-sl-db
                     , cardano-sl-delegation
                     , cardano-sl-lrc
@@ -495,6 +496,7 @@ test-suite wallet-new-specs
                     , cardano-sl-client
                     , cardano-sl-core
                     , cardano-sl-crypto
+                    , cardano-sl-crypto-test
                     , cardano-sl-txp
                     , cardano-sl-util
                     , cardano-sl-util-test

--- a/wallet-new/test/DevelopmentSpec.hs
+++ b/wallet-new/test/DevelopmentSpec.hs
@@ -17,15 +17,17 @@ module DevelopmentSpec (spec) where
 import           Universum
 
 import           Pos.Client.KeyStorage (addSecretKey, getSecretKeysPlain)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 
 import           Pos.Launcher (HasConfigurations)
 import           Pos.Util.BackupPhrase (BackupPhrase (..), safeKeysFromPhrase)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
-import           Test.Pos.Configuration (withDefConfigurations)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
+import           Test.QuickCheck (arbitrary, generate)
 
 import           Cardano.Wallet.API.Development.LegacyHandlers (deleteSecretKeys)
 import           Cardano.Wallet.Server.CLI (RunMode (..))
@@ -34,8 +36,19 @@ import           Servant
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 spec :: Spec
-spec =
-    withDefConfigurations $ \_ _ ->
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm =
+    withProvidedMagicConfig pm $
         describe "development endpoint" $
         describe "secret-keys" $ modifyMaxSuccess (const 10) deleteAllSecretKeysSpec
 

--- a/wallet-new/test/unit/Test/Infrastructure/Generator.hs
+++ b/wallet-new/test/unit/Test/Infrastructure/Generator.hs
@@ -23,7 +23,8 @@ import           UTxO.Generator
 import           Wallet.Inductive
 import           Wallet.Inductive.Generator
 
-import           Pos.Core ( TxSizeLinear, calculateTxSizeLinear )
+import           Pos.Core (TxSizeLinear, calculateTxSizeLinear)
+import           Pos.Crypto (RequiresNetworkMagic (..))
 import           Serokell.Data.Memory.Units (Byte, fromBytes)
 
 {-------------------------------------------------------------------------------
@@ -51,20 +52,21 @@ data GeneratorModel h a = GeneratorModel {
     , gmMaxNumOurs    :: Int
 
       -- | Estimate fees
-    , gmEstimateFee   :: Int -> [Value] -> Value
+    , gmEstimateFee   :: RequiresNetworkMagic -> Int -> [Value] -> Value
     }
 
-genChainUsingModel :: (Hash h a, Ord a) => GeneratorModel h a -> Gen (Chain h a)
-genChainUsingModel GeneratorModel{..} =
+genChainUsingModel :: (Hash h a, Ord a)
+                   => RequiresNetworkMagic -> GeneratorModel h a -> Gen (Chain h a)
+genChainUsingModel rnm GeneratorModel{..} =
     evalStateT (genChain params) initState
   where
-    params    = defChainParams gmEstimateFee gmAllAddresses
+    params    = defChainParams (gmEstimateFee rnm) gmAllAddresses
     initUtxo  = utxoRestrictToAddr (`elem` gmAllAddresses) $ trUtxo gmBoot
     initState = initTrState initUtxo 1
 
-genInductiveUsingModel :: (Hash h a, Ord a)
-                       => GeneratorModel h a -> Gen (Inductive h a)
-genInductiveUsingModel GeneratorModel{..} = do
+genInductiveUsingModel :: (Hash h a, Ord a) => RequiresNetworkMagic
+                       -> GeneratorModel h a -> Gen (Inductive h a)
+genInductiveUsingModel rnm GeneratorModel{..} = do
     numOurs <- choose (1, min (length potentialOurs) gmMaxNumOurs)
     addrs'  <- shuffle potentialOurs
     let ours = Set.fromList (take numOurs addrs')
@@ -76,7 +78,8 @@ genInductiveUsingModel GeneratorModel{..} = do
       }
   where
     potentialOurs = filter gmPotentialOurs gmAllAddresses
-    params ours   = defEventsParams gmEstimateFee gmAllAddresses ours initUtxo
+    params ours   =
+        defEventsParams (gmEstimateFee rnm) gmAllAddresses ours initUtxo
     initUtxo      = utxoRestrictToAddr (`elem` gmAllAddresses) $ trUtxo gmBoot
     initState     = initEventsGlobalState 1
 
@@ -91,7 +94,7 @@ simpleModel :: GeneratorModel GivenHash Char
 simpleModel = GeneratorModel {
       gmAllAddresses  = addrs
     , gmPotentialOurs = \_ -> True
-    , gmEstimateFee   = \_ _ -> 0
+    , gmEstimateFee   = \_ _ _ -> 0
     , gmMaxNumOurs    = 3
     , gmBoot          = Transaction {
                             trFresh = fromIntegral (length addrs) * initBal
@@ -176,9 +179,12 @@ estimateSize saa sta ins outs
 --   NOTE: The average size of @Attributes AddrAttributes@ and
 --         the transaction attributes @Attributes ()@ are both hard-coded
 --         here with some (hopefully) realistic values.
-estimateCardanoFee :: TxSizeLinear -> Int -> [Value] -> Value
-estimateCardanoFee linearFeePolicy ins outs
-    = round (calculateTxSizeLinear linearFeePolicy (estimateSize 128 16 ins outs))
+estimateCardanoFee :: TxSizeLinear -> RequiresNetworkMagic -> Int -> [Value] -> Value
+estimateCardanoFee linearFeePolicy rnm ins outs
+    = round (calculateTxSizeLinear linearFeePolicy (estimateSize addrAttrSize 16 ins outs))
+  where
+    addrAttrSize = 128 + (case rnm of NMMustBeNothing -> 0
+                                      NMMustBeJust    -> 7)
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/wallet-new/test/unit/Test/Infrastructure/Genesis.hs
+++ b/wallet-new/test/unit/Test/Infrastructure/Genesis.hs
@@ -11,6 +11,7 @@ import           UTxO.Context
 import           UTxO.DSL
 
 import           Pos.Core (TxSizeLinear)
+import           Pos.Crypto (RequiresNetworkMagic)
 import           Test.Infrastructure.Generator (estimateCardanoFee)
 
 {-------------------------------------------------------------------------------
@@ -35,12 +36,13 @@ data GenesisValues h = GenesisValues {
     , hashBoot :: h (Transaction h Addr)
 
       -- | Fee policy
-    , txFee :: Int -> [Value] -> Value
+    , txFee    :: Int -> [Value] -> Value
     }
 
 -- | Compute genesis values from the bootstrap transaction
-genesisValues :: (Hash h Addr) => TxSizeLinear -> Transaction h Addr -> GenesisValues h
-genesisValues txSizeLinear boot@Transaction{..} = GenesisValues{..}
+genesisValues :: (Hash h Addr) => TxSizeLinear
+              -> RequiresNetworkMagic -> Transaction h Addr -> GenesisValues h
+genesisValues txSizeLinear rnm boot@Transaction{..} = GenesisValues{..}
   where
     initR0 = unsafeHead [val | Output a val <- trOuts, a == r0]
 
@@ -52,7 +54,7 @@ genesisValues txSizeLinear boot@Transaction{..} = GenesisValues{..}
 
     hashBoot = hash boot
 
-    txFee = estimateCardanoFee  txSizeLinear
+    txFee = estimateCardanoFee txSizeLinear rnm
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -43,7 +43,8 @@ runWithMagic rnm = do
 specBody :: ProtocolMagic -> Spec
 specBody pm =
     it "Compare wallet kernel to pure model" $
-      forAll (genInductiveUsingModel model) $ \ind -> do
+      let rnm = getRequiresNetworkMagic pm in
+      forAll (genInductiveUsingModel rnm model) $ \ind -> do
         -- TODO: remove once we have support for rollback in the kernel
         let indDontRoll = uptoFirstRollback ind
         bracketActiveWallet pm $ \activeWallet -> do

--- a/wallet-new/test/unit/Test/Spec/Models.hs
+++ b/wallet-new/test/unit/Test/Spec/Models.hs
@@ -45,10 +45,11 @@ runWithMagic rnm = do
 specBody :: ProtocolMagic -> Spec
 specBody pm =
     describe "Test pure wallets" $ do
+      let rnm = getRequiresNetworkMagic pm
       it "Using simple model" $
-        forAll (genInductiveUsingModel simpleModel) $ testPureWalletWith
+        forAll (genInductiveUsingModel rnm simpleModel) $ testPureWalletWith
       it "Using Cardano model" $
-        forAll (genInductiveUsingModel (cardanoModel linearFeePolicy boot)) $ testPureWalletWith
+        forAll (genInductiveUsingModel rnm (cardanoModel linearFeePolicy boot)) $ testPureWalletWith
   where
     transCtxt = runTranslateNoErrors pm ask
     boot      = bootstrapTransaction transCtxt

--- a/wallet-new/test/unit/Test/Spec/Models.hs
+++ b/wallet-new/test/unit/Test/Spec/Models.hs
@@ -24,6 +24,7 @@ import qualified Wallet.Rollback.Basic as Roll
 import qualified Wallet.Rollback.Full as Full
 
 import           Pos.Core (Coeff (..), TxSizeLinear (..))
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 
 {-------------------------------------------------------------------------------
   Pure wallet tests
@@ -32,13 +33,24 @@ import           Pos.Core (Coeff (..), TxSizeLinear (..))
 -- | Test the pure wallet models
 spec :: Spec
 spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm =
     describe "Test pure wallets" $ do
       it "Using simple model" $
         forAll (genInductiveUsingModel simpleModel) $ testPureWalletWith
       it "Using Cardano model" $
         forAll (genInductiveUsingModel (cardanoModel linearFeePolicy boot)) $ testPureWalletWith
   where
-    transCtxt = runTranslateNoErrors ask
+    transCtxt = runTranslateNoErrors pm ask
     boot      = bootstrapTransaction transCtxt
     linearFeePolicy = TxSizeLinear (Coeff 155381) (Coeff 43.946)
 

--- a/wallet-new/test/unit/Test/Spec/Models.hs
+++ b/wallet-new/test/unit/Test/Spec/Models.hs
@@ -5,8 +5,10 @@ module Test.Spec.Models (
 import           Universum
 
 import qualified Data.Set as Set
+import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 
 import           Test.Infrastructure.Generator
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Util.Buildable.Hspec
 import           Util.Buildable.QuickCheck
 import           UTxO.Bootstrap
@@ -31,16 +33,24 @@ import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 -------------------------------------------------------------------------------}
 
 -- | Test the pure wallet models
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 3
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm =

--- a/wallet-new/test/unit/Test/Spec/Translation.hs
+++ b/wallet-new/test/unit/Test/Spec/Translation.hs
@@ -62,8 +62,9 @@ specBody pm = do
 
     describe "Translation QuickCheck tests" $ do
       prop "can translate randomly generated chains" $
+        let rnm = getRequiresNetworkMagic pm in
         forAll
-          (intAndVerifyGen pm (genChainUsingModel . cardanoModel linearFeePolicy))
+          (intAndVerifyGen pm (genChainUsingModel rnm . cardanoModel linearFeePolicy))
           expectValid
 
   where
@@ -188,7 +189,9 @@ intAndVerifyPure :: ProtocolMagic
                  -> (GenesisValues GivenHash -> Chain GivenHash Addr)
                  -> ValidationResult GivenHash Addr
 intAndVerifyPure pm txSizeLinear pc = runIdentity $
-    intAndVerify pm (Identity . pc . genesisValues txSizeLinear)
+    intAndVerify pm (Identity . pc . genesisValues txSizeLinear rnm)
+  where
+    rnm = getRequiresNetworkMagic pm
 
 -- | Specialization of 'intAndVerify' to 'Gen'
 intAndVerifyGen :: ProtocolMagic -> (Transaction GivenHash Addr

--- a/wallet-new/test/unit/Test/Spec/Translation.hs
+++ b/wallet-new/test/unit/Test/Spec/Translation.hs
@@ -8,12 +8,13 @@ import qualified Data.Set as Set
 import qualified Data.Text.Buildable
 import           Formatting (bprint, build, shown, (%))
 import           Pos.Core.Chrono
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Serokell.Util (mapJson)
 import           Test.Hspec.QuickCheck
 
 import qualified Pos.Block.Error as Cardano
-import qualified Pos.Txp.Toil as Cardano
 import           Pos.Core (Coeff (..), TxSizeLinear (..), getCoin)
+import qualified Pos.Txp.Toil as Cardano
 
 import           Test.Infrastructure.Generator
 import           Test.Infrastructure.Genesis
@@ -32,26 +33,37 @@ import           UTxO.Translate
 
 spec :: Spec
 spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = do
     describe "Translation sanity checks" $ do
       it "can construct and verify empty block" $
-        intAndVerifyPure linearFeePolicy emptyBlock `shouldSatisfy` expectValid
+        intAndVerifyPure pm linearFeePolicy emptyBlock `shouldSatisfy` expectValid
 
       it "can construct and verify block with one transaction" $
-        intAndVerifyPure linearFeePolicy oneTrans `shouldSatisfy` expectValid
+        intAndVerifyPure pm linearFeePolicy oneTrans `shouldSatisfy` expectValid
 
       it "can construct and verify example 1 from the UTxO paper" $
-        intAndVerifyPure linearFeePolicy example1 `shouldSatisfy` expectValid
+        intAndVerifyPure pm linearFeePolicy example1 `shouldSatisfy` expectValid
 
       it "can reject overspending" $
-        intAndVerifyPure linearFeePolicy overspend `shouldSatisfy` expectInvalid
+        intAndVerifyPure pm linearFeePolicy overspend `shouldSatisfy` expectInvalid
 
       it "can reject double spending" $
-        intAndVerifyPure linearFeePolicy doublespend `shouldSatisfy` expectInvalid
+        intAndVerifyPure pm linearFeePolicy doublespend `shouldSatisfy` expectInvalid
 
     describe "Translation QuickCheck tests" $ do
       prop "can translate randomly generated chains" $
         forAll
-          (intAndVerifyGen (genChainUsingModel . cardanoModel linearFeePolicy))
+          (intAndVerifyGen pm (genChainUsingModel . cardanoModel linearFeePolicy))
           expectValid
 
   where
@@ -171,27 +183,31 @@ overestimate getFee ins outs = getFee ins (replicate outs (getCoin maxBound))
   Verify chain
 -------------------------------------------------------------------------------}
 
-intAndVerifyPure :: TxSizeLinear
+intAndVerifyPure :: ProtocolMagic
+                 -> TxSizeLinear
                  -> (GenesisValues GivenHash -> Chain GivenHash Addr)
                  -> ValidationResult GivenHash Addr
-intAndVerifyPure txSizeLinear pc = runIdentity $ intAndVerify (Identity . pc . genesisValues txSizeLinear)
+intAndVerifyPure pm txSizeLinear pc = runIdentity $
+    intAndVerify pm (Identity . pc . genesisValues txSizeLinear)
 
 -- | Specialization of 'intAndVerify' to 'Gen'
-intAndVerifyGen :: (Transaction GivenHash Addr -> Gen (Chain GivenHash Addr))
-                -> Gen (ValidationResult GivenHash Addr)
+intAndVerifyGen :: ProtocolMagic -> (Transaction GivenHash Addr
+                -> Gen (Chain GivenHash Addr)) -> Gen (ValidationResult GivenHash Addr)
 intAndVerifyGen = intAndVerify
 
 -- | Specialization of 'intAndVerifyChain' to 'GivenHash'
 intAndVerify :: Monad m
-             => (Transaction GivenHash Addr -> m (Chain GivenHash Addr))
+             => ProtocolMagic
+             -> (Transaction GivenHash Addr -> m (Chain GivenHash Addr))
              -> m (ValidationResult GivenHash Addr)
 intAndVerify = intAndVerifyChain
 
 -- | Interpret and verify a chain.
 intAndVerifyChain :: (Hash h Addr, Monad m)
-                  => (Transaction h Addr -> m (Chain h Addr))
+                  => ProtocolMagic
+                  -> (Transaction h Addr -> m (Chain h Addr))
                   -> m (ValidationResult h Addr)
-intAndVerifyChain pc = runTranslateT $ do
+intAndVerifyChain pm pc = runTranslateT pm $ do
     boot  <- asks bootstrapTransaction
     chain <- lift $ pc boot
     let ledger      = chainToLedger boot chain

--- a/wallet-new/test/unit/UTxO/Context.hs
+++ b/wallet-new/test/unit/UTxO/Context.hs
@@ -266,8 +266,8 @@ data Avvm = Avvm {
 -------------------------------------------------------------------------------}
 
 -- | Compute generated actors
-initActors :: CardanoContext -> Actors
-initActors CardanoContext{..} = Actors{..}
+initActors :: NetworkMagic -> CardanoContext -> Actors
+initActors nm CardanoContext{..} = Actors{..}
   where
     actorsRich  :: Map PublicKey Rich
     actorsPoor  :: Map PublicKey Poor
@@ -290,7 +290,7 @@ initActors CardanoContext{..} = Actors{..}
         richKey = regularKeyPair richSec
 
         richAddr :: Address
-        richAddr = makePubKeyAddressBoot fixedNM (toPublic richSec)
+        richAddr = makePubKeyAddressBoot nm (toPublic richSec)
 
     mkPoor :: PoorSecret -> (PublicKey, Poor)
     mkPoor (PoorSecret _) = error err
@@ -307,7 +307,7 @@ initActors CardanoContext{..} = Actors{..}
 
         poorAddrs :: [(EncKeyPair, Address)]
         poorAddrs = [ case deriveFirstHDAddress
-                             fixedNM
+                             nm
                              (IsBootstrapEraAddr True)
                              emptyPassphrase
                              poorSec of
@@ -343,7 +343,7 @@ initActors CardanoContext{..} = Actors{..}
         avvmKey = RedeemKeyPair{..}
 
         avvmAddr :: Address
-        avvmAddr = makeRedeemAddress fixedNM redKpPub
+        avvmAddr = makeRedeemAddress nm redKpPub
 
         Just (redKpPub, redKpSec) = redeemDeterministicKeyGen avvmSeed
 
@@ -477,10 +477,10 @@ data TransCtxt = TransCtxt {
     , tcAddrMap :: AddrMap
     }
 
-initContext :: CardanoContext -> TransCtxt
-initContext tcCardano = TransCtxt{..}
+initContext :: NetworkMagic -> CardanoContext -> TransCtxt
+initContext nm tcCardano = TransCtxt{..}
   where
-    tcActors  = initActors  tcCardano
+    tcActors  = initActors nm tcCardano
     tcAddrMap = initAddrMap tcActors
 
 {-------------------------------------------------------------------------------
@@ -649,7 +649,3 @@ instance Buildable TransCtxt where
       tcCardano
       tcActors
       tcAddrMap
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet-new/test/unit/Util/Buildable/Hspec.hs
+++ b/wallet-new/test/unit/Util/Buildable/Hspec.hs
@@ -22,6 +22,7 @@ module Util.Buildable.Hspec (
   , H.it
   , H.beforeAll
   , H.parallel
+  , H.runIO
   ) where
 
 import qualified Test.Hspec as H

--- a/wallet-new/test/unit/Util/Buildable/QuickCheck.hs
+++ b/wallet-new/test/unit/Util/Buildable/QuickCheck.hs
@@ -10,6 +10,8 @@ module Util.Buildable.QuickCheck (
   , QC.Gen
   , QC.conjoin
   , QC.choose
+  , QC.generate
+  , QC.arbitrary
   ) where
 
 import qualified Test.QuickCheck as QC

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -3,13 +3,13 @@ module Main (main) where
 
 import           Universum
 
-import           Formatting (build, sformat)
+-- import           Formatting (build, sformat)
 import           Test.Hspec (Spec, describe, hspec)
 
-import           UTxO.Bootstrap (bootstrapTransaction)
-import           UTxO.Context (Addr, TransCtxt)
-import           UTxO.DSL (GivenHash, Transaction)
-import           UTxO.Translate (runTranslateNoErrors, withConfig)
+-- import           UTxO.Bootstrap (bootstrapTransaction)
+-- import           UTxO.Context (Addr, TransCtxt)
+-- import           UTxO.DSL (GivenHash, Transaction)
+-- import           UTxO.Translate (runTranslateNoErrors, withConfig)
 
 import qualified Test.Spec.Kernel
 import qualified Test.Spec.Models
@@ -25,17 +25,21 @@ import           TxMetaStorageSpecs (txMetaStorageSpecs)
 main :: IO ()
 main = do
 --    _showContext
-    runTranslateNoErrors $ withConfig $ return $ hspec tests
+    -- runTranslateNoErrors $ withConfig $ return $ hspec tests
+
+    -- TODO mhueschen | asses whether this is ok. the above machinery seems
+    -- unnecessary
+    hspec tests
 
 -- | Debugging: show the translation context
-_showContext :: IO ()
-_showContext = do
-    putStrLn $ runTranslateNoErrors $ withConfig $
-      sformat build <$> ask
-    putStrLn $ runTranslateNoErrors $
-      let bootstrapTransaction' :: TransCtxt -> Transaction GivenHash Addr
-          bootstrapTransaction' = bootstrapTransaction
-      in sformat build . bootstrapTransaction' <$> ask
+-- _showContext :: IO ()
+-- _showContext = do
+--     putStrLn $ runTranslateNoErrors $ withConfig $
+--       sformat build <$> ask
+--     putStrLn $ runTranslateNoErrors $
+--       let bootstrapTransaction' :: TransCtxt -> Transaction GivenHash Addr
+--           bootstrapTransaction' = bootstrapTransaction
+--       in sformat build . bootstrapTransaction' <$> ask
 
 {-------------------------------------------------------------------------------
   Tests proper

--- a/wallet/test/Test/Pos/Util/MnemonicsSpec.hs
+++ b/wallet/test/Test/Pos/Util/MnemonicsSpec.hs
@@ -4,20 +4,26 @@ import           Universum
 
 import           Data.ByteString.Char8 (pack)
 import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Test.Hspec (Spec, describe, it, runIO, shouldSatisfy, xit)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import           Test.QuickCheck (Arbitrary (..), arbitrary, forAll, generate, property)
 import           Test.QuickCheck.Gen (oneof, vectorOf)
 
 import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
-import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
+import           Pos.Crypto (RequiresNetworkMagic (..))
 import           Pos.Util.BackupPhrase (BackupPhrase (..), safeKeysFromPhrase)
 import           Pos.Util.Mnemonics (defMnemonic, fromMnemonic, toMnemonic)
 import           Pos.Wallet.Web.ClientTypes.Functions (encToCId)
 import           Pos.Wallet.Web.ClientTypes.Types (CId)
 
-import qualified Data.Set as Set
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
 
 spec :: Spec
 spec = do
@@ -25,10 +31,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody (makeNetworkMagic pm)
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody (makeNetworkMagic pm)
 
 specBody :: NetworkMagic -> Spec
 specBody _nm = do

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
@@ -9,23 +9,37 @@ import           Universum
 
 import           Pos.Launcher (HasConfigurations)
 
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Wallet.Web.ClientTypes (CWallet (..))
 import           Pos.Wallet.Web.Methods.Restore (restoreWalletFromBackup)
-import           Test.Hspec (Spec, describe)
+
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
-import           Test.Pos.Configuration (withDefConfigurations)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
-import           Test.QuickCheck (Arbitrary (..))
+import           Test.QuickCheck (arbitrary, generate)
 import           Test.QuickCheck.Monadic (pick)
 
 spec :: Spec
-spec = withDefConfigurations $ \_ _ ->
-       describe "restoreAddressFromWalletBackup" $ modifyMaxSuccess (const 10) $ do
-           restoreWalletAddressFromBackupSpec
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
 
-restoreWalletAddressFromBackupSpec :: HasConfigurations => Spec
-restoreWalletAddressFromBackupSpec =
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $
+       describe "restoreAddressFromWalletBackup" $ modifyMaxSuccess (const 10) $ do
+           (restoreWalletAddressFromBackupSpec (makeNetworkMagic pm))
+
+restoreWalletAddressFromBackupSpec :: HasConfigurations => NetworkMagic -> Spec
+restoreWalletAddressFromBackupSpec _nm =
     walletPropertySpec restoreWalletAddressFromBackupDesc $ do
         walletBackup   <- pick arbitrary
         restoredWallet <- lift $ restoreWalletFromBackup walletBackup

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
@@ -17,10 +17,18 @@ import           Pos.Wallet.Web.Methods.Restore (restoreWalletFromBackup)
 import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
 import           Test.QuickCheck (arbitrary, generate)
 import           Test.QuickCheck.Monadic (pick)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
 
 spec :: Spec
 spec = do
@@ -28,10 +36,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/LogicSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/LogicSpec.hs
@@ -7,26 +7,40 @@ module Test.Pos.Wallet.Web.Methods.LogicSpec
 
 import           Universum
 
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (prop)
+import           Test.QuickCheck (arbitrary, generate)
 
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Launcher (HasConfigurations)
 import           Pos.Wallet.Web.Methods.Logic (getAccounts, getWallets)
 
-import           Test.Pos.Configuration (withDefConfigurations)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (stopProperty)
 import           Test.Pos.Wallet.Web.Mode (WalletProperty)
 
 -- TODO remove HasCompileInfo when MonadWalletWebMode will be splitted.
 spec :: Spec
-spec = withDefConfigurations $ \_ _ ->
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $
        describe "Pos.Wallet.Web.Methods" $ do
-    prop emptyWalletOnStarts emptyWallet
+    prop emptyWalletOnStarts (emptyWallet (makeNetworkMagic pm))
   where
     emptyWalletOnStarts = "wallet must be empty on start"
 
-emptyWallet :: HasConfigurations => WalletProperty ()
-emptyWallet = do
+emptyWallet :: HasConfigurations => NetworkMagic -> WalletProperty ()
+emptyWallet _nm = do
     wallets <- lift getWallets
     unless (null wallets) $
         stopProperty "Wallets aren't empty"

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
@@ -14,11 +14,10 @@ module Test.Pos.Wallet.Web.Methods.PaymentSpec
 import           Universum
 
 import           Control.Exception.Safe (try)
-import           Data.Default (def)
 import           Data.List ((!!), (\\))
 import           Data.List.NonEmpty (fromList)
 import           Formatting (build, sformat, (%))
-import           Test.Hspec (Spec, describe, shouldBe)
+import           Test.Hspec (Spec, describe, runIO, shouldBe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 import           Test.QuickCheck (arbitrary, choose, generate)
 import           Test.QuickCheck.Monadic (pick)
@@ -28,11 +27,10 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..), txToLinearFee)
 import           Pos.Core (Address, Coin, TxFeePolicy (..), bvdTxFeePolicy, mkCoin, sumCoins,
                            unsafeGetCoin, unsafeSubCoin)
 import           Pos.Core.Txp (Tx (..), TxAux (..), _TxOut)
-import           Pos.Crypto (PassPhrase)
+import           Pos.Crypto (PassPhrase, ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.DB.Class (MonadGState (..))
 import           Pos.Launcher (HasConfigurations)
 import           Pos.Txp (TxFee (..))
-import           Pos.Util.CompileInfo (withCompileInfo)
 import           Pos.Wallet.Web.Account (myRootAddresses)
 import           Pos.Wallet.Web.ClientTypes (Addr, CAccount (..), CId, CTx (..),
                                              NewBatchPayment (..), Wal)
@@ -46,8 +44,7 @@ import           Pos.Wallet.Web.Util (decodeCTypeOrFail, getAccountAddrsOrThrow)
 
 import           Pos.Util.Servant (encodeCType)
 
-import           Test.Pos.Configuration (withDefConfigurations)
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty, expectedOne, maybeStopProperty,
                                                     splitWord, stopProperty)
 import           Test.Pos.Wallet.Web.Mode (WalletProperty, getSentTxs, submitTxTestMode,
@@ -61,12 +58,18 @@ deriving instance Eq CTx
 
 -- TODO remove HasCompileInfo when MonadWalletWebMode will be splitted.
 spec :: Spec
-spec = withCompileInfo def $
-       withDefConfigurations $ \_ _ ->
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+       withProvidedMagicConfig pm $
        describe "Wallet.Web.Methods.Payment" $ modifyMaxSuccess (const 10) $ do
-    describe "newPaymentBatch" $ do
-        describe "Submitting a payment when restoring" rejectPaymentIfRestoringSpec
-        describe "One payment" oneNewPaymentBatchSpec
+           describe "Submitting a payment when restoring" (rejectPaymentIfRestoringSpec pm)
+           describe "One payment" (oneNewPaymentBatchSpec pm)
 
 data PaymentFixture = PaymentFixture {
       pswd        :: PassPhrase
@@ -81,8 +84,8 @@ data PaymentFixture = PaymentFixture {
 }
 
 -- | Generic block of code to be reused across all the different payment specs.
-newPaymentFixture :: HasConfigurations => WalletProperty PaymentFixture
-newPaymentFixture = do
+newPaymentFixture :: HasConfigurations => ProtocolMagic -> WalletProperty PaymentFixture
+newPaymentFixture _pm = do
     passphrases <- importSomeWallets mostlyEmptyPassphrases
     let l = length passphrases
     destLen <- pick $ choose (1, l)
@@ -120,23 +123,23 @@ newPaymentFixture = do
 
 -- | Assess that if we try to submit a payment when the wallet is restoring,
 -- the backend prevents us from doing that.
-rejectPaymentIfRestoringSpec :: HasConfigurations => Spec
-rejectPaymentIfRestoringSpec = walletPropertySpec "should fail with 403" $ do
-    PaymentFixture{..} <- newPaymentFixture
-    res <- lift $ try (newPaymentBatch dummyProtocolMagic submitTxTestMode pswd batch)
+rejectPaymentIfRestoringSpec :: HasConfigurations => ProtocolMagic -> Spec
+rejectPaymentIfRestoringSpec pm = walletPropertySpec "should fail with 403" $ do
+    PaymentFixture{..} <- newPaymentFixture pm
+    res <- lift $ try (newPaymentBatch pm submitTxTestMode pswd batch)
     liftIO $ shouldBe res (Left (err403 { errReasonPhrase = "Transaction creation is disabled when the wallet is restoring." }))
 
 -- | Test one single, successful payment.
-oneNewPaymentBatchSpec :: HasConfigurations => Spec
-oneNewPaymentBatchSpec = walletPropertySpec oneNewPaymentBatchDesc $ do
-    PaymentFixture{..} <- newPaymentFixture
+oneNewPaymentBatchSpec :: HasConfigurations => ProtocolMagic -> Spec
+oneNewPaymentBatchSpec pm = walletPropertySpec oneNewPaymentBatchDesc $ do
+    PaymentFixture{..} <- newPaymentFixture pm
 
     -- Force the wallet to be in a (fake) synced state
     db <- WS.askWalletDB
     randomSyncTip <- liftIO $ generate arbitrary
     WS.setWalletSyncTip db walId randomSyncTip
 
-    void $ lift $ newPaymentBatch dummyProtocolMagic submitTxTestMode pswd batch
+    void $ lift $ newPaymentBatch pm submitTxTestMode pswd batch
     dstAddrs <- lift $ mapM decodeCTypeOrFail dstCAddrs
     txLinearPolicy <- lift $ (bvdTxFeePolicy <$> gsAdoptedBVData) <&> \case
         TxFeePolicyTxSizeLinear linear -> linear

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
@@ -45,6 +45,7 @@ import           Pos.Wallet.Web.Util (decodeCTypeOrFail, getAccountAddrsOrThrow)
 import           Pos.Util.Servant (encodeCType)
 
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty, expectedOne, maybeStopProperty,
                                                     splitWord, stopProperty)
 import           Test.Pos.Wallet.Web.Mode (WalletProperty, getSentTxs, submitTxTestMode,
@@ -57,19 +58,27 @@ import           Test.Pos.Wallet.Web.Util (deriveRandomAddress, expectedAddrBala
 deriving instance Eq CTx
 
 -- TODO remove HasCompileInfo when MonadWalletWebMode will be splitted.
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
+
 spec :: Spec
 spec = do
     runWithMagic NMMustBeNothing
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-       withProvidedMagicConfig pm $
-       describe "Wallet.Web.Methods.Payment" $ modifyMaxSuccess (const 10) $ do
-           describe "Submitting a payment when restoring" (rejectPaymentIfRestoringSpec pm)
-           describe "One payment" (oneNewPaymentBatchSpec pm)
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+           withProvidedMagicConfig pm $
+           describe "Wallet.Web.Methods.Payment" $ modifyMaxSuccess (const 10) $ do
+               describe "Submitting a payment when restoring" (rejectPaymentIfRestoringSpec pm)
+               describe "One payment" (oneNewPaymentBatchSpec pm)
 
 data PaymentFixture = PaymentFixture {
       pswd        :: PassPhrase

--- a/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
@@ -12,17 +12,17 @@ import           Universum
 import qualified Data.HashSet as HS
 import           Data.List (intersect, (\\))
 import           Pos.Client.KeyStorage (getSecretKeysPlain)
-import           Test.Hspec (Spec, describe, xdescribe)
+import           Test.Hspec (Spec, describe, runIO, xdescribe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Arbitrary (..), Property, choose, oneof, sublistOf, suchThat,
-                                  vectorOf, (===))
+import           Test.QuickCheck (Arbitrary (..), Property, arbitrary, choose, generate, oneof,
+                                  sublistOf, suchThat, vectorOf, (===))
 import           Test.QuickCheck.Monadic (pick)
 
 import           Pos.Arbitrary.Wallet.Web.ClientTypes ()
 import           Pos.Block.Logic (rollbackBlocks)
 import           Pos.Core (Address, BlockCount (..), blkSecurityParam)
 import           Pos.Core.Chrono (nonEmptyOldestFirst, toNewestFirst)
-import           Pos.Crypto (emptyPassphrase)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..), emptyPassphrase)
 import           Pos.Launcher (HasConfigurations)
 
 import qualified Pos.Wallet.Web.State as WS
@@ -38,16 +38,26 @@ import           Pos.Wallet.Web.Tracking.Types (newSyncRequest)
 
 
 import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..))
-import           Test.Pos.Configuration (withDefConfigurations)
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
 import           Test.Pos.Wallet.Web.Util (importSomeWallets, wpGenBlocks)
 
 spec :: Spec
-spec = withDefConfigurations $ \_ _ -> do
+spec = do
+    runWithMagic NMMustBeNothing
+    runWithMagic NMMustBeJust
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ do
     describe "Pos.Wallet.Web.Tracking.BListener" $ modifyMaxSuccess (const 10) $ do
-        describe "Two applications and rollbacks" twoApplyTwoRollbacksSpec
+        describe "Two applications and rollbacks" (twoApplyTwoRollbacksSpec pm)
     xdescribe "Pos.Wallet.Web.Tracking.evalChange (pending, CSL-2473)" $ do
         prop evalChangeDiffAccountsDesc evalChangeDiffAccounts
         prop evalChangeSameAccountsDesc evalChangeSameAccounts
@@ -57,8 +67,8 @@ spec = withDefConfigurations $ \_ _ -> do
     evalChangeSameAccountsDesc =
       "Outgoing transaction from account to the same account."
 
-twoApplyTwoRollbacksSpec :: HasConfigurations => Spec
-twoApplyTwoRollbacksSpec = walletPropertySpec twoApplyTwoRollbacksDesc $ do
+twoApplyTwoRollbacksSpec :: HasConfigurations => ProtocolMagic -> Spec
+twoApplyTwoRollbacksSpec pm = walletPropertySpec twoApplyTwoRollbacksDesc $ do
     let k = fromIntegral blkSecurityParam :: Word64
     -- During these tests we need to manually switch back to the old synchronous
     -- way of restoring.
@@ -70,12 +80,12 @@ twoApplyTwoRollbacksSpec = walletPropertySpec twoApplyTwoRollbacksDesc $ do
     genesisWalletDB <- lift WS.askWalletSnapshot
     applyBlocksCnt1 <- pick $ choose (1, k `div` 2)
     applyBlocksCnt2 <- pick $ choose (1, k `div` 2)
-    blunds1 <- wpGenBlocks dummyProtocolMagic
+    blunds1 <- wpGenBlocks pm
                            (Just $ BlockCount applyBlocksCnt1)
                            (EnableTxPayload True)
                            (InplaceDB True)
     after1ApplyDB <- lift WS.askWalletSnapshot
-    blunds2 <- wpGenBlocks dummyProtocolMagic
+    blunds2 <- wpGenBlocks pm
                            (Just $ BlockCount applyBlocksCnt2)
                            (EnableTxPayload True)
                            (InplaceDB True)
@@ -83,9 +93,9 @@ twoApplyTwoRollbacksSpec = walletPropertySpec twoApplyTwoRollbacksDesc $ do
     let toNE = fromMaybe (error "sequence of blocks are empty") . nonEmptyOldestFirst
     let to1Rollback = toNewestFirst $ toNE blunds2
     let to2Rollback = toNewestFirst $ toNE blunds1
-    lift $ rollbackBlocks dummyProtocolMagic to1Rollback
+    lift $ rollbackBlocks pm to1Rollback
     after1RollbackDB <- lift WS.askWalletSnapshot
-    lift $ rollbackBlocks dummyProtocolMagic to2Rollback
+    lift $ rollbackBlocks pm to2Rollback
     after2RollbackDB <- lift WS.askWalletSnapshot
     assertProperty (after1RollbackDB == after1ApplyDB)
         "wallet-db after first apply doesn't equal to wallet-db after first rollback"

--- a/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
@@ -39,9 +39,17 @@ import           Pos.Wallet.Web.Tracking.Types (newSyncRequest)
 
 import           Test.Pos.Block.Logic.Util (EnableTxPayload (..), InplaceDB (..))
 import           Test.Pos.Configuration (withProvidedMagicConfig)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
 import           Test.Pos.Wallet.Web.Util (importSomeWallets, wpGenBlocks)
+
+
+-- We run the tests this number of times, with different `ProtocolMagics`, to get increased
+-- coverage. We should really do this inside of the `prop`, but it is difficult to do that
+-- without significant rewriting of the testsuite.
+testMultiple :: Int
+testMultiple = 1
 
 spec :: Spec
 spec = do
@@ -49,10 +57,11 @@ spec = do
     runWithMagic NMMustBeJust
 
 runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
+runWithMagic rnm = replicateM_ testMultiple $
+    modifyMaxSuccess (`div` testMultiple) $ do
+        pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+        describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+            specBody pm
 
 specBody :: ProtocolMagic -> Spec
 specBody pm = withProvidedMagicConfig pm $ do


### PR DESCRIPTION
## Description

"Split" the test-suites, for both NMMustBeNothing and NMMustBeJust cases. Also, introduce arbitrary ProtocolMagics (replace dummyProtocolMagic values). Since we hardcoded values in (3), both splits should pass.

Motivation: in order to follow best practices of modifying tests & source code in separate PRs, today I factored out the testsuite modifications into a separate PR. We are PR'ing this before the full implementation of `NetworkMagic` is PR'ed, because we want to demonstrate that the tests can be split & parameterized by arbitrary `ProtocolMagic`s, without modifying source code, and still pass. Then, when we modify the source and pass the tests, we will have more confidence in a correct implementation.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-354

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.
^ there is no 1.3.1 section in the CHANGELOG, and this is dev work on a release branch, so I'm skipping this.

## Testing checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.