### PR TITLE
[CBR-461] Improve diagnostic for `NotEnoughMoney` error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 - The codebase now relies on the package `cryptonite` (instead of `ed25519`) for Ed25519 implementation (CO-325)
 
+- **[API BREAKING CHANGE]** Improve diagnostic for `NotEnoughMoney` error (CBR-461)
 
 ### Specifications
 

--- a/wallet-new/integration/TransactionSpecs.hs
+++ b/wallet-new/integration/TransactionSpecs.hs
@@ -171,7 +171,7 @@ transactionSpecs wRef wc = beforeAll_ (setupLogging "wallet-new_transactionSpecs
                         <> " error, got: "
                         <> show err
 
-        randomTest "fails if you spend too much money" 1 $ do
+        randomTest "fails if you spend more money than your available balance" 1 $ do
             wallet <- run $ sampleWallet wRef wc
             (toAcct, toAddr) <- run $ firstAccountAndId wc wallet
 
@@ -189,8 +189,72 @@ transactionSpecs wRef wc = beforeAll_ (setupLogging "wallet-new_transactionSpecs
                     }
                 tooMuchCash (V1 c) = V1 (Core.mkCoin (Core.getCoin c * 2))
             etxn <- run $ postTransaction wc payment
+            err <- liftIO (etxn `shouldPrism` _Left)
+            case err of
+                ClientWalletError (NotEnoughMoney (ErrAvailableBalanceIsInsufficient _)) ->
+                    return ()
 
-            liftIO $ void $ etxn `shouldPrism` _Left
+                _ ->
+                    liftIO $ expectationFailure $
+                        "Expected 'NotEnoughMoney ~ ErrAvailableBalanceIsInsufficient', got: "
+                        <> show err
+
+        randomTest "fails if you can't cover fee with a transaction" 1 $ run $ do
+            let makePayment
+                    :: Core.Coin
+                    -> (Wallet, Account)
+                    -> Core.Address
+                    -> IO (Either ClientError Transaction)
+                makePayment amount (sourceW, sourceA) destination = do
+                    let payment = Payment
+                            { pmtSource = PaymentSource
+                                { psWalletId     = walId sourceW
+                                , psAccountIndex = accIndex sourceA
+                                }
+                            , pmtDestinations = pure PaymentDistribution
+                                { pdAddress = V1 destination
+                                , pdAmount  = V1 amount
+                                }
+                            , pmtGroupingPolicy   = Nothing
+                            , pmtSpendingPassword = Nothing
+                            }
+                    fmap (fmap wrData) $ postTransaction wc payment
+
+            let getRandomAddress
+                    :: IO Core.Address
+                getRandomAddress = do
+                    wallet <- randomWallet CreateWallet >>= createWalletCheck wc
+                    (_, toAddr) <- firstAccountAndId wc wallet
+                    return (unV1 $ addrId toAddr)
+
+            let fixtureWallet
+                    :: Core.Coin
+                    -> IO (Wallet, Account)
+                fixtureWallet coin = do
+                    genesis <- genesisWallet wc
+                    (genesisAccount, _) <- firstAccountAndId wc genesis
+                    wallet <- randomWallet CreateWallet >>= createWalletCheck wc
+                    (account, address) <- firstAccountAndId wc wallet
+                    txn <- makePayment coin (genesis, genesisAccount) (unV1 $ addrId address) >>= shouldPrismFlipped _Right
+                    pollTransactions wc (walId wallet) (accIndex account) (txId txn)
+                    return (wallet, account)
+
+            let expectFailure
+                    :: Show a
+                    => ClientError
+                    -> Either ClientError a
+                    -> IO ()
+                expectFailure want eresp = do
+                    resp <- eresp `shouldPrism` _Left
+                    want `shouldBe` resp
+
+            --
+            -- Actual test
+            --
+            (wallet, account) <- fixtureWallet (Core.mkCoin 42)
+            resp <- makePayment (Core.mkCoin 42) (wallet, account) =<< getRandomAddress
+            let err = NotEnoughMoney ErrCannotCoverFee
+            expectFailure (ClientWalletError err) resp
 
         randomTest "posted transactions gives rise to nonempty Utxo histogram" 1 $ do
             genesis <- run $ genesisWallet wc

--- a/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/LegacyHandlers/Transactions.hs
@@ -33,10 +33,10 @@ import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 
 convertTxError :: V0.TxError -> WalletError
 convertTxError err = case err of
-    V0.NotEnoughMoney coin ->
-        NotEnoughMoney . fromIntegral . Core.getCoin $ coin
-    V0.NotEnoughAllowedMoney coin ->
-        NotEnoughMoney . fromIntegral . Core.getCoin $ coin
+    V0.NotEnoughMoney _coin ->
+        NotEnoughMoney ErrCannotCoverFee
+    V0.NotEnoughAllowedMoney _coin ->
+        NotEnoughMoney (ErrAvailableBalanceIsInsufficient (-1))
     V0.FailedToStabilize ->
         TxFailedToStabilize
     V0.OutputIsRedeem addr ->

--- a/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -250,12 +250,8 @@ newTransactionError e = case e of
         unknownHdAccount e'
 
     (Kernel.NewTransactionErrorCoinSelectionFailed e') -> case e' of
-          ex@(CoinSelHardErrOutputCannotCoverFee _outputs fee) ->
-                case (readMaybe $ T.unpack fee) of
-                    Just coin ->
-                        V1.NotEnoughMoney coin
-                    Nothing ->
-                        V1.UnknownError $ (sformat build ex)
+          CoinSelHardErrOutputCannotCoverFee _outputs _fee ->
+                V1.NotEnoughMoney V1.ErrCannotCoverFee
 
           ex@(CoinSelHardErrOutputIsRedeemAddress addr) ->
                 case (decodeTextAddress addr) of
@@ -265,7 +261,7 @@ newTransactionError e = case e of
                         V1.UnknownError $ (sformat build ex)
 
           CoinSelHardErrCannotCoverFee ->
-                V1.NotEnoughMoney (-1)
+                V1.NotEnoughMoney V1.ErrCannotCoverFee
 
           (CoinSelHardErrMaxInputsReached _txt) ->
                 V1.TooBigTransaction
@@ -273,12 +269,12 @@ newTransactionError e = case e of
           ex@(CoinSelHardErrUtxoExhausted balance _payment) ->
               case (readMaybe $ T.unpack balance) of
                   Just coin ->
-                      V1.NotEnoughMoney coin
+                      V1.NotEnoughMoney (V1.ErrAvailableBalanceIsInsufficient coin)
                   Nothing ->
                       V1.UnknownError $ (sformat build ex)
 
           CoinSelHardErrUtxoDepleted ->
-            V1.NotEnoughMoney (-1)
+            V1.NotEnoughMoney (V1.ErrAvailableBalanceIsInsufficient 0)
 
     (Kernel.NewTransactionErrorCreateAddressFailed e') ->
         createAddressErrorKernel e'

--- a/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -350,7 +350,7 @@ $errors
   errors = T.intercalate "\n" rows
   rows =
     -- 'WalletError'
-    [ mkRow fmtErr $ NotEnoughMoney 1400
+    [ mkRow fmtErr $ NotEnoughMoney (ErrAvailableBalanceIsInsufficient 1400)
     , mkRow fmtErr $ OutputIsRedeem sampleAddress
     , mkRow fmtErr $ UnknownError "Unknown error."
     , mkRow fmtErr $ InvalidAddressFormat "Invalid Base58 representation."

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -288,6 +288,7 @@ runCoinSelT opts pickUtxo policy request utxo = do
     policy' :: CoinSelT Core.Utxo CoinSelHardErr m
                  ([CoinSelResult Cardano], SelectedUtxo Cardano)
     policy' = do
+        when (Map.null utxo) $ throwError CoinSelHardErrUtxoDepleted
         mapM_ validateOutput request
         css <- intInputGrouping (csoInputGrouping opts)
         -- We adjust for fees /after/ potentially dealing with grouping

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -302,7 +302,11 @@ data CoinSelHardErr =
     -- See also 'CoinSelHardErrCannotCoverFee'
   | CoinSelHardErrUtxoExhausted Text Text
 
-    -- | UTxO depleted using input selection
+    -- | UTxO depleted using input selection.
+    --
+    -- This occurs when there's actually no UTxO to pick from in a first place,
+    -- like an edge-case of CoinSelHardErrUtxoExhausted (which suggests that we
+    -- could at least start selecting UTxO).
   | CoinSelHardErrUtxoDepleted
 
 instance Arbitrary CoinSelHardErr where

--- a/wallet-new/test/WalletNewJson.hs
+++ b/wallet-new/test/WalletNewJson.hs
@@ -9,8 +9,8 @@ import           Hedgehog (Property)
 import           Cardano.Wallet.API.Response (JSONValidationError (..))
 import           Cardano.Wallet.API.V1.Migration.Types (MigrationError (..))
 import           Cardano.Wallet.API.V1.Swagger.Example (genExample)
-import           Cardano.Wallet.API.V1.Types (V1 (..), WalletError (..),
-                     exampleWalletId)
+import           Cardano.Wallet.API.V1.Types (ErrNotEnoughMoney (..), V1 (..),
+                     WalletError (..), exampleWalletId)
 
 import           Test.Pos.Core.ExampleHelpers (exampleAddress)
 import           Test.Pos.Util.Golden (discoverGolden, goldenTestJSON)
@@ -30,11 +30,18 @@ tests =
 -- WalletError
 -------------------------------------------------------------------------------
 
-golden_WalletError_NotEnoughMoney :: Property
-golden_WalletError_NotEnoughMoney =
+golden_WalletError_NotEnoughMoneyAvailableBalanceIsInsufficient :: Property
+golden_WalletError_NotEnoughMoneyAvailableBalanceIsInsufficient =
     goldenTestJSON
-        (NotEnoughMoney 10)
-            "test/golden/WalletError_NotEnoughMoney"
+        (NotEnoughMoney (ErrAvailableBalanceIsInsufficient 14))
+            "test/golden/WalletError_NotEnoughMoneyAvailableBalanceIsInsufficient"
+
+golden_WalletError_NotEnoughMoneyCannotCoverFee :: Property
+golden_WalletError_NotEnoughMoneyCannotCoverFee =
+    goldenTestJSON
+        (NotEnoughMoney ErrCannotCoverFee)
+            "test/golden/WalletError_NotEnoughMoneyCannotCoverFee"
+
 
 golden_WalletError_OutputIsRedeem :: Property
 golden_WalletError_OutputIsRedeem =

--- a/wallet-new/test/golden/WalletError_NotEnoughMoney
+++ b/wallet-new/test/golden/WalletError_NotEnoughMoney
@@ -1,1 +1,0 @@
-{"status":"error","diagnostic":{"needMore":10},"message":"NotEnoughMoney"}

--- a/wallet-new/test/golden/WalletError_NotEnoughMoneyAvailableBalanceIsInsufficient
+++ b/wallet-new/test/golden/WalletError_NotEnoughMoneyAvailableBalanceIsInsufficient
@@ -1,0 +1,1 @@
+{"status":"error","diagnostic":{"details":{"msg":"Not enough available coins to proceed.","availableBalance":14}},"message":"NotEnoughMoney"}

--- a/wallet-new/test/golden/WalletError_NotEnoughMoneyCannotCoverFee
+++ b/wallet-new/test/golden/WalletError_NotEnoughMoneyCannotCoverFee
@@ -1,0 +1,1 @@
+{"status":"error","diagnostic":{"details":{"msg":"Not enough coins to cover fee."}},"message":"NotEnoughMoney"}


### PR DESCRIPTION
## Description

When computing fees or making a transaction, it could happen that funds
are currently "locked" out because selected in a pending transaction. In
such case, the UTxO can't be spent until the transaction has been
accepted by (at least) a node. The API currently returns a
NotEnoughMoney error in such case, whereas the total balance (as
returned by /api/v1/wallets/{walletId} endpoint) might show enough
funds.

This refines a bit the `NotEnoughMoney` error to make the reason
of failure clearer without breaking (too much) the existing API.

NOTE: There's one "expected" failing integration test which actually shed the light on a newly discovered bug (0 fee transaction).

## Linked issue

[[CBR-461]](https://iohk.myjetbrains.com/youtrack/issue/CBR-461)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- ~~[ ] All new and existing tests passed.~~

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
