### PR TITLE
[CBR-440] Do not require the spending password for the estimation of the fees

### DIFF
--- a/client/src/Pos/Client/Txp/Util.hs
+++ b/client/src/Pos/Client/Txp/Util.hs
@@ -18,6 +18,7 @@ module Pos.Client.Txp.Util
        -- * Tx creation
        , TxCreateMode
        , makeAbstractTx
+       , makeUnsignedAbstractTx
        , runTxCreator
        , makePubKeyTx
        , makeMPubKeyTx

--- a/wallet-new/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Handlers/Transactions.hs
@@ -95,9 +95,7 @@ estimateFees :: ActiveWalletLayer IO
              -> Payment
              -> Handler (WalletResponse EstimatedFees)
 estimateFees aw payment@Payment{..} = do
-    let spendingPassword = maybe mempty coerce pmtSpendingPassword
-    res <- liftIO $ (WalletLayer.estimateFees aw) spendingPassword
-                                                  (toInputGrouping pmtGroupingPolicy)
+    res <- liftIO $ (WalletLayer.estimateFees aw) (toInputGrouping pmtGroupingPolicy)
                                                   SenderPaysFee
                                                   payment
     case res of

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -1042,6 +1042,15 @@ endpoint is during API integration testing. Note also that this will fail by
 default unless the node is running in debug mode.
 |]
 
+estimateFeesDescription :: Text
+estimateFeesDescription = [text|
+Estimate the fees which would incur from the input payment. This endpoint
+**does not** require a _spending password_ to be supplied as it generates
+under the hood an unsigned transaction. Therefore, callers can simply set
+the `spendingPassword` field to `null` as that won't influence the fee
+calculation.
+|]
+
 
 --
 -- The API
@@ -1077,3 +1086,4 @@ api (compileInfo, curSoftwareVersion) walletAPI mkDescription = toSwagger wallet
   & paths %~ (POST, "/api/internal/apply-update") `setDescription` applyUpdateDescription
   & paths %~ (POST, "/api/internal/postpone-update") `setDescription` postponeUpdateDescription
   & paths %~ (DELETE, "/api/internal/reset-wallet-state") `setDescription` resetWalletStateDescription
