### PR TITLE
[CBR-345] clean formatting of slots/epoch indexes

### DIFF
--- a/chain/src/Pos/Chain/Ssc/Error/Verify.hs
+++ b/chain/src/Pos/Chain/Ssc/Error/Verify.hs
@@ -7,12 +7,13 @@ module Pos.Chain.Ssc.Error.Verify
 
 import           Universum
 
-import           Formatting (bprint, build, ords, stext, (%))
+import           Formatting (bprint, build, stext, (%))
 import qualified Formatting.Buildable
 import           Serokell.Util (listJson)
 
 import           Pos.Chain.Ssc.VssCertificate (VssCertificate)
-import           Pos.Core (EpochIndex, SlotId, StakeholderId)
+import           Pos.Core (EpochIndex (..), SlotId, StakeholderId)
+import           Pos.Util.Util (intords)
 
 type NEStIds = NonEmpty StakeholderId
 
@@ -66,7 +67,7 @@ instance Buildable SscVerifyError where
     build (NoRichmen epoch) =
         bprint ("no richmen for epoch"%build) epoch
     build (TossUnknownRichmen epoch) =
-        bprint ("richmen aren't know for "%ords%" epoch") epoch
+        bprint ("richmen aren't know for "%intords%" epoch") (getEpochIndex epoch)
 
     build (CommitmentInvalid ids) =
         bprint ("verifySignedCommitment has failed for some commitments: "%listJson) ids

--- a/chain/src/Pos/Chain/Ssc/Toss/Base.hs
+++ b/chain/src/Pos/Chain/Ssc/Toss/Base.hs
@@ -44,7 +44,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import qualified Data.List.NonEmpty as NE
 import           Data.STRef (newSTRef, readSTRef, writeSTRef)
-import           Formatting (ords, sformat, (%))
+import           Formatting (sformat, (%))
 
 import           Pos.Binary.Class (AsBinary, fromBinary)
 import           Pos.Chain.Genesis as Genesis (Config)
@@ -66,10 +66,11 @@ import           Pos.Chain.Ssc.VssCertificate (vcSigningKey, vcVssKey)
 import           Pos.Chain.Ssc.VssCertificatesMap (VssCertificatesMap (..),
                      lookupVss, memberVss)
 import           Pos.Chain.Update.BlockVersionData (bvdMpcThd)
-import           Pos.Core (CoinPortion, EpochIndex, StakeholderId, addressHash,
-                     coinPortionDenominator, getCoinPortion, unsafeGetCoin)
+import           Pos.Core (CoinPortion, EpochIndex (..), StakeholderId,
+                     addressHash, coinPortionDenominator, getCoinPortion,
+                     unsafeGetCoin)
 import           Pos.Crypto (DecShare, verifyDecShare, verifyEncShares)
-import           Pos.Util.Util (getKeys)
+import           Pos.Util.Util (getKeys, intords)
 import           Pos.Util.Wlog (logWarning)
 
 ----------------------------------------------------------------------------
@@ -131,9 +132,9 @@ checkShares
     -> m Bool
 checkShares genesisConfig epoch (id, sh) = do
     certs <- getStableCertificates genesisConfig epoch
-    let warnFmt = ("checkShares: no richmen for "%ords%" epoch")
+    let warnFmt = ("checkShares: no richmen for "%intords%" epoch")
     getRichmen epoch >>= \case
-        Nothing -> False <$ logWarning (sformat warnFmt epoch)
+        Nothing -> False <$ logWarning (sformat warnFmt (getEpochIndex epoch))
         Just richmen -> do
             let parts = computeParticipants (getKeys richmen) certs
             coms <- getCommitments

