### PR TITLE
[CBR-419] Enforce invariant on defaultHdAddressWith

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Create.hs
@@ -41,6 +41,7 @@ import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 data CreateHdRootError =
     -- | We already have a wallet with the specified ID
     CreateHdRootExists HdRootId
+  | CreateHdRootDefaultAddressDerivationFailed
 
 -- | Errors thrown by 'createHdAccount'
 data CreateHdAccountError =
@@ -183,6 +184,8 @@ initHdAddress addrId address = HdAddress {
 instance Buildable CreateHdRootError where
     build (CreateHdRootExists rootId)
         = bprint ("CreateHdRootError::CreateHdRootExists "%build) rootId
+    build CreateHdRootDefaultAddressDerivationFailed
+        = bprint "CreateHdRootError::CreateHdRootDefaultAddressDerivationFailed"
 
 instance Buildable CreateHdAccountError where
     build (CreateHdAccountUnknownRoot (UnknownHdRoot rootId))

--- a/wallet-new/src/Cardano/Wallet/Kernel/Decrypt.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Decrypt.hs
@@ -1,8 +1,28 @@
 module Cardano.Wallet.Kernel.Decrypt
     ( decryptAddress
+    , decryptHdLvl2DerivationPath
     , keyToWalletDecrCredentials
     , WalletDecrCredentials
     , WalletDecrCredentialsKey(..)
     ) where
 
+import           Universum
+
+import           Data.List ((!!))
+
 import           Pos.Wallet.Web.Tracking.Decrypt
+
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdAccountIx (..),
+                     HdAddressIx (..))
+import           Pos.Core (Address, aaPkDerivationPath, addrAttributesUnwrapped)
+import           Pos.Crypto (HDPassphrase, unpackHDAddressAttr)
+
+
+decryptHdLvl2DerivationPath :: HDPassphrase
+                            -> Address
+                            -> Maybe (HdAccountIx, HdAddressIx)
+decryptHdLvl2DerivationPath hdPass addr = do
+    hdPayload <- aaPkDerivationPath $ addrAttributesUnwrapped addr
+    derPath <- unpackHDAddressAttr hdPass hdPayload
+    guard $ length derPath == 2
+    pure (HdAccountIx (derPath !! 0), HdAddressIx (derPath !! 1))


### PR DESCRIPTION
This commit enforces that when we build a new 'HdAddress' out of an
Address, we decrypt the HD payload contained within and we use it to
retrieve the derivation path for both the newly-generated 'HdAddress'
and the parent 'HdAccount'.

## Description

https://iohk.myjetbrains.com/youtrack/issue/CBR-419

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
