### PR TITLE
[DEVOPS-1059] Build and cache the nix-shell environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -219,6 +219,8 @@ let
       };
     in localLib.forEnvironments mkTest;
 
+    shell = import ./shell.nix { inherit system config pkgs cardanoPkgs; };
+
     cardano-sl-config = pkgs.runCommand "cardano-sl-config" {} ''
       mkdir -p $out/lib
       cp -R ${./log-configs} $out/log-configs

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ let
     buildInputs = [ iohkPkgs.stylish-haskell git ];
     shellHook = ''
       git diff > pre-stylish.diff
-      find . -type f -name "*hs" -not -path '.git' -not -path '*.stack-work*' -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
+      find . -type f -not -path '.git' -not -path '*.stack-work*' -name "*.hs" -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
       git diff > post-stylish.diff
       diff pre-stylish.diff post-stylish.diff > /dev/null
       if [ $? != 0 ]

--- a/shell.nix
+++ b/shell.nix
@@ -12,29 +12,31 @@ in
 { system ? builtins.currentSystem
 , config ? {}
 , pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; overlays = [ jemallocOverlay ]; })
+, cardanoPkgs ? import ./. {inherit config system pkgs; }
 }:
 with pkgs;
 let
   hsPkgs = haskell.packages.ghc822;
-  iohkPkgs = import ./. {inherit config system pkgs; };
   cardanoSL = haskell.lib.buildStackProject {
-     name = "cardano-sl";
+     name = "cardano-sl-env";
      ghc = hsPkgs.ghc;
      buildInputs = [
        zlib openssh autoreconfHook openssl
        gmp rocksdb git bsdiff ncurses
        hsPkgs.happy hsPkgs.cpphs lzma
        perl bash
-       iohkPkgs.stylish-haskell
+       cardanoPkgs.stylish-haskell
        hlint
      # cabal-install and stack pull in lots of dependencies on OSX so skip them
      # See https://github.com/NixOS/nixpkgs/issues/21200
      ] ++ (lib.optionals stdenv.isLinux [ cabal-install stack ])
        ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
+    phases = ["nobuildPhase"];
+    nobuildPhase = "mkdir -p $out";
   };
   fixStylishHaskell = stdenv.mkDerivation {
     name = "fix-stylish-haskell";
-    buildInputs = [ iohkPkgs.stylish-haskell git ];
+    buildInputs = [ cardanoPkgs.stylish-haskell git ];
     shellHook = ''
       git diff > pre-stylish.diff
       find . -type f -not -path '.git' -not -path '*.stack-work*' -name "*.hs" -not -name 'HLint.hs' -exec stylish-haskell -i {} \;


### PR DESCRIPTION
## Description

If you checkout the develop branch of cardano-sl and type nix-shell, it will start building packages, e.g. stack and cabal-install (!), rather than downloading them from a binary cache.

Continued from #3627.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1059

## Type of change

- [x] Build and dev environment

## Tests

1. `nix-shell`
2. `nix-build release.nix -A shell.x86_64-linux`
