### PR TITLE
[CBR-97] logging configuration for Daedalus with structured logging

### DIFF
--- a/log-configs/daedalus.yaml
+++ b/log-configs/daedalus.yaml
@@ -2,10 +2,17 @@
 
 rotation:
     logLimit: 5242880 # 5MB
-    keepFiles: 20
+    keepFiles: 10
 loggerTree:
-  severity: Debug+
-  syncWalletWorker: Error+
+  severity: Info+
+  cardano-sl.syncWalletWorker: Error+
   files:
-    - pub/node.pub
     - node
+
+  handlers:
+    - { name: "JSON"
+      , filepath: "pub/node.json"
+      , logsafety: PublicLogLevel
+      , severity: Info
+      , backend: FileJsonBE }
+


### PR DESCRIPTION
## Description

Daedalus now expects the node's public log files in `$log_prefix/pub` in JSON format.

this is a prerequisite for end-to-end tests

## Linked issue

CBR-97
DDW-413

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [~] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps

end-to-end test with log submission to ReportServer