### PR TITLE
[CBR-452] Restoration stuck at completed

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
@@ -177,8 +177,8 @@ addOrReplaceRestoration pw wId restoreInfo =
 removeRestoration :: PassiveWallet -> WalletId -> IO ()
 removeRestoration pw wId = do
     wri <- lookupRestorationInfo pw wId
-    whenJust wri cancelRestoration
     modifyMVar_ (pw ^. walletRestorationTask . to _wrt) (pure . Map.delete wId)
+    whenJust wri cancelRestoration
 
 currentRestorations :: PassiveWallet -> IO (Map WalletId WalletRestorationInfo)
 currentRestorations pw = readMVar (pw ^. walletRestorationTask . to _wrt)


### PR DESCRIPTION
## Description

`beginRestoration` runs `restoreWalletHistoryAsync` on the same thread used in the definition of `_wriCancel`:

```haskell
beginRestoration
       ...
        restoreTask <- async $
        catch (restoreWalletHistoryAsync ...)
              \e ::SomeException -> ...

    theTask <- newMVar restoreTask
    addOrReplaceRestoration pw wId $ WalletRestorationInfo
       { ...
       , _wriCancel   = readMVar theTask >>= cancel
       }
```

In `restoreWalletHistoryAsync` we call `finish` when the restoration is complete, which in 
turn calls `removeRestoration`. 

Since `_wriCancel` kills the thread that runs 

```
 restoreWalletHistoryAsync -> finish -> removeRestoration
```

we need to cancel only after removing the restoration task: 

```haskell
removeRestoration :: PassiveWallet -> WalletId -> IO ()
removeRestoration pw wId = do
    wri <- lookupRestorationInfo pw wId
    -- bug:
    whenJust wri cancelRestoration
    modifyMVar_ (pw ^. walletRestorationTask . to _wrt) (pure . Map.delete wId)
    -- fix
    modifyMVar_ (pw ^. walletRestorationTask . to _wrt) (pure . Map.delete wId)
    whenJust wri cancelRestoration

cancelRestoration = _wriCancel
```

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-452

## Type of change
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)

## QA Steps

Test that Daedelus completes restoration and no longer stays stuck at "100% (0 seconds left)"
