### PR TITLE
[CBR-467] fix STM and exception mistakes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,8 @@ steps:
     command: "cd explorer/frontend && ./nix/generate-frontend-deps.hs --test"
     agents:
       system: x86_64-linux
+
+  - label: 'triggerShutdown test'
+    command: "rm -rf test-state ; nix-shell node-ipc/shell.nix --run 'node node-ipc/server.js'"
+    agents:
+      system: x86_64-linux

--- a/node-ipc/wallet-topology.yaml
+++ b/node-ipc/wallet-topology.yaml
@@ -1,0 +1,5 @@
+wallet:
+  fallbacks: 7
+  valency: 1
+  relays:
+  - - host: relays.awstest.iohkdev.io

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.WalletLayer.Kernel
 import           Universum hiding (for_)
 
 import qualified Control.Concurrent.STM as STM
+import           Control.Monad.IO.Unlift (MonadUnliftIO)
 import qualified Data.List.NonEmpty as NE
 
 import           Data.Foldable (for_)
@@ -49,7 +50,7 @@ import qualified Cardano.Wallet.WalletLayer.Kernel.Wallets as Wallets
 -- | Initialize the passive wallet.
 -- The passive wallet cannot send new transactions.
 bracketPassiveWallet
-    :: forall m n a. (MonadIO n, MonadIO m, MonadMask m)
+    :: forall m n a. (MonadIO n, MonadUnliftIO m, MonadMask m)
     => Kernel.DatabaseMode
     -> (Severity -> Text -> IO ())
     -> Keystore


### PR DESCRIPTION
## Description

Like #3740 but with more fixes.

- The bracket_ order was wrong for walletWorker
- withWalletWorker is simpler and better: if either the reader or writer thread dies exceptionally, the other also dies. The writer would previously close the queue and then wait on the reader. Now this happens only on normal termination.
- `node` would deadlock in the call to `killNode` on exceptional shutdown. `killNode` would cancel the dispatcher thread, then close the network-transport endpoint. Since we used network-transport-tcp with the fair `QDisc`, which blocks on write, there would be deadlock, for the dispatcher thread would no longer be reading that `QDisc`. Thus `killNode` would throw a blocked indefinitely on `STM` transaction exception, overriding the `exitFailure (ExitCode 20)` raised by a `triggerShutdown`.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
