### PR TITLE
[CBR-460] Improve the archive pruner

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18120,6 +18120,7 @@ license = stdenv.lib.licenses.mit;
 , string-conv
 , swagger2
 , tabl
+, tar
 , text
 , time
 , time-units
@@ -18136,6 +18137,7 @@ license = stdenv.lib.licenses.mit;
 , x509
 , x509-store
 , yaml
+, zlib
 }:
 mkDerivation {
 
@@ -18224,6 +18226,7 @@ sqlite-simple
 sqlite-simple-errors
 stm
 swagger2
+tar
 text
 time
 time-units
@@ -18239,6 +18242,7 @@ wai-middleware-throttle
 warp
 x509
 x509-store
+zlib
 ];
 executableHaskellDepends = [
 aeson

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -241,6 +241,7 @@ library
                      , stm
                      , stm
                      , swagger2
+                     , tar
                      , text
                      , time
                      , time-units
@@ -256,6 +257,7 @@ library
                      , warp
                      , x509
                      , x509-store
+                     , zlib
 
   default-language:    Haskell2010
   default-extensions: TypeOperators

--- a/wallet-new/src/Cardano/Wallet/Server/Plugins/AcidState.hs
+++ b/wallet-new/src/Cardano/Wallet/Server/Plugins/AcidState.hs
@@ -71,7 +71,7 @@ pruneAndCompress n dbPath = liftIO $ do
         sequence [(f,) <$> getModificationTime (fullRelPath f) | f <- archives]
 
     -- Partition the files into @toPrune@ and @toCompress@ (the @n@ newest).
-    -- Filter from the second subset any previously-created tarball.
+    -- Filter from the first subset any previously-created tarball.
     let (toCompress, toPrune) = first (filter (not . isTarball))
                               . splitAt n
                               $ newestFirst


### PR DESCRIPTION
## Description

This commit improves the archive pruner function called as part of the
acid-state worker plugin.

In particular, we keep only the 3 most recent archives and we compress
them, deleting the rest. This allows us to go from this:

<img width="575" alt="screen shot 2018-10-02 at 14 49 17" src="https://user-images.githubusercontent.com/29383371/46354149-3d272080-c65e-11e8-9d2d-9201223ef657.png">

to something like this:

<img width="640" alt="screen shot 2018-10-02 at 16 13 15" src="https://user-images.githubusercontent.com/29383371/46354164-46b08880-c65e-11e8-937b-1b80f2c6723d.png">

And the produced archive can be opened just fine:

<img width="662" alt="screen shot 2018-10-02 at 16 13 22" src="https://user-images.githubusercontent.com/29383371/46354187-54fea480-c65e-11e8-8764-f69caf9f1b6f.png">


<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-460

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
