### PR TITLE
[release/1.3.1] [CO-354] Implement `NetworkMagic` logic

### DIFF
--- a/auxx/src/Command/BlockGen.hs
+++ b/auxx/src/Command/BlockGen.hs
@@ -14,6 +14,7 @@ import           System.Wlog (logInfo)
 import           Pos.AllSecrets (mkAllSecretsSimple)
 import           Pos.Client.KeyStorage (getSecretKeysPlain)
 import           Pos.Core (gdBootStakeholders, genesisData)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic, encToSecret)
 import           Pos.Generator.Block (BlockGenParams (..), genBlocks, tgpTxCountRange)
 import           Pos.Infra.StateLock (Priority (..), withStateLock)
@@ -30,7 +31,8 @@ generateBlocks pm GenBlocksParams{..} = withStateLock HighPriority ApplyBlock $ 
     seed <- liftIO $ maybe randomIO pure bgoSeed
     logInfo $ "Generating with seed " <> show seed
 
-    allSecrets <- mkAllSecretsSimple . map encToSecret <$> getSecretKeysPlain
+    let nm = makeNetworkMagic pm
+    allSecrets <- mkAllSecretsSimple nm . map encToSecret <$> getSecretKeysPlain
 
     let bgenParams =
             BlockGenParams

--- a/auxx/src/Command/Tx.hs
+++ b/auxx/src/Command/Tx.hs
@@ -40,7 +40,7 @@ import           Pos.Client.Txp.Util (createTx)
 import           Pos.Core (BlockVersionData (bvdSlotDuration), IsBootstrapEraAddr (..),
                            Timestamp (..), deriveFirstHDAddress, makePubKeyAddress, mkCoin)
 import           Pos.Core.Configuration (genesisBlockVersionData, genesisSecretKeys)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Txp (TxAux (..), TxIn (TxInUtxo), TxOut (..), TxOutAux (..), txaF)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, emptyPassphrase, encToPublic,
                              fakeSigner, hash, safeToPublic, toPublic, withSafeSigners)
@@ -104,18 +104,19 @@ sendToAllGenesis pm diffusion (SendToAllGenesisParams genesisTxsPerThread txsPer
         logInfo $ sformat ("Found "%shown%" keys in the genesis block.") (length keysToSend)
         startAtTxt <- liftIO $ lookupEnv "AUXX_START_AT"
         let startAt = fromMaybe 0 . readMaybe . fromMaybe "" $ startAtTxt :: Int
+        let nm = makeNetworkMagic pm
         -- construct a transaction, and add it to the queue
         let addTx secretKey = do
                 let signer = fakeSigner secretKey
                     publicKey = toPublic secretKey
                 -- construct transaction output
-                outAddr <- makePubKeyAddressAuxx fixedNM publicKey
+                outAddr <- makePubKeyAddressAuxx nm publicKey
                 let txOut1 = TxOut {
                     txOutAddress = outAddr,
                     txOutValue = mkCoin 1
                     }
                     txOuts = TxOutAux txOut1 :| []
-                utxo <- getOwnUtxoForPk fixedNM $ safeToPublic signer
+                utxo <- getOwnUtxoForPk nm $ safeToPublic signer
                 etx <- createTx pm mempty utxo signer txOuts publicKey
                 case etx of
                     Left err -> logError (sformat ("Error: "%build%" while trying to contruct tx") err)
@@ -221,11 +222,12 @@ send
     -> m ()
 send pm diffusion idx outputs = do
     skey <- takeSecret
+    let nm = makeNetworkMagic pm
     let curPk = encToPublic skey
-    let plainAddresses = map (flip (makePubKeyAddress fixedNM) curPk . IsBootstrapEraAddr) [False, True]
+    let plainAddresses = map (flip (makePubKeyAddress nm) curPk . IsBootstrapEraAddr) [False, True]
     let (hdAddresses, hdSecrets) = unzip $ map
             (\ibea -> fromMaybe (error "send: pass mismatch") $
-                    deriveFirstHDAddress fixedNM (IsBootstrapEraAddr ibea) emptyPassphrase skey) [False, True]
+                    deriveFirstHDAddress nm (IsBootstrapEraAddr ibea) emptyPassphrase skey) [False, True]
     let allAddresses = hdAddresses ++ plainAddresses
     let allSecrets = hdSecrets ++ [skey, skey]
     etx <- withSafeSigners allSecrets (pure emptyPassphrase) $ \signers -> runExceptT @AuxxException $ do
