### PR TITLE
Fix typo {Micro->Milli}Second

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ Section `"blockVersionData"` contains fundamental blockchain-related values:
 *  `"maxTxSize"` - maximum size of transaction, in bytes,
 *  `"mpcThd"` - threshold for participation in SSC (shared seed computation),
 *  `"scriptVersion"` - script version,
-*  `"slotDuration"` - slot duration, in microseconds,
+*  `"slotDuration"` - slot duration, in milliseconds,
 *  `"softforkRule"` - rules for softfork:
    *  `"initThd"` - initial threshold, right after proposal is confirmed,
    *  `"minThd"` - minimal threshold (i.e. threshold can't become less than this one),


### PR DESCRIPTION
See the [datatype declaration](https://github.com/input-output-hk/cardano-sl/blob/bd0b7eac015a6ddba2ecbd07e81c6132ec3ea4dc/chain/src/Pos/Chain/Update/BlockVersionData.hs#L32) - we clearly use Milliseconds rather than Microseconds.