### PR TITLE
[DEVOPS-1045] pkgs/generate.sh: Fix purity of script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,11 +72,11 @@ scripts/haskell/dependencies.hi
 scripts/haskell/dependencies.o
 scripts/haskell/dependencies
 
-# 'pkgs/stack2nix' is a symlink into the nix store, it can safely be ignored
-pkgs/stack2nix
+# Cache for pkgs/generate.sh
+/pkgs/.cabal/
+/pkgs/.stack/
 # in case generate.sh clones nixpkgs in here
 nixpkgs
-pkgs/result
 
 # explorer
 explorer-node.log.*

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -5,4 +5,4 @@
 
 set -euo pipefail
 cd "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
-exec $(nix-build --no-out-link regen.nix) "$@"
+exec "$(nix-build --no-out-link regen.nix)" "$@"

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -1,39 +1,8 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash cabal2nix stack cabal-install ghc
+#!/usr/bin/env bash
 
 # Regenerate the `pkgs/default.nix` file based on the current
 # contents of cardano-sl.cabal and stack.yaml, with a hackage snapshot.
 
-# Update this if you need a package version recently uploaded to hackage.
-# Any timestamp works.
-hackageSnapshot="2018-07-17T09:58:14Z"
-
-function runInShell {
-  local inputs="$1"
-  shift
-  nix-shell -j 4 -E "with import (import $scriptDir/../fetch-nixpkgs.nix) {}; runCommand \"shell\" { buildInputs = [ $inputs ]; } \"\"" --run "LANG=en_US.utf-8 NIX_REMOTE=$NIX_REMOTE $*"
-}
-
-set -xe
-set -v
-
-# Ensure that nix 1.11 (used by cabal2nix) works in multi-user mode.
-if [ ! -w /nix/store ]; then
-    export NIX_REMOTE=${NIX_REMOTE:-daemon}
-fi
-
-# Get relative path to script directory
-scriptDir="$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
-
-echo "Using hackage snapshot from ${hackageSnapshot}"
-
-pushd "${scriptDir}"
-
-  # https://github.com/NixOS/cabal2nix/issues/146
-  runInShell "cabal2nix glibcLocales" cabal2nix --system x86_64-darwin --revision 25a53d417d7c7a8fc3116b63e3ba14ca7c8f188f \
-     https://github.com/luite/hfsevents.git > hfsevents.nix
-
-  # Generate cardano-sl package set
-  runInShell "cabal2nix glibcLocales" "$(nix-build -A stack2nix --no-out-link -Q ../)/bin/stack2nix" --platform x86_64-linux --hackage-snapshot "${hackageSnapshot}" -j8 --test --bench --no-indent ./.. > default.nix.new
-  mv default.nix.new default.nix
-popd
+set -euo pipefail
+cd "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")"
+exec $(nix-build --no-out-link regen.nix) "$@"

--- a/pkgs/regen.nix
+++ b/pkgs/regen.nix
@@ -1,0 +1,53 @@
+let
+  localLib = import ../lib.nix;
+  jemallocOverlay = self: super: {
+    # jemalloc has a bug that caused cardano-sl-db to fail to link (via
+    # rocksdb, which can use jemalloc).
+    # https://github.com/jemalloc/jemalloc/issues/937
+    # Using jemalloc 510 with the --disable-initial-exec-tls flag seems to
+    # fix it.
+    jemalloc = self.callPackage ../nix/jemalloc/jemalloc510.nix {};
+  };
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; overlays = [ jemallocOverlay ]; })
+
+# Update this if you need a package version recently uploaded to hackage.
+# Any timestamp works.
+, hackageSnapshot ? "2018-07-17T09:58:14Z"
+}:
+
+with pkgs;
+
+let
+  iohkPkgs = import ../. { inherit system config pkgs; };
+  deps = [ nixStable coreutils git findutils cabal2nix glibcLocales stack cabal-install iohkPkgs.stack2nix ];
+in
+  writeScript "generate.sh" ''
+    #!${stdenv.shell}
+    set -euo pipefail
+    export PATH=${lib.makeBinPath deps}
+    export HOME=$(pwd)
+
+    echo "Using hackage snapshot from ${hackageSnapshot}"
+
+    # Ensure that nix 1.11 (used by cabal2nix) works in multi-user mode.
+    if [ ! -w /nix/store ]; then
+        export NIX_REMOTE=''${NIX_REMOTE:-daemon}
+    fi
+
+    function cleanup {
+      rm -rf hfsevents.nix.new default.nix.new
+    }
+    trap cleanup EXIT
+
+    # https://github.com/NixOS/cabal2nix/issues/146
+    cabal2nix --system x86_64-darwin --revision 25a53d417d7c7a8fc3116b63e3ba14ca7c8f188f \
+      https://github.com/luite/hfsevents.git > hfsevents.nix.new
+    mv hfsevents.nix.new hfsevents.nix
+
+    # Generate cardano-sl package set
+    stack2nix --platform x86_64-linux --hackage-snapshot "${hackageSnapshot}" -j8 --test --bench --no-indent ./.. > default.nix.new
+    mv default.nix.new default.nix
+  ''

--- a/pkgs/regen.nix
+++ b/pkgs/regen.nix
@@ -1,17 +1,7 @@
-let
-  localLib = import ../lib.nix;
-  jemallocOverlay = self: super: {
-    # jemalloc has a bug that caused cardano-sl-db to fail to link (via
-    # rocksdb, which can use jemalloc).
-    # https://github.com/jemalloc/jemalloc/issues/937
-    # Using jemalloc 510 with the --disable-initial-exec-tls flag seems to
-    # fix it.
-    jemalloc = self.callPackage ../nix/jemalloc/jemalloc510.nix {};
-  };
-in
 { system ? builtins.currentSystem
 , config ? {}
-, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; overlays = [ jemallocOverlay ]; })
+, iohkPkgs ? import ../. { inherit config system; }
+, pkgs ? iohkPkgs.pkgs
 
 # Update this if you need a package version recently uploaded to hackage.
 # Any timestamp works.
@@ -21,7 +11,6 @@ in
 with pkgs;
 
 let
-  iohkPkgs = import ../. { inherit system config pkgs; };
   deps = [ nixStable coreutils git findutils cabal2nix glibcLocales stack cabal-install iohkPkgs.stack2nix ];
 in
   writeScript "generate.sh" ''

--- a/scripts/check-stack2nix.sh
+++ b/scripts/check-stack2nix.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p git bash
+#!nix-shell -i bash -p git bash nixStable
 
 # check and warn if `pkgs/default.nix` is out of date
 
@@ -20,8 +20,6 @@ fail_stack2nix_check() {
 # Get relative path to script directory
 scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 
-# shellcheck source=/dev/null
-source "${scriptDir}/../pkgs/generate.sh"
-
+"${scriptDir}/../pkgs/generate.sh"
 
 git diff -w --text --exit-code || fail_stack2nix_check


### PR DESCRIPTION
## Description

It was returning different results on Buildkite compared to when run locally.

## Linked issue

https://iohk.myjetbrains.com/youtrack/v2/issue/DEVOPS-1045

## Type of change
- Bug fix for build scripts and dev environment

## QA Steps

```
./pkgs/generate.sh
git diff  # there should be no difference
```