@@ -273,6 +275,3 @@ sendTxsFromFile diffusion txsFile = do
                 (topsortTxAuxes txAuxes)
         let submitOne = submitTxRaw diffusion
         mapM_ submitOne sortedTxAuxes
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/client/src/Pos/Client/Txp/Network.hs
+++ b/client/src/Pos/Client/Txp/Network.hs
@@ -25,7 +25,7 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy, PendingAddresses (..
 import           Pos.Communication.Message ()
 import           Pos.Communication.Types (InvOrDataTK)
 import           Pos.Core (Address, Coin, makeRedeemAddress, mkCoin, unsafeAddCoin)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Txp (TxAux (..), TxId, TxOut (..), TxOutAux (..), txaF)
 import           Pos.Crypto (ProtocolMagic, RedeemSecretKey, SafeSigner, hash, redeemToPublic)
 import           Pos.Infra.Communication.Protocol (OutSpecs)
@@ -68,7 +68,8 @@ prepareRedemptionTx
     -> Address
     -> m (TxAux, Address, Coin)
 prepareRedemptionTx pm rsk output = do
-    let redeemAddress = makeRedeemAddress fixedNM $ redeemToPublic rsk
+    let nm = makeNetworkMagic pm
+    let redeemAddress = makeRedeemAddress nm $ redeemToPublic rsk
     utxo <- getOwnUtxo redeemAddress
     let addCoin c = unsafeAddCoin c . txOutValue . toaOut
         redeemBalance = foldl' addCoin (mkCoin 0) utxo
@@ -90,7 +91,3 @@ submitTxRaw diffusion txAux@TxAux {..} = do
 
 sendTxOuts :: OutSpecs
 sendTxOuts = createOutSpecs (Proxy :: Proxy (InvOrDataTK TxId TxMsgContents))
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/client/test/Test/Pos/Client/Txp/Mode.hs
+++ b/client/test/Test/Pos/Client/Txp/Mode.hs
@@ -54,16 +54,16 @@ instance MonadGState TxpTestMode where
 
 instance MonadAddresses TxpTestMode where
     type AddrData TxpTestMode = ()
-    getNewAddress _ _ = pure fakeAddressForMonadAddresses
-    getFakeChangeAddress _ = pure fakeAddressForMonadAddresses
+    getNewAddress nm _ = pure (fakeAddressForMonadAddresses nm)
+    getFakeChangeAddress = pure . fakeAddressForMonadAddresses
 
-fakeAddressForMonadAddresses :: Address
-fakeAddressForMonadAddresses = address
+fakeAddressForMonadAddresses :: NetworkMagic -> Address
+fakeAddressForMonadAddresses nm = address
   where
     -- seed for address generation is a ByteString with 32 255's
     seedSize = 32
     seed = BS.replicate seedSize (255 :: Word8)
-    address = makePubKeyAddressBoot fixedNM $ fst $ deterministicKeyGen seed
+    address = makePubKeyAddressBoot nm $ fst $ deterministicKeyGen seed
 
 withBVData
   :: MonadReader BlockVersionData m
@@ -87,7 +87,3 @@ instance MonadAddresses TxpTestProperty where
 
 instance (HasTxpConfigurations, Testable a) => Testable (TxpTestProperty a) where
     property = monadic (ioProperty . flip runReaderT genesisBlockVersionData)
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/core/src/Pos/Core/Genesis/Generate.hs
+++ b/core/src/Pos/Core/Genesis/Generate.hs
@@ -33,7 +33,7 @@ import           Pos.Core.Common (Address, Coin, IsBootstrapEraAddr (..), Stakeh
                                   unsafeIntegerToCoin)
 import           Pos.Core.Configuration.Protocol (HasProtocolConstants, vssMaxTTL, vssMinTTL)
 import           Pos.Core.Delegation (HeavyDlgIndex (..), ProxySKHeavy)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Ssc (VssCertificate, mkVssCertificate, mkVssCertificatesMap)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, RedeemPublicKey, SecretKey,
                              VssKeyPair, createPsk, deterministic, emptyPassphrase, encToSecret,
@@ -159,7 +159,7 @@ generateGenesisData pm (GenesisInitializer{..}) realAvvmBalances = deterministic
     let toVss = mkVssCertificatesMap
         vssCerts = GenesisVssCertificatesMap $ toVss vssCertsList
 
-    let nm = fixedNM
+    let nm = makeNetworkMagic pm
 
     -- Non AVVM balances
     ---- Addresses
@@ -303,7 +303,3 @@ genTestnetDistribution TestnetBalanceOptions {..} testBalance =
 
     getShare :: Double -> Integer -> Integer
     getShare sh n = round $ sh * fromInteger n
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/Arbitrary/Unsafe.hs
+++ b/core/test/Test/Pos/Core/Arbitrary/Unsafe.hs
@@ -28,12 +28,13 @@ instance ArbitraryUnsafe Coin where
 instance ArbitraryUnsafe Address where
     arbitraryUnsafe = do
         addrRoot <- arbitraryUnsafe
+        aaNM <- arbitraryUnsafe
         let addrAttributes =
                 mkAttributes $
                 AddrAttributes
                 { aaPkDerivationPath = Nothing
                 , aaStakeDistribution = BootstrapEraDistr
-                , aaNetworkMagic = fixedNM
+                , aaNetworkMagic = aaNM
                 }
         let addrType = ATPubKey
         return Address {..}
@@ -42,7 +43,3 @@ instance HasProtocolConstants => ArbitraryUnsafe SlotId where
     arbitraryUnsafe = SlotId <$> arbitraryUnsafe <*> arbitraryUnsafe
 
 instance ArbitraryUnsafe NetworkMagic
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -345,7 +345,9 @@ genAddrAttributes :: Gen AddrAttributes
 genAddrAttributes = AddrAttributes <$> hap <*> genAddrStakeDistribution <*> nm
   where
     hap = Gen.maybe genHDAddressPayload
-    nm = pure fixedNM
+    nm  = Gen.choice [ pure NMNothing
+                     , NMJust <$> genInt32
+                     ]
 
 genAddress :: Gen Address
 genAddress = makeAddress <$> genAddrSpendingData <*> genAddrAttributes
@@ -1060,6 +1062,5 @@ genWord32 = Gen.word32 Range.constantBounded
 genWord8 :: Gen Word8
 genWord8 = Gen.word8 Range.constantBounded
 
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing
+genInt32 :: Gen Int32
+genInt32 = Gen.int32 Range.constantBounded

--- a/explorer/src/Pos/Explorer/TestUtil.hs
+++ b/explorer/src/Pos/Explorer/TestUtil.hs
@@ -39,7 +39,7 @@ import           Pos.Core (Address, BlockCount (..), ChainDifficulty (..), Epoch
                            headerHash, makePubKeyAddressBoot)
 import           Pos.Core.Block (Block, BlockHeader, GenesisBlock, MainBlock, getBlockHeader)
 import           Pos.Core.Block.Constructors (mkGenesisBlock)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Core.Ssc (SscPayload)
 import           Pos.Core.Txp (TxAux)
 import           Pos.Core.Update (UpdatePayload (..))
@@ -399,9 +399,5 @@ produceSecretKeys blocksNumber = liftIO $ secretKeys
 -- | Factory to create an `Address`
 -- | Friendly borrowed from `Test.Pos.Client.Txp.UtilSpec`
 -- | TODO: Remove it as soon as ^ is exposed
-secretKeyToAddress :: SecretKey -> Address
-secretKeyToAddress = makePubKeyAddressBoot fixedNM . toPublic
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing
+secretKeyToAddress :: NetworkMagic -> SecretKey -> Address
+secretKeyToAddress nm = makePubKeyAddressBoot nm . toPublic

--- a/explorer/src/Pos/Explorer/Web/ClientTypes.hs
+++ b/explorer/src/Pos/Explorer/Web/ClientTypes.hs
@@ -433,4 +433,4 @@ sumCoinOfInputsOutputs addressListMB
 --------------------------------------------------------------------------------
 
 instance Arbitrary CAddress where
-    arbitrary = toCAddress . secretKeyToAddress <$> arbitrary
+    arbitrary = toCAddress <$> (secretKeyToAddress <$> arbitrary <*> arbitrary)

--- a/explorer/src/explorer/Main.hs
+++ b/explorer/src/explorer/Main.hs
@@ -30,8 +30,8 @@ import           Pos.Explorer.Txp (ExplorerExtraModifier, explorerTxpGlobalSetti
 import           Pos.Explorer.Web (ExplorerProd, explorerPlugin, notifierPlugin, runExplorerProd)
 import           Pos.Infra.Diffusion.Types (Diffusion, hoistDiffusion)
 import           Pos.Launcher (ConfigurationOptions (..), HasConfigurations, NodeParams (..),
-                               NodeResources (..), bracketNodeResources,
-                               loggerBracket, runNode, runRealMode, withConfigurations)
+                               NodeResources (..), bracketNodeResources, loggerBracket, runNode,
+                               runRealMode, withConfigurations)
 import           Pos.Launcher.Configuration (AssetLockPath (..))
 import           Pos.Update.Worker (updateTriggerWorker)
 import           Pos.Util (logException)
@@ -66,7 +66,7 @@ action (ExplorerNodeArgs (cArgs@CommonNodeArgs{..}) ExplorerArgs{..}) =
 
         let plugins :: [Diffusion ExplorerProd -> ExplorerProd ()]
             plugins =
-                [ explorerPlugin webPort
+                [ explorerPlugin pm webPort
                 , notifierPlugin NotifierSettings{ nsPort = notifierPort }
                 , updateTriggerWorker
                 ]

--- a/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
@@ -128,10 +128,10 @@ specBody nm =
 
 
 addressSetByTxsProp :: NetworkMagic -> SecretKey -> Bool
-addressSetByTxsProp _nm key =
+addressSetByTxsProp nm key =
     let
-        addrA = secretKeyToAddress key
-        addrB = secretKeyToAddress key
+        addrA = secretKeyToAddress nm key
+        addrB = secretKeyToAddress nm key
         txA = mkTxOut 2 addrA
         txB = mkTxOut 3 addrA
         txC = mkTxOut 4 addrB

--- a/generator/src/Pos/Generator/Block/Payload.hs
+++ b/generator/src/Pos/Generator/Block/Payload.hs
@@ -27,7 +27,7 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..), TxError (..), c
                                       makeMPubKeyTxAddrs)
 import           Pos.Core (AddrSpendingData (..), Address (..), Coin, SlotId (..), addressHash,
                            coinToInteger, makePubKeyAddressBoot, unsafeIntegerToCoin)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Txp (Tx (..), TxAux (..), TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (ProtocolMagic, SecretKey, WithHash (..), fakeSigner, hash, toPublic)
 import           Pos.Generator.Block.Error (BlockGenError (..))
@@ -133,7 +133,7 @@ genTxPayload pm = do
         txsN <- fromIntegral <$> getRandomR (a, a + d)
         void $ replicateM txsN genTransaction
   where
-    nm = fixedNM
+    nm = makeNetworkMagic pm
     genTransaction :: StateT GenTxData (BlockGenRandMode ext g m) ()
     genTransaction = do
         utxo <- use gtdUtxo
@@ -247,7 +247,3 @@ genPayload
     -> SlotId
     -> BlockGenRandMode ext g m ()
 genPayload pm _ = genTxPayload pm
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/generator/src/Test/Pos/Block/Logic/Mode.hs
+++ b/generator/src/Test/Pos/Block/Logic/Mode.hs
@@ -66,6 +66,7 @@ import           Pos.Core (BlockVersionData, CoreConfiguration (..), GenesisConf
                            epochSlots, genesisSecretKeys, withGenesisSpec)
 import           Pos.Core.Configuration (HasGenesisBlockVersionData, coreConfiguration,
                                          withGenesisBlockVersionData)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.DB (DBPure, MonadDB (..), MonadDBRead (..), MonadGState (..))
 import qualified Pos.DB as DB
@@ -281,7 +282,7 @@ initBlockTestContext tp@TestParams {..} callback = do
                         Nothing ->
                             error "initBlockTestContext: no genesisSecretKeys"
                         Just ks -> ks
-            let btcAllSecrets = mkAllSecretsSimple secretKeys
+            let btcAllSecrets = mkAllSecretsSimple (makeNetworkMagic pm) secretKeys
             let btCtx = BlockTestContext {btcSystemStart = systemStart, btcSSlottingStateVar = slottingState, ..}
             liftIO $ flip runReaderT clockVar $ unEmulation $ callback btCtx
     sudoLiftIO $ runTestInitMode initCtx $ initBlockTestContextDo

--- a/lib/src/Pos/AllSecrets.hs
+++ b/lib/src/Pos/AllSecrets.hs
@@ -27,7 +27,7 @@ import           Pos.Binary.Core ()
 import           Pos.Core (AddrSpendingData (..), Address, IsBootstrapEraAddr (..), StakeholderId,
                            addressHash, checkAddrSpendingData, makePubKeyAddress,
                            makePubKeyAddressBoot)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (PublicKey, SecretKey, toPublic)
 
 -- | This map effectively provides inverse of 'hash' and
@@ -85,14 +85,13 @@ instance Buildable AllSecrets where
 -- | Make simple 'AllSecrets' assuming that only public key addresses
 -- with bootstrap era distribution and single key distribution exist
 -- in the system.
-mkAllSecretsSimple :: [SecretKey] -> AllSecrets
-mkAllSecretsSimple sks =
+mkAllSecretsSimple :: NetworkMagic -> [SecretKey] -> AllSecrets
+mkAllSecretsSimple nm sks =
     AllSecrets
     { _asSecretKeys = mkInvSecretsMap sks
     , _asSpendingData = invAddrSpendingData
     }
   where
-    nm = fixedNM
     pks :: [PublicKey]
     pks = map toPublic sks
     spendingDataList = map PubKeyASD pks
@@ -102,7 +101,3 @@ mkAllSecretsSimple sks =
         mkInvAddrSpendingData $
         zip addressesNonBoot spendingDataList <>
         zip addressesBoot spendingDataList
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/scripts/test/wallet/integration/default.nix
+++ b/scripts/test/wallet/integration/default.nix
@@ -15,7 +15,7 @@ let
   demo-cluster = iohkPkgs.demoCluster.override {
     inherit gitrev numCoreNodes stateDir;
     keepAlive = false;
-    assetLockAddresses = [ "DdzFFzCqrhswMWoTiWaqXUDZJuYUx63qB6Aq8rbVbhFbc8NWqhpZkC7Lhn5eVA7kWf4JwKvJ9PqQF78AewMCzDZLabkzm99rFzpNDKp5" ];
+    assetLockAddresses = [ "37btjrVyb4KFoqHWWGxtcfNJETEVxekMkM1sSanpUpXnGivFdssbvyaF69XAUF94rZosRNUB4pBPxEAEYaiqZhaH1tvcK7mAVdTvd9dgjjbMwWQQC5" ];
   };
   executables =  {
     integration-test = "${iohkPkgs.cardano-sl-wallet-new}/bin/wal-integr-test";

--- a/tools/src/addr-convert/Main.hs
+++ b/tools/src/addr-convert/Main.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 import           Universum
 
+import           Data.Text.Read (decimal)
 import           Data.Version (showVersion)
 import           NeatInterpolation (text)
 import           Options.Applicative (Parser, execParser, footerDoc, fullDesc, header, help, helper,
@@ -14,12 +15,15 @@ import           Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import           Paths_cardano_sl (version)
 import           Pos.Core (makeRedeemAddress)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic (..), makeNetworkMagic)
+import           Pos.Crypto.Configuration (ProtocolMagic (..), ProtocolMagicId (..),
+                                           RequiresNetworkMagic (..))
 import           Pos.Crypto.Signing (fromAvvmPk)
 import           Pos.Util.Util (eitherToThrow)
 
 data AddrConvertOptions = AddrConvertOptions
-    { address :: !(Maybe Text)
+    { address       :: !(Maybe Text)
+    , protocolMagic :: !Text
     }
 
 optionsParser :: Parser AddrConvertOptions
@@ -29,7 +33,12 @@ optionsParser = do
         <> long    "address"
         <> help    "Address to convert. It must be in base64(url) format."
         <> metavar "STRING"
-    return AddrConvertOptions{..}
+    pm      <- textOption $
+           short   'p'
+        <> long    "protocolMagic"
+        <> help    "Generate mainnet or testnet address."
+        <> metavar "STRING"
+    return $ AddrConvertOptions address pm
     where
       textOption = option (toText <$> readerAsk)
 
@@ -49,27 +58,54 @@ usageExample :: Maybe Doc
 usageExample = (Just . fromString @Doc . toString @Text) [text|
 Command example:
 
-  stack exec -- cardano-addr-convert -a 2HF83bvYCTzoCbVta6t64W8rFEnvnkJbIUFoT5tOyoU=
+  stack exec -- cardano-addr-convert -a 2HF83bvYCTzoCbVta6t64W8rFEnvnkJbIUFoT5tOyoU= -p mainnet
 
 Output example:
 
-  3mhNKjfhaCT13DjcQ9eMK4VHfZrFxmyXq8SjVPRtz7SWfP
+  Ae2tdPwUPEZLTt73QktZUahV9FXnBRJNgzpbueBqQKGyPDgPdzPdwVretyk
 
-You can also run it without arguments to switch to interactive mode.
+You can also run it without the address argument to switch to interactive mode.
 In this case each entered vending address is echoed with a testnet address.|]
 
-convertAddr :: Text -> IO Text
-convertAddr addr =
-    pretty . makeRedeemAddress fixedNM <$>
+convertAddr :: NetworkMagic -> Text -> IO Text
+convertAddr nm addr =
+    pretty . (makeRedeemAddress nm) <$>
     (eitherToThrow . fromAvvmPk) (toText addr)
+
+-- Both mainnet & staging use NMNothing. We explicity disallow provision of
+-- their integer values, so as to avoid confusion with NMJust.
+toNetworkMagic :: Text -> Either Text NetworkMagic
+toNetworkMagic txt =
+    case txt of
+        "mainnet" -> Right NMNothing
+        "staging" -> Right NMNothing
+
+        num -> case decimal num of
+            Right (pm, _)
+                | pm == stagingProtocolMagic ->
+                    Left "Got staging's ProtocolMagic;\
+                        \ please enter 'staging' instead"
+                | pm == mainnetProtocolMagic ->
+                    Left "Got mainnet's ProtocolMagic;\
+                        \ please enter 'mainnet' instead"
+            Right (ident, _) ->
+                Right (makeNetworkMagic (ProtocolMagic (ProtocolMagicId ident)
+                                        NMMustBeJust))
+            Left err -> Left $ toText ("Please enter either 'mainnet', 'staging', or\
+                                      \ an Int32 value: " ++ err)
+
+-- As documented [here](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-844), these are
+-- the ProtocolMagic Int32 values of mainnet & staging.
+stagingProtocolMagic :: Int32
+stagingProtocolMagic = 633343913
+
+mainnetProtocolMagic :: Int32
+mainnetProtocolMagic = 764824073
 
 main :: IO ()
 main = do
     AddrConvertOptions{..} <- getAddrConvertOptions
-    case address of
-        Just addr -> convertAddr addr >>= putText
-        Nothing   -> forever (getLine >>= convertAddr >>= putText)
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing
+    case (address, toNetworkMagic protocolMagic) of
+        (_        , Left txt) -> putTextLn txt >> exitFailure
+        (Just addr, Right nm) -> convertAddr nm addr >>= putTextLn
+        (Nothing  , Right nm) -> forever (getLine >>= convertAddr nm >>= putTextLn)

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -21,6 +21,7 @@ import           Options.Generic (getRecord)
 import           Pos.Client.CLI (CommonArgs (..), CommonNodeArgs (..), NodeArgs (..), getNodeParams,
                                  gtSscParams)
 import           Pos.Core (ProtocolMagic, Timestamp (..), epochSlots)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.DB.DB (initNodeDBs)
 import           Pos.DB.Rocks.Functions (openNodeDBs)
 import           Pos.DB.Rocks.Types (NodeDBs)
@@ -169,7 +170,8 @@ main = do
         spec <- loadGenSpec config
         ws   <- newWalletState (isJust addTo) walletPath -- Recreate or not
 
-        let generatedWallet = generateWalletDB cli spec
+        let nm = makeNetworkMagic pm
+        let generatedWallet = generateWalletDB nm cli spec
         walletRunner pm cfg dbs secretKeyPath ws generatedWallet
         closeState ws
 

--- a/tools/src/dbgen/QueryMethods.hs
+++ b/tools/src/dbgen/QueryMethods.hs
@@ -5,6 +5,7 @@ module QueryMethods where
 
 import           Universum
 
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Wallet.Web.Methods.Logic (getWallets)
 import           Text.Printf (printf)
 
@@ -12,15 +13,15 @@ import           Lib (timed)
 import           Rendering (say)
 import           Types (Method (..), UberMonad)
 
-queryMethods :: Maybe Method -> UberMonad ()
-queryMethods Nothing = say "No valid method read from the CLI."
-queryMethods (Just method) = case method of
-  GetWallets -> queryGetWallets
+queryMethods :: NetworkMagic -> Maybe Method -> UberMonad ()
+queryMethods _  Nothing = say "No valid method read from the CLI."
+queryMethods nm (Just method) = case method of
+  GetWallets -> queryGetWallets nm
 
 
-queryGetWallets :: UberMonad ()
-queryGetWallets = do
-  wallets <- timed getWallets
+queryGetWallets :: NetworkMagic -> UberMonad ()
+queryGetWallets nm = do
+  wallets <- timed (getWallets nm)
   case wallets of
     [] -> say "No wallets returned."
     _  -> say $ printf "%d wallets found." (length wallets)

--- a/txp/src/Pos/Txp/GenesisUtxo.hs
+++ b/txp/src/Pos/Txp/GenesisUtxo.hs
@@ -12,9 +12,10 @@ import           Universum
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 
-import           Pos.Core (Address, Coin, GenesisData (..), HasGenesisData, StakesMap, genesisData,
-                           getGenesisAvvmBalances, getGenesisNonAvvmBalances, makeRedeemAddress)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core (Address, Coin, GenesisData (..), GenesisProtocolConstants (..),
+                           HasGenesisData, StakesMap, genesisData, getGenesisAvvmBalances,
+                           getGenesisNonAvvmBalances, makeRedeemAddress)
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import           Pos.Core.Txp (TxIn (..), TxOut (..), TxOutAux (..))
 import           Pos.Crypto (unsafeHash)
 import           Pos.Txp.Toil (GenesisUtxo (..), utxoToStakes)
@@ -27,10 +28,11 @@ genesisUtxo :: HasGenesisData => GenesisUtxo
 genesisUtxo =
     let GenesisData{ gdNonAvvmBalances
                    , gdAvvmDistr
+                   , gdProtocolConsts
                    } = genesisData
 
         networkMagic :: NetworkMagic
-        networkMagic = fixedNM
+        networkMagic = makeNetworkMagic (gpcProtocolMagic gdProtocolConsts)
 
         preUtxo :: [(Address, Coin)]
         preUtxo = (first (makeRedeemAddress networkMagic) <$> HM.toList (getGenesisAvvmBalances gdAvvmDistr))
@@ -43,7 +45,3 @@ genesisUtxo =
                  )
 
      in GenesisUtxo . Map.fromList $ utxoEntry <$> preUtxo
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet-new/integration/Util.hs
+++ b/wallet-new/integration/Util.hs
@@ -84,7 +84,7 @@ genesisAssetLockedWallet wc = do
 
 lockedWallet :: WalletId
 lockedWallet =
-    WalletId "Ae2tdPwUPEZ5YjF9WuDoWfCZLPQ56MdQC6CZa2VKwMVRVqBBfTLPNcPvET4"
+    WalletId "2cWKMJemoBakxGHgy85BN6JJooy54EmWxCoobAXe3NRfyEbuMnJAZSr5oAzD5F5aoodRD"
 
 genesisRef :: WalletRef
 genesisRef = unsafePerformIO newEmptyMVar

--- a/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Errors.hs
@@ -138,7 +138,7 @@ sampleAddress = V1 $ Core.Address
     { Core.addrRoot =
         Crypto.unsafeAbstractHash ("asdfasdf" :: String)
     , Core.addrAttributes =
-        Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr fixedNM
+        Core.mkAttributes $ Core.AddrAttributes Nothing Core.BootstrapEraDistr NMNothing
     , Core.addrType =
         Core.ATPubKey
     }
@@ -245,7 +245,3 @@ applicationJson :: HTTP.Header
 applicationJson =
     let [hdr] = getHeaders (addHeader "application/json" mempty :: (Headers '[Header "Content-Type" String] String))
     in hdr
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.API.V1.LegacyHandlers where
 import           Universum
 
 import           Ntp.Client (NtpStatus)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.Diffusion.Types (Diffusion (sendTx))
 
@@ -45,9 +46,11 @@ handlers :: ( HasConfigurations
             -> TVar NtpStatus
             -> Server V1.API
 handlers naturalTransformation pm diffusion ntpStatus =
-         hoistServer (Proxy @Addresses.API) naturalTransformation Addresses.handlers
-    :<|> hoistServer (Proxy @Wallets.API) naturalTransformation Wallets.handlers
-    :<|> hoistServer (Proxy @Accounts.API) naturalTransformation Accounts.handlers
+         hoistServer (Proxy @Addresses.API) naturalTransformation (Addresses.handlers nm)
+    :<|> hoistServer (Proxy @Wallets.API) naturalTransformation (Wallets.handlers nm)
+    :<|> hoistServer (Proxy @Accounts.API) naturalTransformation (Accounts.handlers nm)
     :<|> hoistServer (Proxy @Transactions.API) naturalTransformation (Transactions.handlers pm (sendTx diffusion))
     :<|> hoistServer (Proxy @Settings.API) naturalTransformation Settings.handlers
     :<|> hoistServer (Proxy @Info.API) naturalTransformation (Info.handlers diffusion ntpStatus)
+  where
+    nm = makeNetworkMagic pm

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Accounts.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Accounts.hs
@@ -12,6 +12,7 @@ import           Cardano.Wallet.API.V1.Migration
 import           Cardano.Wallet.API.V1.Types
 import qualified Data.IxSet.Typed as IxSet
 
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import qualified Pos.Wallet.Web.Account as V0
 import qualified Pos.Wallet.Web.ClientTypes.Types as V0
 import qualified Pos.Wallet.Web.Methods.Logic as V0
@@ -19,32 +20,41 @@ import           Servant
 
 handlers
     :: HasConfigurations
-    => ServerT Accounts.API MonadV1
-handlers =
+    => NetworkMagic
+    -> ServerT Accounts.API MonadV1
+handlers nm =
          deleteAccount
-    :<|> getAccount
-    :<|> listAccounts
-    :<|> newAccount
-    :<|> updateAccount
+    :<|> getAccount nm
+    :<|> listAccounts nm
+    :<|> newAccount nm
+    :<|> updateAccount nm
 
 deleteAccount
     :: (V0.MonadWalletLogic ctx m)
-    => WalletId -> AccountIndex -> m NoContent
+    => WalletId
+    -> AccountIndex
+    -> m NoContent
 deleteAccount wId accIdx =
     migrate (wId, accIdx) >>= V0.deleteAccount
 
 getAccount
     :: (MonadThrow m, V0.MonadWalletLogicRead ctx m)
-    => WalletId -> AccountIndex -> m (WalletResponse Account)
-getAccount wId accIdx =
-    single <$> (migrate (wId, accIdx) >>= V0.getAccount >>= migrate)
+    => NetworkMagic
+    -> WalletId
+    -> AccountIndex
+    -> m (WalletResponse Account)
+getAccount nm wId accIdx =
+    single <$> (migrate (wId, accIdx) >>= V0.getAccount nm >>= migrate)
 
 listAccounts
     :: (MonadThrow m, V0.MonadWalletLogicRead ctx m)
-    => WalletId -> RequestParams -> m (WalletResponse [Account])
-listAccounts wId params = do
+    => NetworkMagic
+    -> WalletId
+    -> RequestParams
+    -> m (WalletResponse [Account])
+listAccounts nm wId params = do
     wid' <- migrate wId
-    oldAccounts <- V0.getAccounts (Just wid')
+    oldAccounts <- V0.getAccounts nm (Just wid')
     newAccounts <- migrate @[V0.CAccount] @[Account] oldAccounts
     respondWith params
         (NoFilters :: FilterOperations Account)
@@ -53,18 +63,25 @@ listAccounts wId params = do
 
 newAccount
     :: (V0.MonadWalletLogic ctx m)
-    => WalletId -> NewAccount -> m (WalletResponse Account)
-newAccount wId nAccount@NewAccount{..} = do
+    => NetworkMagic
+    -> WalletId
+    -> NewAccount
+    -> m (WalletResponse Account)
+newAccount nm wId nAccount@NewAccount{..} = do
     let (V1 spendingPw) = fromMaybe (V1 mempty) naccSpendingPassword
     accInit <- migrate (wId, nAccount)
-    cAccount <- V0.newAccount V0.RandomSeed spendingPw accInit
+    cAccount <- V0.newAccount nm V0.RandomSeed spendingPw accInit
     single <$> (migrate cAccount)
 
 updateAccount
     :: (V0.MonadWalletLogic ctx m)
-    => WalletId -> AccountIndex -> AccountUpdate -> m (WalletResponse Account)
-updateAccount wId accIdx accUpdate = do
+    => NetworkMagic
+    -> WalletId
+    -> AccountIndex
+    -> AccountUpdate
+    -> m (WalletResponse Account)
+updateAccount nm wId accIdx accUpdate = do
     newAccId <- migrate (wId, accIdx)
     accMeta <- migrate accUpdate
-    cAccount <- V0.updateAccount newAccId accMeta
+    cAccount <- V0.updateAccount nm newAccId accMeta
     single <$> (migrate cAccount)

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger/Example.hs
@@ -17,7 +17,6 @@ import           Pos.Wallet.Web.Methods.Misc (WalletStateSnapshot (..))
 
 import qualified Data.Map.Strict as Map
 import qualified Pos.Core.Common as Core
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import qualified Pos.Crypto.Signing as Core
 
 
@@ -65,7 +64,7 @@ instance Example (V1 Address) where
                     [ pure Core.BootstrapEraDistr
                     , Core.SingleKeyDistr <$> arbitrary
                     ]
-                <*> pure fixedNM
+                <*> arbitrary
 
 instance Example BackupPhrase where
     example = pure def
@@ -145,7 +144,3 @@ instance Example WalletStateSnapshot
 -- TODO: We should probably add this as a part of our swagger CI script and fail swagger if we find some of them - with instruction to the developer above what is said above.
 --
 -- Most of it comes to removing Nothing from `Arbitrary (Maybe a)` instance and removing empty list from `Arbitrary [a]` instance. It could be done automatically with some quickcheck hacks but I think it would be an overkill.
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet-new/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer.hs
@@ -23,16 +23,19 @@ import qualified Cardano.Wallet.WalletLayer.Kernel as Kernel
 import qualified Cardano.Wallet.WalletLayer.Legacy as Legacy
 import qualified Cardano.Wallet.WalletLayer.QuickCheck as QuickCheck
 import           Cardano.Wallet.WalletLayer.Types (ActiveWalletLayer (..), PassiveWalletLayer (..),
-                                                  applyBlocks, rollbackBlocks)
+                                                   applyBlocks, rollbackBlocks)
+
+import           Pos.Crypto (ProtocolMagic)
 
 ------------------------------------------------------------
 -- Kernel
 ------------------------------------------------------------
 bracketKernelPassiveWallet
     :: forall m n a. (MonadIO m, MonadIO n, MonadMask n)
-    => (Severity -> Text -> IO ())
+    => ProtocolMagic
+    -> (Severity -> Text -> IO ())
     -> (PassiveWalletLayer m -> n a) -> n a
-bracketKernelPassiveWallet = Kernel.bracketPassiveWallet
+bracketKernelPassiveWallet pm = Kernel.bracketPassiveWallet pm
 
 bracketKernelActiveWallet
     :: forall m n a. (MonadIO n, MonadMask n)
@@ -45,8 +48,8 @@ bracketKernelActiveWallet  = Kernel.bracketActiveWallet
 
 bracketLegacyPassiveWallet
     :: forall ctx m n a. (MonadMask n, Legacy.MonadLegacyWallet ctx m)
-    => (PassiveWalletLayer m -> n a) -> n a
-bracketLegacyPassiveWallet = Legacy.bracketPassiveWallet
+    => ProtocolMagic -> (PassiveWalletLayer m -> n a) -> n a
+bracketLegacyPassiveWallet pm = Legacy.bracketPassiveWallet pm
 
 bracketLegacyActiveWallet
     :: forall m n a. (MonadMask n)

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.WalletLayer.Kernel
 import           Universum
 
 import           Data.Maybe (fromJust)
-import           System.Wlog (Severity(Debug))
+import           System.Wlog (Severity (Debug))
 
 import           Pos.Block.Types (Blund, Undo (..))
 
@@ -23,17 +23,19 @@ import           Pos.Core.Chrono (OldestFirst (..))
 
 import qualified Cardano.Wallet.Kernel.Actions as Actions
 import qualified Data.Map.Strict as Map
-import           Pos.Util.BackupPhrase
+import           Pos.Crypto (ProtocolMagic)
 import           Pos.Crypto.Signing
+import           Pos.Util.BackupPhrase
 
 -- | Initialize the passive wallet.
 -- The passive wallet cannot send new transactions.
 bracketPassiveWallet
     :: forall m n a. (MonadIO n, MonadIO m, MonadMask m)
-    => (Severity -> Text -> IO ())
+    => ProtocolMagic
+    -> (Severity -> Text -> IO ())
     -> (PassiveWalletLayer n -> m a) -> m a
-bracketPassiveWallet logFunction f =
-    Kernel.bracketPassiveWallet logFunction $ \w -> do
+bracketPassiveWallet pm logFunction f =
+    Kernel.bracketPassiveWallet pm logFunction $ \w -> do
 
       -- Create the wallet worker and its communication endpoint `invoke`.
       invoke <- Actions.forkWalletWorker $ Actions.WalletActionInterp

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -90,7 +90,7 @@ specBody pm =
 
 -- | Initialize passive wallet in a manner suitable for the unit tests
 bracketPassiveWallet :: ProtocolMagic -> (Kernel.PassiveWallet -> IO a) -> IO a
-bracketPassiveWallet _pm = Kernel.bracketPassiveWallet logMessage
+bracketPassiveWallet pm = Kernel.bracketPassiveWallet pm logMessage
   where
    -- TODO: Decide what to do with logging
     logMessage _sev txt = print txt

--- a/wallet-new/test/unit/UTxO/Translate.hs
+++ b/wallet-new/test/unit/UTxO/Translate.hs
@@ -32,7 +32,7 @@ import           Pos.Block.Error
 import           Pos.Block.Types
 import           Pos.Core
 import           Pos.Core.Chrono
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.DB.Class (MonadGState (..))
 import           Pos.Txp.Toil
@@ -101,7 +101,7 @@ runTranslateT :: Monad m => Exception e
 runTranslateT pm (TranslateT ta) =
     withProvidedMagicConfig pm $
     withDefUpdateConfiguration $
-      let nm = NMNothing
+      let nm = makeNetworkMagic pm
           env :: TranslateEnv
           env = TranslateEnv {
                     teContext       = initContext nm (initCardanoContext pm)

--- a/wallet/src/Pos/Wallet/Web/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Backup.hs
@@ -13,6 +13,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.SemVer as V
 import           Test.QuickCheck (Arbitrary (..), elements)
 
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Crypto.Signing.Safe (emptyPassphrase, safeKeyGen)
 import           Pos.Util.Util (maybeThrow)
@@ -55,11 +56,12 @@ instance Arbitrary WalletBackup where
             }
 
 getWalletBackup :: AccountMode ctx m
-                => WalletSnapshot
+                => NetworkMagic
+                -> WalletSnapshot
                 -> CId Wal
                 -> m WalletBackup
-getWalletBackup ws wId = do
-    sk <- getSKById wId
+getWalletBackup nm ws wId = do
+    sk <- getSKById nm wId
     meta <- maybeThrow (InternalError "Wallet have no meta") $
             getWalletMeta ws wId
     let accountIds = getWalletAccountIds ws wId

--- a/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
+++ b/wallet/src/Pos/Wallet/Web/ClientTypes/Functions.hs
@@ -48,8 +48,8 @@ cIdToAddress (CId (CHash h)) = decodeTextAddress h
 -- TODO: pass extra information to this function and choose
 -- distribution based on this information. Currently it's always
 -- bootstrap era distribution.
-encToCId :: EncryptedSecretKey -> CId w
-encToCId = encodeCType . makePubKeyAddressBoot fixedNM . encToPublic
+encToCId :: NetworkMagic -> EncryptedSecretKey -> CId w
+encToCId nm = encodeCType . makePubKeyAddressBoot nm . encToPublic
 
 mergeTxOuts :: [TxOut] -> [TxOut]
 mergeTxOuts = map stick . NE.groupWith txOutAddress
@@ -128,7 +128,3 @@ toCUpdateInfo bvd ConfirmedProposalState {..} =
         cuiPositiveStake    = encodeCType cpsPositiveStake
         cuiNegativeStake    = encodeCType cpsNegativeStake
     in CUpdateInfo {..}
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Backup.hs
@@ -13,6 +13,7 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import           Formatting (sformat, stext, (%))
 
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Util (HasLens (..))
 import           Pos.Wallet.Web.Backup (TotalBackup (..), getWalletBackup)
 import           Pos.Wallet.Web.ClientTypes (CFilePath (..), CId, CWallet, Wal)
@@ -29,19 +30,28 @@ type MonadWalletBackup ctx m = ( L.MonadWalletLogic ctx m
                                , HasLens SyncQueue ctx SyncQueue
                                )
 
-importWalletJSON :: MonadWalletBackup ctx m => CFilePath -> m CWallet
-importWalletJSON (CFilePath (toString -> fp)) = do
+importWalletJSON
+    :: MonadWalletBackup ctx m
+    => NetworkMagic
+    -> CFilePath
+    -> m CWallet
+importWalletJSON nm (CFilePath (toString -> fp)) = do
     contents <- liftIO $ BSL.readFile fp
     TotalBackup wBackup <- either parseErr pure $ A.eitherDecode contents
-    restoreWalletFromBackup wBackup
+    restoreWalletFromBackup nm wBackup
   where
     parseErr err = throwM . RequestError $
         sformat ("Error while reading JSON backup file: "%stext) $
         toText err
 
-exportWalletJSON :: MonadWalletBackup ctx m => CId Wal -> CFilePath -> m NoContent
-exportWalletJSON wid (CFilePath (toString -> fp)) = do
+exportWalletJSON
+    :: MonadWalletBackup ctx m
+    => NetworkMagic
+    -> CId Wal
+    -> CFilePath
+    -> m NoContent
+exportWalletJSON nm wid (CFilePath (toString -> fp)) = do
     ws <- askWalletSnapshot
-    wBackup <- TotalBackup <$> getWalletBackup ws wid
+    wBackup <- TotalBackup <$> getWalletBackup nm ws wid
     liftIO $ BSL.writeFile fp $ A.encode wBackup
     return NoContent

--- a/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
+++ b/wallet/src/Pos/Wallet/Web/Methods/Redeem.hs
@@ -15,6 +15,7 @@ import qualified Serokell.Util.Base64 as B64
 import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Client.Txp.Network (prepareRedemptionTx)
 import           Pos.Core (TxAux (..), TxOut (..), getCurrentTimestamp)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (PassPhrase, ProtocolMagic, aesDecrypt, deriveAesKeyBS, hash,
                              redeemDeterministicKeyGen)
 import           Pos.Util (maybeThrow)
@@ -84,10 +85,11 @@ redeemAdaInternal pm submitTx passphrase cAccId seedBs = do
     accId <- decodeCTypeOrFail cAccId
     db <- askWalletDB
 
+    let nm = makeNetworkMagic pm
     -- new redemption wallet
-    _ <- L.getAccount accId
+    _ <- L.getAccount nm accId
 
-    dstAddr <- decodeCTypeOrFail . cadId =<< L.newAddress RandomSeed passphrase accId
+    dstAddr <- decodeCTypeOrFail . cadId =<< L.newAddress nm RandomSeed passphrase accId
     ws <- getWalletSnapshot db
     th <- rewrapTxError "Cannot send redemption transaction" $ do
         (txAux, redeemAddress, redeemBalance) <-

--- a/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Launcher.hs
@@ -30,6 +30,7 @@ import           Ntp.Client (NtpStatus)
 
 import           Pos.Client.Txp.Network (sendTxOuts)
 import           Pos.Communication (OutSpecs)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.Diffusion.Types (Diffusion (sendTx))
 import           Pos.Infra.Util.TimeWarp (NetworkAddress)
@@ -87,7 +88,8 @@ walletServer
     -> (forall x. m x -> Handler x)
     -> m (Server WalletSwaggerApi)
 walletServer pm diffusion ntpStatus nat = do
-    mapM_ (findKey >=> syncWallet . eskToWalletDecrCredentials) =<< myRootAddresses
+    let nm = makeNetworkMagic pm
+    mapM_ (findKey nm >=> syncWallet . eskToWalletDecrCredentials nm) =<< myRootAddresses nm
     return $ servantHandlersWithSwagger pm ntpStatus submitTx nat
   where
     -- Diffusion layer takes care of submitting transactions.

--- a/wallet/src/Pos/Wallet/Web/Server/Runner.hs
+++ b/wallet/src/Pos/Wallet/Web/Server/Runner.hs
@@ -26,6 +26,7 @@ import           Servant.Server (Handler)
 import           System.Wlog (logInfo, usingLoggerName)
 
 import           Cardano.NodeIPC (startNodeJsIPC)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.Diffusion.Types (Diffusion, hoistDiffusion)
 import           Pos.Infra.Shutdown.Class (HasShutdownContext (shutdownContext))
@@ -85,7 +86,7 @@ walletServeWebFull pm diffusion ntpStatus debug address mTlsParams = do
     action :: WalletWebMode Application
     action = do
         logInfo "Wallet Web API has STARTED!"
-        when debug $ addInitialRichAccount 0
+        when debug $ addInitialRichAccount (makeNetworkMagic pm) 0
 
         wwmc <- walletWebModeContext
         walletApplication $

--- a/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/BListener.hs
@@ -24,6 +24,7 @@ import           Pos.Block.Types (Blund, undoTx)
 import           Pos.Core (HeaderHash, Timestamp, difficultyL, headerSlotL, prevBlockL)
 import           Pos.Core.Block (BlockHeader (..), blockHeader, getBlockHeader, mainBlockTxPayload)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Core.Txp (TxAux (..), TxUndo)
 import           Pos.DB.BatchOp (SomeBatchOp)
 import           Pos.DB.Class (MonadDBRead)
@@ -77,8 +78,8 @@ onApplyBlocksWebWallet
     , MonadReporting m
     , CanLogInParallel m
     )
-    => OldestFirst NE Blund -> m SomeBatchOp
-onApplyBlocksWebWallet blunds = setLogger . reportTimeouts "apply" $ do
+    => NetworkMagic -> OldestFirst NE Blund -> m SomeBatchOp
+onApplyBlocksWebWallet nm blunds = setLogger . reportTimeouts "apply" $ do
     db <- WS.askWalletDB
     ws <- WS.getWalletSnapshot db
     let oldestFirst = getOldestFirst blunds
@@ -102,9 +103,9 @@ onApplyBlocksWebWallet blunds = setLogger . reportTimeouts "apply" $ do
         -> m ()
     syncWallet db ws curTip newTipH blkTxsWUndo wAddr = walletGuard ws curTip wAddr $ do
         blkHeaderTs <- blkHeaderTsGetter
-        encSK <- getSKById wAddr
+        encSK <- getSKById nm wAddr
 
-        let credentials = eskToWalletDecrCredentials encSK
+        let credentials = eskToWalletDecrCredentials nm encSK
         let dbUsed = WS.getCustomAddresses ws WS.UsedAddr
         let applyBlockWith trackingOp = do
               let mapModifier = trackingApplyTxs credentials dbUsed gbDiff blkHeaderTs ptxBlkInfo blkTxsWUndo
@@ -128,8 +129,10 @@ onRollbackBlocksWebWallet
     , MonadReporting m
     , CanLogInParallel m
     )
-    => NewestFirst NE Blund -> m SomeBatchOp
-onRollbackBlocksWebWallet blunds = setLogger . reportTimeouts "rollback" $ do
+    => NetworkMagic
+    -> NewestFirst NE Blund
+    -> m SomeBatchOp
+onRollbackBlocksWebWallet nm blunds = setLogger . reportTimeouts "rollback" $ do
     db <- WS.askWalletDB
     ws <- WS.getWalletSnapshot db
     let newestFirst = getNewestFirst blunds
@@ -152,12 +155,12 @@ onRollbackBlocksWebWallet blunds = setLogger . reportTimeouts "rollback" $ do
         -> CId Wal
         -> m ()
     syncWallet db ws curTip newTip txs wid = walletGuard ws curTip wid $ do
-        encSK <- getSKById wid
+        encSK <- getSKById nm wid
         blkHeaderTs <- blkHeaderTsGetter
 
         let rollbackBlockWith trackingOperation = do
               let dbUsed = WS.getCustomAddresses ws WS.UsedAddr
-                  mapModifier = trackingRollbackTxs (eskToWalletDecrCredentials encSK) dbUsed gbDiff blkHeaderTs txs
+                  mapModifier = trackingRollbackTxs (eskToWalletDecrCredentials nm encSK) dbUsed gbDiff blkHeaderTs txs
               rollbackModifierFromWallet db trackingOperation wid newTip mapModifier
               logMsg "Rolled back" (getNewestFirst blunds) wid mapModifier
 

--- a/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Decrypt.hs
@@ -22,7 +22,7 @@ import           Serokell.Util (enumerate)
 import           Pos.Client.Txp.History (TxHistoryEntry (..))
 import           Pos.Core (Address (..), ChainDifficulty, Timestamp, aaPkDerivationPath,
                            addrAttributesUnwrapped, makeRootPubKeyAddress)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Core.Txp (Tx (..), TxIn (..), TxOut, TxOutAux (..), TxUndo, toaOut,
                                txOutAddress)
 import           Pos.Crypto (EncryptedSecretKey, HDPassphrase, WithHash (..), deriveHDPassphrase,
@@ -75,11 +75,11 @@ buildTHEntryExtra wdc (WithHash tx txId, NE.toList -> undoL) (mDiff, mTs) =
 
 type WalletDecrCredentials = (HDPassphrase, CId Wal)
 
-eskToWalletDecrCredentials :: EncryptedSecretKey -> WalletDecrCredentials
-eskToWalletDecrCredentials encSK = do
+eskToWalletDecrCredentials :: NetworkMagic -> EncryptedSecretKey -> WalletDecrCredentials
+eskToWalletDecrCredentials nm encSK = do
     let pubKey = encToPublic encSK
     let hdPass = deriveHDPassphrase pubKey
-    let wCId = encodeCType $ makeRootPubKeyAddress fixedNM pubKey
+    let wCId = encodeCType $ makeRootPubKeyAddress nm pubKey
     (hdPass, wCId)
 
 selectOwnAddresses
@@ -96,7 +96,3 @@ decryptAddress (hdPass, wCId) addr = do
     derPath <- unpackHDAddressAttr hdPass hdPayload
     guard $ length derPath == 2
     pure $ WAddressMeta wCId (derPath !! 0) (derPath !! 1) addr
-
-
-fixedNM :: NetworkMagic
-fixedNM = NMNothing

--- a/wallet/test/Test/Pos/Util/MnemonicsSpec.hs
+++ b/wallet/test/Test/Pos/Util/MnemonicsSpec.hs
@@ -38,7 +38,7 @@ runWithMagic rnm = replicateM_ testMultiple $
             specBody (makeNetworkMagic pm)
 
 specBody :: NetworkMagic -> Spec
-specBody _nm = do
+specBody nm = do
     it "No example mnemonic" $
         fromMnemonic defMnemonic `shouldSatisfy` isLeft
 
@@ -71,7 +71,7 @@ specBody _nm = do
 
             cid = either
                 (error . (<>) "Couldn't create keys from generated BackupPhrase" . show)
-                (encToCId . fst)
+                (encToCId nm . fst)
                 (safeKeysFromPhrase mempty backupPhrase)
 
 

--- a/wallet/test/Test/Pos/Wallet/Web/AddressSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/AddressSpec.hs
@@ -74,11 +74,11 @@ fakeAddressHasMaxSizeTest
     -> Word32
     -> WalletProperty ()
 fakeAddressHasMaxSizeTest nm generator accSeed = do
-    passphrase <- importSingleWallet mostlyEmptyPassphrases
+    passphrase <- importSingleWallet nm mostlyEmptyPassphrases
     ws <- askWalletSnapshot
     wid <- expectedOne "wallet addresses" $ getWalletAddresses ws
     accId <- lift $ decodeCTypeOrFail . caId
-         =<< newAccount (DeterminedSeed accSeed) passphrase (CAccountInit def wid)
+         =<< newAccount nm (DeterminedSeed accSeed) passphrase (CAccountInit def wid)
     address <- generator nm accId passphrase
 
     largeAddress <- lift $ getFakeChangeAddress nm
@@ -95,10 +95,10 @@ changeAddressGenerator nm accId passphrase = lift $ getNewAddress nm (accId, pas
 
 -- | Generator which is directly used in endpoints.
 commonAddressGenerator :: AddressGenerator
-commonAddressGenerator _nm accId passphrase = do
+commonAddressGenerator nm accId passphrase = do
     ws <- askWalletSnapshot
     addrSeed <- pick arbitrary
-    let genAddress = genUniqueAddress ws (DeterminedSeed addrSeed) passphrase accId
+    let genAddress = genUniqueAddress nm ws (DeterminedSeed addrSeed) passphrase accId
     -- can't catch under 'PropertyM', workarounding
     maddr <- lift $ (Just <$> genAddress) `catch` seedBusyHandler
     addr <- maybe (stop Discard) pure maddr

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
@@ -48,10 +48,10 @@ specBody pm = withProvidedMagicConfig pm $
            (restoreWalletAddressFromBackupSpec (makeNetworkMagic pm))
 
 restoreWalletAddressFromBackupSpec :: HasConfigurations => NetworkMagic -> Spec
-restoreWalletAddressFromBackupSpec _nm =
+restoreWalletAddressFromBackupSpec nm =
     walletPropertySpec restoreWalletAddressFromBackupDesc $ do
         walletBackup   <- pick arbitrary
-        restoredWallet <- lift $ restoreWalletFromBackup walletBackup
+        restoredWallet <- lift $ restoreWalletFromBackup nm walletBackup
         let noOfAccounts = cwAccountsNumber restoredWallet
         assertProperty (noOfAccounts > 0) $ "Exported wallet has no accounts!"
   where

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/LogicSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/LogicSpec.hs
@@ -49,10 +49,10 @@ specBody pm = withProvidedMagicConfig pm $
     emptyWalletOnStarts = "wallet must be empty on start"
 
 emptyWallet :: HasConfigurations => NetworkMagic -> WalletProperty ()
-emptyWallet _nm = do
-    wallets <- lift getWallets
+emptyWallet nm = do
+    wallets <- lift (getWallets nm)
     unless (null wallets) $
         stopProperty "Wallets aren't empty"
-    accounts <- lift $ getAccounts Nothing
+    accounts <- lift $ getAccounts nm Nothing
     unless (null accounts) $
         stopProperty "Accounts aren't empty"

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -370,8 +370,8 @@ instance HasLens (StateLockMetrics MemPoolModifyReason) WalletTestContext (State
 
 instance HasConfigurations => MonadAddresses WalletTestMode where
     type AddrData WalletTestMode = (AccountId, PassPhrase)
-    getNewAddress _nm = getNewAddressWebWallet
-    getFakeChangeAddress nm = pure (largestHDAddressBoot nm)
+    getNewAddress = getNewAddressWebWallet
+    getFakeChangeAddress = pure . largestHDAddressBoot
 
 instance MonadKeysRead WalletTestMode where
     getSecret = getSecretDefault
@@ -393,8 +393,8 @@ instance MonadUpdates WalletTestMode where
     applyLastUpdate = applyLastUpdateWebWallet
 
 instance (HasConfigurations) => MonadBListener WalletTestMode where
-    onApplyBlocks _nm = onApplyBlocksWebWallet
-    onRollbackBlocks _nm = onRollbackBlocksWebWallet
+    onApplyBlocks = onApplyBlocksWebWallet
+    onRollbackBlocks = onRollbackBlocksWebWallet
 
 instance HasConfiguration => MonadBlockchainInfo WalletTestMode where
     networkChainDifficulty = networkChainDifficultyWebWallet

--- a/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
@@ -22,6 +22,7 @@ import           Pos.Arbitrary.Wallet.Web.ClientTypes ()
 import           Pos.Block.Logic (rollbackBlocks)
 import           Pos.Core (Address, BlockCount (..), blkSecurityParam)
 import           Pos.Core.Chrono (nonEmptyOldestFirst, toNewestFirst)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..), emptyPassphrase)
 import           Pos.Launcher (HasConfigurations)
 
@@ -81,9 +82,10 @@ twoApplyTwoRollbacksSpec pm = walletPropertySpec twoApplyTwoRollbacksDesc $ do
     let k = fromIntegral blkSecurityParam :: Word64
     -- During these tests we need to manually switch back to the old synchronous
     -- way of restoring.
-    void $ importSomeWallets (pure emptyPassphrase)
+    let nm = makeNetworkMagic pm
+    void $ importSomeWallets nm (pure emptyPassphrase)
     sks <- lift getSecretKeysPlain
-    lift $ forM_ sks $ \s -> syncWalletWithBlockchain (newSyncRequest (eskToWalletDecrCredentials s))
+    lift $ forM_ sks $ \s -> syncWalletWithBlockchain (newSyncRequest (eskToWalletDecrCredentials nm s))
 
     -- Testing starts here
     genesisWalletDB <- lift WS.askWalletSnapshot


### PR DESCRIPTION
## Description

This PR/commit implements part (4) of [our plan](https://iohk.myjetbrains.com/youtrack/issue/CO-354#comment=93-27892).

We pipe the full NetworkMagic to the "frontier" outlined above. This means bridging the gap from where we have ProtocolMagic to where we need NetworkMagic (and had NMMustBeNothing hardcoded).

Since PR #3559 splits the test-suites, we see most of the changes in this PR are to source-code files.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-354

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)
^ this PR adds the capability for differently formatted `Address`es, which include a `NetworkMagic` value. Thus it is a breaking change for testnets (`NMJust`), but backwards compatible for mainnet/staging (`NMNothing`).

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.
^ there is no 1.3.1 section in the CHANGELOG, and this is dev work on a release branch, so I'm skipping this.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
^ tests we added/modified in #3559 - we are relying on those.