### PR TITLE
[CO-370] Make Content-Type parsing more lenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 
 - Small refactor of wallet Errors implementation to be more maintainable (CBR-26)
 
+- Content-Type parser is now more lenient and accepts `application/json`, `application/json;charset=utf-8` and 
+  no Content-Type at all (defaulting to `application/json`).
+
 ### Specifications
 
 ### Documentation

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17759,7 +17759,6 @@ license = stdenv.lib.licenses.mit;
 , unordered-containers
 , vector
 , wai
-, wai-cors
 , wai-middleware-throttle
 , warp
 , x509
@@ -17861,7 +17860,6 @@ unliftio-core
 unordered-containers
 vector
 wai
-wai-cors
 wai-middleware-throttle
 warp
 x509

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -135,6 +135,7 @@ library
                        Cardano.Wallet.Orphans.Bi
                        Cardano.Wallet.Server
                        Cardano.Wallet.Server.CLI
+                       Cardano.Wallet.Server.Middlewares
                        Cardano.Wallet.Server.Plugins
                        Cardano.Wallet.Server.Plugins.AcidState
                        Cardano.Wallet.Server.LegacyPlugins

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -246,7 +246,6 @@ library
                      , unordered-containers
                      , vector
                      , wai
-                     , wai-cors
                      , wai-middleware-throttle
                      , warp
                      , x509

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -39,6 +39,7 @@ import           Pos.Wallet.Web.Tracking.Sync (syncWallet)
 
 import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 
+import qualified Cardano.Wallet.API.V1.Headers as Headers
 import           Cardano.Wallet.Kernel (PassiveWallet)
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.Internal as Kernel.Internal
@@ -50,7 +51,8 @@ import           Cardano.Wallet.Server.CLI (ChooseWalletBackend (..),
                      getWalletNodeOptions, walletDbPath, walletFlushDb,
                      walletRebuildDb)
 import qualified Cardano.Wallet.Server.LegacyPlugins as LegacyPlugins
-import           Cardano.Wallet.Server.Middlewares (throttleMiddleware)
+import           Cardano.Wallet.Server.Middlewares (throttleMiddleware,
+                     withDefaultHeader)
 import qualified Cardano.Wallet.Server.Plugins as Plugins
 import           Cardano.Wallet.WalletLayer (PassiveWalletLayer)
 import qualified Cardano.Wallet.WalletLayer.Kernel as WalletLayer.Kernel
