### PR TITLE
[CBR-182] Add resubmission TTL estimation to the docs.

### DIFF
--- a/wallet-new/docs/RelatingWalletSpecToCardano.md
+++ b/wallet-new/docs/RelatingWalletSpecToCardano.md
@@ -1520,6 +1520,14 @@ Note: the above code was added shortly after this document was pinned to a git h
 
 Cardano does not implement transaction TTL yet and instead relies on submission count and a maximum retry limit.
 
+Currently, a transaction TTL may be estimated based on the creation timestamp of the transaction.
+The process has a constant number of submission attempts per transaction as well as a constant submission attempt rate.
+We attempt to run the submission function every five seconds, and the maximum attempt count is 255.
+This indicates a TTL of `255 * 5`, which is 1,275 seconds (or 21 minutes and 15 seconds).
+
+The `resubmitFunction` that is used currently lives in `Cardano.Wallet.Kernel.Submission` and includes the 255 count of resubmission limit.
+The 5 second tick rate is currently hardcoded in `Cardano.Wallet.Kernel.Submission.Worker`.
+
 **Fig 14 - Wallet Spec**
 
 ```haskell

--- a/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
@@ -204,7 +204,7 @@ instance Buildable ScheduleEvents where
 -- the lifetime of the wallet, as it will reset to 0 each time we restart it (the entire
 -- 'WalletSubmission' is ephimeral and not persisted on disk).
 --
--- The acute reader might ask why we are casting to 'Int' and what is the
+-- The astute reader might ask why we are casting to 'Int' and what is the
 -- implication of a possible overflow: in practice, none, as in case we overflow
 -- the 'Int' positive capacity we will effectively treat this as a \"circular buffer\",
 -- storing the elements for slots @(maxBound :: Int) + 1@ in negative positions.
@@ -635,4 +635,11 @@ emptyWalletSubmission :: WalletSubmission
 emptyWalletSubmission = newWalletSubmission resubmitFunction
 
 resubmitFunction :: ResubmissionFunction
-resubmitFunction = defaultResubmitFunction (exponentialBackoff 255 1.25)
+resubmitFunction =
+    defaultResubmitFunction (exponentialBackoff defaultResubmissionLimit 1.25)
+
+-- | This value is the default resubmission limit. It is referred to in the
+-- @RelatingWalletSpecToCardano.md@ document in section 10.4. If this value is
+-- altered, then that document should be updated.
+defaultResubmissionLimit :: Int
+defaultResubmissionLimit = 255

--- a/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Submission.hs
@@ -642,4 +642,4 @@ resubmitFunction =
 -- @RelatingWalletSpecToCardano.md@ document in section 10.4. If this value is
 -- altered, then that document should be updated.
 defaultResubmissionLimit :: Int
-defaultResubmissionLimit = 255
+defaultResubmissionLimit = 23

--- a/wallet-new/src/Cardano/Wallet/Kernel/Submission/Worker.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Submission/Worker.hs
@@ -35,5 +35,11 @@ tickSubmissionLayer logFunction tick =
           -- is completely independent by the time of the underlying blockchain,
           -- and this arbitrary choice of 5 seconds delay is yet another witness
           -- of such independence.
-          liftIO $ threadDelay 5000000
+          liftIO $ threadDelay tickRate
           go
+
+-- | The tick rate for resubmitting transactions. This value is documented in
+-- @docs/RelatingWalletSpecToCardano.md@, and if this value is changed, then
+-- section 10.4 should be updated.
+tickRate :: Int
+tickRate = 5000000


### PR DESCRIPTION
## Description

This PR addresses CBR-182.

The old wallet had a 60 minute TTL hardcoded into the interface.

The new wallet has a constant retry time of around 21 minutes, after which the wallet removes it from the set of transactions to attempt to send.

We could attempt to calculate the TTL more exactly, but this would be inefficient. The `Schedule` type maintains a mapping from `Slot` to a `ScheduleEvent` which contains a list of `ScheduleSend`s. These `ScheduleSend` contain a transaction ID. We would need to convert the `Schedule` into a `Map TxId SubmissionCount` (an operation that is linear in size of the schedule) and, for each pending Transaction, look up the submission count and calculate the TTL based on the remaining submissions and the time between submissions.

As this is currently hardcoded, this is quite a lot of computational work for what is essentially a constant: `txCreationTimestamp + 1275s`.

The new core layer will (apparently) include a notion of TTL directly, and this will be computationally efficient to provide.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-182

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
