### PR TITLE
some cleanups in preparation for adding new functionalities

### DIFF
--- a/wallet-new/README.md
+++ b/wallet-new/README.md
@@ -188,14 +188,11 @@ $ nix-build -A walletIntegrationTests --arg useStackBinaries true
 > test, you can pass the `--check` flag to force the test to run again. `--check`
 > is used to confirm that results from one test match the results again.
 
-Wallet integration tests can be used also with seed/match options that behave like hspec test runner (and are passed to).
---match PATTERN - behave exactly like Hspec's --match allowing to run only a subset of tests
---seed SEED - enable passing an external, predictable seed to the test runner
-Example allowing the use of concrete seed and testing Address related tests only:
-
+The wallet integration tests support --hspec-options to pass options to HSpec. 
+For example:
 ```
 $ nix-build -A walletIntegrationTests -o launch_integration_tests
-$ ./launch_integration_tests --match 'Address' --seed 47286650
+$ ./launch_integration_tests --hspec-options '--match Address --seed 47286650'
 ```
 
 

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -362,12 +362,13 @@ executable wal-integr-test
                        -O2
   other-modules:       CLI
                        Types
-                       Functions
                        Error
                        Util
                        WalletSpecs
                        AccountSpecs
                        AddressSpecs
+                       RandomStateWalk
+                       SetupTestEnv
                        TransactionSpecs
                        QuickCheckSpecs
 

--- a/wallet-new/integration/AccountSpecs.hs
+++ b/wallet-new/integration/AccountSpecs.hs
@@ -10,7 +10,6 @@ import           Cardano.Wallet.API.Indices (accessIx)
 import           Cardano.Wallet.Client.Http
 import           Control.Lens
 import qualified Data.Text as T
-import           Functions (randomTest)
 import           Pos.Core.Common (mkCoin)
 import           Test.Hspec
 import           Test.QuickCheck (arbitrary, shuffle)

--- a/wallet-new/integration/AddressSpecs.hs
+++ b/wallet-new/integration/AddressSpecs.hs
@@ -7,13 +7,10 @@ import           Universum
 
 import           Cardano.Wallet.Client.Http
 import           Control.Lens
-import           Functions (randomTest)
 import           Test.Hspec
 import           Test.QuickCheck.Monadic (run)
 
-
 import           Util
-
 
 addressSpecs :: WalletRef -> WalletClient IO -> Spec
 addressSpecs wRef wc = do

--- a/wallet-new/integration/CLI.hs
+++ b/wallet-new/integration/CLI.hs
@@ -3,17 +3,16 @@
 -- | Functions for working with command-line options.
 
 module CLI
