### PR TITLE
[CBR-466] fix address reported as unused during restoration

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -55,6 +55,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet (
   , hdAccountName
   , hdAccountState
   , hdAccountStateCurrent
+  , hdAccountStateCurrentCombined
   , hdAccountStateUpToDate
   , hdAccountRestorationState
     -- *** Account state: up to date
@@ -474,6 +475,16 @@ hdAccountStateCurrent g = to $ \case
       st ^. hdUpToDateCheckpoints . unCheckpoints . _Wrapped . SNE.head . g
     HdAccountStateIncomplete st ->
       st ^. hdIncompleteCurrent   . unCheckpoints . _Wrapped . SNE.head . g
+
+hdAccountStateCurrentCombined :: (a -> a -> a)
+                              -> (forall c. IsCheckpoint c => Getter c a)
+                              -> Getter HdAccountState a
+hdAccountStateCurrentCombined combine g = to $ \case
+    HdAccountStateUpToDate st ->
+      st ^. hdUpToDateCheckpoints . unCheckpoints . _Wrapped . SNE.head . g
+    HdAccountStateIncomplete st ->
+      combine (st ^. hdIncompleteCurrent    . unCheckpoints . _Wrapped . SNE.head . g)
+              (st ^. hdIncompleteHistorical . unCheckpoints . _Wrapped . SNE.head . g)
 
 {-------------------------------------------------------------------------------
   Predicates and tests

--- a/wallet-new/src/Cardano/Wallet/Kernel/Util/Core.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Util/Core.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Kernel.Util.Core (
   , utxoRestrictToInputs
   , utxoRemoveInputs
   , utxoUnions
+  , toAddress
     -- * Transactions
   , paymentAmount
   , toCoin

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Conv.hs
@@ -200,7 +200,7 @@ toAddress acc hdAddress =
                      (V1 addressOwnership)
   where
     cardanoAddress   = hdAddress ^. HD.hdAddressAddress . fromDb
-    addressMeta      = acc ^. HD.hdAccountState . HD.hdAccountStateCurrent (cpAddressMeta cardanoAddress)
+    addressMeta      = acc ^. HD.hdAccountState . HD.hdAccountStateCurrentCombined (<>) (cpAddressMeta cardanoAddress)
     -- NOTE
     -- In this particular case, the address had to be known by us. As a matter
     -- of fact, to construct a 'WalletAddress', we have to be aware of pieces


### PR DESCRIPTION
## Description
This pr has two parts:
- The first part is a bug fix (CBR-466). When we ask for addresses during restoration, even after a tx that uses an address is discovered, the address is still reported as unused. This happens because currently only partial checkpoints are queried and historical checkpoint are ignored. The first commit of this pr solves this issue.

- The second part is more of an improvement that was not provided by the old wallet (CBR-193). When we discover a utxo at the begining of restoration, we mark the relevant addresses as used. This means that some addresses are reported as used, even before the tx that uses them is discovered.

## Linked issue
https://iohk.myjetbrains.com/youtrack/issue/CBR-193
https://iohk.myjetbrains.com/youtrack/issue/CBR-466

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
Start a restoration. When a tx of the wallet is discovered and before restoration finishes, use endpoint api/v1/addresses. The addresses of the tx should all be used:true

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
