### PR TITLE
[DEVOPS-1052] tests: Limit memory usage of nightly blockchain sync

### DIFF
--- a/scripts/test/acceptance/default.nix
+++ b/scripts/test/acceptance/default.nix
@@ -19,8 +19,12 @@ let
 
   wallet = pkgs.callPackage ../../launch/connect-to-cluster {
     inherit gitrev stateDir environment;
+
     # This will limit heap size to 1GB, along with the usual RTS options.
     ghcRuntimeArgs = "-N2 -qg -A1m -I0 -T -M1G";
+
+    # Temporarily run the old wallet code until CBR-420 is resolved.
+    additionalNodeArgs = "--legacy-wallet";
   };
 
 in


### PR DESCRIPTION
## Description

Tests will fail if more that 2GB memory is used. This is a simple way of noticing space leaks in the sync code.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1052

## Type of change
- New or improved tests for existing code