-    ( CLOptions (..)
+    ( CLIOptions (..)
     , getOptions
     ) where
 
+import           Data.String (words)
+import           Options.Applicative
 import           Universum
 
-import           Options.Applicative
-
-
 -- | Parser for command-line options.
-optionsParser :: Parser CLOptions
+optionsParser :: Parser CLIOptions
 optionsParser = do
     tlsClientCertPath <- strOption $
         long        "tls-client-cert"
@@ -44,24 +43,18 @@ optionsParser = do
        <> help      "Server port"
        <> showDefault
 
-    testRunnerMatch <- optional . strOption $
-        long        "match"
-        <> metavar  "PATTERN"
-        <> help     "Only tests that match PATTERN will be run"
+    hSpecOptions <- fmap Data.String.words $ strOption $
+        long        "hspec-options"
+        <> metavar  "OPTIONS"
+        <> value    ""
+        <> help     "extra options to pass to HSpec"
         <> showDefault
 
-    testRunnerSeed <- optional . option auto $
-        long        "seed"
-        <> metavar  "SEED"
-        <> help     "Seed for a test runner"
-        <> showDefault
-
-
-    pure CLOptions{..}
+    pure CLIOptions{..}
 
 
 -- | Get command-line options.
-getOptions :: IO CLOptions
+getOptions :: IO CLIOptions
 getOptions = execParser programInfo
   where
     programInfo = info (helper <*> optionsParser) $
@@ -70,12 +63,11 @@ getOptions = execParser programInfo
 
 
 -- | The configuration for the application.
-data CLOptions = CLOptions
+data CLIOptions = CLIOptions
     { tlsClientCertPath :: FilePath
     , tlsPrivKeyPath    :: FilePath
     , tlsCACertPath     :: FilePath
     , serverHost        :: String
     , serverPort        :: Int
-    , testRunnerMatch   :: Maybe String
-    , testRunnerSeed    :: Maybe Integer
+    , hSpecOptions      :: [String]
     } deriving (Show, Eq)

--- a/wallet-new/integration/Main.hs
+++ b/wallet-new/integration/Main.hs
@@ -5,115 +5,40 @@ module Main where
 
 import           Universum
 
-import           Cardano.Wallet.Client.Http
-import           Data.Map (fromList)
-import           Data.Traversable (for)
-import           Data.X509.File (readSignedObject)
+import           Cardano.Wallet.Client.Http (WalletClient)
 import           Network.HTTP.Client (Manager)
+import qualified QuickCheckSpecs as QuickCheck
 import           System.Environment (withArgs)
-import           System.IO (hSetEncoding, stdout, utf8)
-import           Test.Hspec
+import           Test.Hspec (Spec, hspec)
 
 import           AccountSpecs (accountSpecs)
 import           AddressSpecs (addressSpecs)
-import           CLI
-import           Functions
+import           CLI (CLIOptions (..), getOptions)
+import           RandomStateWalk (randomStateWalkTest)
+import           SetupTestEnv (setupClient)
+import           System.IO (hSetEncoding, stdout, utf8)
 import           TransactionSpecs (transactionSpecs)
-import           Types
-import           Util (WalletRef, newWalletRef)
+import           Util (WalletRef, newWalletRef, printT)
 import           WalletSpecs (walletSpecs)
 
-import qualified Data.ByteString.Char8 as B8
-import qualified QuickCheckSpecs as QuickCheck
-
-
--- | Here we want to run main when the (local) nodes
--- have started.
+-- | Here we want to run main when the (local) nodes have started.
 main :: IO ()
 main = do
     hSetEncoding stdout utf8
-    CLOptions {..} <- getOptions
-
-    -- TODO (akegalj): run server cluster in haskell, instead of using shell scripts
-    -- serverThread <- async (runWalletServer options)
+    options@CLIOptions {..} <- getOptions
 
     printT "Starting the integration testing for wallet."
-
-    let serverId = (serverHost, B8.pack $ show serverPort)
-    caChain <- readSignedObject tlsCACertPath
-    clientCredentials <- orFail =<< credentialLoadX509 tlsClientCertPath tlsPrivKeyPath
-    manager <- newManager $ mkHttpsManagerSettings serverId caChain clientCredentials
-
-    let baseUrl = BaseUrl Https serverHost serverPort mempty
-
-    let walletClient :: MonadIO m => WalletClient m
-        walletClient = withThrottlingRetry
-            . liftClient
-            $ mkHttpClient baseUrl manager
-
+    (walletClient, manager) <- setupClient options
     -- Acquire the initial state for the deterministic tests
     wRef <- newWalletRef
 
-    -- NOTE Our own CLI options interfere with `hspec` which parse them for
-    -- itself when executed, leading to a VERY unclear message:
-    --
-    --     cardano-integration-test: unrecognized option `--tls-ca-cert'
-    --     Try `cardano-integration-test --help' for more information.
-    --
-    -- See also: https://github.com/hspec/hspec/issues/135
-
-    let optionsFromAbove = case (testRunnerMatch, testRunnerSeed) of
-            (Nothing, Nothing)      -> []
-            (Nothing, Just seed)    -> ["--seed", show seed]
-            (Just match, Nothing)   -> ["-m", match]
-            (Just match, Just seed) -> ["-m", match, "--seed", show seed]
-
-    withArgs optionsFromAbove  $ do
+    withArgs hSpecOptions $ do
         printT "Starting deterministic tests."
-        printT $ "match from options: " <> show testRunnerMatch
-        printT $ "seed from options: " <> show testRunnerSeed
-
+        printT $ "HSpec options: " <> show hSpecOptions
         hspec $ deterministicTests wRef walletClient manager
 
         printT $ "The 'runActionCheck' tests were disabled because they were highly un-reliable."
-        when False $ do
-            walletState <- initialWalletState walletClient
-
-            printT $ "Initial wallet state: " <> show walletState
-
-            -- some monadic fold or smth similar
-            void $ runActionCheck
-                walletClient
-                walletState
-                actionDistribution
-  where
-    orFail :: MonadFail m => Either String a -> m a
-    orFail =
-        either (fail . ("Error decoding X509 certificates: " <>)) return
-
-    actionDistribution :: ActionProbabilities
-    actionDistribution =
-        (PostWallet, Weight 2)
-            :| (PostTransaction, Weight 5)
-            : fmap (, Weight 1) [minBound .. maxBound]
-
-initialWalletState :: WalletClient IO -> IO WalletState
-initialWalletState wc = do
-    -- We will have single genesis wallet in intial state that was imported from launching script
-    _wallets <- fromResp $ getWallets wc
-    _accounts <- concat <$> for _wallets (fromResp . getAccounts wc . walId)
-    -- Lets set all wallet passwords for initial wallets (genesis) to default (emptyPassphrase)
-    let _lastAction       = NoOp
-        _walletsPass      = fromList $ map ((, V1 mempty) . walId) _wallets
-        _addresses        = concatMap accAddresses _accounts
-        -- TODO(akegalj): I am not sure does importing a genesis wallet (which we do prior launching integration tests) creates a transaction
-        -- If it does, we should add this transaction to the list
-        _transactions     = mempty
-        _actionsNum       = 0
-        _successActions   = mempty
-    return WalletState {..}
-  where
-    fromResp = (either throwM (pure . wrData) =<<)
+        when False $ randomStateWalkTest walletClient
 
 deterministicTests :: WalletRef -> WalletClient IO -> Manager -> Spec
 deterministicTests wref wc manager = do

--- a/wallet-new/integration/SetupTestEnv.hs
+++ b/wallet-new/integration/SetupTestEnv.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE LambdaCase #-}
+module SetupTestEnv where
+import           Universum
+
+import           Cardano.Wallet.Client.Http
+import           CLI
+import qualified Data.ByteString.Char8 as B8
+import           Data.X509.File (readSignedObject)
+import           Network.HTTP.Client (Manager)
+
+setupClient :: CLIOptions -> IO (WalletClient IO, Manager)
+setupClient CLIOptions {..} = do
+    let serverId = (serverHost, B8.pack $ show serverPort)
+    caChain <- readSignedObject tlsCACertPath
+    clientCredentials <- credentialLoadX509 tlsClientCertPath tlsPrivKeyPath >>= \case
+        Right   a -> return a
+        Left  err -> fail $ "Error decoding X509 certificates: " <> err
+    manager <- newManager $ mkHttpsManagerSettings serverId caChain clientCredentials
+
+    let
+        baseUrl = BaseUrl Https serverHost serverPort mempty
+        walletClient :: MonadIO m => WalletClient m
+        walletClient = withThrottlingRetry
+            . liftClient
+            $ mkHttpClient baseUrl manager
+
+    return (walletClient, manager)
+

--- a/wallet-new/integration/TransactionSpecs.hs
+++ b/wallet-new/integration/TransactionSpecs.hs
@@ -7,7 +7,6 @@ import           Universum
 
 import           Cardano.Wallet.Client.Http
 import           Control.Lens
-import           Functions (randomTest)
 import           Test.Hspec
 import           Test.QuickCheck.Monadic (PropertyM, run)
 import           Text.Show.Pretty (ppShow)

--- a/wallet-new/integration/Util.hs
+++ b/wallet-new/integration/Util.hs
@@ -10,7 +10,10 @@ import           Control.Concurrent.Async (race)
 import           Control.Lens
 import           System.IO.Unsafe (unsafePerformIO)
 import           Test.Hspec
-import           Test.QuickCheck (arbitrary, generate)
+import           Test.Hspec.QuickCheck (prop)
+import           Test.QuickCheck (arbitrary, generate, withMaxSuccess)
+import           Test.QuickCheck.Monadic (PropertyM, monadicIO)
+import           Test.QuickCheck.Property (Testable)
 
 import qualified Pos.Chain.Txp as Txp
 
@@ -166,3 +169,12 @@ noLongerThan action maxWaitingTime = do
     case res of
         Left _  -> return Nothing
         Right a -> return $ Just a
+
+
+-- | Output for @Text@.
+printT :: Text -> IO ()
+printT = putStrLn
+
+randomTest :: (Testable a) => String -> Int -> PropertyM IO a -> Spec
+randomTest msg maxSuccesses =
+    prop msg . withMaxSuccess maxSuccesses . monadicIO

--- a/wallet-new/integration/WalletSpecs.hs
+++ b/wallet-new/integration/WalletSpecs.hs
@@ -7,7 +7,6 @@ import           Universum
 
 import           Cardano.Wallet.Client.Http
 import           Control.Lens
-import           Functions (randomTest)
 import           Test.Hspec
 import           Test.QuickCheck.Monadic (run)
 


### PR DESCRIPTION
## Description
Most of this PR consists of  refactorings that don't change functionality.
The motivations for this PR are to clean up parts of the code and to make it easier to add new features.

### Changes:

* `Main.hs`: has been reduced to a minimum to make it easy to read and modifiy.
Functions that are related to the RandomStateWalk have been moved to that module.
Functions for setting up the `WalletClient` have been moved to `SetupTestEnv.hs`.
* `SetupTestEnv.hs`
exports exports `setupClient :: CLIOptions -> IO (WalletClient IO, Manager)`
 which has been inlined in `main :: IO ()` before.
`setupClient` is needed to run tests and single queries from the REPL.
* `Functions.hs` / `RandomStateWalk.hs`
The module `Functions.hs` has been renamed to  `RandomStateWalk.hs`.
some weeks ago some 5 lines have been added to `Functions.hs` that do not deal with the random state walk. these have been moved to `Utils.hs`
With this change the module `RandomStateWalk.hs` contains all random-state-walk code and nothing else.
The random-state-walk has been disabled some weeks ago is dead code (is compiled but does not run)

There is also one breaking change in the way arguments are forwarded to HSpec.

The wallet integration tests now uses `--hspec-options` to pass options to HSpec. 
For example:
```
$ nix-build -A walletIntegrationTests -o launch_integration_tests
$ ./launch_integration_tests --hspec-options '--match Address --seed 47286650'
```
#####  Motivation :
The old version defined local options `--seed` and `--match` which are then repacked and passed to HSpec.
Problems with the old approach:
* It does not make clear that `--seed` and `--match` are indeed HSpec options. (its not clear where to lookup the documentation etc)
* It does not scale and does not support all the other
[useful options of HSpec](http://hspec.github.io/options.html)
* The implementation uses an anti-pattern. That pattern uses
2 lines for one option, 4 lines for two option, 8 lines for three options...
it makes it difficult to add new options.
<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue
CO-424

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [X] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [X] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [X] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [X] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