+  & paths %~ (POST, "/api/v1/transactions/fees") `setDescription` estimateFeesDescription

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -16,7 +16,6 @@ module Cardano.Wallet.Kernel.CoinSelection.FromGeneric (
   , utxOwnedInputs
   , utxOutputs
   , utxChange
-  , utxAttributes
   , mkStdTx
   , mkStdUnsignedTx
     -- * Coin selection policies
@@ -192,24 +191,17 @@ data UnsignedTx = UnsignedTx {
     utxOwnedInputs :: NonEmpty (Core.TxIn, Core.TxOutAux)
   , utxOutputs     :: NonEmpty Core.TxOutAux
   , utxChange      :: [Core.Coin]
-  , utxAttributes  :: Core.TxAttributes
 }
 
 -- | Creates a "standard" unsigned transaction.
-mkStdUnsignedTx :: Monad m
-             => (forall a. NonEmpty a -> m (NonEmpty a))
-             -- ^ Shuffle function
-             -> NonEmpty (Core.TxIn, Core.TxOutAux)
-             -- ^ Selected inputs
-             -> NonEmpty Core.TxOutAux
-             -- ^ Selected outputs
-             -> [Core.Coin]
-             -- ^ Change coins
-             -> m UnsignedTx
-mkStdUnsignedTx shuffle inps outs change = do
-    allOuts <- shuffle outs
-    let Core.UnsafeTx{..} = CTxp.makeUnsignedAbstractTx (fmap repack inps) allOuts
-    return $ UnsignedTx inps (fmap Core.TxOutAux _txOutputs) change _txAttributes
+mkStdUnsignedTx :: NonEmpty (Core.TxIn, Core.TxOutAux)
+                -- ^ Selected inputs
+                -> NonEmpty Core.TxOutAux
+                -- ^ Selected outputs
+                -> [Core.Coin]
+                -- ^ Change coins
+                -> UnsignedTx
+mkStdUnsignedTx inps outs change = UnsignedTx inps outs change
 
 
 -- | Build a transaction

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -12,7 +12,13 @@ module Cardano.Wallet.Kernel.CoinSelection.FromGeneric (
   , newOptions
     -- * Transaction building
   , CoinSelFinalResult(..)
+  , UnsignedTx -- opaque
+  , utxOwnedInputs
+  , utxOutputs
+  , utxChange
+  , utxAttributes
   , mkStdTx
+  , mkStdUnsignedTx
     -- * Coin selection policies
   , random
   , largestFirst
@@ -178,6 +184,34 @@ feeOptions CoinSelectionOptions{..} = FeeOptions{
   Building transactions
 -------------------------------------------------------------------------------}
 
+-- | Our notion of @unsigned transaction@. Unfortunately we cannot reuse
+-- directly the 'Tx' from @Core@ as that discards the information about
+-- "ownership" of inputs, which is instead required when dealing with the
+-- Core Txp.Util API.
+data UnsignedTx = UnsignedTx {
+    utxOwnedInputs :: NonEmpty (Core.TxIn, Core.TxOutAux)
+  , utxOutputs     :: NonEmpty Core.TxOutAux
+  , utxChange      :: [Core.Coin]
+  , utxAttributes  :: Core.TxAttributes
+}
+
+-- | Creates a "standard" unsigned transaction.
+mkStdUnsignedTx :: Monad m
+             => (forall a. NonEmpty a -> m (NonEmpty a))
+             -- ^ Shuffle function
+             -> NonEmpty (Core.TxIn, Core.TxOutAux)
+             -- ^ Selected inputs
+             -> NonEmpty Core.TxOutAux
+             -- ^ Selected outputs
+             -> [Core.Coin]
+             -- ^ Change coins
+             -> m UnsignedTx
+mkStdUnsignedTx shuffle inps outs change = do
+    allOuts <- shuffle outs
+    let Core.UnsafeTx{..} = CTxp.makeUnsignedAbstractTx (fmap repack inps) allOuts
+    return $ UnsignedTx inps (fmap Core.TxOutAux _txOutputs) change _txAttributes
+
+
 -- | Build a transaction
 
 -- | Construct a standard transaction
@@ -200,11 +234,12 @@ mkStdTx :: Monad m
 mkStdTx pm shuffle hdwSigners inps outs change = do
     allOuts <- shuffle $ foldl' (flip NE.cons) outs change
     return $ CTxp.makeMPubKeyTxAddrs pm hdwSigners (fmap repack inps) allOuts
-  where
-    -- Repack a utxo-derived tuple into a format suitable for
-    -- 'TxOwnedInputs'.
-    repack :: (Core.TxIn, Core.TxOutAux) -> (Core.TxOut, Core.TxIn)
-    repack (txIn, aux) = (Core.toaOut aux, txIn)
+
+-- | Repacks a utxo-derived tuple into a format suitable for
+-- 'TxOwnedInputs'.
+repack :: (Core.TxIn, Core.TxOutAux) -> (Core.TxOut, Core.TxIn)
+repack (txIn, aux) = (Core.toaOut aux, txIn)
+
 
 {-------------------------------------------------------------------------------
   Coin selection policy top-level entry point

--- a/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -10,8 +10,9 @@ module Cardano.Wallet.Kernel.Transactions (
     , EstimateFeesError(..)
     , RedeemAdaError(..)
     , cardanoFee
-    -- * Internal & testing use only
+    -- * Internal & testing use only low-level APIs
     , newTransaction
+    , newUnsignedTransaction
     , toMeta
   ) where
 
@@ -46,7 +47,9 @@ import           Pos.Crypto (EncryptedSecretKey, PassPhrase, RedeemSecretKey,
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
                      (CoinSelFinalResult (..), CoinSelectionOptions,
-                     estimateCardanoFee, estimateMaxTxInputs, mkStdTx)
+                     UnsignedTx (utxChange, utxOutputs, utxOwnedInputs),
+                     estimateCardanoFee, estimateMaxTxInputs, mkStdTx,
+                     mkStdUnsignedTx)
 import qualified Cardano.Wallet.Kernel.CoinSelection.FromGeneric as CoinSelection
 import           Cardano.Wallet.Kernel.CoinSelection.Generic
                      (CoinSelHardErr (..))
@@ -57,8 +60,8 @@ import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Read as Getters
 import           Cardano.Wallet.Kernel.DB.TxMeta.Types
-import           Cardano.Wallet.Kernel.Internal (ActiveWallet (..),
-                     walletKeystore, walletNode)
+import           Cardano.Wallet.Kernel.Internal (ActiveWallet (..), walletNode)
+import qualified Cardano.Wallet.Kernel.Internal as Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.Pending (PartialTxMeta, newForeign,
@@ -130,24 +133,24 @@ pay :: ActiveWallet
     -- ^ The payees
     -> IO (Either PaymentError (Tx, TxMeta))
 pay activeWallet spendingPassword opts accountId payees = do
-        retrying retryPolicy shouldRetry $ \rs -> do
-            res <- newTransaction activeWallet spendingPassword opts accountId payees
-            case res of
-                 Left e      -> return (Left $ PaymentNewTransactionError e)
-                 Right (txAux, partialMeta, _utxo) -> do
-                     succeeded <- newPending activeWallet accountId txAux partialMeta
-                     case succeeded of
-                          Left e   -> do
-                              -- If the next retry would bring us to the
-                              -- end of our allowed retries, we fail with
-                              -- a proper error
-                              retriesLeft <- applyPolicy retryPolicy rs
-                              return . Left $ case retriesLeft of
-                                   Nothing ->
-                                       PaymentSubmissionMaxAttemptsReached
-                                   Just _  ->
-                                       PaymentNewPendingError e
-                          Right meta -> return $ Right (taTx $ txAux, meta)
+    retrying retryPolicy shouldRetry $ \rs -> do
+        res <- newTransaction activeWallet spendingPassword opts accountId payees
+        case res of
+             Left e      -> return (Left $ PaymentNewTransactionError e)
+             Right (txAux, partialMeta, _utxo) -> do
+                 succeeded <- newPending activeWallet accountId txAux partialMeta
+                 case succeeded of
+                      Left e   -> do
+                          -- If the next retry would bring us to the
+                          -- end of our allowed retries, we fail with
+                          -- a proper error
+                          retriesLeft <- applyPolicy retryPolicy rs
+                          return . Left $ case retriesLeft of
+                               Nothing ->
+                                   PaymentSubmissionMaxAttemptsReached
+                               Just _  ->
+                                   PaymentNewPendingError e
+                      Right meta -> return $ Right (taTx $ txAux, meta)
     where
         -- See <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter>
         retryPolicy :: RetryPolicyM IO
@@ -166,6 +169,7 @@ pay activeWallet spendingPassword opts accountId payees = do
 -- For testing purposes, if successful this additionally returns the utxo
 -- that coin selection was run against.
 newTransaction :: ActiveWallet
+               -- ^ The active wallet.
                -> PassPhrase
                -- ^ The spending password.
                -> CoinSelectionOptions
@@ -175,66 +179,40 @@ newTransaction :: ActiveWallet
                -> NonEmpty (Address, Coin)
                -- ^ The payees
                -> IO (Either NewTransactionError (TxAux, PartialTxMeta, Utxo))
-newTransaction ActiveWallet{..} spendingPassword options accountId payees = runExceptT $ do
-    initialEnv <- liftIO $ newEnvironment
-    maxTxSize  <- liftIO $ Node.getMaxTxSize (walletPassive ^. walletNode)
-    -- TODO: We should cache this maxInputs value
-    let maxInputs = estimateMaxTxInputs maxTxSize
+newTransaction aw@ActiveWallet{..} spendingPassword options accountId payees = do
+    tx <- newUnsignedTransaction aw options accountId payees
+    case tx of
+         Left e   -> return (Left e)
+         Right (db, unsignedTx, availableUtxo) -> runExceptT $ do
 
-    -- STEP 0: Get available UTxO
-    snapshot      <- liftIO $ getWalletSnapshot walletPassive
-    availableUtxo <- withExceptT NewTransactionUnknownAccount $ exceptT $
-                       currentAvailableUtxo snapshot accountId
+             -- STEP 1: Perform the signing and forge the final TxAux.
+             mbEsk <- liftIO $ Keystore.lookup
+                        (WalletIdHdRnd $ accountId ^. hdAccountIdParent)
+                        (walletPassive ^. Internal.walletKeystore)
 
-    -- STEP 1: Run coin selection.
-    CoinSelFinalResult inputs outputs coins <-
-      withExceptT NewTransactionErrorCoinSelectionFailed $ ExceptT $
-        flip runReaderT initialEnv . buildPayment $
-          CoinSelection.random options
-                               maxInputs
-                               (fmap toTxOut payees)
-                               availableUtxo
+             -- STEP 2: Generate the change addresses needed.
+             changeAddresses <- withExceptT NewTransactionErrorCreateAddressFailed $
+                                  genChangeOuts (utxChange unsignedTx)
 
-    -- STEP 2: Generate the change addresses needed.
-    changeAddresses <- withExceptT NewTransactionErrorCreateAddressFailed $
-                         genChangeOuts coins
+             let inputs      = utxOwnedInputs unsignedTx
+                 outputs     = utxOutputs unsignedTx
+                 signAddress = mkSigner spendingPassword mbEsk db
+                 mkTx        = mkStdTx walletProtocolMagic shuffleNE signAddress
 
-    -- STEP 3: Perform the signing and forge the final TxAux.
-    mbEsk <- liftIO $ Keystore.lookup
-               (WalletIdHdRnd $ accountId ^. hdAccountIdParent)
-               (walletPassive ^. walletKeystore)
-    let signAddress = mkSigner spendingPassword mbEsk snapshot
-        mkTx        = mkStdTx walletProtocolMagic shuffleNE signAddress
+             txAux <- withExceptT NewTransactionErrorSignTxFailed $ ExceptT $
+                          mkTx inputs outputs changeAddresses
 
-    txAux <- withExceptT NewTransactionErrorSignTxFailed $ ExceptT $
-               mkTx inputs outputs changeAddresses
-
-    -- STEP 4: Compute metadata
-    let txId = hash . taTx $ txAux
-    -- This is the sum of inputs coins.
-    let spentInputCoins = paymentAmount (toaOut . snd <$> inputs)
-    -- we use `getCreationTimestamp` provided by the `NodeStateAdaptor`
-    -- to compute the createdAt timestamp for `TxMeta`
-    txMetaCreatedAt_  <- liftIO $ Node.getCreationTimestamp (walletPassive ^. walletNode)
-    -- partially applied, because we don`t know here which outputs are ours
-    partialMeta <- liftIO $ createNewMeta accountId txId txMetaCreatedAt_ inputs (toaOut <$> outputs) True spentInputCoins
-    return (txAux, partialMeta, availableUtxo)
+             -- STEP 4: Compute metadata
+             let txId = hash . taTx $ txAux
+             -- This is the sum of inputs coins.
+             let spentInputCoins = paymentAmount (toaOut . snd <$> inputs)
+             -- we use `getCreationTimestamp` provided by the `NodeStateAdaptor`
+             -- to compute the createdAt timestamp for `TxMeta`
+             txMetaCreatedAt_  <- liftIO $ Node.getCreationTimestamp (walletPassive ^. walletNode)
+             -- partially applied, because we don`t know here which outputs are ours
+             partialMeta <- liftIO $ createNewMeta accountId txId txMetaCreatedAt_ inputs (toaOut <$> outputs) True spentInputCoins
+             return (txAux, partialMeta, availableUtxo)
   where
-    -- Generate an initial seed for the random generator using the hash of
-    -- the payees, which ensure that the coin selection (and the fee estimation)
-    -- is \"pseudo deterministic\" and replicable.
-    newEnvironment :: IO Env
-    newEnvironment =
-        let initialSeed = V.fromList . map fromIntegral
-                                     . B.unpack
-                                     . encodeUtf8 @Text @ByteString
-                                     . sformat build
-                                     $ hash payees
-        in Env <$> initialize initialSeed
-
-    toTxOut :: (Address, Coin) -> TxOutAux
-    toTxOut (a, c) = TxOutAux (TxOut a c)
-
     -- | Generates the list of change outputs from a list of change coins.
     genChangeOuts :: MonadIO m
                   => [Coin]
@@ -337,8 +315,6 @@ instance Arbitrary EstimateFeesError where
     arbitrary = EstFeesTxCreationFailed <$> arbitrary
 
 estimateFees :: ActiveWallet
-             -> PassPhrase
-             -- ^ The spending password.
              -> CoinSelectionOptions
              -- ^ The options describing how to tune the coin selection.
              -> HdAccountId
@@ -346,31 +322,41 @@ estimateFees :: ActiveWallet
              -> NonEmpty (Address, Coin)
              -- ^ The payees
              -> IO (Either EstimateFeesError Coin)
-estimateFees activeWallet@ActiveWallet{..} spendingPassword options accountId payees = do
-    res <- newTransaction activeWallet spendingPassword options accountId payees
+estimateFees activeWallet@ActiveWallet{..} options accountId payees = do
+    res <- newUnsignedTransaction activeWallet options accountId payees
     case res of
          Left e  -> return . Left . EstFeesTxCreationFailed $ e
-         Right (tx, _txMeta, originalUtxo) ->
-             -- calculate the fee as the difference between inputs and outputs.
+         Right (_db, tx, originalUtxo) -> do
+             let change = utxChange tx
+             -- calculate the fee as the difference between inputs and outputs. The
+             -- final 'sumOfOutputs' must be augmented by the change, which we have
+             -- available in the 'UnsignedTx' as a '[Coin]'.
+             --
              -- NOTE(adn) In case of 'SenderPaysFee' is practice there might be a slightly
              -- increase of the projected fee in the case we are forced to pick "yet another input"
              -- to be able to pay the fee, which would, in turn, also increase the fee due to
              -- the extra input being picked.
              return $ Right
-                    $ sumOfInputs tx originalUtxo `unsafeSubCoin` sumOfOutputs tx
+                    $ sumOfInputs tx originalUtxo
+                    `unsafeSubCoin`
+                    (repeatedly Core.unsafeAddCoin change (sumOfOutputs tx))
   where
-      -- Unlike a block, a /single transaction/ cannot have inputs that sum to
-      -- more than maxCoinVal
-      sumOfInputs :: TxAux -> Utxo -> Coin
-      sumOfInputs tx utxo =
-          let inputs = Set.fromList $ toList . _txInputs . taTx $ tx
-          in unsafeIntegerToCoin $
-               utxoBalance (utxo `utxoRestrictToInputs` inputs)
+    -- Tribute to @edsko
+    repeatedly :: (a -> b -> b) -> ([a] -> b -> b)
+    repeatedly = flip . foldl' . flip
 
-      sumOfOutputs :: TxAux -> Coin
-      sumOfOutputs tx =
-          let outputs = _txOutputs . taTx $ tx
-          in paymentAmount outputs
+    -- Unlike a block, a /single transaction/ cannot have inputs that sum to
+    -- more than maxCoinVal
+    sumOfInputs :: UnsignedTx -> Utxo -> Coin
+    sumOfInputs tx utxo =
+        let inputs = Set.fromList $ map fst . toList . utxOwnedInputs $ tx
+        in unsafeIntegerToCoin $
+             utxoBalance (utxo `utxoRestrictToInputs` inputs)
+
+    sumOfOutputs :: UnsignedTx -> Coin
+    sumOfOutputs tx =
+        let outputs = map toaOut $ utxOutputs tx
+        in paymentAmount outputs
 
 -- | Errors during transaction signing
 --
@@ -542,3 +528,67 @@ redeemAda w@ActiveWallet{..} accId pw rsk = runExceptT $ do
         isOutput (inp, TxOutAux (TxOut addr coin)) = do
             guard $ addr == redeemAddr
             return (inp, coin)
+
+{-----------------------------------------------------------------------------
+  Creating unsigned tranasctions
+------------------------------------------------------------------------------}
+
+-- | Creates a new unsigned 'Tx', without submitting it to the network. Please
+-- note that this is a low-level API. Considering using 'pay' and 'estimateFee'
+-- in user's code.
+--
+-- For testing purposes, if successful this additionally returns the utxo
+-- that coin selection was run against.
+newUnsignedTransaction :: ActiveWallet
+                       -- ^ An Active wallet.
+                       -> CoinSelectionOptions
+                       -- ^ The options describing how to tune the coin selection.
+                       -> HdAccountId
+                       -- ^ The source HD account from where the payment should originate
+                       -> NonEmpty (Address, Coin)
+                       -- ^ The payees
+                       -> IO (Either NewTransactionError (DB, UnsignedTx, Utxo))
+                       -- ^ Returns the state of the world (i.e. the DB snapshot)
+                       -- at the time of the coin selection, so that it can later
+                       -- on be used to sign the addresses.
+newUnsignedTransaction ActiveWallet{..} options accountId payees = runExceptT $ do
+    snapshot <- liftIO $ getWalletSnapshot walletPassive
+    initialEnv <- liftIO $ newEnvironment
+    maxTxSize  <- liftIO $ Node.getMaxTxSize (walletPassive ^. walletNode)
+    -- TODO: We should cache this maxInputs value
+    let maxInputs = estimateMaxTxInputs maxTxSize
+
+    -- STEP 0: Get available UTxO
+    availableUtxo <- withExceptT NewTransactionUnknownAccount $ exceptT $
+                       currentAvailableUtxo snapshot accountId
+
+    -- STEP 1: Run coin selection.
+    CoinSelFinalResult inputs outputs coins <-
+      withExceptT NewTransactionErrorCoinSelectionFailed $ ExceptT $
+        flip runReaderT initialEnv . buildPayment $
+          CoinSelection.random options
+                               maxInputs
+                               (fmap toTxOut payees)
+                               availableUtxo
+
+    -- STEP 2: Assemble the unsigned transactions, @without@ generating the
+    -- change addresses, as that would require the spending password.
+
+    tx <- liftIO $ mkStdUnsignedTx shuffleNE inputs outputs coins
+    return (snapshot, tx, availableUtxo)
+  where
+    -- Generate an initial seed for the random generator using the hash of
+    -- the payees, which ensure that the coin selection (and the fee estimation)
+    -- is \"pseudo deterministic\" and replicable.
+    newEnvironment :: IO Env
+    newEnvironment =
+        let initialSeed = V.fromList . map fromIntegral
+                                     . B.unpack
+                                     . encodeUtf8 @Text @ByteString
+                                     . sformat build
+                                     $ hash payees
+        in Env <$> initialize initialSeed
+
+    toTxOut :: (Address, Coin) -> TxOutAux
+    toTxOut (a, c) = TxOutAux (TxOut a c)
+

--- a/wallet-new/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer.hs
@@ -477,9 +477,7 @@ data ActiveWalletLayer m = ActiveWalletLayer {
           -> m (Either NewPaymentError (Tx, TxMeta))
 
       -- | Estimates the fees for a payment.
-    , estimateFees :: PassPhrase
-                   -- The \"spending password\" to decrypt the 'EncryptedSecretKey'.
-                   -> InputGrouping
+    , estimateFees :: InputGrouping
                    -- An preference on how to group inputs during coin selection
                    -> ExpenseRegulation
                    -- Who pays the fee, if the sender or the receivers.

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
@@ -48,19 +48,18 @@ pay activeWallet pw grouping regulation payment = liftIO $ do
 -- | Estimates the fees for a payment.
 estimateFees :: MonadIO m
              => Kernel.ActiveWallet
-             -> PassPhrase
              -> InputGrouping
              -> ExpenseRegulation
              -> V1.Payment
              -> m (Either EstimateFeesError Coin)
-estimateFees activeWallet pw grouping regulation payment = liftIO $ do
+estimateFees activeWallet grouping regulation payment = liftIO $ do
     policy <- Node.getFeePolicy (Kernel.walletPassive activeWallet ^. Kernel.walletNode)
     limitExecutionTimeTo (60 :: Second) EstimateFeesTimeLimitReached $ do
       runExceptT $ do
         (opts, accId, payees) <- withExceptT EstimateFeesWalletIdDecodingFailed $
                                    setupPayment policy grouping regulation payment
         withExceptT EstimateFeesError $ ExceptT $
-          Kernel.estimateFees activeWallet pw opts accId payees
+          Kernel.estimateFees activeWallet opts accId payees
 
 -- | Redeem an Ada voucher
 --

--- a/wallet-new/test/unit/Test/Spec/NewPayment.hs
+++ b/wallet-new/test/unit/Test/Spec/NewPayment.hs
@@ -317,6 +317,6 @@ spec = describe "NewPayment" $ do
                     withPayment (InitialADA 1000) (PayADA 1) $ \activeLayer newPayment -> do
                         -- mangle the spending password to be something arbitrary, check
                         -- that this doesn't hinder our ability to estimate fees.
-                        let pmt = newPayment { V1.pmtSpendingPassword = Just randomPass }
+                        let pmt = newPayment { V1.pmtSpendingPassword = randomPass }
                         res <- liftIO (runExceptT . runHandler' $ Handlers.estimateFees activeLayer pmt)
                         liftIO ((bimap identity STB res) `shouldSatisfy` isRight)

--- a/wallet-new/test/unit/Test/Spec/NewPayment.hs
+++ b/wallet-new/test/unit/Test/Spec/NewPayment.hs
@@ -233,8 +233,7 @@ spec = describe "NewPayment" $ do
             prop "estimating fees works (SenderPaysFee)" $ withMaxSuccess 50 $ do
                 monadicIO $
                     withPayment (InitialADA 10000) (PayLovelace 10) $ \activeLayer newPayment -> do
-                        res <- liftIO ((WalletLayer.estimateFees activeLayer) mempty
-                                                                              IgnoreGrouping
+                        res <- liftIO ((WalletLayer.estimateFees activeLayer) IgnoreGrouping
                                                                               SenderPaysFee
                                                                               newPayment
                                       )
@@ -254,7 +253,6 @@ spec = describe "NewPayment" $ do
                         let (AccountIdHdRnd hdAccountId) = fixtureAccountId
 
                         res <- liftIO (Kernel.estimateFees aw
-                                                           mempty
                                                            opts
                                                            hdAccountId
                                                            fixturePayees
@@ -274,7 +272,6 @@ spec = describe "NewPayment" $ do
                         let (AccountIdHdRnd hdAccountId) = fixtureAccountId
 
                         res <- liftIO (Kernel.estimateFees aw
-                                                           mempty
                                                            opts
                                                            hdAccountId
                                                            fixturePayees
@@ -295,7 +292,6 @@ spec = describe "NewPayment" $ do
                         let (AccountIdHdRnd hdAccountId) = fixtureAccountId
 
                         res <- liftIO (Kernel.estimateFees aw
-                                                           mempty
                                                            opts
                                                            hdAccountId
                                                            fixturePayees


### PR DESCRIPTION
## Description

This PR relax a constraint we had in the previous implemention of `Kernel.estimateFee` where the spending password was needed. The reason was that we did piggyback on the `Kernel.newTransaction` low level API to first generate a new `TxAux` and then compute the fee as the difference between the `balance(inputs) - balance(outputs)`. But this meant we did need a `spendingPassword` in order to a) generate the change addresses and b) sign the addresses for the `TxWitnesses`.

This PR reshuffles the internals by creating another low-level API called `newUnsignedTransaction` (which hopefully will be also useful to @denisshevchenko or adaptable to his use case with minimal modifications) which computes an _unsigned_ transaction and uses that for the estimation of the fees.

This resolves the issue where otherwise Daedalus would have had to modify the UI by adding the spending password form all over the place, making the user experience significantly worse.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-440

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)

<img width="931" alt="screen shot 2018-09-20 at 12 18 34" src="https://user-images.githubusercontent.com/29383371/45812406-04875e80-bcd0-11e8-9bc5-2cf5b677d3d2.png">

