### PR TITLE
[DEVOPS-1061] shell.nix: Undo change to buildStackProject shell

### DIFF
--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -184,7 +184,7 @@ cabal 2.0.0.1 which doesn't work.
 
 Enter the `nix-shell`:
 
-    [nix-shell:~/cardano-sl]$ nix-shell
+    [nix-shell:~/cardano-sl]$ nix-shell -A forCabal
 
 Then build all cardano-sl packages:
 


### PR DESCRIPTION
We can't use a "ghcWithPackages" as the compiler for stack with Nix integration because the packages conflict with what stack has built.
    
This reverts the ghc change in the haskell.lib.buildStackProject shell and adds an additional attribute for a shell where "cabal new-build" can use prebuilt package dependencies.
