### PR TITLE
[CBR-415] Fix a race condition when stopping restoration threads

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
@@ -63,8 +63,9 @@ data WalletRestorationInfo = WalletRestorationInfo
      -- it is finished and the wallet is up-to-date.
   , _wriThroughput  :: MeasuredIn 'BlocksPerSecond BlockCount
     -- ^ Speed of restoration.
-  , _wriCancel      :: IO ()
+  , _wriCancel      :: IO Bool
     -- ^ The action that can be used to cancel the restoration task.
+    -- This may fail, so we return a Bool.
   }
 
 {-------------------------------------------------------------------------------

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Internal.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Internal.hs
@@ -90,7 +90,7 @@ resetWalletState w = liftIO $ do
     -- stop restoration and empty it`s state.
     -- TODO: A restoration may start between this call and the db modification
     -- but as this is for testing only we keep it that way for now. (CBR-415)
-    Restore.stopAllRestorations w
+    _ <- Restore.stopAllRestorations w
 
     -- This pauses any effect the Submission worker can have.
     -- We don`t actually stop and restart the thread, but once


### PR DESCRIPTION
When we call the stop function for a restoration thread it may fail, because the cancel function with the real effect has not been updated yet. This means that a thread may fail to stop, while its state is cleaned. I am not sure how catastrophic this can be: the thread may just die the next time it tries to lookup its state. This pr tries to make it impossible to ever have a restoration thread, without its state, when using the resetWallet endpoint.

## Description
https://iohk.myjetbrains.com/youtrack/issue/CBR-415 (partially)

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
