### PR TITLE
[CBR-465] Sort payees by amount in coin selection tests

### DIFF
--- a/wallet-new/test/unit/Test/Spec/CoinSelection.hs
+++ b/wallet-new/test/unit/Test/Spec/CoinSelection.hs
@@ -495,7 +495,16 @@ payRestrictInputsTo :: Word64
 payRestrictInputsTo maxInputs genU genP feeFunction adjustOptions bal amount policy =
     withDefConfiguration $ \genesisConfig -> do
         utxo  <- genU bal
-        payee <- genP utxo amount
+        -- Sort the payees by amount, so that biggest entries comes first. This
+        -- is to mitigate some pathological generator's corner cases in
+        -- @largestFirst@ where the selection would pick the largest to cover
+        -- the smallest inputs, not having enough Utxo to cover the rest. We do
+        -- this here in the tests and not by modifying the coin selection code
+        -- because we never run @largestFirst@ in production; in @random@ we
+        -- merely piggyback on the @atLeast@ function (a low-level API used
+        --for @largestFirst') but the @random@ policy doesn't require outputs
+        -- to be sorted, and doing so every time would be a waste of CPU cycles.
+        payee <- sortByAmount <$> genP utxo amount
         key   <- arbitrary
         let options = adjustOptions (newOptions feeFunction)
         res <- policy options
@@ -512,6 +521,9 @@ payRestrictInputsTo maxInputs genU genP feeFunction adjustOptions bal amount pol
                                    outputs
                                    change
                     return (utxo, payee, bimap STB identity txAux)
+    where
+        sortByAmount :: NonEmpty Core.TxOut -> NonEmpty Core.TxOut
+        sortByAmount = NE.sort
 
 pay :: (InitialBalance -> Gen Core.Utxo)
     -> (Core.Utxo -> Pay -> Gen (NonEmpty Core.TxOut))


### PR DESCRIPTION
## Description

One of our tests picked up a corner case in the generators and in the
largestFirst policy, where big UTxO entries were going to be picked to
satisfy small payments, leaving beefy ones "uncovered". The fix here was
simply to sort the payees by amount _in the tests_, not in the coin
selection code. The reason is simple:

* We don't use `largestFirst` in production code. We rely only on the
  `atLeast` low-level API inside the `random` policy, which is the one
  we use in production;
* We have tests hitting `largestFirst` only for the sake of implicitly
  testing `atLeast`;
* The `random` policy doesn't require this sorting precondition.

Therefore, embedding this sorting into the main coin selection code
would have been a waste of CPU cycles. Doing it in the tests only
suffices.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-465

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