@@ -109,6 +111,7 @@ actionWithLegacyWallet genesisConfig walletConfig txpConfig sscParams nodeParams
         mconcat [ LegacyPlugins.conversation wArgs
                 , LegacyPlugins.legacyWalletBackend genesisConfig txpConfig wArgs ntpStatus
                     [ throttleMiddleware (ccThrottle walletConfig)
+                    , withDefaultHeader Headers.applicationJson
                     ]
                 , LegacyPlugins.walletDocumentation wArgs
                 , LegacyPlugins.acidCleanupWorker wArgs
@@ -177,6 +180,7 @@ actionWithWallet genesisConfig walletConfig txpConfig sscParams nodeParams ntpCo
         [ Plugins.apiServer pm params w
             -- Throttle requests.
             [ throttleMiddleware (ccThrottle walletConfig)
+            , withDefaultHeader Headers.applicationJson
             ]
 
         -- The corresponding wallet documention, served as a different

--- a/wallet-new/server/Main.hs
+++ b/wallet-new/server/Main.hs
@@ -50,6 +50,7 @@ import           Cardano.Wallet.Server.CLI (ChooseWalletBackend (..),
                      getWalletNodeOptions, walletDbPath, walletFlushDb,
                      walletRebuildDb)
 import qualified Cardano.Wallet.Server.LegacyPlugins as LegacyPlugins
+import           Cardano.Wallet.Server.Middlewares (throttleMiddleware)
 import qualified Cardano.Wallet.Server.Plugins as Plugins
 import           Cardano.Wallet.WalletLayer (PassiveWalletLayer)
 import qualified Cardano.Wallet.WalletLayer.Kernel as WalletLayer.Kernel
@@ -106,8 +107,8 @@ actionWithLegacyWallet genesisConfig walletConfig txpConfig sscParams nodeParams
     plugins :: TVar NtpStatus -> LegacyPlugins.Plugin WalletWebMode
     plugins ntpStatus =
         mconcat [ LegacyPlugins.conversation wArgs
-                , LegacyPlugins.legacyWalletBackend genesisConfig walletConfig txpConfig wArgs ntpStatus
-                    [ LegacyPlugins.throttleMiddleware (ccThrottle walletConfig)
+                , LegacyPlugins.legacyWalletBackend genesisConfig txpConfig wArgs ntpStatus
+                    [ throttleMiddleware (ccThrottle walletConfig)
                     ]
                 , LegacyPlugins.walletDocumentation wArgs
                 , LegacyPlugins.acidCleanupWorker wArgs
@@ -175,7 +176,7 @@ actionWithWallet genesisConfig walletConfig txpConfig sscParams nodeParams ntpCo
         -- The actual wallet backend server.
         [ Plugins.apiServer pm params w
             -- Throttle requests.
-            [ Plugins.throttleMiddleware (ccThrottle walletConfig)
+            [ throttleMiddleware (ccThrottle walletConfig)
             ]
 
         -- The corresponding wallet documention, served as a different

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -229,7 +229,7 @@ instance FromJSON a => MimeUnrender ValidJSON a where
         Right v  -> return v
 
 instance Accept ValidJSON where
-    contentType _ = contentType (Proxy @ JSON)
+    contentTypes _ = contentTypes (Proxy @ JSON)
 
 instance ToJSON a => MimeRender ValidJSON a where
     mimeRender _ = mimeRender (Proxy @ JSON)

--- a/wallet-new/src/Cardano/Wallet/Server/Middlewares.hs
+++ b/wallet-new/src/Cardano/Wallet/Server/Middlewares.hs
@@ -1,0 +1,42 @@
+{- | A collection of middlewares used by this edge node.
+     @Middleware@ is a component that sits between the server and application.
+     It can do such tasks as GZIP encoding or response caching.
+-}
+
+module Cardano.Wallet.Server.Middlewares
+    ( withMiddlewares
+    , throttleMiddleware
+    ) where
+
+import           Universum
+
+import           Data.Aeson (encode)
+import           Network.Wai (Application, Middleware, responseLBS)
+import qualified Network.Wai.Middleware.Throttle as Throttle
+
+import           Cardano.Wallet.API.V1.Headers (applicationJson)
+import qualified Cardano.Wallet.API.V1.Types as V1
+
+import           Pos.Launcher.Configuration (ThrottleSettings (..))
+
+-- | "Attaches" the middlewares to this 'Application'.
+withMiddlewares :: [Middleware] -> Application -> Application
+withMiddlewares = flip $ foldr ($)
+
+-- | A @Middleware@ to throttle requests.
+throttleMiddleware :: Maybe ThrottleSettings -> Middleware
+throttleMiddleware Nothing app = app
+throttleMiddleware (Just ts) app = \req respond -> do
+    throttler <- Throttle.initThrottler
+    Throttle.throttle throttleSettings throttler app req respond
+  where
+    throttleSettings = Throttle.defaultThrottleSettings
+        { Throttle.onThrottled = \microsTilRetry ->
+            let
+                err = V1.RequestThrottled microsTilRetry
+            in
+                responseLBS (V1.toHttpErrorStatus err) [applicationJson] (encode err)
+        , Throttle.throttleRate = fromIntegral $ tsRate ts
+        , Throttle.throttlePeriod = fromIntegral $ tsPeriod ts
+        , Throttle.throttleBurst = fromIntegral $ tsBurst ts
+        }

--- a/wallet-new/src/Cardano/Wallet/Server/Plugins.hs
+++ b/wallet-new/src/Cardano/Wallet/Server/Plugins.hs
@@ -19,14 +19,13 @@ import           Data.Aeson (encode)
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text as T
 import           Data.Typeable (typeOf)
+import qualified Servant
 
 import           Network.HTTP.Types.Status (badRequest400)
 import           Network.Wai (Application, Middleware, Response, responseLBS)
 import           Network.Wai.Handler.Warp (defaultSettings,
                      setOnExceptionResponse)
-import           Network.Wai.Middleware.Cors (cors, corsMethods,
-                     corsRequestHeaders, simpleCorsResourcePolicy,
-                     simpleMethods)
+import qualified Network.Wai.Middleware.Throttle as Throttle
 
 import           Cardano.NodeIPC (startNodeJsIPC)
 import           Cardano.Wallet.API as API
@@ -39,8 +38,8 @@ import qualified Cardano.Wallet.Kernel.Diffusion as Kernel
 import qualified Cardano.Wallet.Kernel.Mode as Kernel
 import qualified Cardano.Wallet.Server as Server
 import           Cardano.Wallet.Server.CLI (NewWalletBackendParams (..),
-                     RunMode, WalletBackendParams (..), getWalletDbOptions,
-                     isDebugMode, walletAcidInterval)
+                     WalletBackendParams (..), getWalletDbOptions, isDebugMode,
+                     walletAcidInterval)
 import           Cardano.Wallet.Server.Plugins.AcidState
                      (createAndArchiveCheckpoints)
 import           Cardano.Wallet.WalletLayer (ActiveWalletLayer,
@@ -53,13 +52,12 @@ import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.Diffusion.Types (Diffusion (..))
 import           Pos.Infra.Shutdown (HasShutdownContext (shutdownContext),
                      ShutdownContext)
-import           Pos.Launcher.Configuration (HasConfigurations)
+import           Pos.Launcher.Configuration (HasConfigurations,
+                     ThrottleSettings (..))
 import           Pos.Util.CompileInfo (HasCompileInfo)
 import           Pos.Util.Wlog (logInfo, modifyLoggerName, usingLoggerName)
 import           Pos.Web (serveDocImpl, serveImpl)
 import qualified Pos.Web.Server
-
-import qualified Servant
 
 
 -- Needed for Orphan Instance 'Buildable Servant.NoContent' :|
@@ -75,8 +73,9 @@ apiServer
     :: ProtocolMagic
     -> NewWalletBackendParams
     -> (PassiveWalletLayer IO, PassiveWallet)
+    -> [Middleware]
     -> Plugin Kernel.WalletMode
-apiServer protocolMagic (NewWalletBackendParams WalletBackendParams{..}) (passiveLayer, passiveWallet) =
+apiServer protocolMagic (NewWalletBackendParams WalletBackendParams{..}) (passiveLayer, passiveWallet) middlewares =
     pure $ \diffusion -> do
         env <- ask
         let diffusion' = Kernel.fromDiffusion (lower env) diffusion
@@ -113,9 +112,11 @@ apiServer protocolMagic (NewWalletBackendParams WalletBackendParams{..}) (passiv
 
     getApplication :: ActiveWalletLayer IO -> Kernel.WalletMode Application
     getApplication active = do
-      logInfo "New wallet API has STARTED!"
-      return $ withMiddleware walletRunMode $
-        Servant.serve API.newWalletAPI $ Server.walletServer active walletRunMode
+        logInfo "New wallet API has STARTED!"
+        return
+            $ withMiddlewares middlewares
+            $ Servant.serve API.newWalletAPI
+            $ Server.walletServer active walletRunMode
 
     lower :: env -> ReaderT env IO a -> IO a
     lower env m = runReaderT m env
@@ -124,21 +125,9 @@ apiServer protocolMagic (NewWalletBackendParams WalletBackendParams{..}) (passiv
     portCallback ctx =
         usingLoggerName "NodeIPC" . flip runReaderT ctx . startNodeJsIPC
 
-    -- | "Attaches" the middleware to this 'Application', if any.
-    -- When running in debug mode, chances are we want to at least allow CORS to test the API
-    -- with a Swagger editor, locally.
-    withMiddleware :: RunMode -> Application -> Application
-    withMiddleware wrm app
-      | isDebugMode wrm = corsMiddleware app
-      | otherwise = app
-
-    corsMiddleware :: Middleware
-    corsMiddleware = cors (const $ Just policy)
-        where
-          policy = simpleCorsResourcePolicy
-            { corsRequestHeaders = ["Content-Type"]
-            , corsMethods = "PUT" : simpleMethods
-            }
+    -- | "Attaches" the middlewares to this 'Application'.
+    withMiddlewares :: [Middleware] -> Application -> Application
+    withMiddlewares = flip $ foldr ($)
 
 
 -- | A @Plugin@ to serve the wallet documentation


### PR DESCRIPTION
## Description

We have had a lot of trouble where people will send no content-type or
simply 'application/json' and request would fail with 415 Unsupported
Media Type. Without knowing where to look, the error looks quite
unexpected and could give a lot of headache. This commit does two
changes:

- It slightly modifies the 'Accept' instance to use 'contentTypes'
  instead of 'contentType'. The latter is defined from the former by
  simply taking the head of the list returned by 'contentTypes', which in
  our case is 'application/json;charset=utf-8'

- It provides a default content-type 'application/json' when no
  content-type is provided

## TODO

- Add entry in the CHANGELOG once changing base against `develop`

## Linked issue

[[CO-370]](https://iohk.myjetbrains.com/youtrack/issue/CO-370)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

With cURL:

#### Content-Type is "application/json;charset=utf-8" 

> > POST /api/v1/wallets HTTP/1.1
> > Host: localhost:8090
> > User-Agent: curl/7.47.0
> > Accept: \*/\*
> > Content-Type: **application/json;charset=utf-8**
> > Content-Length: 209
> > 
> < HTTP/1.1 201 Created
> < Transfer-Encoding: chunked
> < Date: Fri, 14 Sep 2018 04:53:31 GMT
> < Server: Warp/3.2.22
> < Content-Type: **application/json;charset=utf-8**

#### Content-Type is "application/json"

> > POST /api/v1/wallets HTTP/1.1
> > Host: localhost:8090
> > User-Agent: curl/7.47.0
> > Accept: \*/\*
> > Content-Type: **application/json**
> > Content-Length: 209
> > 
> < HTTP/1.1 201 Created
> < Transfer-Encoding: chunked
> < Date: Fri, 14 Sep 2018 04:51:55 GMT
> < Server: Warp/3.2.22
> < Content-Type: **application/json;charset=utf-8**

#### Content-Type is not defined

>  > POST /api/v1/wallets HTTP/1.1
>  > Host: localhost:8090
>  > User-Agent: curl/7.47.0
>  > Accept: */*
>  > Content-Length: 209
>  > 
>  < HTTP/1.1 201 Created
>  < Transfer-Encoding: chunked
>  < Date: Fri, 14 Sep 2018 04:56:23 GMT
>  < Server: Warp/3.2.22
>  < Content-Type: **application/json;charset=utf-8**

#### Content-Type is "application/x-www-form-urlencoded"

> > POST /api/v1/wallets HTTP/1.1
> > Host: localhost:8090
> > User-Agent: curl/7.47.0
> > Accept: \*/\*
> > Content-Length: 209
> > Content-Type: **application/x-www-form-urlencoded**
> > 
> < **HTTP/1.1 415 Unsupported Media Type**
> < Transfer-Encoding: chunked
> < Date: Fri, 14 Sep 2018 04:56:08 GMT
> < Server: Warp/3.2.22


## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
