### PR TITLE
[CO-399] Correct transactions spec for new data layer and adopting po…

### DIFF
--- a/wallet-new/integration/AccountSpecs.hs
+++ b/wallet-new/integration/AccountSpecs.hs
@@ -8,8 +8,6 @@ import           Universum
 
 import           Cardano.Wallet.API.Indices (accessIx)
 import           Cardano.Wallet.Client.Http
-import           Control.Concurrent (threadDelay)
-import           Control.Concurrent.Async (race)
 import           Control.Lens
 import qualified Data.Text as T
 import           Functions (randomTest)
@@ -20,7 +18,6 @@ import           Test.QuickCheck.Monadic (pick, run)
 
 import           Util
 
-import qualified Pos.Chain.Txp as Txp
 import qualified Pos.Core as Core
 import qualified Prelude
 
@@ -107,13 +104,13 @@ accountSpecs wRef wc =
                     }
             amounts <- pick $ shuffle [1..5]
 
-            let addrAndAmount = zip (map (\(addr : _) -> addr) $ map accAddresses accs) amounts
+            let addrAmountAcct = zip3 (map (\(addr : _) -> addr) $ map accAddresses accs) amounts accs
 
-            etxnsResp <- forM addrAndAmount $ \(addr, amount) -> do
-                -- we have to wait until the previous transaction is accommodated in the blockchain
-                liftIO $ threadDelay 120000000
-                run $ postTransaction wc (payment amount addr)
-
+            etxnsResp <- run $ forM addrAmountAcct $ \(addr, amount, acct) -> do
+                etxn <- postTransaction wc (payment amount addr)
+                txn  <- fmap wrData etxn `shouldPrism` _Right
+                pollTransactions wc (walId wallet) (accIndex acct) (txId txn)
+                return etxn
 
             accUpdatedResp' <- run $ getAccounts wc (walId wallet)
             accsUpdated <- run $ wrData <$> accUpdatedResp' `shouldPrism` _Right
@@ -177,8 +174,7 @@ accountSpecs wRef wc =
             txn <- run $ fmap wrData etxn `shouldPrism` _Right
 
             --checking if redemption give rise to transaction indexing
-            let poll = pollTransactions walId (accIndex newAcct) (txId txn)
-            run $ ("waiting for Tx to be accepted", poll) `noLongerThan` (120 * oneSecond)
+            run $ pollTransactions wc walId (accIndex newAcct) (txId txn)
 
             --balance for the previously zero-balance account should increase by 100000
             balancePartialResp <- run $ getAccountBalance wc walId (accIndex newAcct)
@@ -194,26 +190,6 @@ accountSpecs wRef wc =
                 `shouldBe`
                     ClientWalletError TxRedemptionDepleted
   where
-    pollTransactions :: WalletId -> AccountIndex -> V1 Txp.TxId -> IO ()
-    pollTransactions wid cid tid = do
-        resp <- getTransactionIndex wc (Just wid) (Just cid) Nothing
-            >>= shouldPrismFlipped _Right
-        let Just tx = find ((== tid) . txId) (wrData resp)
-        if (txStatus tx `elem` [InNewestBlocks, Persisted]) then
-            return ()
-        else
-            threadDelay oneSecond >> pollTransactions wid cid tid
-
-    oneSecond :: Int
-    oneSecond = 1000000
-
-    noLongerThan :: (String, IO a) -> Int -> IO a
-    noLongerThan (msg, action) maxWaitingTime = do
-        res <- race (threadDelay maxWaitingTime) action
-        case res of
-            Left _  -> fail ("Waiting too long for action: " <> msg)
-            Right a -> return a
-
     filterByAddress :: WalletAddress -> FilterOperations '[V1 Address] WalletAddress
     filterByAddress addr =
         FilterOp (FilterByIndex $ accessIx @_ @(V1 Core.Address) addr) NoFilters


### PR DESCRIPTION
…lling everywhere to shorten whole run

## Description

There were a number of issues to be solved:
1. After postTransaction (so using Transaction.pay) and taking response with the transaction value I have to add delay in order to see this transaction value using WalletLayer.getTransactions. 
2. In old data layer when trying to send money from asset-locked address resulted in an entry of transaction with txConfirmations=0 when invoking WalletLayer.getTransactions. Now I do not see the corresponding entry when invoking WalletLayer.getTransactions in such a case (ie., no corresponding transaction value = [] )
3. utxoStatistics is done for already used wallet and needs to be done for the fresh one

In new data layer when the Tx is submitted the recepient does not see it immediately afterwards. It has to wait to see it once Tx is verified later. `getTransactions Nothing Nothing Nothing` allows to investigate transaction upon submitting, while `getTransactions (Just walletId) (Just AccountId) Nothing` allows to query transactions as seen from the perspective of payee/payer. 

The corresponding changes to Transactions spec were applied in this PR to take the above paradigm into consideration.

Moreover, in order to shorten whole time of integration tests polling mechanism was adopted. Considerable time shortening is experienced as a consequence (>5x)

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-399

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
```
nix-build -A walletIntegrationTests -o launch_integration_tests
./launch_integration_tests
```

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
