### PR TITLE
[DEVOPS-1028] Enable Bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,18 @@
+status = [
+  # Hydra: Cardano SL build for Linux
+  "ci/hydra:serokell:cardano-sl:all-cardano-sl.x86_64-linux",
+
+  # Hydra: Wallet build for macOS
+  "ci/hydra:serokell:cardano-sl:daedalus-bridge.x86_64-darwin",
+
+  # Buildkite: stack2nix checks, etc.
+  "buildkite/cardano-sl",
+
+  # Windows: builds are too unreliable to use at present
+  # "continuous-integration/appveyor/branch",
+]
+timeout_sec = 7200
+required_approvals = 1
+cut_body_after = "## Type of change"
+delete_merged_branches = true
+block_labels = [ "DO NOT MERGE", "wip" ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,6 @@
 status = [
-  # Hydra: Cardano SL build for Linux
-  "ci/hydra:serokell:cardano-sl:all-cardano-sl.x86_64-linux",
-
-  # Hydra: Wallet build for macOS
-  "ci/hydra:serokell:cardano-sl:daedalus-bridge.x86_64-darwin",
+  # Hydra: Aggregate job from release.nix
+  "ci/hydra:serokell:cardano-sl:required",
 
   # Buildkite: stack2nix checks, etc.
   "buildkite/cardano-sl",

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -32,3 +32,8 @@
 
 ## Screenshots (if available)
 <!--- Upload a GIF, an asciinema video or an image demoing the feature -->
+
+## How to merge
+
+Send the message `bors r+` to merge this PR. For more information, see
+[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).

--- a/docs/how-to/bors.md
+++ b/docs/how-to/bors.md
@@ -1,0 +1,50 @@
+# How to merge PRs with Bors
+
+[Bors](https://bors.tech/) is a GitHub bot that queues merging and
+testing of PRs to prevent breaking code merges from reaching the
+`develop` branch. These
+
+It works by sending commands in messages on GitHub pull requests.
+
+On the [Bors website](https://bors.tech/) this is a [reference
+documentation page](https://bors.tech/documentation/) which lists all
+the possible commands you can use.
+
+## Before merging
+
+Before merging, your PR must have:
+
+- at least one review approval
+- no review rejections
+- green CI status
+
+## How to merge
+
+Add a comment to the pull request with the text `bors r+`.
+
+Bors will handle things from there. It merges your PR into a staging
+branch and then waits for that branch to pass CI before merging to
+`develop`. If something fails, it will send a message to the PR saying
+so.
+
+## Who can merge
+
+Anyone with push access to the GitHub repository can send commands to
+`iohk-bors`.
+
+## Hosting
+
+IOHK host our own Bors bot called `iohk-bors`.
+
+The web interface is at https://bors-ng.aws.iohkdev.io/. Generally,
+you don't need the web interface to merge PRs.
+
+If using the web interface, ensure that you are using ours, rather
+than the one hosted by the Bors developers at https://app.bors.tech/.
+
+## Configuration
+
+Most of the settings for Bors are in [`bors.toml`](./../../bors.toml).
+
+The settings for branches and permissions are found in the web
+interface at https://bors-ng.aws.iohkdev.io/repositories .

--- a/docs/how-to/bors.md
+++ b/docs/how-to/bors.md
@@ -2,7 +2,7 @@
 
 [Bors](https://bors.tech/) is a GitHub bot that queues merging and
 testing of PRs to prevent breaking code merges from reaching the
-`develop` branch. These
+`develop` branch.
 
 It works by sending commands in messages on GitHub pull requests.
 
@@ -48,3 +48,6 @@ Most of the settings for Bors are in [`bors.toml`](./../../bors.toml).
 
 The settings for branches and permissions are found in the web
 interface at https://bors-ng.aws.iohkdev.io/repositories .
+
+There are full instructions for setting up Bors for a new repo in
+[`iohk-ops/docs/bors.md`](https://github.com/input-output-hk/iohk-ops/blob/master/docs/bors.md).


### PR DESCRIPTION
## Description

Adds the config file and documentation for Bors.

The bot won't be enabled without warning, and not until the trial on [iohk-ops](https://github.com/input-output-hk/iohk-ops) has succeeded.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1028

## Type of change
- CI
