### PR TITLE
[CBR-453] Fix bug in backfilling

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs
@@ -28,6 +28,7 @@ import qualified Data.Set as Set
 import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable
 import           Serokell.Util (listJsonIndent)
+import           Serokell.Util.Text (listBuilderJSON)
 import           Test.QuickCheck (Arbitrary (..), elements)
 
 import qualified Pos.Chain.Block as Core
@@ -110,6 +111,9 @@ instance Buildable ApplyBlockFailed where
         )
         context
         checkpoint
+
+instance Buildable [ApplyBlockFailed] where
+   build = listBuilderJSON
 
 instance Arbitrary ApplyBlockFailed where
    arbitrary = elements []


### PR DESCRIPTION
## Description

`ApplyBlock` takes an arg `Maybe (Set HdAccountId)` to allow callers to restrict the accounts.
In the backfilling code we were calling applyBlock with restricted accounts = `Just {}`

The effect was that the first block in backfilling would not be applied, and all subsequent blocks would fail because of the "missing predecessor block" that was not applied. Since we retry failures, this was causing an infinite loop with backfilling never happening.

This fix:

* removes the bug that was creating the empty restrictions `Just {}`
* changes the type of the restrictions in the ApplyBlock  signature to `Maybe (NonEmpty HdAccountId)` to prevent invalid restrictions
* add info log messages for the start and end of Backfilling, add a warning message when we recursively handle errors (so that an infinite loop occurring here is at least visible in the logs)

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-453

## Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc

## QA Steps

This PR fixes backfilling - we can now test that a wallet catches up with a node if it falls behind.
