### PR TITLE
[DEVOPS-949] nix: Support building from git worktrees

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -92,4 +92,6 @@ in lib // (rec {
   in pkgs.runCommand name env ''
     ${builtBinary}/bin/$name
   '';
+
+  commitIdFromGitRepo = import ./nix/commit-id.nix { inherit lib; };
 })

--- a/nix/commit-id.nix
+++ b/nix/commit-id.nix
@@ -1,0 +1,60 @@
+# Get the commit id of a git repo
+# Example: commitIdFromGitRepo ./.git
+#
+# This is an improved version of the one from <nixpkgs/lib/sources.nix>
+# with support for git worktrees.
+
+{ lib }:
+with builtins;
+
+let
+  readCommitFromFile = path: file:
+    let fileName       = toString path + "/" + file;
+        packedRefsName = toString path + "/packed-refs";
+    in if lib.pathExists fileName
+       then readCommitFromRefFile path fileName
+       # Sometimes, the file isn't there at all and has been packed away in the
+       # packed-refs file, so we have to grep through it:
+       else if lib.pathExists packedRefsName
+         then readCommitFromPackedRefsFile path packedRefsName
+         else throw ("Not a .git directory: " + path);
+
+  readCommitFromRefFile = path: fileName:
+    let fileContent = lib.fileContents fileName;
+        # Sometimes git stores the commitId directly in the file but
+        # sometimes it stores something like: «ref: refs/heads/branch-name»
+        matchRef    = match "^ref: (.*)$" fileContent;
+    in if   isNull matchRef
+       then fileContent
+       else readCommitFromFile path (lib.head matchRef);
+
+  readCommitFromPackedRefsFile = path: packedRefsName:
+    let fileContent = readFile packedRefsName;
+        matchRef    = match (".*\n([^\n ]*) " + file + "\n.*") fileContent;
+    in if   isNull matchRef
+       then throw ("Could not find " + file + " in " + packedRefsName)
+       else lib.head matchRef;
+
+  # Inside a worktree gitdir there is a pointer to the common gitdir
+  # and a symbolic reference to the worktree branch.
+  readCommitFromGitDir = path: gitDir:
+    let
+      commonDir = lib.fileContents (gitDir + "/commondir");
+      refFile = gitDir + "/HEAD";
+    in
+      readCommitFromRefFile (gitDir + "/" + commonDir) refFile;
+
+  # .git may be a file containing a pointer to the worktree
+  readCommitFromWorkTreeFile = path: 
+    let
+      fileContent = readFile path;
+      matchGitDir = match ("^gitdir:[ \t]*([^\n]*).*") fileContent;
+    in if isNull matchGitDir
+      then throw ("Not a .git directory: " + path)
+      else readCommitFromGitDir path (lib.head matchGitDir);
+
+in
+  path:
+    if lib.pathType path == "regular"
+      then readCommitFromWorkTreeFile path
+      else readCommitFromFile path "HEAD"


### PR DESCRIPTION
## Description

Previously it would fail to get the gitrev value:

    error: illegal name: '.git'
    (use '--show-trace' to show detailed location information)

You would have to supply a `--argstr gitrev NNN` manually to get it to work.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-949

## Type of change
- Bug fix to build system and dev environment.

## QA Steps

```
git checkout develop
git worktree add ../csl/devops-949 devops-949-nix-git-worktree
cd ../csl/devops-949
nix-build -A cardano-sl-wallet-new-static
./result/bin/cardano-node --version
```
