### PR TITLE
[CBR-427] Make NtpCheck non-blocking unless explicitly forced

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/NodeStateAdaptor.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/NodeStateAdaptor.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE RankNTypes                 #-}
 
 module Cardano.Wallet.Kernel.NodeStateAdaptor (
@@ -488,28 +489,59 @@ waitForUpdate = liftIO . takeMVar =<< asks l
     l :: Res -> MVar ConfirmedProposalState
     l = ucDownloadedUpdate . view lensOf'
 
+
 -- | Get the difference between NTP time and local system time, nothing if the
 -- NTP server couldn't be reached in the last 30min.
 --
 -- Note that one can force a new query to the NTP server in which case, it may
 -- take up to 30s to resolve.
-defaultGetNtpDrift :: MonadIO m => TVar NtpStatus -> V1.ForceNtpCheck -> m V1.TimeInfo
-defaultGetNtpDrift tvar ntpCheckBehavior = liftIO $ do
-    when (ntpCheckBehavior == V1.ForceNtpCheck) $
-        atomically $ writeTVar tvar NtpSyncPending
-    mkTimeInfo <$> waitForNtpStatus
+defaultGetNtpDrift
+    :: MonadIO m
+    => TVar NtpStatus
+    -> V1.ForceNtpCheck
+    -> m V1.TimeInfo
+defaultGetNtpDrift tvar ntpCheckBehavior = liftIO $ mkTimeInfo <$>
+    if (ntpCheckBehavior == V1.ForceNtpCheck) then
+        forceNtpCheck >> getNtpOffset blockingLookupNtpOffset
+    else
+        getNtpOffset nonBlockingLookupNtpOffset
   where
-    mkTimeInfo :: Maybe NtpOffset -> V1.TimeInfo
-    mkTimeInfo = V1.TimeInfo . fmap (V1.mkLocalTimeDifference . toMicroseconds)
+    forceNtpCheck :: MonadIO m => m ()
+    forceNtpCheck =
+        atomically $ writeTVar tvar NtpSyncPending
 
-    -- NOTE This usually takes ~100-300ms and at most 30s
-    waitForNtpStatus :: MonadIO m => m (Maybe NtpOffset)
-    waitForNtpStatus = atomically $ do
-        status <- readTVar tvar
-        case status of
-            NtpSyncPending     -> retry
-            NtpDrift offset    -> pure (Just offset)
-            NtpSyncUnavailable -> pure Nothing
+    getNtpOffset :: MonadIO m => (NtpStatus -> STM (Maybe NtpOffset)) -> m (Maybe NtpOffset)
+    getNtpOffset lookupNtpOffset =
+        atomically $ (readTVar tvar >>= lookupNtpOffset)
+
+    mkTimeInfo :: Maybe NtpOffset -> V1.TimeInfo
+    mkTimeInfo =
+        V1.TimeInfo . fmap (V1.mkLocalTimeDifference . toMicroseconds)
+
+
+-- Lookup NtpOffset from an NTPStatus in a non-blocking manner
+--
+-- i.e. Returns immediately with 'Nothing' if the NtpSync is pending.
+nonBlockingLookupNtpOffset
+    :: NtpStatus
+    -> STM (Maybe NtpOffset)
+nonBlockingLookupNtpOffset = \case
+    NtpSyncPending     -> pure Nothing
+    NtpDrift offset    -> pure (Just offset)
+    NtpSyncUnavailable -> pure Nothing
+
+
+-- Lookup NtpOffset from an NTPStatus in a blocking manner, this usually
+-- take ~100ms
+--
+-- i.e. Wait (at most 30s) for the NtpSync to resolve if pending
+blockingLookupNtpOffset
+    :: NtpStatus
+    -> STM (Maybe NtpOffset)
+blockingLookupNtpOffset = \case
+    NtpSyncPending     -> retry
+    NtpDrift offset    -> pure (Just offset)
+    NtpSyncUnavailable -> pure Nothing
 
 
 -- | Get the most recent main block starting at the specified header


### PR DESCRIPTION
## Description

When implementing the new data-layer 'node-info' handler, we've made the
choice to have the underlying check for NtpStatus blocking /
synchronous. This choices is usually fine as the check normally takes
around ~100ms. However, when running on CI, we do not connect to the
Internet and therefore, will always timeout for those check.  This could
be the cause for the integration tests bootstrap not syncing properly
(not telling us about it).

## Linked issue

[[CBR-427]](https://iohk.myjetbrains.com/youtrack/issue/CBR-427)


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- ~~[ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.~~

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- ~~[ ] I have added tests to cover my changes.~~
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
