### PR TITLE
[CBR-462] Fix 0 fee transaction

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -590,16 +590,30 @@ nLargestFromListBy f n = \xs ->
     dropOne (Just [_])    = Nothing
     dropOne (Just (_:as)) = Just as
 
--- | Proportionally divide the fee over each output
+-- | Proportionally divide the fee over each output.
+--
+-- There's a special 'edge-case' when the given input is a singleton list
+-- with one 0 coin. This is artifically created during input selection when
+-- the transaction's amount matches exactly the source's balance.
+-- In such case, we can't really compute any ratio for fees and simply return
+-- the whole fee back with the given change value.
 divvyFee :: forall dom a. CoinSelDom dom
           => (a -> Value dom) -> Fee dom -> [a] -> [(Fee dom, a)]
-divvyFee _ _   [] = error "divvyFee: empty list"
-divvyFee f fee as = map (\a -> (feeForOut a, a)) as
+divvyFee _ _   []                     = error "divvyFee: empty list"
+divvyFee f fee [a] | f a == valueZero = [(fee, a)]
+divvyFee f fee as                     = map (\a -> (feeForOut a, a)) as
   where
     -- All outputs are selected from well-formed UTxO, so their sum cannot
     -- overflow
     totalOut :: Value dom
-    totalOut = unsafeValueSum (map f as)
+    totalOut =
+        let
+            total = unsafeValueSum (map f as)
+        in
+            if total == valueZero then
+                error "divyyFee: invalid set of coins, total is 0"
+            else
+                total
 
     -- The ratio will be between 0 and 1 so cannot overflow
     feeForOut :: a -> Fee dom


### PR DESCRIPTION
## Description

commit 527afc745b463475e143c5c6079cd9a94f516515
Author: KtorZ <matthias.benkort@gmail.com>
Date:   Wed Oct 3 17:12:00 2018 +0200

    [CBR-462] Throws right error when running out of UTxO in fee calculation
    
    In this context, @CoinSelHardErrUtxoDepleted@ might be thrown by
    `pickUtxo` as we iterate over the selected change outputs which here
    means that we are running out of UTxOs to cover the fee.  Hence, we
    ought to remap the error accordingly to @CoinSelHardErrCannotCoverFee@.

commit 78c113e95420691a71b22e3bed26c9b730eb7168
Author: KtorZ <matthias.benkort@gmail.com>
Date:   Wed Oct 3 17:05:48 2018 +0200

    [CBR-462] Fix fee estimation when transaction's amount matches account's balance
    
    When calling
    
    ```
    reduceChangeOutputs
      :: forall dom. CoinSelDom dom
      => Fee dom
      -> [Value dom]
      -> ([Value dom], Fee dom)
    ```
    
    If the `[Value dom]` is a singleton array with a zero coin, we're going
    to end up dividing by zero and silently obliterating fee as we do it.
    This happens when making a transaction with no change, i.e., when the
    transaction's amount matches exactly the source account's balance.
    
    This commit provides a fix handling this special edge-case.


## Linked issue

[[CBR-462]](https://iohk.myjetbrains.com/youtrack/issue/CBR-462)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- ~~[ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.~~

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
