### PR TITLE
[CBR-345] Create symbolic link for log files.

### DIFF
--- a/util/src/Pos/Util/Log/Internal.hs
+++ b/util/src/Pos/Util/Log/Internal.hs
@@ -18,11 +18,13 @@ module Pos.Util.Log.Internal
        , LoggingHandler      --  only export name
        , FileDescription (..)
        , mkFileDescription
+       , prtoutException
        ) where
 
 import           Control.AutoUpdate (UpdateSettings (..), defaultUpdateSettings,
                      mkAutoUpdate)
 import           Control.Concurrent.MVar (modifyMVar_, newMVar, withMVar)
+import           Control.Exception.Safe (Exception (..))
 
 import qualified Data.Text as T
 import           Data.Time (UTCTime, getCurrentTime)
@@ -37,6 +39,12 @@ import qualified Katip.Core as KC
 import           Pos.Util.Log.LoggerConfig (LoggerConfig (..))
 import           Pos.Util.Log.Severity
 
+
+-- | display message and stack trace of exception on stdout
+prtoutException :: Exception e => String -> e -> IO ()
+prtoutException msg e = do
+    putStrLn msg
+    putStrLn ("exception: " ++ displayException e)
 
 -- | translate Severity to @Katip.Severity@
 sev2klog :: Severity -> K.Severity

--- a/util/src/Pos/Util/Log/Rotator.hs
+++ b/util/src/Pos/Util/Log/Rotator.hs
@@ -15,7 +15,7 @@ module Pos.Util.Log.Rotator
 
 import           Universum
 
-import           Control.Exception.Safe (Exception (..), catchIO)
+import           Control.Exception.Safe (catchIO)
 import qualified Data.List.NonEmpty as NE
 import           Data.Time (UTCTime, addUTCTime, diffUTCTime, getCurrentTime,
                      parseTimeM)
@@ -25,7 +25,7 @@ import           System.FilePath ((</>))
 import           System.IO (BufferMode (LineBuffering), Handle,
                      IOMode (WriteMode), hFileSize, hSetBuffering, stdout)
 
-import           Pos.Util.Log.Internal (FileDescription (..))
+import           Pos.Util.Log.Internal (FileDescription (..), prtoutException)
 import           Pos.Util.Log.LoggerConfig
 
 #ifdef POSIX
@@ -78,11 +78,6 @@ evalRotator rotation fdesc@FileDescription{..} = do
     let rottime = addUTCTime (fromInteger $ maxAge * 3600) now
 
     return (hdl, maxSize, rottime)
-
-prtoutException :: Exception e => String -> e -> IO ()
-prtoutException msg e = do
-    putStrLn msg
-    putStrLn ("exception: " ++ displayException e)
 
 -- | list filenames in prefix dir which match 'filename'
 listLogFiles :: FileDescription -> IO (Maybe (NonEmpty FilePath))


### PR DESCRIPTION
## Description

Create a symbolic link for every log file created for UNIX-like systems. Symbolic link will follow the latest active log file.

For example:
 * logs/node -> node-20180919092116
 * logs/node-20180919091013
 * logs/node-20180919091536
 * logs/node-20180919092116

This allows a `tail -F` to follow the log files even when they are recreated under log rotation.

Also, create the log prefix directory on startup if it does not exist.

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

[CBR-345](https://iohk.myjetbrains.com/youtrack/issue/CBR-345)
<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
