### PR TITLE
[CBR-437] Kernel.Wallets.updatePassword should record if the user decided to remove it

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Wallets.hs
@@ -384,7 +384,15 @@ updatePassword pw hdRootId oldPassword newPassword = do
                                -- was set.
                                -- Fix this properly as part of [CBR-404].
                                lastUpdateNow <- InDb <$> getCurrentTimestamp
-                               let hasSpendingPassword = HD.HasSpendingPassword lastUpdateNow
+
+                               -- There is no such thing as "removing" the spending password.
+                               -- However, it can be set to the empty string. We check for that
+                               -- here and update 'hasSpendingPassword' on 'HdRoot' accordingly.
+                               let hasSpendingPassword =
+                                       if newPassword == emptyPassphrase
+                                       then HD.NoSpendingPassword
+                                       else HD.HasSpendingPassword lastUpdateNow
+
                                res <- update' (pw ^. wallets)
                                               (UpdateHdRootPassword hdRootId hasSpendingPassword)
                                case res of


### PR DESCRIPTION
## Description
When the password is updated we should check if it is the
`emptyPassphrase` and, if so, update `HdRoot` to have no spending
password.

This <s>commit</s> pr also adds a test property that ensures the hdRoot has no
spending password afterwards, and modifies the existing property to only
test updates with non-empty passwords, where we expect the new hdRoot to
*have* a spending password.

## Linked issue

[CBR-437](https://iohk.myjetbrains.com/youtrack/issue/CBR-437)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->