### PR TITLE
[DDW-318] Remove pretty-encoding for JSONValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - The creation of mnemonic doesn't throw anymore when provided words outside of the BIP39 English dictionnary.
   Instead, it returns an error value gracefully (CO-325)
 
+- Response from `JSONValidationError` are now also encoded inline (instead of a pretty-encoding with newlines) (DDW-318)
+
 ### Improvements
 
 - Friendly error mistakes from deserializing invalid addresses instead of brutal 500 (CBR-283)

--- a/wallet-new/src/Cardano/Wallet/API/Response.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Response.hs
@@ -25,7 +25,6 @@ import           Universum (Buildable, Exception, Text, decodeUtf8, toText,
 
 import           Control.Lens hiding (Indexable)
 import           Data.Aeson (FromJSON (..), ToJSON (..), eitherDecode, encode)
-import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Options as Serokell
 import           Data.Aeson.TH
 import qualified Data.Char as Char
@@ -225,7 +224,7 @@ data ValidJSON deriving Typeable
 
 instance FromJSON a => MimeUnrender ValidJSON a where
     mimeUnrender _ bs = case eitherDecode bs of
-        Left err -> Left $ decodeUtf8 $ encodePretty (JSONValidationFailed $ toText err)
+        Left err -> Left $ decodeUtf8 $ encode (JSONValidationFailed $ toText err)
         Right v  -> return v
 
 instance Accept ValidJSON where


### PR DESCRIPTION
## Description

This is inherited from the old times but is actually wrong.
Pretty encoding is good for human to look at, but when it comes
to parsers, newlines aren't much appreciated (e.g. Daedalus parser).

Curious that this was never caught before, probably because
JSONValidationError weren't really caught by Daedalus. Now some of
them are so we better have well-formed responses :)

## Linked issue

[[DDW-318]](https://iohk.myjetbrains.com/youtrack/issue/DDW-318)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- ~~[ ] I have added tests to cover my changes.~~
- [z] All new and existing tests passed.

## QA Steps

With cURL, an invalid request to trigger a JSONValidationFailed (e.g. using the example mnemonic) returns a response that is correctly encoded.

```
> POST /api/v1/wallets HTTP/1.1
> Host: localhost:8090
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Length: 224

< HTTP/1.1 400 Bad Request
< Transfer-Encoding: chunked
< Date: Tue, 18 Sep 2018 05:08:30 GMT
< Server: Warp/3.2.22

{"status":"error","diagnostic":{"validationError":"Error in $.backupPhrase: Forbidden Mnemonic: an example Mnemonic has been submitted. Please generate a fresh and private Mnemonic from a trusted source"},"message":"JSONValidationFailed"}
```

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
