### PR TITLE
[CO-322] Fix Swagger names in the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 
 - Improve type safety (and as a consequence, API documentation) of account indexes (CBR-306)
 
+- The Swagger specification had names with illegal characters. These names
+  where changed to be URL friendly. [PR #3595](https://github.com/input-output-hk/cardano-sl/pull/3595)
+
 ### Improvements
 
 - Friendly error mistakes from deserializing invalid addresses instead of brutal 500 (CBR-283)

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17704,6 +17704,7 @@ license = stdenv.lib.licenses.mit;
 , http-client
 , http-client-tls
 , http-types
+, insert-ordered-containers
 , ixset-typed
 , lens
 , memory
@@ -17924,6 +17925,7 @@ formatting
 hedgehog
 hspec
 hspec-core
+insert-ordered-containers
 lens
 mtl
 normaldistribution

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -611,6 +611,7 @@ test-suite wallet-new-specs
                     , formatting
                     , hedgehog
                     , hspec
+                    , insert-ordered-containers
                     , lens
                     , QuickCheck
                     , quickcheck-instances

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -601,6 +601,7 @@ test-suite wallet-new-specs
                     , cardano-sl-core-test
                     , cardano-sl-crypto
                     , cardano-sl-chain
+                    , cardano-sl-util
                     , cardano-sl-util-test
                     , cardano-sl-wallet
                     , cardano-sl-wallet-new

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -114,11 +114,14 @@ instance ToJSON a => MimeRender OctetStream (WalletResponse a) where
 instance (ToSchema a, Typeable a) => ToSchema (WalletResponse a) where
     declareNamedSchema _ = do
         let a = Proxy @a
-            tyName = toText . show $ typeRep a
+            tyName = toText . map sanitize . show $ typeRep a
+            sanitize c
+                | c `elem` (":/?#[]@!$&'()*+,;=" :: String) = '_'
+                | otherwise = c
         aRef <- declareSchemaRef a
         respRef <- declareSchemaRef (Proxy @ResponseStatus)
         metaRef <- declareSchemaRef (Proxy @Metadata)
-        pure $ NamedSchema (Just $ "WalletResponse<" <> tyName <> ">") $ mempty
+        pure $ NamedSchema (Just $ "WalletResponse-" <> tyName) $ mempty
             & type_ .~ SwaggerObject
             & required .~ ["data", "status", "meta"]
             & properties .~

--- a/wallet-new/test/SwaggerSpec.hs
+++ b/wallet-new/test/SwaggerSpec.hs
@@ -6,20 +6,26 @@ import           Universum
 
 import qualified Prelude
 
+import qualified Data.HashMap.Strict.InsOrd as IOMap
 import           Data.String.Conv
 import           Data.Swagger
 import           Pos.Wallet.Aeson.ClientTypes ()
-import           Servant.API.ContentTypes
+import           Servant
 import           Servant.Swagger.Test ()
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck.Instances ()
 
+import           Cardano.Wallet.API (InternalAPI, V1API)
 import           Cardano.Wallet.API.Response (ValidJSON)
 import qualified Cardano.Wallet.API.V1 as V1
 import           Cardano.Wallet.API.V1.Swagger ()
+import qualified Cardano.Wallet.API.V1.Swagger as Swagger
 import           Cardano.Wallet.Orphans.Aeson ()
 import           Cardano.Wallet.Orphans.Arbitrary ()
+import           Pos.Core.Update (ApplicationName (..), SoftwareVersion (..))
+import           Pos.Util.CompileInfo (CompileTimeInfo (CompileTimeInfo),
+                     gitRev)
 
 -- for vendored code
 import           Data.Aeson (ToJSON)
@@ -47,10 +53,25 @@ instance ToSchema NoContent where
             & maxLength .~ Just 0
 
 spec :: Spec
-spec = modifyMaxSuccess (const 10) $
+spec = modifyMaxSuccess (const 10) $ do
     describe "Swagger Integration" $ do
         parallel $ describe "(V1) ToJSON matches ToSchema" $
             validateEveryToJSON' (Proxy @ V1.API)
+    describe "Swagger Validity" $ do
+        it "has valid URL-compatible names" $ do
+            let details =
+                    ( CompileTimeInfo gitRev
+                    , SoftwareVersion (ApplicationName "cardano-sl") 1
+                    )
+                swagger = Swagger.api details v1API' Swagger.highLevelDescription
+                v1API' = Proxy :: Proxy (V1API :<|> InternalAPI)
+            for_
+                (IOMap.keys (swagger ^. definitions))
+                (`shouldSatisfy` noReservedCharacters)
+
+noReservedCharacters :: Text -> Bool
+noReservedCharacters =
+    all (`notElem` (":/?#[]@!$&'()*+,;=" :: [Char]))
 
 -- vendored
 validateEveryToJSON'


### PR DESCRIPTION
## Description

The previous swagger spec had names like `WalletResponse<[Wallet]>` where `<[]>` are banned characters. This PR replaces them with URI friendly characters -- specifically, the above would now be `WalletResponse-_Wallet_`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-322

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
