### PR TITLE
[CBR-464] Raise Correct `CoinSelHardErr` during coin selection

### DIFF
--- a/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -273,9 +273,6 @@ newTransactionError e = case e of
                   Nothing ->
                       V1.UnknownError $ (sformat build ex)
 
-          CoinSelHardErrUtxoDepleted ->
-            V1.NotEnoughMoney (V1.ErrAvailableBalanceIsInsufficient 0)
-
     (Kernel.NewTransactionErrorCreateAddressFailed e') ->
         createAddressErrorKernel e'
 

--- a/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -11,6 +11,7 @@ import qualified Data.Text as T
 import           Formatting (build, sformat)
 import           Universum
 
+import qualified Data.Char as C
 import           Pos.Core (decodeTextAddress)
 
 import           Cardano.Wallet.API.V1.Types (V1 (..))
@@ -267,7 +268,8 @@ newTransactionError e = case e of
                 V1.TooBigTransaction
 
           ex@(CoinSelHardErrUtxoExhausted balance _payment) ->
-              case (readMaybe $ T.unpack balance) of
+              -- NOTE balance & payment are "prettified" coins representation (e.g. "42 coin(s)")
+              case (readMaybe $ T.unpack $ T.dropWhileEnd (not . C.isDigit) balance) of
                   Just coin ->
                       V1.NotEnoughMoney (V1.ErrAvailableBalanceIsInsufficient coin)
                   Nothing ->

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -239,7 +239,7 @@ repack (txIn, aux) = (Core.toaOut aux, txIn)
 
 -- | Pick an element from the UTxO to cover any remaining fee
 type PickUtxo m = Core.Coin  -- ^ Fee to still cover
-               -> CoinSelT Core.Utxo CoinSelHardErr m (Core.TxIn, Core.TxOutAux)
+               -> CoinSelT Core.Utxo CoinSelHardErr m (Maybe (Core.TxIn, Core.TxOutAux))
 
 data CoinSelFinalResult = CoinSelFinalResult {
       csrInputs  :: NonEmpty (Core.TxIn, Core.TxOutAux)
@@ -288,7 +288,6 @@ runCoinSelT opts pickUtxo policy request utxo = do
     policy' :: CoinSelT Core.Utxo CoinSelHardErr m
                  ([CoinSelResult Cardano], SelectedUtxo Cardano)
     policy' = do
-        when (Map.null utxo) $ throwError CoinSelHardErrUtxoDepleted
         mapM_ validateOutput request
         css <- intInputGrouping (csoInputGrouping opts)
         -- We adjust for fees /after/ potentially dealing with grouping
@@ -387,10 +386,10 @@ largestFirst opts maxInps =
     pickUtxo val = search . Map.toList =<< get
       where
         search :: [(Core.TxIn, Core.TxOutAux)]
-               -> CoinSelT Core.Utxo CoinSelHardErr m (Core.TxIn, Core.TxOutAux)
+               -> CoinSelT Core.Utxo CoinSelHardErr m (Maybe (Core.TxIn, Core.TxOutAux))
         search [] = throwError CoinSelHardErrCannotCoverFee
         search ((i, o):ios)
-          | Core.txOutValue (Core.toaOut o) >= val = return (i, o)
+          | Core.txOutValue (Core.toaOut o) >= val = return $ Just (i, o)
           | otherwise                              = search ios
 
 

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -73,7 +73,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable
-import           Test.QuickCheck (Arbitrary (..))
 
 import           Cardano.Wallet.Kernel.Util.StrictStateT
 import           UTxO.Util (withoutKeys)
@@ -302,15 +301,6 @@ data CoinSelHardErr =
     -- See also 'CoinSelHardErrCannotCoverFee'
   | CoinSelHardErrUtxoExhausted Text Text
 
-    -- | UTxO depleted using input selection.
-    --
-    -- This occurs when there's actually no UTxO to pick from in a first place,
-    -- like an edge-case of CoinSelHardErrUtxoExhausted (which suggests that we
-    -- could at least start selecting UTxO).
-  | CoinSelHardErrUtxoDepleted
-
-instance Arbitrary CoinSelHardErr where
-    arbitrary = pure CoinSelHardErrUtxoDepleted
 
 -- | The input selection request failed
 --
@@ -656,8 +646,6 @@ instance Buildable CoinSelHardErr where
     )
     bal
     val
-  build (CoinSelHardErrUtxoDepleted) = bprint
-    ( "CoinSelHardErrUtxoDepleted" )
 
 instance CoinSelDom dom => Buildable (Fee dom) where
   build = bprint build . getFee

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Read.hs
@@ -56,9 +56,7 @@ cpAvailableBalance :: IsCheckpoint c => c -> Core.Coin
 cpAvailableBalance c =
     fromMaybe subCoinErr balance'
   where
-    pendingIns   = Set.union
-        (Pending.txIns $ c ^. cpPending)
-        (Pending.txIns $ c ^. cpForeign)
+    pendingIns   = Pending.txIns $ c ^. cpPending
     spentUtxo    = Core.utxoRestrictToInputs (c ^. cpUtxo) pendingIns
     spentBalance = Core.unsafeIntegerToCoin $ Core.utxoBalance spentUtxo
     balance'     = Core.subCoin (c ^. cpUtxoBalance) spentBalance

--- a/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -97,7 +97,10 @@ instance Buildable NewTransactionError where
 instance Arbitrary NewTransactionError where
     arbitrary = oneof [
         NewTransactionUnknownAccount <$> arbitrary
-      , NewTransactionErrorCoinSelectionFailed <$> arbitrary
+      , NewTransactionErrorCoinSelectionFailed <$> oneof
+            [ pure $ CoinSelHardErrUtxoExhausted "0 coin(s)" "14 coin(s)"
+            , pure CoinSelHardErrCannotCoverFee
+            ]
       , NewTransactionErrorCreateAddressFailed <$> arbitrary
       , NewTransactionErrorSignTxFailed <$> arbitrary
       , pure NewTransactionInvalidTxIn

--- a/wallet-new/test/unit/Test/Spec/CoinSelection.hs
+++ b/wallet-new/test/unit/Test/Spec/CoinSelection.hs
@@ -377,7 +377,6 @@ paymentFailedWith utxo payees res extraChecks =
 
 notEnoughMoney :: CoinSelHardErr -> Bool
 notEnoughMoney (CoinSelHardErrUtxoExhausted _ _) = True
-notEnoughMoney CoinSelHardErrUtxoDepleted        = True
 notEnoughMoney _                                 = False
 
 outputWasRedeem :: CoinSelHardErr -> Bool

--- a/wallet-new/test/unit/Test/Spec/CoinSelection/Generators.hs
+++ b/wallet-new/test/unit/Test/Spec/CoinSelection/Generators.hs
@@ -267,7 +267,7 @@ utxoSmallestEntry utxo =
 genPayees :: Core.Utxo -> Pay -> Gen (NonEmpty Core.TxOut)
 genPayees utxo payment = do
     let balance            = toLovelaces payment
-        halfOfUtxoSmallest = (Core.getCoin $ utxoSmallestEntry utxo) `div` 2
+        halfOfUtxoSmallest = max 1 $ (Core.getCoin $ utxoSmallestEntry utxo) `div` 2
     genTxOut StakeGenOptions {
                stakeMaxValue         = Just (Core.mkCoin halfOfUtxoSmallest)
              , stakeGenerationTarget = AtLeast


### PR DESCRIPTION
## Description

In a previous PR (#3704 - CBR-462), we patched the coin selection and remap the `UTxODepleted` error to a `CannotCoverFee` error. 
From this, the frontend team discovered a new bug caused because again, `UTxODepleted` was thrown instead of a correct `UTxOExhausted`. 

Instead of patching again and re-mapping the error to the correct one, I took a step back and slightly reviewed the original abstraction such that we would now have:

```hs
type PickUtxo m = Core.Coin  -- ^ Fee to still cover
               -> CoinSelT Core.Utxo CoinSelHardErr m (Maybe (Core.TxIn, Core.TxOutAux))
```

instead of

```hs
type PickUtxo m = Core.Coin  -- ^ Fee to still cover
               -> CoinSelT Core.Utxo CoinSelHardErr m (Core.TxIn, Core.TxOutAux)
```

The rational here is that, the outcome may depend of the context. We use this function in
multiple places where running out of UTxO may have a different meaning. Therefore, instead
of introducing the 'UtxoDepleted' error, we return a raw Maybe and let the caller decides
what error should be thrown (here, most likely: CannotCoverFee or UtxoExhausted)


---

Note that in theory, we could simply have the following to make it obvious that `PickUtxo` _can't fail_:

```hs
type PickUtxo m = Core.Coin  -- ^ Fee to still cover
               -> StrictStateT Core.Utxo m (Maybe (Core.TxIn, Core.TxOutAux))

-- | Hoist (m ~> ExceptT e m) to handle non failing implementation
hoistExceptT :: Functor m => StrictStateT utxo m a -> CoinSelT utxo e m a
hoistExceptT = CoinSelT . mapStrictStateT (ExceptT . fmap Right)
```

However, this exposes the `StrictStateT` from `CoinSelT` which is opaque.. So, we could go even further and have exposed instead. 

```hs
newtype NonFailingCoinSelT utxo m a :: NonFailingCoinSelT (StrictStateT utxo m a)
  deriving ( Functor
           , Applicative
           , Monad
           , MonadState utxo
           )
```

## Linked issue

[[CBR-464]](https://iohk.myjetbrains.com/youtrack/issue/CBR-464)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] ~~CHANGELOG entry has been added and is linked to the correct PR on GitHub.~~

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
