### PR TITLE
[CBR-445] Adds the option to associate partial and historical checkpoints during restoration

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
@@ -104,7 +104,7 @@ currentAvailableBalance = liftHd1 HD.currentAvailableBalance
 currentAddressMeta :: DB -> HdAddress -> Either UnknownHdAccount AddressMeta
 currentAddressMeta = liftHd1 HD.currentAddressMeta
 
-currentTxSlotId :: DB -> TxId -> HdAccountId -> Either UnknownHdAccount (Maybe SlotId)
+currentTxSlotId :: DB -> TxId -> HdAccountId -> Either UnknownHdAccount (CombinedWithAccountState (Maybe SlotId))
 currentTxSlotId = liftHd2 HD.currentTxSlotId
 
 currentTxIsPending :: DB -> TxId -> HdAccountId -> Either UnknownHdAccount Bool


### PR DESCRIPTION
While restoring a wallet in daedalus, it was reported that all txs appeared as failed, until restoration ended and they were turned into confirmed. This was caused because during restoration we totally ignored historical checkpoints. We provide a new zooming operation which uses a function which associated the results of the two checkpoints - partial and historical . We use this zooping operation for txs and this resolves the issue with daedalus


![cbr-445-fixed](https://user-images.githubusercontent.com/11467473/46582978-07b47580-ca58-11e8-9104-edd7c0904e2b.png)

If the tx is in Sqlite but not in acid-state, we report it as Applying (Pending in Daedalus).

![starting-restoration](https://user-images.githubusercontent.com/11467473/46662906-50d60800-cbc5-11e8-9404-c755055913c1.png)

The same zooping operation can be used to fix also addresses, which are reported as "used":failed, until resotration finishes. This pr does NOT fix this issue:


During restoration:
```
$ curl --capath  "/path/to/tls" https://localhost:8090/api/v1/addresses
{"data":[{"id":"DdzFFzCqrhsvsFAYWRvfPxnR7qEm7WGTVLFLbZzbJ8pysgknaCga98tc1BeJEsJjAz5L3ajBZ5rcjhrHGfb2f1DX2QwMcjLa82UF4b6d","used":false,"changeAddress":false,"ownership":"isOurs"}],"status":"success","meta":{"pagination":{"totalPages":1,"page":1,"perPage":10,"totalEntries":1}}}
```

After restoration completed:
```
$ curl --capath  "/path/to/tls" https://localhost:8090/api/v1/addresses
{"data":[{"id":"DdzFFzCqrhsvsFAYWRvfPxnR7qEm7WGTVLFLbZzbJ8pysgknaCga98tc1BeJEsJjAz5L3ajBZ5rcjhrHGfb2f1DX2QwMcjLa82UF4b6d","used":true,"changeAddress":false,"ownership":"isOurs"}],"status":"success","meta":{"pagination":{"totalPages":1,"page":1,"perPage":10,"totalEntries":1}}} 
```


## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-445

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
