### PR TITLE
CO-363: When streaming blocks, reconnect on error

### DIFF
--- a/lib/src/Pos/Network/Block/Retrieval.hs
+++ b/lib/src/Pos/Network/Block/Retrieval.hs
@@ -9,8 +9,8 @@ module Pos.Network.Block.Retrieval
 
 import           Universum
 
-import           Control.Concurrent.STM (putTMVar, swapTMVar, tryReadTBQueue,
-                     tryReadTMVar, tryTakeTMVar)
+import           Control.Concurrent.STM (TVar, newTVar, putTMVar, swapTMVar,
+                     swapTVar, tryReadTBQueue, tryReadTMVar, tryTakeTMVar)
 import           Control.Exception.Safe (handleAny)
 import           Control.Lens (to)
 import           Control.Monad.STM (retry)
@@ -341,16 +341,37 @@ streamProcessBlocks
     -> m ()
 streamProcessBlocks genesisConfig txpConfig diffusion nodeId desired checkpoints = do
     logInfo "streaming start"
-    r <- Diffusion.streamBlocks diffusion nodeId desired checkpoints writeCallback
+    mostDifficultBlock <- atomically $ newTVar Nothing
+    r <- Diffusion.streamBlocks diffusion nodeId desired checkpoints (writeCallback mostDifficultBlock)
     case r of
          Nothing -> do
              logInfo "streaming not supported, reverting to batch mode"
              getProcessBlocks genesisConfig txpConfig diffusion nodeId desired checkpoints
          Just _  -> do
              logInfo "streaming done"
-             return ()
+
+             recHeaderVar <- view (lensOf @RecoveryHeaderTag)
+             exitedRecovery <- atomically $ do
+                 mbMostDifficult <- readTVar mostDifficultBlock
+                 mbRecHeader <- tryReadTMVar recHeaderVar
+                 case (mbMostDifficult, mbRecHeader) of
+                      (Nothing, _)                 -> pure False -- We have not gotten a single block
+                      (Just _, Nothing)            -> pure False -- We where not in recovery?
+                      (Just mostDifficult, Just (_, recHeader)) ->
+                          if (mostDifficult ^. difficultyL) >= (recHeader ^. difficultyL)
+                             then isJust <$> tryTakeTMVar recHeaderVar
+                             else pure False
+
+             if exitedRecovery
+                then do
+                    logInfo "Recovery mode exited gracefully on receiving block we needed"
+                    return ()
+                else do -- Streaming stopped but we didn't make any progress
+                    _ <- dropRecoveryHeaderAndRepeat genesisConfig diffusion nodeId
+                    return ()
   where
-    writeCallback :: [Block] -> m ()
-    writeCallback [] = return ()
-    writeCallback (block:blocks) =
+    writeCallback :: (TVar (Maybe Block)) -> [Block] -> m ()
+    writeCallback _ [] = return ()
+    writeCallback mostDifficultBlock (block:blocks) = do
+        _ <- atomically $ swapTVar mostDifficultBlock (Just block)
         handleBlocks genesisConfig txpConfig (OldestFirst (NE.reverse $ block :| blocks)) diffusion


### PR DESCRIPTION
## Description
When streaming blocks we never left recovery mode. This meant that in case the peer we streamed data from died we would never switch to a different node from which to sync from.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-363

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->
1. Build the acceptance test, nix-build -A acceptanceTests.mainnet.full -o acceptance-test
2. Start the acceptance test, ./acceptance-test
3. Block the IP address of the peer the node is syncing with, e.g iptables -D INPUT -s  PEERIP -j DROP
4. Wait for connection to time out.
5. Verify that syncing resumes with a new peer.
## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