--- a/core/src/Pos/Core/Slotting/SlotId.hs
+++ b/core/src/Pos/Core/Slotting/SlotId.hs
@@ -26,15 +26,13 @@ import           Universum
 import           Control.Lens (Iso', iso, lens, makeLensesFor)
 import           Data.Aeson.TH (defaultOptions, deriveJSON)
 import           Data.SafeCopy (base, deriveSafeCopySimple)
-import           Data.Text (pack)
-import           Data.Text.Lazy.Builder (fromText)
-import           Formatting (Format, bprint, build, later, (%))
+import           Formatting (Format, bprint, build, (%))
 import qualified Formatting.Buildable as Buildable
 
 import           Pos.Binary.Class (Cons (..), Field (..), deriveSimpleBi)
 import           Pos.Core.Common (BlockCount)
 import           Pos.Core.ProtocolConstants (kEpochSlots, kSlotSecurityParam)
-import           Pos.Util.Util (leftToPanic)
+import           Pos.Util.Util (intords, leftToPanic)
 
 import           Pos.Core.Slotting.EpochIndex
 import           Pos.Core.Slotting.LocalSlotIndex
@@ -52,23 +50,6 @@ instance Buildable SlotId where
     build SlotId {..} =
         bprint (intords%" slot of "%intords%" epoch")
             (getSlotIndex siSlot) (getEpochIndex siEpoch)
-
--- | temporary reimplementation of 'ords' from "Formatting"
---   because the original function converts the integer value to a real number
-intords :: (Show n, Integral n) => Format r (n -> r)
-intords = later go
-  where
-    fmt = fromText . pack . show
-    go n
-      | tens > 3 && tens < 21 = fmt n <> "th"
-      | otherwise =
-            fmt n <>
-            case n `mod` 10 of
-              1 -> "st"
-              2 -> "nd"
-              3 -> "rd"
-              _ -> "th"
-      where tens = n `mod` 100
 
 instance NFData SlotId
 

--- a/db/src/Pos/DB/Block/Lrc.hs
+++ b/db/src/Pos/DB/Block/Lrc.hs
@@ -19,7 +19,7 @@ import           Data.Coerce (coerce)
 import           Data.Conduit (ConduitT, runConduitRes, (.|))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
-import           Formatting (build, ords, sformat, (%))
+import           Formatting (build, sformat, (%))
 import qualified System.Metrics.Counter as Metrics
 import           UnliftIO (MonadUnliftIO)
 
@@ -31,7 +31,7 @@ import           Pos.Chain.Lrc (LrcError (..), RichmenStakes,
                      followTheSatoshiM)
 import           Pos.Chain.Ssc (MonadSscMem, noReportNoSecretsForEpoch1)
 import           Pos.Chain.Update (BlockVersionState (..))
-import           Pos.Core (Coin, EpochIndex, EpochOrSlot (..), SharedSeed,
+import           Pos.Core (Coin, EpochIndex (..), EpochOrSlot (..), SharedSeed,
                      SlotCount, StakeholderId, crucialSlot, epochIndexL,
                      getEpochOrSlot)
 import           Pos.Core.Chrono (NE, NewestFirst (..), toOldestFirst)
@@ -56,7 +56,7 @@ import           Pos.DB.Ssc (sscCalculateSeed)
 import qualified Pos.DB.Txp.Stakes as GS
 import           Pos.DB.Update (getCompetingBVStates)
 import           Pos.Util (maybeThrow)
-import           Pos.Util.Util (HasLens (..))
+import           Pos.Util.Util (HasLens (..), intords)
 import           Pos.Util.Wlog (logDebug, logInfo, logWarning)
 
 
@@ -90,7 +90,7 @@ lrcSingleShot genesisConfig epoch = do
     tryAcquireExclusiveLock epoch lock onAcquiredLock
   where
     consumers = allLrcConsumers @ctx @m (configBlockVersionData genesisConfig)
-    for_thEpochMsg = sformat (" for "%ords%" epoch") epoch
+    for_thEpochMsg = sformat (" for "%intords%" epoch") (getEpochIndex epoch)
     onAcquiredLock = do
         logDebug "lrcSingleShot has acquired LRC lock"
         (need, filteredConsumers) <-

--- a/lib/src/Pos/Worker/Ssc.hs
+++ b/lib/src/Pos/Worker/Ssc.hs
@@ -13,7 +13,7 @@ import           Control.Monad.Except (runExceptT)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Units (Microsecond, Millisecond, convertUnit)
-import           Formatting (build, ords, sformat, shown, (%))
+import           Formatting (build, sformat, shown, (%))
 import           Serokell.Util.Exceptions ()
 import           Serokell.Util.Text (listJson)
 import qualified System.Metrics.Gauge as Metrics
@@ -66,7 +66,7 @@ import           Pos.Infra.Slotting (MonadSlots, defaultOnNewSlotParams,
 import           Pos.Infra.Util.LogSafe (logDebugS, logErrorS, logInfoS,
                      logWarningS)
 import           Pos.Util.AssertMode (inAssertMode)
-import           Pos.Util.Util (HasLens (..), getKeys, leftToPanic)
+import           Pos.Util.Util (HasLens (..), getKeys, intords, leftToPanic)
 import           Pos.Util.Wlog (WithLogger)
 
 
@@ -219,12 +219,12 @@ onNewSlotCommitment genesisConfig slotId@SlotId {..} sendCommitment
 
     onNewSlotCommDo = do
         ourSk <- getOurSecretKey
-        logDebugS $ sformat ("Generating secret for "%ords%" epoch") siEpoch
+        logDebugS $ sformat ("Generating secret for "%intords%" epoch") siEpoch
         generated <- generateAndSetNewSecret genesisConfig ourSk slotId
         case generated of
             Nothing -> logWarningS "I failed to generate secret for SSC"
             Just comm -> do
-              logInfoS (sformat ("Generated secret for "%ords%" epoch") siEpoch)
+              logInfoS (sformat ("Generated secret for "%intords%" epoch") siEpoch)
               sendOurCommitment comm
 
     sendOurCommitment comm = do

--- a/util/src/Pos/Util/Util.hs
+++ b/util/src/Pos/Util/Util.hs
@@ -70,6 +70,7 @@ module Pos.Util.Util
        , (<//>)
        , divRoundUp
        , sleep
+       , intords
 
        , tMeasureLog
        , tMeasureIO
@@ -96,6 +97,8 @@ import qualified Data.Map as M
 import           Data.Ratio ((%))
 import qualified Data.Semigroup as Smg
 import qualified Data.Serialize as Cereal
+import           Data.Text (pack)
+import           Data.Text.Lazy.Builder (fromText)
 import           Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime,
                      getCurrentTime)
 import           Data.Time.Clock.POSIX (getPOSIXTime, posixSecondsToUTCTime)
@@ -433,6 +436,23 @@ median l = NE.sort l NE.!! middle
 -}
 sleep :: MonadIO m => NominalDiffTime -> m ()
 sleep n = liftIO (threadDelay (truncate (n * 10^(6::Int))))
+
+-- | temporary reimplementation of 'ords' from "Formatting"
+--   because the original function converts the integer value to a real number
+intords :: (Show n, Integral n) => F.Format r (n -> r)
+intords = F.later go
+  where
+    fmt = fromText . pack . show
+    go n
+      | tens > 3 && tens < 21 = fmt n <> "th"
+      | otherwise =
+            fmt n <>
+            case n `mod` 10 of
+              1 -> "st"
+              2 -> "nd"
+              3 -> "rd"
+              _ -> "th"
+      where tens = n `mod` 100
 
 -- | 'tMeasure' with 'logDebug'.
 tMeasureLog :: (MonadIO m, WithLogger m) => Text -> m a -> m a


### PR DESCRIPTION
## Description

clean formatting of slots/epoch indexes as proposed by @cleverca22 
reason: there were more occurences of wrong formatting in the logs.
moved the formatting code 'intords' from `core` to `util`
reason: the formatting should be available in all modules

## Linked issue

CBR-345

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [x] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

verifiable in logs  from benchmarking, or "block sync" test