### PR TITLE
[CO-409] Fix `withConfigurations` usage of `WithLogger` ==> Allow pure logger to be used.

### DIFF
--- a/generator/app/VerificationBench.hs
+++ b/generator/app/VerificationBench.hs
@@ -38,7 +38,7 @@ import           Pos.Generator.Block (BlockGenParams (..), TxGenParams (..),
                      genBlocks)
 import           Pos.Launcher.Configuration (ConfigurationOptions (..),
                      HasConfigurations, defaultConfigurationOptions,
-                     withConfigurationsM)
+                     withConfigurations)
 import           Pos.Util.CompileInfo (withCompileInfo)
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration)
 import           Pos.Util.Util (realTime)
@@ -183,7 +183,7 @@ readBlocks path = do
 
 main :: IO ()
 main = do
-    setupLogging "generator" loggerConfig
+    setupLogging "verification-bench" loggerConfig
     args <- Opts.execParser
         $ Opts.info
             (benchArgsParser <**> Opts.helper)
@@ -198,7 +198,7 @@ main = do
             , cfoSystemStart = Just (Timestamp startTime)
             }
     withCompileInfo $
-        withConfigurationsM "verification-bench" Nothing Nothing False cfo $ \ !genesisConfig !_ !txpConfig !_ -> do
+        withConfigurations Nothing Nothing False cfo $ \ !genesisConfig !_ !txpConfig !_ -> do
             let genesisConfig' = genesisConfig
                     { configProtocolConstants =
                         (configProtocolConstants genesisConfig) { pcK = baK args }

--- a/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
+++ b/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
@@ -38,9 +38,11 @@ import           Pos.Generator.Block (BlockGenParams (..), TxGenParams (..),
                      genBlockNoApply, genBlocks, mkBlockGenContext)
 import           Pos.Launcher.Configuration (ConfigurationOptions (..),
                      HasConfigurations, defaultConfigurationOptions,
-                     withConfigurationsM)
+                     withConfigurations)
 import           Pos.Util.CompileInfo (withCompileInfo)
+import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration)
 import           Pos.Util.Util (realTime)
+import           Pos.Util.Wlog (Severity (Debug), setupLogging)
 
 import           Test.Pos.Block.Logic.Emulation (runEmulation, sudoLiftIO)
 import           Test.Pos.Block.Logic.Mode (BlockTestContext, BlockTestMode,
@@ -220,6 +222,8 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp = env (runBlockTestMode gen
 
 runBenchmark :: IO ()
 runBenchmark = do
+    let loggerConfig = defaultInteractiveConfiguration Debug
+    setupLogging "verifyBenchmark" loggerConfig
     startTime <- realTime
     let cfo = defaultConfigurationOptions
             { cfoFilePath = "../lib/configuration.yaml"
@@ -227,7 +231,7 @@ runBenchmark = do
             , cfoSystemStart = Just (Timestamp startTime)
             }
     withCompileInfo
-        $ withConfigurationsM "verifyBenchmark" Nothing Nothing False cfo
+        $ withConfigurations Nothing Nothing False cfo
         $ \genesisConfig _ txpConfig _ -> do
             let tp = TestParams
                     { _tpStartTime = Timestamp (convertUnit startTime)

--- a/lib/test/Test/Pos/Launcher/ConfigurationSpec.hs
+++ b/lib/test/Test/Pos/Launcher/ConfigurationSpec.hs
@@ -9,15 +9,15 @@ import           Test.Hspec (Spec, describe, it, shouldSatisfy)
 
 import           Pos.Core.Slotting (Timestamp (..))
 import           Pos.Launcher.Configuration (ConfigurationOptions (..),
-                     defaultConfigurationOptions, withConfigurationsM)
+                     defaultConfigurationOptions, withConfigurations)
 import           Pos.Util.Config (ConfigurationException)
 import           Pos.Util.Wlog (setupTestLogging)
 
 spec :: Spec
 spec = describe "Pos.Launcher.Configuration" $ do
-    describe "withConfigurationsM" $ do
+    describe "withConfigurations" $ do
         it "should parse `lib/configuration.yaml` file" $ do
-            liftIO $ setupTestLogging
+            liftIO setupTestLogging
             startTime <- Timestamp . round . (* 1000000) <$> liftIO getPOSIXTime
             let cfo = defaultConfigurationOptions
                         { cfoFilePath = "./configuration.yaml"
@@ -26,6 +26,6 @@ spec = describe "Pos.Launcher.Configuration" $ do
             let catchFn :: ConfigurationException -> IO (Maybe ConfigurationException)
                 catchFn e = return $ Just e
             res  <- liftIO $ catch
-                (withConfigurationsM "test" Nothing Nothing False cfo (\_ _ _ _ -> return Nothing))
+                (withConfigurations Nothing Nothing False cfo (\_ _ _ _ -> return Nothing))
                 catchFn
             res `shouldSatisfy` isNothing

--- a/util/src/Pos/Util/Wlog/Compatibility.hs
+++ b/util/src/Pos/Util/Wlog/Compatibility.hs
@@ -32,6 +32,7 @@ module Pos.Util.Wlog.Compatibility
            -- * Named Pure logging
          , NamedPureLogger (..)
          , launchNamedPureLog
+         , usingNamedPureLogger
          , runNamedPureLog
            -- * reimplementations
          , removeAllHandlers
@@ -219,6 +220,8 @@ instance Monad m => CanLog (NamedPureLogger m) where
         NamedPureLogger $ dispatchMessage name sev msg
 instance MFunctor NamedPureLogger where
     hoist f = NamedPureLogger . hoist (hoist f) . runNamedPureLogger
+instance MonadIO m => MonadIO (NamedPureLogger m) where
+    liftIO = lift . liftIO
 
 runNamedPureLog
     :: (Monad m, HasLoggerName m)


### PR DESCRIPTION
## Description


`Pos.Launcher.Configurations` exposes a function:

```hs
withConfigurations
    :: (WithLogger m, MonadThrow m, MonadIO m)
    => ...
    -> m r
```

which highly suggests that the caller Monad `m` could define its own logger instance and expect `withConfigurations` to leverage it for whatever logging this function must perform. However:

```hs
 usingNamedPureLogger "pure-logger" $ withConfigurations Nothing Nothing False opts
```

This will fail with a hard `LoggingHandler MVar isn't initialized` which suggests that some other logger than the one provided is used.
Turns out that `withConfigurations` relies on `withConfigurationsM` which perform logging in plain IO only using the given logger's name to do so. 
This was most likely introduced when before pure loggers and ability to log in IO were introduced and has now became obsolete. 

## Linked issue

[[CO-409]](https://iohk.myjetbrains.com/youtrack/issue/CO-409)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- ~~[ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.~~

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
