### PR TITLE
[CBR-422] Fix acid-state memory leak

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/AcidState.hs
@@ -55,6 +55,7 @@ import qualified Data.Map.Strict as Map
 import           Data.SafeCopy (base, deriveSafeCopy)
 import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable
+import           Serokell.Util (listJson, mapJson)
 import           Test.QuickCheck (Arbitrary (..), oneof)
 
 import           Pos.Chain.Txp (TxAux, TxId, Utxo)
@@ -741,6 +742,35 @@ instance Buildable NewForeignError where
         bprint ("NewForeignUnknown " % build) unknownAccount
     build (NewForeignFailed npf) =
         bprint ("NewForeignFailed " % build) npf
+
+instance Buildable (AccountUpdate e a) where
+    build AccountUpdate{..} = bprint
+        ( "AccountUpdate "
+        % "{ updateId:    " % build
+        % ", updateNew:   " % build
+        % ", updateAddrs: " % listJson
+        % ", update:      <update>"
+        % "}"
+        )
+        accountUpdateId
+        accountUpdateNew
+        accountUpdateAddrs
+
+instance Buildable AccountUpdateNew where
+    build (AccountUpdateNewUpToDate cur) = bprint
+        ( "AccountUpdateNewUpToDate "
+        % "{ cur: " % mapJson
+        % "}"
+        )
+        cur
+    build (AccountUpdateNewIncomplete cur gen) = bprint
+        ( "AccountUpdateNewUpToDate "
+        % "{ cur: " % mapJson
+        % "{ gen: " % mapJson
+        % "}"
+        )
+        cur
+        gen
 
 {-------------------------------------------------------------------------------
   Arbitrary

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Util/AcidState.hs
@@ -60,8 +60,11 @@ newtype Update' e st a = Update' (StrictStateT st (Except e) a)
 instance Z.Zoomable (Update' e) where
   type Result (Update' e) = Z.UpdResult e
 
-  wrap   = coerce
   unwrap = coerce
+
+  -- Almost coerce, but make sure that we cannot sneak in functions that leave
+  -- the state in non-whnf.
+  wrap f = Update' $ strictStateT $ Z.getUpdResult . f
 
 mapUpdateErrors :: (e -> e') -> Update' e st a -> Update' e' st a
 mapUpdateErrors f (Update' upd) = Update' $


### PR DESCRIPTION
## Description

Each time the node applies a block (which happens a _lot_ when the node is synching with the block chain) we call an acid-state `applyBlock` transaction. The argument to this transaction is a map from account IDs (which belong to the wallet) to updates to those accounts. For an empty wallet, this map would be empty, but we would nonetheless still call the transaction. This transaction then gets written to the DB log, making it grow unnecessarily; what's worse, due to (what I think is) a bug in acid-state, this also needs to a memory leak. I've filed this separately at https://github.com/acid-state/acid state/issues/103 . For now, the most important fix for us (useful independently) is to avoid doing a DB transaction _at all_ when this map is empty. During node synching when there is no wallet this will reduce the number of DB transactions to zero (since there are no accounts in the wallet at all). When there _are_ wallets/accounts, we will still have a small memory leak, _but_ it will grow _much_ slower, and moreover each time we create a DB checkpoint (which we do anyway), the leak is cleaned up (at least, I hope so -- that's what my small-scale test suggests, as reported in that acid-state ticket; I haven't verified whether this also translates to the our use case).

This PR also makes one another important fix: in the zooming code, we are effectively injecting `state -> state` functions into the strict update monad. We should make sure that these functions cannot leave the state in non-whnf. I initially thought that this was the culprit here, but it turned out not to be. Not totally convinced that this change is really necessary, since we always _create_ these state to state functions using the `StrictStateT` monad, but may as well leave it in, in case we manually construct a function someplace else.

Finally, this adds some `Buildable` instances for some types that didn't have them; I used that during debugging and figured may as well leave it in as it may be useful in the future.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
