### PR TITLE
[release/1.3.1] [DEVOPS-998] Bump applicationVersion

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14781,7 +14781,7 @@ mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 9
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14791,7 +14791,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 9
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14801,7 +14801,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 9
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14916,7 +14916,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14926,7 +14926,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14936,7 +14936,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 14
+    applicationVersion: 15
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14874,7 +14874,7 @@ testnet_wallet: &testnet_wallet
     applicationVersion: 0
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 1
+      bvMinor: 0
       bvAlt: 0
 
 testnet_wallet_win64: &testnet_wallet_win64


### PR DESCRIPTION
## Description

Bump the applicationVersion for mainnet and staging which is used by the update system for the wallets.

## Linked issue

https://iohk.myjetbrains.com/youtrack/v2/issue/DEVOPS-998

## Type of change
- Configuration change
