### PR TITLE
Nix shell - more caching

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -25,6 +25,7 @@ let
             # Filter out cabal build products.
             baseName == "dist" || baseName == "dist-newstyle" ||
             baseName == "cabal.project.local" ||
+            lib.hasPrefix ".ghc.environment" baseName ||
             # Filter out stack build products.
             lib.hasPrefix ".stack-work" baseName ||
             # Filter out files which are commonly edited but don't

--- a/release.nix
+++ b/release.nix
@@ -20,6 +20,7 @@ with (import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") {
 let
   iohkPkgs = import ./. { gitrev = cardano.rev; };
   pkgs = import fixedNixpkgs { config = {}; };
+  shellEnv = import ./shell.nix { };
   wrapDockerImage = cluster: let
     images = {
       mainnet = iohkPkgs.dockerImages.mainnet;
@@ -51,6 +52,7 @@ let
     stack2nix = supportedSystems;
     purescript = supportedSystems;
     daedalus-bridge = supportedSystems;
+    shell = supportedSystems;
   };
   platforms' = {
     connectScripts.mainnet.wallet   = [ "x86_64-linux" "x86_64-darwin" ];


### PR DESCRIPTION
## Description

1. Makes sure that `shell.nix` is built by hydra ⇒ available to download from cache.
2. Prevents locally created `.ghc.environment*` files from being included in the local nix-build and breaking it mysteriously.

## Type of change

- Build and dev environment
