### PR TITLE
[CBR-438] Create checkpoints in applyBlock

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
@@ -10,15 +10,20 @@ module Cardano.Wallet.Kernel.BListener (
 import           Universum hiding (State)
 
 import           Control.Concurrent.MVar (modifyMVar_)
+import           Control.Lens (to)
+import           Data.Acid (createCheckpoint)
 import           Data.Acid.Advanced (update')
 
+import           Pos.Core (getSlotIndex, siSlotL)
 import           Pos.Crypto (EncryptedSecretKey)
+import           Pos.Util.Log (Severity (Info))
 
 import           Cardano.Wallet.Kernel.DB.AcidState (ApplyBlock (..),
                      ObservableRollbackUseInTestsOnly (..), SwitchToFork (..),
                      SwitchToForkError (..))
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.HdWallet
+import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
 import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock, rbContext)
 import           Cardano.Wallet.Kernel.DB.Spec.Update (ApplyBlockFailed)
 import           Cardano.Wallet.Kernel.DB.TxMeta.Types
@@ -63,7 +68,32 @@ applyBlock pw@PassiveWallet{..} b = do
       Right confirmed -> do
         modifyMVar_ _walletSubmission $ return . Submission.remPending confirmed
         mapM_ (putTxMeta _walletMeta) metas
+        createCheckpointIfNeeded
         return $ Right ()
+  where
+      -- | Interim fix, see CBR-438 and
+      -- https://github.com/acid-state/acid-state/issues/103. In brief, when
+      -- the note initially syncs and lots of blocks gets passed to the wallet
+      -- worker, a new `ApplyBlock` acidic transaction will be committed on the
+      -- transaction log but not written to disk _yet_ (that's what checkpoints
+      -- are for). However, this might lead to memory leaks if such checkpointing
+      -- step doesn't happen fast enough. Therefore, every time we apply a block,
+      -- we decrement this counter and when it reaches 0, we enforce a new
+      -- checkpoint.
+      createCheckpointIfNeeded :: IO ()
+      createCheckpointIfNeeded = do
+          -- Look at the 'ResolvedBlock' 's 'SlotId', and assess if a new
+          -- checkpoint is needed by doing @localBlockIx `modulo` someConstant@
+          -- where @someConstant@ is chosen to be 1000.
+          let blockSlotIx = b ^. rbContext
+                               . bcSlotId
+                               . fromDb
+                               . siSlotL
+                               . to getSlotIndex
+              checkpointNeeded = (blockSlotIx - 1) `mod` 1000 == 0
+          when checkpointNeeded $ do
+              _walletLogMessage Info "applyBlock: making an acid-state DB checkpoint..."
+              createCheckpoint _wallets
 
 -- | Switch to a new fork
 --


### PR DESCRIPTION
## Description

This PR tries to put an interim solution to the recent memory leaks we have been experiencing for the new data layer. In a nutshell, every time we receive a block, we call applyBlock (even if the block is not relevant to this wallet node) and that has the unfortunate consequence of appending an entry to the acid-state transaction log, which can grow very big up until we don't call createAcidStateCheckpoint (something we do periodically as part of a plugin every 12 minutes, by default).

The proper fix would be to simply stop calling applyBlock when a block is not interesting to us, but this is not easy to do currently as we do need to write to the DB a new Checkpoint (unfortunate naming, it's the wallet checkpoint as-per-the-spec) in our list of Checkpoints.

So, the plan is to fix this properly as part of CBR-439, but this patch should hopefully give some relief for the short/medium term.

*Note* This PR is virtually the same as #3631, but it doesn't suffer from the snag of modifying the `DB` (incurring in the migration overhead). As such, it should fix the leak (alas I cannot test this one due to bigger problems, i.e. it seems like on darwin my node _always_ leak, and I need to get to the bottom of it. But @edsko tried out my previous PR and that showed a flat memory profile).

I have a question for @erikd and @dcoutts : This PR creates a new checkpoint every 1000 blocks. In practice, this means that for something like mainnet, on a cold wallet sync up to `tip` we would create 1500 checkpoints. In practice I don't think this is going to be a problem (considering the transaction log at that point would be really small) but nevertheless I'm asking the `acid-state` pros here if that's a problem.

To Erik, all I'm asking is: give this a spin, and let us know if it does solve your node-crashes problems 😉 

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
