### PR TITLE
[CO-410] Split test-suites for NetworkMainOrStage/NetworkTestnet

### DIFF
--- a/auxx/src/Command/BlockGen.hs
+++ b/auxx/src/Command/BlockGen.hs
@@ -17,6 +17,7 @@ import           Pos.Chain.Genesis as Genesis (Config (..),
                      configBootStakeholders)
 import           Pos.Chain.Txp (TxpConfiguration)
 import           Pos.Client.KeyStorage (getSecretKeysPlain)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (encToSecret)
 import           Pos.DB.Txp (txpGlobalSettings)
 import           Pos.Generator.Block (BlockGenParams (..), genBlocks,
@@ -38,7 +39,8 @@ generateBlocks genesisConfig txpConfig GenBlocksParams{..} = withStateLock HighP
     seed <- liftIO $ maybe randomIO pure bgoSeed
     logInfo $ "Generating with seed " <> show seed
 
-    allSecrets <- mkAllSecretsSimple . map encToSecret <$> getSecretKeysPlain
+    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
+    allSecrets <- (mkAllSecretsSimple nm) . map encToSecret <$> getSecretKeysPlain
 
     let bgenParams =
             BlockGenParams

--- a/chain/src/Pos/Chain/Genesis/Generate.hs
+++ b/chain/src/Pos/Chain/Genesis/Generate.hs
@@ -40,7 +40,7 @@ import           Pos.Core.Common (Address, Coin, IsBootstrapEraAddr (..),
                      coinToInteger, deriveFirstHDAddress,
                      makePubKeyAddressBoot, mkCoin, sumCoins,
                      unsafeIntegerToCoin)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.ProtocolConstants (ProtocolConstants, vssMaxTTL,
                      vssMinTTL)
 import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic, RedeemPublicKey,
@@ -176,7 +176,7 @@ generateGenesisData pm pc (GenesisInitializer{..}) realAvvmBalances = determinis
     vssCerts <- mkVssCertificatesMap
         <$> mapM (generateVssCert pm pc) richmenSecrets
 
-    let nm = fixedNM
+    let nm = makeNetworkMagic pm
 
     -- Non AVVM balances
     ---- Addresses
@@ -321,7 +321,3 @@ genTestnetDistribution TestnetBalanceOptions {..} testBalance =
 
     getShare :: Double -> Integer -> Integer
     getShare sh n = round $ sh * fromInteger n
-
-
-fixedNM :: NetworkMagic
-fixedNM = NetworkMainOrStage

--- a/chain/src/Pos/Chain/Txp/GenesisUtxo.hs
+++ b/chain/src/Pos/Chain/Txp/GenesisUtxo.hs
@@ -10,13 +10,14 @@ import           Universum
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 
-import           Pos.Chain.Genesis (GenesisData (..), getGenesisAvvmBalances,
+import           Pos.Chain.Genesis (GenesisData (..),
+                     GenesisProtocolConstants (..), getGenesisAvvmBalances,
                      getGenesisNonAvvmBalances)
 import           Pos.Chain.Txp.Toil (Utxo, utxoToStakes)
 import           Pos.Chain.Txp.Tx (TxIn (..), TxOut (..))
 import           Pos.Chain.Txp.TxOutAux (TxOutAux (..))
 import           Pos.Core (Address, Coin, StakesMap, makeRedeemAddress)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (NetworkMagic, makeNetworkMagic)
 import           Pos.Crypto (unsafeHash)
 
 
@@ -28,7 +29,9 @@ genesisUtxo :: GenesisData -> Utxo
 genesisUtxo genesisData =
     let
         networkMagic :: NetworkMagic
-        networkMagic = fixedNM
+        networkMagic = makeNetworkMagic $
+                       gpcProtocolMagic $
+                       gdProtocolConsts genesisData
 
         preUtxo :: [(Address, Coin)]
         preUtxo =
@@ -44,6 +47,3 @@ genesisUtxo genesisData =
             (TxInUtxo (unsafeHash addr) 0, TxOutAux (TxOut addr coin))
     in
         Map.fromList $ utxoEntry <$> preUtxo
-
-fixedNM :: NetworkMagic
-fixedNM = NetworkMainOrStage

--- a/chain/test/Test/Pos/Chain/Delegation/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Delegation/Arbitrary.hs
@@ -21,7 +21,6 @@ import           Pos.Core (EpochIndex)
 import           Pos.Crypto (ProtocolMagic, ProxySecretKey (..), createPsk)
 
 import           Test.Pos.Core.Arbitrary ()
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 
 genDlgPayload :: ProtocolMagic -> EpochIndex -> Gen DlgPayload
 genDlgPayload pm epoch =
@@ -31,7 +30,10 @@ genDlgPayload pm epoch =
     genPSK = createPsk pm <$> arbitrary <*> arbitrary <*> pure (HeavyDlgIndex epoch)
 
 instance Arbitrary DlgPayload where
-    arbitrary = arbitrary >>= genDlgPayload dummyProtocolMagic
+    arbitrary = do
+        pm <- arbitrary
+        ei <- arbitrary
+        genDlgPayload pm ei
     shrink = genericShrink
 
 instance Arbitrary DlgUndo where

--- a/chain/test/Test/Pos/Chain/Genesis/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Genesis/Arbitrary.hs
@@ -29,7 +29,6 @@ import           Pos.Util.Util (leftToPanic)
 import           Test.Pos.Chain.Ssc.Arbitrary ()
 import           Test.Pos.Chain.Update.Arbitrary ()
 import           Test.Pos.Core.Arbitrary ()
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Util.QuickCheck.Arbitrary (nonrepeating)
 
 instance Arbitrary TestnetBalanceOptions where
@@ -56,12 +55,13 @@ instance Arbitrary GenesisDelegation where
                                                         -- because 'nonrepeating' fails when
                                                         -- we want too many items, because
                                                         -- life is hard
+            pm <- arbitrary
             return $
                 case secretKeys of
                     []                 -> []
-                    (delegate:issuers) -> mkCert (toPublic delegate) <$> issuers
+                    (delegate:issuers) -> mkCert pm (toPublic delegate) <$> issuers
       where
-        mkCert delegatePk issuer = createPsk dummyProtocolMagic issuer delegatePk (HeavyDlgIndex 0)
+        mkCert pm delegatePk issuer = createPsk pm issuer delegatePk (HeavyDlgIndex 0)
 
 instance Arbitrary GenesisWStakeholders where
     arbitrary = GenesisWStakeholders <$> arbitrary

--- a/chain/test/Test/Pos/Chain/Ssc/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Ssc/Arbitrary.hs
@@ -53,7 +53,6 @@ import           Pos.Crypto (ProtocolMagic, SecretKey, deterministic,
 import           Test.Pos.Chain.Genesis.Dummy (dummyK)
 import           Test.Pos.Core.Arbitrary.Unsafe ()
 import           Test.Pos.Crypto.Arbitrary (genSignature)
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Util.QuickCheck.Arbitrary (Nonrepeating (..),
                      sublistN)
 
@@ -141,7 +140,7 @@ genSignedCommitment :: ProtocolMagic -> Gen SignedCommitment
 genSignedCommitment pm = (,,) <$> arbitrary <*> arbitrary <*> genSignature pm arbitrary
 
 instance Arbitrary CommitmentsMap where
-    arbitrary = genCommitmentsMap dummyProtocolMagic
+    arbitrary = arbitrary >>= genCommitmentsMap
     shrink = genericShrink
 
 -- | Generates commitment map having commitments from given epoch.
@@ -179,7 +178,7 @@ genSscPayload pm =
         ]
 
 instance Arbitrary SscPayload where
-    arbitrary = genSscPayload dummyProtocolMagic
+    arbitrary = arbitrary >>= genSscPayload
     shrink = genericShrink
 
 -- | We need the 'ProtocolConstants' because they give meaning to 'SlotId'.
@@ -207,7 +206,9 @@ genSscPayloadForSlot pm slot
     genValidCert SlotId{..} (sk, pk) = mkVssCertificate pm sk pk $ siEpoch + 5
 
 instance Arbitrary SscPayloadDependsOnSlot where
-    arbitrary = pure $ SscPayloadDependsOnSlot (genSscPayloadForSlot dummyProtocolMagic)
+    arbitrary = do
+        pm <- arbitrary
+        pure $ SscPayloadDependsOnSlot (genSscPayloadForSlot pm)
 
 genVssCertificate :: ProtocolMagic -> Gen VssCertificate
 genVssCertificate pm =
@@ -216,7 +217,7 @@ genVssCertificate pm =
                         <*> arbitrary -- EpochIndex
 
 instance Arbitrary VssCertificate where
-    arbitrary = genVssCertificate dummyProtocolMagic
+    arbitrary = arbitrary >>= genVssCertificate
     -- The 'shrink' method wasn't implement to avoid breaking the datatype's invariant.
 
 genVssCertificatesMap :: ProtocolMagic -> Gen VssCertificatesMap
@@ -225,7 +226,7 @@ genVssCertificatesMap pm = do
     pure $ mkVssCertificatesMapLossy certs
 
 instance Arbitrary VssCertificatesMap where
-    arbitrary = genVssCertificatesMap dummyProtocolMagic
+    arbitrary = arbitrary >>= genVssCertificatesMap
     shrink = genericShrink
 
 instance Arbitrary VssCertData where

--- a/chain/test/Test/Pos/Chain/Txp/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Txp/Arbitrary.hs
@@ -21,6 +21,7 @@ module Test.Pos.Chain.Txp.Arbitrary
        , genTxInWitness
        , genTxOutDist
        , genTxPayload
+       , genGoodTxWithMagic
        ) where
 
 import           Universum
@@ -163,6 +164,12 @@ buildProperTx pm inputList (inCoin, outCoin) =
 newtype GoodTx = GoodTx
     { getGoodTx :: NonEmpty (Tx, TxIn, TxOutAux, TxInWitness)
     } deriving (Generic, Show)
+
+genGoodTxWithMagic :: ProtocolMagic -> Gen GoodTx
+genGoodTxWithMagic pm =
+        GoodTx <$> (buildProperTx pm
+                        <$> arbitrary
+                        <*> pure (identity, identity))
 
 goodTxToTxAux :: GoodTx -> TxAux
 goodTxToTxAux (GoodTx l) = TxAux tx witness

--- a/chain/test/Test/Pos/Chain/Txp/Toil/UtxoSpec.hs
+++ b/chain/test/Test/Pos/Chain/Txp/Toil/UtxoSpec.hs
@@ -21,9 +21,10 @@ import           Fmt (blockListF', genericF, nameF, (+|), (|+))
 import qualified Formatting.Buildable as B
 import           Serokell.Util (allDistinct)
 import           Test.Hspec (Expectation, Spec, describe, expectationFailure,
-                     it)
+                     it, runIO)
 import           Test.Hspec.QuickCheck (prop)
-import           Test.QuickCheck (Property, arbitrary, counterexample, (==>))
+import           Test.QuickCheck (Property, arbitrary, counterexample, forAll,
+                     generate, (==>))
 
 import           Pos.Chain.Script (PlutusError (..), Script)
 import           Pos.Chain.Script.Examples (alwaysSuccessValidator,
@@ -42,13 +43,14 @@ import           Pos.Core (addressHash, checkPubKeyAddress,
                      sumCoins)
 import           Pos.Core.Attributes (mkAttributes)
 import           Pos.Core.NetworkMagic (makeNetworkMagic)
-import           Pos.Crypto (SignTag (SignTx), checkSig, fakeSigner, hash,
-                     toPublic, unsafeHash, withHash)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..),
+                     SignTag (SignTx), checkSig, fakeSigner, hash, toPublic,
+                     unsafeHash, withHash)
 import qualified Pos.Util.Modifier as MM
 
 import           Test.Pos.Chain.Txp.Arbitrary (BadSigsTx (..),
-                     DoubleInputTx (..), GoodTx (..))
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+                     DoubleInputTx (..), GoodTx (..), genGoodTxWithMagic)
+import           Test.Pos.Crypto.Arbitrary (genProtocolMagicUniformWithRNM)
 import           Test.Pos.Util.QuickCheck.Arbitrary (SmallGenerator (..),
                      nonrepeating, runGen)
 import           Test.Pos.Util.QuickCheck.Property (qcIsLeft, qcIsRight)
@@ -56,6 +58,12 @@ import           Test.Pos.Util.QuickCheck.Property (qcIsLeft, qcIsRight)
 ----------------------------------------------------------------------------
 -- Spec
 ----------------------------------------------------------------------------
+
+runWithMagic :: RequiresNetworkMagic -> (ProtocolMagic -> Spec) -> Spec
+runWithMagic rnm specBody = do
+    pm <- runIO (generate (genProtocolMagicUniformWithRNM rnm))
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
 
 spec :: Spec
 spec = describe "Txp.Toil.Utxo" $ do
@@ -70,7 +78,10 @@ spec = describe "Txp.Toil.Utxo" $ do
         prop description_doubleInputTx  doubleInputTx
     describe "applyTxToUtxo" $ do
         prop description_applyTxToUtxoGood applyTxToUtxoGood
-    scriptTxSpec
+
+    -- Run scriptTxSpec for each `RequiresNetworkMagic` case
+    runWithMagic RequiresNoMagic scriptTxSpec
+    runWithMagic RequiresMagic   scriptTxSpec
   where
     myTxIn = TxInUtxo myHash 0
     myHash = unsafeHash @Int32 0
@@ -101,8 +112,8 @@ findTxInUtxo key txO utxo =
      in (isJust $ utxoGetSimple newUtxo key) &&
         (isNothing $ utxoGetSimple utxo' key)
 
-verifyTxInUtxo :: SmallGenerator GoodTx -> Property
-verifyTxInUtxo (SmallGenerator (GoodTx ls)) =
+verifyTxInUtxo :: ProtocolMagic -> Property
+verifyTxInUtxo pm = forAll (genGoodTxWithMagic overriddenPM) $ \(GoodTx ls) ->
     let txs = fmap (view _1) ls
         witness = V.fromList $ toList $ fmap (view _4) ls
         (ins, outs) = NE.unzip $ map (\(_, tIs, tOs, _) -> (tIs, tOs)) ls
@@ -112,44 +123,65 @@ verifyTxInUtxo (SmallGenerator (GoodTx ls)) =
             let id = hash tx
             (idx, out) <- zip [0..] (toList _txOutputs)
             pure ((TxInUtxo id idx), TxOutAux out)
-        vtxContext = VTxContext False (makeNetworkMagic dummyProtocolMagic)
+        vtxContext = VTxContext False (makeNetworkMagic overriddenPM)
         txAux = TxAux newTx witness
     in counterexample ("\n"+|nameF "txs" (blockListF' "-" genericF txs)|+""
                            +|nameF "transaction" (B.build txAux)|+"") $
-       qcIsRight $ verifyTxUtxoSimple vtxContext utxo txAux
+       qcIsRight $ verifyTxUtxoSimple overriddenPM vtxContext utxo txAux
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
-badSigsTx :: SmallGenerator BadSigsTx -> Property
-badSigsTx (SmallGenerator (getBadSigsTx -> ls)) =
+badSigsTx :: ProtocolMagic -> SmallGenerator BadSigsTx -> Property
+badSigsTx pm (SmallGenerator (getBadSigsTx -> ls)) =
     let (tx@UnsafeTx {..}, utxo, extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False (makeNetworkMagic dummyProtocolMagic)
+        ctx = VTxContext False (makeNetworkMagic overriddenPM)
         transactionVerRes =
-            verifyTxUtxoSimple ctx utxo $ TxAux tx txWits
+            verifyTxUtxoSimple overriddenPM ctx utxo $ TxAux tx txWits
         notAllSignaturesAreValid =
-            any (signatureIsNotValid tx)
+            any (signatureIsNotValid overriddenPM tx)
                 (NE.zip (NE.fromList (toList txWits))
                         (map (fmap snd) extendedInputs))
     in notAllSignaturesAreValid ==> qcIsLeft transactionVerRes
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
-doubleInputTx :: SmallGenerator DoubleInputTx -> Property
-doubleInputTx (SmallGenerator (getDoubleInputTx -> ls)) =
+doubleInputTx :: ProtocolMagic -> SmallGenerator DoubleInputTx -> Property
+doubleInputTx pm (SmallGenerator (getDoubleInputTx -> ls)) =
     let ((tx@UnsafeTx {..}), utxo, _extendedInputs, txWits) =
             getTxFromGoodTx ls
-        ctx = VTxContext False (makeNetworkMagic dummyProtocolMagic)
+        ctx = VTxContext False (makeNetworkMagic overriddenPM)
         transactionVerRes =
-            verifyTxUtxoSimple ctx utxo $ TxAux tx txWits
+            verifyTxUtxoSimple overriddenPM ctx utxo $ TxAux tx txWits
         someInputsAreDuplicated =
             not $ allDistinct (toList _txInputs)
     in someInputsAreDuplicated ==> qcIsLeft transactionVerRes
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
-validateGoodTx :: SmallGenerator GoodTx -> Property
-validateGoodTx (SmallGenerator (getGoodTx -> ls)) =
-    let quadruple@(tx, utxo, _, txWits) = getTxFromGoodTx ls
-        ctx = VTxContext False (makeNetworkMagic dummyProtocolMagic)
-        transactionVerRes =
-            verifyTxUtxoSimple ctx utxo $ TxAux tx txWits
-        transactionReallyIsGood = individualTxPropertyVerifier quadruple
-    in transactionReallyIsGood ==> qcIsRight transactionVerRes
+validateGoodTx :: ProtocolMagic -> Property
+validateGoodTx pm =
+    forAll (genGoodTxWithMagic overriddenPM) $ \(GoodTx ls) ->
+        let quadruple@(tx, utxo, _, txWits) = getTxFromGoodTx ls
+            ctx = VTxContext False (makeNetworkMagic overriddenPM)
+            transactionVerRes =
+                verifyTxUtxoSimple overriddenPM ctx utxo $ TxAux tx txWits
+            transactionReallyIsGood = individualTxPropertyVerifier overriddenPM quadruple
+        in transactionReallyIsGood ==> qcIsRight transactionVerRes
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -159,13 +191,19 @@ utxoGetSimple :: Utxo -> TxIn -> Maybe TxOutAux
 utxoGetSimple utxo txIn = evalUtxoM mempty (utxoToLookup utxo) (utxoGet txIn)
 
 verifyTxUtxoSimple
-    :: VTxContext
+    :: ProtocolMagic
+    -> VTxContext
     -> Utxo
     -> TxAux
     -> Either ToilVerFailure VerifyTxUtxoRes
-verifyTxUtxoSimple ctx utxo txAux =
+verifyTxUtxoSimple pm ctx utxo txAux =
     evalUtxoM mempty (utxoToLookup utxo) . runExceptT $
-    verifyTxUtxo dummyProtocolMagic ctx mempty txAux
+    verifyTxUtxo overriddenPM ctx mempty txAux
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
 type TxVerifyingTools =
     (Tx, Utxo, NonEmpty (Maybe (TxIn, TxOutAux)), TxWitness)
@@ -202,28 +240,39 @@ getTxFromGoodTx ls =
 -- * every input is signed properly;
 -- * every input is a known unspent output.
 -- It also checks that it has good structure w.r.t. 'verifyTxAlone'.
-individualTxPropertyVerifier :: TxVerifyingTools -> Bool
-individualTxPropertyVerifier (tx@UnsafeTx{..}, _, extendedInputs, txWits) =
+individualTxPropertyVerifier :: ProtocolMagic -> TxVerifyingTools -> Bool
+individualTxPropertyVerifier pm (tx@UnsafeTx{..}, _, extendedInputs, txWits) =
     let hasGoodSum = txChecksum extendedInputs _txOutputs
         hasGoodInputs =
-            all (signatureIsValid tx)
+            all (signatureIsValid overriddenPM tx)
                 (NE.zip (NE.fromList (toList txWits))
                         (map (fmap snd) extendedInputs))
     in hasGoodSum && hasGoodInputs
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
 
 signatureIsValid
-    :: Tx
+    :: ProtocolMagic
+    -> Tx
     -> (TxInWitness, Maybe TxOutAux)
     -- ^ input witness + output spent by the input
     -> Bool
-signatureIsValid tx (PkWitness twKey twSig, Just TxOutAux{..}) =
+signatureIsValid pm tx (PkWitness twKey twSig, Just TxOutAux{..}) =
     let txSigData = TxSigData
             { txSigTxHash = hash tx }
     in checkPubKeyAddress twKey (txOutAddress toaOut) &&
-       checkSig dummyProtocolMagic SignTx twKey txSigData twSig
-signatureIsValid _ _ = False
+       checkSig overriddenPM SignTx twKey txSigData twSig
+  where
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
+signatureIsValid _ _ _ = False
 
-signatureIsNotValid :: Tx -> (TxInWitness, Maybe TxOutAux) -> Bool
+signatureIsNotValid :: ProtocolMagic -> Tx -> (TxInWitness, Maybe TxOutAux) -> Bool
 signatureIsNotValid = not ... signatureIsValid
 
 -- | This function takes a list of resolved inputs from a transaction, that
@@ -264,8 +313,8 @@ applyTxToUtxoGood (txIn0, txOut0) txMap txOuts =
 -- Script Txs spec
 ----------------------------------------------------------------------------
 
-scriptTxSpec :: Spec
-scriptTxSpec = describe "script transactions" $ do
+scriptTxSpec :: ProtocolMagic -> Spec
+scriptTxSpec pm = describe "script transactions" $ do
     describe "good cases" $ do
         it "goodIntRedeemer + intValidator" $ do
             txShouldSucceed $ checkScriptTx
@@ -329,75 +378,75 @@ scriptTxSpec = describe "script transactions" $ do
 
     describe "multisig" $ do
         describe "1-of-1" $ do
-            let val = multisigValidator dummyProtocolMagic 1 [addressHash pk1]
+            let val = multisigValidator overriddenPM 1 [addressHash pk1]
             it "good (1 provided)" $ do
                 txShouldSucceed $ checkScriptTx val
                     (\sd -> ScriptWitness val
-                        (multisigRedeemer dummyProtocolMagic sd [Just $ fakeSigner sk1]))
+                        (multisigRedeemer overriddenPM sd [Just $ fakeSigner sk1]))
             it "bad (0 provided)" $ do
                 let res = checkScriptTx val
                         (\sd -> ScriptWitness val
-                            (multisigRedeemer dummyProtocolMagic sd [Nothing]))
+                            (multisigRedeemer overriddenPM sd [Nothing]))
                 res `txShouldFailWithPlutus` PlutusReturnedFalse
             it "bad (1 provided, wrong sig)" $ do
                 let res = checkScriptTx val
                         (\sd -> ScriptWitness val
-                            (multisigRedeemer dummyProtocolMagic sd [Just $ fakeSigner sk2]))
+                            (multisigRedeemer overriddenPM sd [Just $ fakeSigner sk2]))
                 res `txShouldFailWithPlutus` PlutusReturnedFalse
         describe "2-of-3" $ do
-            let val = multisigValidator dummyProtocolMagic 2 (map addressHash [pk1, pk2, pk3])
+            let val = multisigValidator overriddenPM 2 (map addressHash [pk1, pk2, pk3])
             it "good (2 provided)" $ do
                 txShouldSucceed $ checkScriptTx val
                     (\sd -> ScriptWitness val
-                        (multisigRedeemer dummyProtocolMagic sd
+                        (multisigRedeemer overriddenPM sd
                           [ Just $ fakeSigner sk1
                           , Nothing
                           , Just $ fakeSigner sk3]))
             it "good (3 provided)" $ do
                 txShouldSucceed $ checkScriptTx val
                     (\sd -> ScriptWitness val
-                        (multisigRedeemer dummyProtocolMagic sd
+                        (multisigRedeemer overriddenPM sd
                           [ Just $ fakeSigner sk1
                           , Just $ fakeSigner sk2
                           , Just $ fakeSigner sk3]))
             it "good (3 provided, 1 wrong)" $ do
                 txShouldSucceed $ checkScriptTx val
                     (\sd -> ScriptWitness val
-                        (multisigRedeemer dummyProtocolMagic sd
+                        (multisigRedeemer overriddenPM sd
                          [Just $ fakeSigner sk1,
                           Just $ fakeSigner sk4,
                           Just $ fakeSigner sk3]))
             it "bad (1 provided)" $ do
                 let res = checkScriptTx val
                         (\sd -> ScriptWitness val
-                            (multisigRedeemer dummyProtocolMagic sd
+                            (multisigRedeemer overriddenPM sd
                              [Just $ fakeSigner sk1, Nothing, Nothing]))
                 res `txShouldFailWithPlutus` PlutusReturnedFalse
             it "bad (2 provided, length doesn't match)" $ do
                 let res = checkScriptTx val
                         (\sd -> ScriptWitness val
-                            (multisigRedeemer dummyProtocolMagic sd
+                            (multisigRedeemer overriddenPM sd
                              [Just $ fakeSigner sk1, Just $ fakeSigner sk2]))
                 res `txShouldFailWithPlutus` PlutusReturnedFalse
             it "bad (3 provided, 2 wrong)" $ do
                 let res = checkScriptTx val
                         (\sd -> ScriptWitness val
-                            (multisigRedeemer dummyProtocolMagic sd
+                            (multisigRedeemer overriddenPM sd
                              [Just $ fakeSigner sk1, Just $ fakeSigner sk3, Just $ fakeSigner sk2]))
                 res `txShouldFailWithPlutus` PlutusReturnedFalse
 
     describe "execution limits" $ do
         it "5-of-5 multisig is okay" $ do
-            let val = multisigValidator dummyProtocolMagic 5 (replicate 5 (addressHash pk1))
+            let val = multisigValidator overriddenPM 5 (replicate 5 (addressHash pk1))
             txShouldSucceed $ checkScriptTx val
                 (\sd -> ScriptWitness val
-                    (multisigRedeemer dummyProtocolMagic sd
+                    (multisigRedeemer overriddenPM sd
                      (replicate 5 (Just $ fakeSigner sk1))))
         it "10-of-10 multisig is bad" $ do
-            let val = multisigValidator dummyProtocolMagic 10 (replicate 10 (addressHash pk1))
+            let val = multisigValidator overriddenPM 10 (replicate 10 (addressHash pk1))
             let res = checkScriptTx val
                     (\sd -> ScriptWitness val
-                        (multisigRedeemer dummyProtocolMagic sd
+                        (multisigRedeemer overriddenPM sd
                          (replicate 10 (Just $ fakeSigner sk1))))
             res `txShouldFailWithPlutus` PlutusExecutionFailure
                 "Out of petrol."
@@ -411,15 +460,20 @@ scriptTxSpec = describe "script transactions" $ do
                 "Out of petrol."
         it "100 rounds of sigverify is okay" $ do
             txShouldSucceed $ checkScriptTx idValidator
-                (\_ -> ScriptWitness idValidator (sigStressRedeemer dummyProtocolMagic 100))
+                (\_ -> ScriptWitness idValidator (sigStressRedeemer overriddenPM 100))
         it "200 rounds of sigverify is bad" $ do
             let res = checkScriptTx idValidator
-                      (\_ -> ScriptWitness idValidator (sigStressRedeemer dummyProtocolMagic 200))
+                      (\_ -> ScriptWitness idValidator (sigStressRedeemer overriddenPM 200))
             res `txShouldFailWithPlutus` PlutusExecutionFailure
                 "Out of petrol."
 
   where
-    nm = makeNetworkMagic dummyProtocolMagic
+    -- Ensure that `ProtocolMagic` only contains `RequiresNoMagic`
+    -- until we fully implement logic for `NetworkMagic`.
+    overriddenPM :: ProtocolMagic
+    overriddenPM = overridePM pm
+
+    nm = makeNetworkMagic overriddenPM
     -- Some random stuff we're going to use when building transactions
     randomPkOutput = runGen $ do
         key <- arbitrary
@@ -439,7 +493,7 @@ scriptTxSpec = describe "script transactions" $ do
     tryApplyTx :: Utxo -> TxAux -> Either ToilVerFailure ()
     tryApplyTx utxo txa =
         evalUtxoM mempty (utxoToLookup utxo) . runExceptT $
-        () <$ verifyTxUtxo dummyProtocolMagic vtxContext mempty txa
+        () <$ verifyTxUtxo overriddenPM vtxContext mempty txa
 
     -- Test tx1 against tx0. Tx0 will be a script transaction with given
     -- validator. Tx1 will be a P2PK transaction spending tx0 (with given
@@ -483,3 +537,9 @@ txShouldFailWithPlutus res err = case res of
     other -> expectationFailure $
         "expected: Left ...: " <> show (WitnessScriptError err) <> "\n" <>
         " but got: " <> show other
+
+-- | Override a provided `ProtocolMagic` such that the value of its
+-- `getRequiresNetworkMagic` field is always `RequiresNoMagic`. This will be
+-- removed when we fully implement logic for `NetworkMagic`.
+overridePM :: ProtocolMagic -> ProtocolMagic
+overridePM pm = pm { getRequiresNetworkMagic = RequiresNoMagic }

--- a/client/src/Pos/Client/Txp/Util.hs
+++ b/client/src/Pos/Client/Txp/Util.hs
@@ -562,8 +562,8 @@ prepareInpsOuts
     -> AddrData m
     -> TxCreator m (TxOwnedInputs TxOut, TxOutputs)
 prepareInpsOuts genesisConfig pendingTx utxo outputs addrData = do
-    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     txRaw@TxRaw {..} <- prepareTxWithFee genesisConfig pendingTx utxo outputs
+    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     outputsWithRem <-
         mkOutputsWithRem nm (configEpochSlots genesisConfig) addrData txRaw
     pure (trInputs, outputsWithRem)
@@ -826,15 +826,15 @@ stabilizeTxFee genesisConfig pendingTx linearPolicy utxo outputs = do
                      -> TxCreator m $ Maybe (S.ArgMin TxFee TxRaw)
     stabilizeTxFeeDo (_, 0) _ = pure Nothing
     stabilizeTxFeeDo (isSecondStage, attempt) expectedFee = do
-        let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
         txRaw <- prepareTxRaw pendingTx utxo outputs expectedFee
+        let pm = configProtocolMagic genesisConfig
+            nm = makeNetworkMagic pm
         fakeChangeAddr <- lift . lift $ getFakeChangeAddress nm $ configEpochSlots
             genesisConfig
         txMinFee <- txToLinearFee linearPolicy $ createFakeTxFromRawTx
-            (configProtocolMagic genesisConfig)
+            pm
             fakeChangeAddr
             txRaw
-
         let txRawWithFee = S.Min $ S.Arg expectedFee txRaw
         let iterateDo step = stabilizeTxFeeDo step txMinFee
         case expectedFee `compare` txMinFee of

--- a/core/src/Pos/Core/NetworkMagic.hs
+++ b/core/src/Pos/Core/NetworkMagic.hs
@@ -44,4 +44,4 @@ instance SafeCopy NetworkMagic where
 makeNetworkMagic :: ProtocolMagic -> NetworkMagic
 makeNetworkMagic pm = case getRequiresNetworkMagic pm of
     RequiresNoMagic -> NetworkMainOrStage
-    RequiresMagic   -> NetworkTestnet (fromIntegral (getProtocolMagic pm))
+    RequiresMagic   -> NetworkTestnet (getProtocolMagic pm)

--- a/explorer/src/Pos/Explorer/TestUtil.hs
+++ b/explorer/src/Pos/Explorer/TestUtil.hs
@@ -399,9 +399,5 @@ produceSecretKeys blocksNumber = liftIO $ secretKeys
 -- | Factory to create an `Address`
 -- | Friendly borrowed from `Test.Pos.Client.Txp.UtilSpec`
 -- | TODO: Remove it as soon as ^ is exposed
-secretKeyToAddress :: SecretKey -> Address
-secretKeyToAddress = makePubKeyAddressBoot fixedNM . toPublic
-
-
-fixedNM :: NetworkMagic
-fixedNM = NetworkMainOrStage
+secretKeyToAddress :: NetworkMagic -> SecretKey -> Address
+secretKeyToAddress nm = makePubKeyAddressBoot nm . toPublic

--- a/explorer/src/Pos/Explorer/Web/ClientTypes.hs
+++ b/explorer/src/Pos/Explorer/Web/ClientTypes.hs
@@ -461,4 +461,4 @@ instance Show CByteString where
 --------------------------------------------------------------------------------
 
 instance Arbitrary CAddress where
-    arbitrary = toCAddress . secretKeyToAddress <$> arbitrary
+    arbitrary = toCAddress <$> (secretKeyToAddress <$> arbitrary <*> arbitrary)

--- a/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
+++ b/explorer/test/Test/Pos/Explorer/Socket/MethodsSpec.hs
@@ -59,8 +59,8 @@ spec = beforeAll_ setupTestLogging $ do
                 fromCAddressOrThrow (CAddress "invalid" ) `shouldThrow` anyException
         describe "addressSetByTxs" $
             modifyMaxSize (const 200) $
-                prop "creates a Set of Addresses by given txs" $
-                    \nm -> addressSetByTxsProp nm
+                prop "creates a Set of Addresses by given txs"
+                    addressSetByTxsProp
         describe "addrSubParam" $
             it "stores a given SocketId into SubscriptionParam of address subscribers" $ do
                 let socketId = BS.pack "any-id" -- SocketId

--- a/generator/app/VerificationBench.hs
+++ b/generator/app/VerificationBench.hs
@@ -78,8 +78,8 @@ generateBlocks :: HasConfigurations
                -> BlockCount
                -> BlockTestMode (OldestFirst NE Block)
 generateBlocks genesisConfig secretKeys txpConfig bCount = do
-    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     g <- liftIO $ newStdGen
+    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     bs <- flip evalRandT g $ genBlocks genesisConfig txpConfig
             (BlockGenParams
                 { _bgpSecrets = mkAllSecretsSimple nm secretKeys

--- a/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
+++ b/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
@@ -102,10 +102,10 @@ verifyBlocksBenchmark !genesisConfig !secretKeys !tp !ctx =
             $ \ ~(curSlot, blocks) -> bench "verifyBlocksPrefix" (verifyBlocksPrefixB curSlot blocks)
         ]
     where
+    nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     genEnv :: BlockCount -> BlockTestMode (Maybe SlotId, OldestFirst NE Block)
     genEnv bCount = do
         initNodeDBs genesisConfig
-        let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
         g <- liftIO $ newStdGen
         bs <- flip evalRandT g $ genBlocks genesisConfig (_tpTxpConfiguration tp)
                 (BlockGenParams
@@ -171,12 +171,12 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp = env (runBlockTestMode gen
 
     where
     pm = configProtocolMagic genesisConfig
+    nm = makeNetworkMagic pm
     genEnv :: BlockTestMode (Block, VerifyBlockParams)
     genEnv = do
         initNodeDBs genesisConfig
         g <- liftIO $ newStdGen
         eos <- getEpochOrSlot <$> getTipHeader
-        let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
         let epoch = eos ^. epochIndexL
         let blockGenParams = BlockGenParams
                 { _bgpSecrets = mkAllSecretsSimple nm secretKeys

--- a/generator/src/Pos/Generator/Block/Payload.hs
+++ b/generator/src/Pos/Generator/Block/Payload.hs
@@ -148,7 +148,6 @@ genTxPayload genesisConfig txpConfig = do
         utxoSize <- uses gtdUtxoKeys V.length
         when (utxoSize == 0) $
             lift $ throwM $ BGInternal "Utxo is empty when trying to create tx payload"
-
         secrets <- unInvSecretsMap <$> view (blockGenParams . asSecretKeys)
         invAddrSpendingData <-
             unInvAddrSpendingData <$> view (blockGenParams . asSpendingData)

--- a/generator/src/Pos/Generator/Block/Payload.hs
+++ b/generator/src/Pos/Generator/Block/Payload.hs
@@ -34,7 +34,7 @@ import           Pos.Client.Txp.Util (InputSelectionPolicy (..), TxError (..),
 import           Pos.Core (AddrSpendingData (..), Address (..), Coin,
                      SlotId (..), addressHash, coinToInteger,
                      makePubKeyAddressBoot, unsafeIntegerToCoin)
-import           Pos.Core.NetworkMagic (NetworkMagic (..))
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (SecretKey, WithHash (..), fakeSigner, hash,
                      toPublic)
 import           Pos.DB.Txp (MonadTxpLocal (..), getAllPotentiallyHugeUtxo)
@@ -141,7 +141,7 @@ genTxPayload genesisConfig txpConfig = do
         txsN <- fromIntegral <$> getRandomR (a, a + d)
         replicateM_ txsN genTransaction
   where
-    nm = fixedNM
+    nm = makeNetworkMagic $ configProtocolMagic genesisConfig
     genTransaction :: StateT GenTxData (BlockGenRandMode ext g m) ()
     genTransaction = do
         utxo <- use gtdUtxo
@@ -259,6 +259,3 @@ genPayload
     -> SlotId
     -> BlockGenRandMode ext g m ()
 genPayload genesisConfig txpConfig _ = genTxPayload genesisConfig txpConfig
-
-fixedNM :: NetworkMagic
-fixedNM = NetworkMainOrStage

--- a/generator/src/Test/Pos/Block/Logic/Mode.hs
+++ b/generator/src/Test/Pos/Block/Logic/Mode.hs
@@ -262,8 +262,7 @@ initBlockTestContext genesisConfig tp@TestParams {..} callback = do
     let epochSlots = configEpochSlots genesisConfig
     slottingState <- mkSimpleSlottingStateVar epochSlots
     genesisSecretKeys <- gsSecretKeys <$> configGeneratedSecretsThrow genesisConfig
-    let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
-        initCtx =
+    let initCtx =
             TestInitModeContext
                 dbPureVar
                 futureSlottingVar
@@ -288,6 +287,7 @@ initBlockTestContext genesisConfig tp@TestParams {..} callback = do
             let btcGState = GS.GStateContext {_gscDB = DB.PureDB dbPureVar, ..}
             btcDelegation <- mkDelegationVar
             btcPureDBSnapshots <- PureDBSnapshotsVar <$> newIORef Map.empty
+            let nm = makeNetworkMagic $ configProtocolMagic genesisConfig
             let btcAllSecrets = mkAllSecretsSimple nm genesisSecretKeys
             let btCtx = BlockTestContext {btcSystemStart = systemStart, btcSSlottingStateVar = slottingState, ..}
             liftIO $ flip runReaderT clockVar $ unEmulation $ callback btCtx

--- a/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
+++ b/generator/test/Test/Pos/Block/Logic/CreationSpec.hs
@@ -19,31 +19,40 @@ import           Test.QuickCheck (Gen, Property, Testable, arbitrary, choose,
 import           Pos.Binary.Class (biSize)
 import           Pos.Chain.Block (BlockHeader, MainBlock)
 import           Pos.Chain.Delegation (DlgPayload, ProxySKBlockInfo)
+import           Pos.Chain.Genesis as Genesis (Config (..), GenesisData (..))
 import           Pos.Chain.Ssc (SscPayload (..), defaultSscPayload,
                      mkVssCertificatesMapLossy)
 import           Pos.Chain.Txp (TxAux)
 import           Pos.Chain.Update (BlockVersionData (..),
                      HasUpdateConfiguration, UpdatePayload (..))
 import qualified Pos.Communication ()
-import           Pos.Core (SlotId (..), localSlotIndexMinBound,
-                     unsafeMkLocalSlotIndex)
-import           Pos.Crypto (SecretKey)
+import           Pos.Core (SlotId (..), kEpochSlots, localSlotIndexMinBound,
+                     pcBlkSecurityParam, unsafeMkLocalSlotIndex)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..),
+                     SecretKey)
 import           Pos.DB.Block (RawPayload (..), createMainBlockPure)
 
 import           Test.Pos.Chain.Block.Arbitrary ()
 import           Test.Pos.Chain.Delegation.Arbitrary (genDlgPayload)
-import           Test.Pos.Chain.Genesis.Dummy (dummyBlockVersionData,
-                     dummyConfig, dummyEpochSlots, dummyK,
-                     dummyProtocolConstants)
 import           Test.Pos.Chain.Ssc.Arbitrary (commitmentMapEpochGen,
                      vssCertificateEpochGen)
 import           Test.Pos.Chain.Txp.Arbitrary (GoodTx, goodTxToTxAux)
-import           Test.Pos.Configuration (withDefUpdateConfiguration)
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck (SmallGenerator (..), makeSmall)
 
 spec :: Spec
-spec = withDefUpdateConfiguration $
+spec = do
+    runWithMagic RequiresNoMagic
+    runWithMagic RequiresMagic
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ \genesisConfig _ _ ->
   describe "Block.Logic.Creation" $ do
 
     -- Sampling the minimum empty block size
@@ -54,12 +63,12 @@ spec = withDefUpdateConfiguration $
     -- way to get maximum of them. Some settings produce 390b empty
     -- block, some -- 431b.
     let emptyBSize0 :: Byte
-        emptyBSize0 = biSize (noSscBlock infLimit prevHeader0 [] def def sk0) -- in bytes
+        emptyBSize0 = biSize (noSscBlock genesisConfig infLimit prevHeader0 [] def def sk0) -- in bytes
         emptyBSize :: Integral n => n
         emptyBSize = round $ (1.5 * fromIntegral emptyBSize0 :: Double)
 
     describe "createMainBlockPure" $ modifyMaxSuccess (const 1000) $ do
-        prop "empty block size is sane" $ emptyBlk $ \blk0 -> leftToCounter blk0 $ \blk ->
+        prop "empty block size is sane" $ emptyBlk genesisConfig $ \blk0 -> leftToCounter blk0 $ \blk ->
             let s = biSize blk
             in counterexample ("Real block size: " <> show s <>
                                "\n\nBlock: " <> show blk) $
@@ -67,14 +76,14 @@ spec = withDefUpdateConfiguration $
                  -- bytes; this is *completely* independent of encoding used.
                  -- Empirically, empty blocks don't get bigger than 550
                  -- bytes.
-                 s <= 550 && s <= bvdMaxBlockSize dummyBlockVersionData
+                 s <= 550 && s <= bvdMaxBlockSize (gdBlockVersionData $ configGenesisData genesisConfig)
         prop "doesn't create blocks bigger than the limit" $
             forAll (choose (emptyBSize, emptyBSize * 10)) $ \(fromBytes -> limit) ->
             forAll arbitrary $ \(prevHeader, sk, updatePayload) ->
-            forAll validSscPayloadGen $ \(sscPayload, slotId) ->
-            forAll (genDlgPayload dummyProtocolMagic (siEpoch slotId)) $ \dlgPayload ->
+            forAll (validSscPayloadGen genesisConfig) $ \(sscPayload, slotId) ->
+            forAll (genDlgPayload pm (siEpoch slotId)) $ \dlgPayload ->
             forAll (makeSmall $ listOf1 genTxAux) $ \txs ->
-            let blk = producePureBlock limit prevHeader txs Nothing slotId
+            let blk = producePureBlock genesisConfig limit prevHeader txs Nothing slotId
                                        dlgPayload sscPayload updatePayload sk
             in leftToCounter blk $ \b ->
                 let s = biSize b
@@ -84,22 +93,22 @@ spec = withDefUpdateConfiguration $
             forAll arbitrary $ \(prevHeader, sk) ->
             forAll (makeSmall $ listOf1 genTxAux) $ \txs ->
             forAll (elements [0,0.5,0.9]) $ \(delta :: Double) ->
-            let blk0 = noSscBlock infLimit prevHeader [] def def sk
-                blk1 = noSscBlock infLimit prevHeader txs def def sk
+            let blk0 = noSscBlock genesisConfig infLimit prevHeader [] def def sk
+                blk1 = noSscBlock genesisConfig infLimit prevHeader txs def def sk
             in leftToCounter ((,) <$> blk0 <*> blk1) $ \(b0, b1) ->
                 let s = biSize b0 +
                         round ((fromIntegral $ biSize b1 - biSize b0) * delta)
-                    blk2 = noSscBlock s prevHeader txs def def sk
+                    blk2 = noSscBlock genesisConfig s prevHeader txs def def sk
                 in counterexample ("Tested with block size limit: " <> show s) $
                    leftToCounter blk2 (const True)
         prop "strips ssc data when necessary" $
             forAll arbitrary $ \(prevHeader, sk) ->
-            forAll validSscPayloadGen $ \(sscPayload, slotId) ->
+            forAll (validSscPayloadGen genesisConfig) $ \(sscPayload, slotId) ->
             forAll (elements [0,0.5,0.9]) $ \(delta :: Double) ->
-            let blk0 = producePureBlock infLimit prevHeader [] Nothing
-                                        slotId def (defSscPld slotId) def sk
+            let blk0 = producePureBlock genesisConfig infLimit prevHeader [] Nothing
+                                        slotId def (defSscPld genesisConfig slotId) def sk
                 withPayload lim =
-                    producePureBlock lim prevHeader [] Nothing slotId def sscPayload def sk
+                    producePureBlock genesisConfig lim prevHeader [] Nothing slotId def sscPayload def sk
                 blk1 = withPayload infLimit
             in leftToCounter ((,) <$> blk0 <*> blk1) $ \(b0,b1) ->
                 let s = biSize b0 +
@@ -108,8 +117,10 @@ spec = withDefUpdateConfiguration $
                 in counterexample ("Tested with block size limit: " <> show s) $
                    leftToCounter blk2 (const True)
   where
-    defSscPld :: SlotId -> SscPayload
-    defSscPld sId = defaultSscPayload dummyK $ siSlot sId
+    defSscPld :: Genesis.Config -> SlotId -> SscPayload
+    defSscPld genesisConfig sId = do
+        let k = pcBlkSecurityParam $ configProtocolConstants genesisConfig
+        defaultSscPayload k $ siSlot sId
 
     infLimit = convertUnit @Gigabyte @Byte 1
 
@@ -118,11 +129,12 @@ spec = withDefUpdateConfiguration $
 
     emptyBlk
         :: (HasUpdateConfiguration, Testable p)
-        => (Either Text MainBlock -> p)
+        => Genesis.Config
+        -> (Either Text MainBlock -> p)
         -> Property
-    emptyBlk foo =
+    emptyBlk genesisConfig foo =
         forAll arbitrary $ \(prevHeader, sk, slotId) ->
-        foo $ producePureBlock infLimit prevHeader [] Nothing slotId def (defSscPld slotId) def sk
+        foo $ producePureBlock genesisConfig infLimit prevHeader [] Nothing slotId def (defSscPld genesisConfig slotId) def sk
 
     genTxAux :: Gen TxAux
     genTxAux =
@@ -130,21 +142,25 @@ spec = withDefUpdateConfiguration $
 
     noSscBlock
         :: HasUpdateConfiguration
-        => Byte
+        => Genesis.Config
+        -> Byte
         -> BlockHeader
         -> [TxAux]
         -> DlgPayload
         -> UpdatePayload
         -> SecretKey
         -> Either Text MainBlock
-    noSscBlock limit prevHeader txs proxyCerts updatePayload sk =
-        let neutralSId = SlotId 0 (unsafeMkLocalSlotIndex dummyEpochSlots $ fromIntegral $ dummyK * 2)
+    noSscBlock genesisConfig limit prevHeader txs proxyCerts updatePayload sk =
+        let k          = pcBlkSecurityParam $ configProtocolConstants genesisConfig
+            epochSlots = kEpochSlots k
+            neutralSId = SlotId 0 (unsafeMkLocalSlotIndex epochSlots $ fromIntegral $ k * 2)
         in producePureBlock
-             limit prevHeader txs Nothing neutralSId proxyCerts (defSscPld neutralSId) updatePayload sk
+             genesisConfig limit prevHeader txs Nothing neutralSId proxyCerts (defSscPld genesisConfig neutralSId) updatePayload sk
 
     producePureBlock
         :: HasUpdateConfiguration
-        => Byte
+        => Genesis.Config
+        -> Byte
         -> BlockHeader
         -> [TxAux]
         -> ProxySKBlockInfo
@@ -154,20 +170,24 @@ spec = withDefUpdateConfiguration $
         -> UpdatePayload
         -> SecretKey
         -> Either Text MainBlock
-    producePureBlock limit prev txs psk slot dlgPay sscPay usPay sk =
-        createMainBlockPure dummyConfig limit prev psk slot sk $
+    producePureBlock genesisConfig limit prev txs psk slot dlgPay sscPay usPay sk =
+        createMainBlockPure genesisConfig limit prev psk slot sk $
         RawPayload txs sscPay dlgPay usPay
 
-validSscPayloadGen :: Gen (SscPayload, SlotId)
-validSscPayloadGen = do
+validSscPayloadGen :: Genesis.Config -> Gen (SscPayload, SlotId)
+validSscPayloadGen genesisConfig = do
+    let pm                = configProtocolMagic genesisConfig
+        protocolConstants = configProtocolConstants genesisConfig
+        k                 = pcBlkSecurityParam protocolConstants
+        epochSlots        = kEpochSlots k
     vssCerts <- makeSmall $ fmap mkVssCertificatesMapLossy $ listOf $
-        vssCertificateEpochGen dummyProtocolMagic dummyProtocolConstants 0
-    let mkSlot i = SlotId 0 (unsafeMkLocalSlotIndex dummyEpochSlots (fromIntegral i))
-    oneof [ do commMap <- makeSmall $ commitmentMapEpochGen dummyProtocolMagic 0
+        vssCertificateEpochGen pm protocolConstants 0
+    let mkSlot i = SlotId 0 (unsafeMkLocalSlotIndex epochSlots (fromIntegral i))
+    oneof [ do commMap <- makeSmall $ commitmentMapEpochGen pm 0
                pure (CommitmentsPayload commMap vssCerts , SlotId 0 localSlotIndexMinBound)
           , do openingsMap <- makeSmall arbitrary
-               pure (OpeningsPayload openingsMap vssCerts, mkSlot (4 * dummyK + 1))
+               pure (OpeningsPayload openingsMap vssCerts, mkSlot (4 * k + 1))
           , do sharesMap <- makeSmall arbitrary
-               pure (SharesPayload sharesMap vssCerts, mkSlot (8 * dummyK))
-          , pure (CertificatesPayload vssCerts, mkSlot (7 * dummyK))
+               pure (SharesPayload sharesMap vssCerts, mkSlot (8 * k))
+          , pure (CertificatesPayload vssCerts, mkSlot (7 * k))
           ]

--- a/lib/src/Pos/AllSecrets.hs
+++ b/lib/src/Pos/AllSecrets.hs
@@ -86,14 +86,13 @@ instance Buildable AllSecrets where
 -- | Make simple 'AllSecrets' assuming that only public key addresses
 -- with bootstrap era distribution and single key distribution exist
 -- in the system.
-mkAllSecretsSimple :: [SecretKey] -> AllSecrets
-mkAllSecretsSimple sks =
+mkAllSecretsSimple :: NetworkMagic -> [SecretKey] -> AllSecrets
+mkAllSecretsSimple nm sks =
     AllSecrets
     { _asSecretKeys = mkInvSecretsMap sks
     , _asSpendingData = invAddrSpendingData
     }
   where
-    nm = fixedNM
     pks :: [PublicKey]
     pks = map toPublic sks
     spendingDataList = map PubKeyASD pks
@@ -103,7 +102,3 @@ mkAllSecretsSimple sks =
         mkInvAddrSpendingData $
         zip addressesNonBoot spendingDataList <>
         zip addressesBoot spendingDataList
-
-
-fixedNM :: NetworkMagic
-fixedNM = NetworkMainOrStage

--- a/lib/test/Test/Pos/Cbor/CborSpec.hs
+++ b/lib/test/Test/Pos/Cbor/CborSpec.hs
@@ -17,9 +17,9 @@ import           Universum
 import qualified Cardano.Crypto.Wallet as CC
 import           Data.Tagged (Tagged)
 import           System.FileLock (FileLock)
-import           Test.Hspec (Spec, describe, runIO)
+import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Arbitrary (..), arbitrary, generate)
+import           Test.QuickCheck (Arbitrary (..), arbitrary)
 
 import           Pos.Binary.Communication ()
 import           Pos.Chain.Delegation (DlgPayload, DlgUndo, ProxySKHeavy)
@@ -32,7 +32,6 @@ import qualified Pos.Communication as C
 import           Pos.Communication.Limits (mlOpening, mlUpdateVote,
                      mlVssCertificate)
 import           Pos.Core (StakeholderId)
-import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Crypto.Signing (EncryptedSecretKey)
 import           Pos.Infra.Communication.Limits.Instances (mlDataMsg, mlInvMsg,
                      mlMempoolMsg, mlReqMsg)
@@ -50,7 +49,6 @@ import           Test.Pos.Cbor.Arbitrary.UserSecret ()
 import           Test.Pos.Chain.Delegation.Arbitrary ()
 import           Test.Pos.Chain.Ssc.Arbitrary ()
 import           Test.Pos.Chain.Update.Arbitrary ()
-import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Crypto.Arbitrary ()
 import           Test.Pos.DB.Update.Arbitrary ()
@@ -67,18 +65,7 @@ type UpId' = Tagged (U.UpdateProposal, [U.UpdateVote])U.UpId
 ----------------------------------------
 
 spec :: Spec
-spec = do
-    runWithMagic RequiresNoMagic
-    runWithMagic RequiresMagic
-
-runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
-
-specBody :: ProtocolMagic -> Spec
-specBody pm = withProvidedMagicConfig pm $ \_ _ _ -> do
+spec =
     describe "Cbor.Bi instances" $ do
         modifyMaxSuccess (const 1000) $ do
             describe "Lib/core instances" $ do

--- a/lib/test/Test/Pos/Diffusion/BlockSpec.hs
+++ b/lib/test/Test/Pos/Diffusion/BlockSpec.hs
@@ -16,7 +16,8 @@ import           Data.Conduit.Combinators (yieldMany)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
 import           Data.Semigroup ((<>))
-import           Test.Hspec (Spec, describe, it, shouldBe)
+import           Test.Hspec (Spec, describe, it, runIO, shouldBe)
+import           Test.QuickCheck (arbitrary, generate)
 
 import qualified Network.Broadcast.OutboundQueue as OQ
 import qualified Network.Broadcast.OutboundQueue.Types as OQ
@@ -32,8 +33,7 @@ import qualified Pos.Chain.Block as Block (getBlockHeader)
 import           Pos.Chain.Update (BlockVersion (..))
 import           Pos.Core.Chrono (NewestFirst (..), OldestFirst (..))
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..))
-import           Pos.Crypto (ProtocolMagic (..), ProtocolMagicId (..),
-                     RequiresNetworkMagic (..))
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.Crypto.Hashing (Hash, unsafeMkAbstractHash)
 import           Pos.DB.Class (Serialized (..), SerializedBlock)
 import           Pos.Diffusion.Full (FullDiffusionConfiguration (..),
@@ -53,9 +53,6 @@ import           Test.Pos.Chain.Block.Arbitrary.Generate (generateMainBlock)
 -- HLint warning disabled since I ran into https://ghc.haskell.org/trac/ghc/ticket/13106
 -- when trying to resolve it.
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
-
-protocolMagic :: ProtocolMagic
-protocolMagic = ProtocolMagic (ProtocolMagicId 0) RequiresNoMagic
 
 protocolConstants :: ProtocolConstants
 protocolConstants = ProtocolConstants
@@ -119,8 +116,8 @@ clientLogic = pureLogic
     { getLcaMainChain = \headers -> pure (NewestFirst [], headers)
     }
 
-withServer :: Transport -> Logic IO -> (NodeId -> IO t) -> IO t
-withServer transport logic k = do
+withServer :: ProtocolMagic -> Transport -> Logic IO -> (NodeId -> IO t) -> IO t
+withServer pm transport logic k = do
     logTrace <- liftIO $ setupTestTrace
     -- Morally, the server shouldn't need an outbound queue, but we have to
     -- give one.
@@ -146,7 +143,7 @@ withServer transport logic k = do
     runFullDiffusionInternals runInternals $ \internals -> k (Node.nodeId (fdiNode internals))
   where
     fdconf = FullDiffusionConfiguration
-        { fdcProtocolMagic = protocolMagic
+        { fdcProtocolMagic = pm
         , fdcProtocolConstants = protocolConstants
         -- Just like in production.
         , fdcRecoveryHeadersMessage = 2200
@@ -159,13 +156,14 @@ withServer transport logic k = do
 -- Like 'withServer' but we must set up the outbound queue so that it will
 -- contact the server.
 withClient
-    :: Word32
+    :: ProtocolMagic
+    -> Word32
     -> Transport
     -> Logic IO
     -> NodeId
     -> (Diffusion IO -> IO t)
     -> IO t
-withClient streamWindow transport logic serverAddress@(Node.NodeId _) k = do
+withClient pm streamWindow transport logic serverAddress@(Node.NodeId _) k = do
     -- Morally, the server shouldn't need an outbound queue, but we have to
     -- give one.
     oq <- OQ.new
@@ -192,7 +190,7 @@ withClient streamWindow transport logic serverAddress@(Node.NodeId _) k = do
     runFullDiffusionInternals runInternals $ \_ -> k diffusion
   where
     fdconf = FullDiffusionConfiguration
-        { fdcProtocolMagic = protocolMagic
+        { fdcProtocolMagic = pm
         , fdcProtocolConstants = protocolConstants
         -- Just like in production.
         , fdcRecoveryHeadersMessage = 2200
@@ -226,26 +224,26 @@ blockDownloadStream serverAddress resultIORef streamIORef setStreamIORef ~(block
         modifyIORef' recvBlocks (\d -> blocks <> d)
 
 -- Generate a list of n+1 blocks
-generateBlocks :: Int -> NonEmpty Block
-generateBlocks blocks =
+generateBlocks :: ProtocolMagic -> Int -> NonEmpty Block
+generateBlocks pm blocks =
   let root = doGenerateBlock 0 in
   root :| (doGenerateBlocks blocks)
   where
     doGenerateBlock :: Int -> Block
     doGenerateBlock seed =
         let size = 4 in
-        force $ Right (generateMainBlock protocolMagic seed size)
+        force $ Right (generateMainBlock pm seed size)
 
     doGenerateBlocks :: Int -> [Block]
     doGenerateBlocks 0 = []
     doGenerateBlocks x = do
         [doGenerateBlock x] ++ (doGenerateBlocks (x-1))
 
-streamSimple :: Word32 -> Int -> IO Bool
-streamSimple streamWindow blocks = do
+streamSimple :: ProtocolMagic -> Word32 -> Int -> IO Bool
+streamSimple pm streamWindow blocks = do
     streamIORef <- newIORef []
     resultIORef <- newIORef False
-    let arbitraryBlocks = generateBlocks (blocks - 1)
+    let arbitraryBlocks = generateBlocks pm (blocks - 1)
         arbitraryHeaders = NE.map Block.getBlockHeader arbitraryBlocks
         arbitraryHashes = NE.map blockHeaderHash arbitraryHeaders
         !arbitraryBlock = NE.head arbitraryBlocks
@@ -253,44 +251,52 @@ streamSimple streamWindow blocks = do
         checkpoints = [tipHash]
         setStreamIORef = \_ -> writeIORef streamIORef $ NE.tail arbitraryBlocks
     withTransport $ \transport ->
-        withServer transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
-        withClient streamWindow transport clientLogic serverAddress $
+        withServer pm transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
+        withClient pm streamWindow transport clientLogic serverAddress $
             liftIO . blockDownloadStream serverAddress resultIORef streamIORef setStreamIORef
                 (tipHash, checkpoints)
     readIORef resultIORef
 
-batchSimple :: Int -> IO Bool
-batchSimple blocks = do
+batchSimple :: ProtocolMagic -> Int -> IO Bool
+batchSimple pm blocks = do
     streamIORef <- newIORef []
-    let arbitraryBlocks = generateBlocks (blocks - 1)
+    let arbitraryBlocks = generateBlocks pm (blocks - 1)
         arbitraryHeaders = NE.map Block.getBlockHeader arbitraryBlocks
         arbitraryHashes = NE.map blockHeaderHash arbitraryHeaders
         arbitraryBlock = NE.head arbitraryBlocks
         !checkPoints = if blocks == 1 then [someHash]
                                       else [someHash' (blocks + 1) []]
     withTransport $ \transport ->
-        withServer transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
-        withClient 2048 transport clientLogic serverAddress $
+        withServer pm transport (serverLogic streamIORef arbitraryBlock arbitraryHashes arbitraryHeaders) $ \serverAddress ->
+        withClient pm 2048 transport clientLogic serverAddress $
             liftIO . blockDownloadBatch serverAddress (someHash, checkPoints)
     return True
 
 spec :: Spec
-spec = describe "Blockdownload" $ do
-    it "Stream 4 blocks" $ do
-        r <- streamSimple 2048 4
-        r `shouldBe` True
-    it "Stream 128 blocks" $ do
-        r <- streamSimple 2048 128
-        r `shouldBe` True
-    it "Stream 4096 blocks" $ do
-        r <- streamSimple 128 4096
-        r `shouldBe` True
-    it "Streaming dislabed by client" $ do
-        r <- streamSimple 0 4
-        r `shouldBe` False
-    it "Batch, single block" $ do
-        r <- batchSimple 1
-        r `shouldBe` True
-    it "Batch of blocks" $ do
-        r <- batchSimple 2200
-        r `shouldBe` True
+spec = do
+    runWithMagic RequiresNoMagic
+    runWithMagic RequiresMagic
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        describe "Blockdownload" $ do
+            it "Stream 4 blocks" $ do
+                r <- streamSimple pm 2048 4
+                r `shouldBe` True
+            it "Stream 128 blocks" $ do
+                r <- streamSimple pm 2048 128
+                r `shouldBe` True
+            it "Stream 4096 blocks" $ do
+                r <- streamSimple pm 128 4096
+                r `shouldBe` True
+            it "Streaming dislabed by client" $ do
+                r <- streamSimple pm 0 4
+                r `shouldBe` False
+            it "Batch, single block" $ do
+                r <- batchSimple pm 1
+                r `shouldBe` True
+            it "Batch of blocks" $ do
+                r <- batchSimple pm 2200
+                r `shouldBe` True

--- a/lib/test/Test/Pos/Ssc/ComputeSharesSpec.hs
+++ b/lib/test/Test/Pos/Ssc/ComputeSharesSpec.hs
@@ -11,9 +11,9 @@ import           Universum
 
 import qualified Data.HashMap.Strict as HM
 import           Data.Reflection (Reifies (..))
-import           Test.Hspec (Expectation, Spec, describe, runIO, shouldBe)
+import           Test.Hspec (Expectation, Spec, describe, shouldBe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Property, arbitrary, generate, (.&&.), (===))
+import           Test.QuickCheck (Property, (.&&.), (===))
 
 import           Pos.Chain.Lrc (RichmenStakes)
 import           Pos.Chain.Ssc (SharesDistribution, SscVerifyError,
@@ -23,27 +23,14 @@ import           Pos.Core (Coin, CoinPortion, StakeholderId, mkCoin,
                      unsafeAddressHash, unsafeCoinPortionFromDouble,
                      unsafeGetCoin, unsafeSubCoin)
 import           Pos.Core.Common (applyCoinPortionDown, sumCoins)
-import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Pos.DB.Lrc (RichmenType (..), findRichmenPure)
 
 import           Test.Pos.Chain.Lrc.Arbitrary (GenesisMpcThd,
                      InvalidRichmenStakes (..), ValidRichmenStakes (..))
-import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (qcIsLeft)
 
 spec :: Spec
-spec = do
-    runWithMagic RequiresNoMagic
-    runWithMagic RequiresMagic
-
-runWithMagic :: RequiresNetworkMagic -> Spec
-runWithMagic rnm = do
-    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
-    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-        specBody pm
-
-specBody :: ProtocolMagic -> Spec
-specBody pm = withProvidedMagicConfig pm $ \_ _ _ -> describe "computeSharesDistr" $ do
+spec = describe "computeSharesDistr" $ do
     prop emptyRichmenStakesDesc emptyRichmenStakes
     modifyMaxSuccess (const 3) $
         prop invalidStakeErrorsDesc invalidStakeErrors

--- a/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
+++ b/lib/test/Test/Pos/Ssc/Toss/BaseSpec.hs
@@ -36,7 +36,7 @@ import           Pos.Chain.Ssc (Commitment, CommitmentSignature,
                      verifyCommitmentSignature, verifyOpening, _vcVssKey)
 import           Pos.Core (Coin, EpochIndex, EpochOrSlot (..), StakeholderId,
                      addressHash, crucialSlot, mkCoin)
-import           Pos.Crypto (DecShare, PublicKey, SecretKey,
+import           Pos.Crypto (DecShare, ProtocolMagic, PublicKey, SecretKey,
                      SignTag (SignCommitment), sign, toPublic)
 import           Test.Pos.Chain.Lrc.Arbitrary (GenesisMpcThd,
                      ValidRichmenStakes (..))
@@ -46,7 +46,6 @@ import           Test.Pos.Chain.Genesis.Dummy (dummyBlockVersionData,
                      dummyConfig, dummyK)
 import           Test.Pos.Chain.Ssc.Arbitrary (BadCommAndOpening (..),
                      BadSignedCommitment (..), CommitmentOpening (..))
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 
 spec :: Spec
 spec = describe "Ssc.Base" $ do
@@ -115,18 +114,18 @@ verifiesOkComm :: CommitmentOpening -> Bool
 verifiesOkComm CommitmentOpening{..} =
     verifyCommitment coCommitment
 
-verifiesOkCommSig :: SecretKey -> Commitment -> EpochIndex -> Bool
-verifiesOkCommSig sk comm epoch =
+verifiesOkCommSig :: ProtocolMagic -> SecretKey -> Commitment -> EpochIndex -> Bool
+verifiesOkCommSig pm sk comm epoch =
     let commSig =
             ( toPublic sk
             , comm
-            , sign dummyProtocolMagic SignCommitment sk (epoch, comm)
+            , sign pm SignCommitment sk (epoch, comm)
             )
-    in  verifyCommitmentSignature dummyProtocolMagic epoch commSig
+    in  verifyCommitmentSignature pm epoch commSig
 
-notVerifiesBadCommSig :: BadSignedCommitment -> EpochIndex -> Bool
-notVerifiesBadCommSig (getBadSignedC -> badSignedComm) epoch =
-    not $ verifyCommitmentSignature dummyProtocolMagic epoch badSignedComm
+notVerifiesBadCommSig :: ProtocolMagic -> BadSignedCommitment -> EpochIndex -> Bool
+notVerifiesBadCommSig pm (getBadSignedC -> badSignedComm) epoch =
+    not $ verifyCommitmentSignature pm epoch badSignedComm
 
 verifiesOkOpening :: CommitmentOpening -> Bool
 verifiesOkOpening CommitmentOpening{..} =

--- a/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
+++ b/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
@@ -13,11 +13,11 @@ import qualified Data.HashSet as HS
 import           Data.List.Extra (nubOrdOn)
 import qualified Data.Set as S
 import           Data.Tuple (swap)
-import           Test.Hspec (Spec, describe)
+import           Test.Hspec (Spec, describe, runIO)
 import           Test.Hspec.QuickCheck (prop)
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, choose,
-                     conjoin, counterexample, suchThat, vectorOf, (.&&.),
-                     (==>))
+                     conjoin, counterexample, generate, suchThat, vectorOf,
+                     (.&&.), (==>))
 
 import           Pos.Chain.Ssc (SscGlobalState (..), VssCertData (..),
                      VssCertificate (..), expiryEoS, getCertId,
@@ -27,17 +27,29 @@ import qualified Pos.Chain.Ssc as Ssc
 import           Pos.Core (EpochIndex (..), EpochOrSlot (..), SlotId (..))
 import           Pos.Core.Chrono (NewestFirst (..))
 import           Pos.Core.Slotting (flattenEpochOrSlot, unflattenSlotId)
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 
 import           Test.Pos.Chain.Genesis.Dummy (dummyEpochSlots,
                      dummySlotSecurityParam)
-import           Test.Pos.Configuration (withDefConfiguration)
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Infra.Arbitrary.Ssc ()
 import           Test.Pos.Util.QuickCheck.Property (qcIsJust)
 
 spec :: Spec
-spec = withDefConfiguration $ \_ -> describe "Ssc.VssCertData" $ do
+spec = do
+    runWithMagic RequiresNoMagic
+    runWithMagic RequiresMagic
+
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = withProvidedMagicConfig pm $ \_ _ _ -> describe "Ssc.VssCertData" $ do
     describe "verifyInsertVssCertData" $
         prop description_verifyInsertVssCertData verifyInsertVssCertData
     describe "verifyDeleteVssCertData" $

--- a/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
+++ b/lib/test/Test/Pos/Ssc/VssCertDataSpec.hs
@@ -31,9 +31,7 @@ import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 
 import           Test.Pos.Chain.Genesis.Dummy (dummyEpochSlots,
                      dummySlotSecurityParam)
-import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Core.Arbitrary ()
-import           Test.Pos.Crypto.Dummy (dummyProtocolMagic)
 import           Test.Pos.Infra.Arbitrary.Ssc ()
 import           Test.Pos.Util.QuickCheck.Property (qcIsJust)
 
@@ -49,7 +47,7 @@ runWithMagic rnm = do
         specBody pm
 
 specBody :: ProtocolMagic -> Spec
-specBody pm = withProvidedMagicConfig pm $ \_ _ _ -> describe "Ssc.VssCertData" $ do
+specBody _pm = describe "Ssc.VssCertData" $ do
     describe "verifyInsertVssCertData" $
         prop description_verifyInsertVssCertData verifyInsertVssCertData
     describe "verifyDeleteVssCertData" $
@@ -202,7 +200,8 @@ instance Arbitrary RollbackData where
                 thisEpoch <-
                     siEpoch . unflattenSlotId dummyEpochSlots <$>
                         choose (succ lastKEoSWord, rollbackFrom)
-                return $ mkVssCertificate dummyProtocolMagic sk binVssPK thisEpoch
+                pm <- arbitrary
+                return $ mkVssCertificate pm sk binVssPK thisEpoch
         certsToRollback <- nubOrdOn vcVssKey <$>
             vectorOf @VssCertificate certsToRollbackN rollbackGen
         return $ Rollback (SscGlobalState mempty mempty mempty goodVssCertData)

--- a/tools/src/Pos/Tools/Dbgen/QueryMethods.hs
+++ b/tools/src/Pos/Tools/Dbgen/QueryMethods.hs
@@ -7,6 +7,7 @@ module Pos.Tools.Dbgen.QueryMethods where
 
 import           Universum
 
+import           Pos.Core.NetworkMagic (NetworkMagic)
 import           Pos.Wallet.Web.Methods.Logic (getWallets)
 import           Text.Printf (printf)
 
@@ -14,15 +15,15 @@ import           Pos.Tools.Dbgen.Lib (timed)
 import           Pos.Tools.Dbgen.Rendering (say)
 import           Pos.Tools.Dbgen.Types (Method (..), UberMonad)
 
-queryMethods :: Maybe Method -> UberMonad ()
-queryMethods Nothing = say "No valid method read from the CLI."
-queryMethods (Just method) = case method of
-  GetWallets -> queryGetWallets
+queryMethods :: NetworkMagic -> Maybe Method -> UberMonad ()
+queryMethods _  Nothing = say "No valid method read from the CLI."
+queryMethods nm (Just method) = case method of
+  GetWallets -> queryGetWallets nm
 
 
-queryGetWallets :: UberMonad ()
-queryGetWallets = do
-  wallets <- timed getWallets
+queryGetWallets :: NetworkMagic -> UberMonad ()
+queryGetWallets nm = do
+  wallets <- timed (getWallets nm)
   case wallets of
     [] -> say "No wallets returned."
     _  -> say $ printf "%d wallets found." (length wallets)

--- a/wallet-new/src/Cardano/Wallet/Action.hs
+++ b/wallet-new/src/Cardano/Wallet/Action.hs
@@ -65,7 +65,8 @@ actionWithWallet params genesisConfig walletConfig txpConfig ntpConfig nodeParam
             , Kernel.dbPathMetadata  = dbPath <> "-sqlite.sqlite3"
             , Kernel.dbRebuild       = rebuildDB
             })
-        WalletLayer.Kernel.bracketPassiveWallet dbMode logMessage' keystore nodeState (npFInjects nodeParams) $ \walletLayer passiveWallet -> do
+        let pm = configProtocolMagic genesisConfig
+        WalletLayer.Kernel.bracketPassiveWallet pm dbMode logMessage' keystore nodeState (npFInjects nodeParams) $ \walletLayer passiveWallet -> do
             migrateLegacyDataLayer passiveWallet dbPath (getFullMigrationFlag params)
 
             let plugs = plugins (walletLayer, passiveWallet) dbMode
@@ -77,15 +78,13 @@ actionWithWallet params genesisConfig walletConfig txpConfig ntpConfig nodeParam
                 walletLayer
                 (runNode genesisConfig txpConfig nodeRes plugs)
   where
-    pm = configProtocolMagic genesisConfig
-
     plugins :: (PassiveWalletLayer IO, PassiveWallet)
             -> Kernel.DatabaseMode
             -> [ (Text, Plugins.Plugin Kernel.Mode.WalletMode) ]
     plugins w dbMode = concat [
             -- The actual wallet backend server.
             [
-              ("wallet-new api worker", Plugins.apiServer pm params w
+              ("wallet-new api worker", Plugins.apiServer params w
                 [ faultInjectionHandleIgnoreAPI (npFInjects nodeParams) -- This allows dynamic control of fault injection
                 , throttleMiddleware (ccThrottle walletConfig)          -- Throttle requests
                 , withDefaultHeader Headers.applicationJson

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -420,8 +420,10 @@ estimateCardanoFee linearFeePolicy ins outs
 --
 -- NOTE: When the /actual/ size exceeds this bounds, we may underestimate
 -- tranasction fees and potentially generate invalid transactions.
+--
+-- TODO @intricate: Ensure this makes sense.
 boundAddrAttrSize :: Byte
-boundAddrAttrSize = 34
+boundAddrAttrSize = 34 + 7 -- 7 bytes for potential NetworkMagic
 
 -- | Size to use for a value of type @Attributes ()@ when estimating
 --   encoded transaction sizes. The minimum possible value is 2.

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -421,7 +421,13 @@ estimateCardanoFee linearFeePolicy ins outs
 -- NOTE: When the /actual/ size exceeds this bounds, we may underestimate
 -- tranasction fees and potentially generate invalid transactions.
 --
--- TODO @intricate: Ensure this makes sense.
+-- `boundAddrAttrSize` needed to increase due to the inclusion of
+-- `NetworkMagic` in `AddrAttributes`. The `Bi` instance of
+-- `AddrAttributes` serializes `NetworkTestnet` as [(Word8,Int32)] and
+-- `NetworkMainOrStage` as []; this should require a 5 Byte increase in
+--`boundAddrAttrSize`. Because encoding in unit tests is not guaranteed
+-- to be efficient, it was decided to increase by 7 Bytes to mitigate
+-- against potential random test failures in the future.
 boundAddrAttrSize :: Byte
 boundAddrAttrSize = 34 + 7 -- 7 bytes for potential NetworkMagic
 

--- a/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
@@ -86,7 +86,6 @@ data PassiveWallet = PassiveWallet {
     , _wallets               :: AcidState DB
 
       -- | The protocol magic used by an `ActiveWallet` to make transactions.
-      -- TODO @intricate: is it suitable to move this here from `ActiveWallet`?
     , _walletProtocolMagic   :: ProtocolMagic
 
       -- | Database handle

--- a/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Internal.hs
@@ -13,6 +13,7 @@ module Cardano.Wallet.Kernel.Internal (
   , walletKeystore
   , walletMeta
   , wallets
+  , walletProtocolMagic
   , walletLogMessage
   , walletNode
   , walletSubmission
@@ -83,6 +84,10 @@ data PassiveWallet = PassiveWallet {
 
       -- | An opaque handle to a place where we store the 'EncryptedSecretKey'.
     , _wallets               :: AcidState DB
+
+      -- | The protocol magic used by an `ActiveWallet` to make transactions.
+      -- TODO @intricate: is it suitable to move this here from `ActiveWallet`?
+    , _walletProtocolMagic   :: ProtocolMagic
 
       -- | Database handle
     , _walletMeta            :: MetaDBHandle
@@ -214,9 +219,7 @@ stopAllRestorations pw = do
 -- send new transactions.
 data ActiveWallet = ActiveWallet {
       -- | The underlying passive wallet
-      walletPassive       :: PassiveWallet
+      walletPassive   :: PassiveWallet
       -- | The wallet diffusion layer
-    , walletDiffusion     :: WalletDiffusion
-      -- | The protocol magic used to make transactions.
-    , walletProtocolMagic :: ProtocolMagic
+    , walletDiffusion :: WalletDiffusion
     }

--- a/wallet-new/src/Cardano/Wallet/Server/Plugins.hs
+++ b/wallet-new/src/Cardano/Wallet/Server/Plugins.hs
@@ -48,7 +48,6 @@ import qualified Cardano.Wallet.WalletLayer as WalletLayer
 import qualified Cardano.Wallet.WalletLayer.Kernel as WalletLayer.Kernel
 
 import           Pos.Chain.Update (cpsSoftwareVersion)
-import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.Diffusion.Types (Diffusion (..))
 import           Pos.Infra.Shutdown (HasShutdownContext (shutdownContext),
                      ShutdownContext)
@@ -68,15 +67,14 @@ type Plugin m = Diffusion m -> m ()
 
 -- | A @Plugin@ to start the wallet REST server
 apiServer
-    :: ProtocolMagic
-    -> NewWalletBackendParams
+    :: NewWalletBackendParams
     -> (PassiveWalletLayer IO, PassiveWallet)
     -> [Middleware]
     -> Plugin Kernel.WalletMode
-apiServer protocolMagic (NewWalletBackendParams WalletBackendParams{..}) (passiveLayer, passiveWallet) middlewares diffusion = do
+apiServer (NewWalletBackendParams WalletBackendParams{..}) (passiveLayer, passiveWallet) middlewares diffusion = do
         env <- ask
         let diffusion' = Kernel.fromDiffusion (lower env) diffusion
-        WalletLayer.Kernel.bracketActiveWallet protocolMagic passiveLayer passiveWallet diffusion' $ \active _ -> do
+        WalletLayer.Kernel.bracketActiveWallet passiveLayer passiveWallet diffusion' $ \active _ -> do
           ctx <- view shutdownContext
           serveImpl
             (getApplication active)

--- a/wallet-new/test/unit/Test/Spec/Fixture.hs
+++ b/wallet-new/test/unit/Test/Spec/Fixture.hs
@@ -19,7 +19,6 @@ import           Pos.Util.Wlog (Severity)
 import           Pos.Crypto (ProtocolMagic)
 import           Pos.Infra.InjectFail (mkFInjects)
 
-import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.QuickCheck (arbitrary, frequency)
 import           Test.QuickCheck.Monadic (PropertyM, pick)
 
@@ -90,14 +89,13 @@ withActiveWalletFixture pm prepareFixtures cc = do
     liftIO $ Keystore.bracketTestKeystore $ \keystore -> do
         mockFInjects <- mkFInjects mempty
         WalletLayer.Kernel.bracketPassiveWallet pm Kernel.UseInMemory devNull keystore mockNodeStateDef mockFInjects $ \passiveLayer passiveWallet -> do
-            withProvidedMagicConfig pm $ \_ _ _ -> do
-                WalletLayer.Kernel.bracketActiveWallet
-                        passiveLayer
-                        passiveWallet
-                        diffusion
-                    $ \activeLayer activeWallet -> do
-                        fixtures <- generateFixtures keystore activeWallet
-                        cc keystore activeLayer activeWallet fixtures
+            WalletLayer.Kernel.bracketActiveWallet
+                    passiveLayer
+                    passiveWallet
+                    diffusion
+                $ \activeLayer activeWallet -> do
+                    fixtures <- generateFixtures keystore activeWallet
+                    cc keystore activeLayer activeWallet fixtures
     where
         diffusion :: Kernel.WalletDiffusion
         diffusion = Kernel.WalletDiffusion {

--- a/wallet-new/test/unit/Test/Spec/Kernel.hs
+++ b/wallet-new/test/unit/Test/Spec/Kernel.hs
@@ -57,7 +57,7 @@ withWithoutWW specWith = do
 
 spec :: Spec
 spec = do
-    -- runWithMagic RequiresNoMagic
+    runWithMagic RequiresNoMagic
     runWithMagic RequiresMagic
 
 runWithMagic :: RequiresNetworkMagic -> Spec
@@ -70,16 +70,16 @@ specBody :: ProtocolMagic -> Spec
 specBody pm = do
     describe "test TxMeta insertion" $ do
       withWithoutWW $ \useWW -> do
-        it "TxMetaScenarioA" $ bracketTxMeta useWW (txMetaScenarioA pm genesis)
-        it "TxMetaScenarioB" $ bracketTxMeta useWW (txMetaScenarioB pm genesis)
-        it "TxMetaScenarioC" $ bracketTxMeta useWW (txMetaScenarioC pm genesis)
-        it "TxMetaScenarioD" $ bracketTxMeta useWW (txMetaScenarioD pm genesis)
-        it "TxMetaScenarioE" $ bracketTxMeta useWW (txMetaScenarioE pm genesis)
-        it "TxMetaScenarioF" $ bracketTxMeta useWW (txMetaScenarioF pm genesis)
+        it "TxMetaScenarioA" $ bracketTxMeta useWW (txMetaScenarioA genesis)
+        it "TxMetaScenarioB" $ bracketTxMeta useWW (txMetaScenarioB genesis)
+        it "TxMetaScenarioC" $ bracketTxMeta useWW (txMetaScenarioC genesis)
+        it "TxMetaScenarioD" $ bracketTxMeta useWW (txMetaScenarioD genesis)
+        it "TxMetaScenarioE" $ bracketTxMeta useWW (txMetaScenarioE genesis)
+        it "TxMetaScenarioF" $ bracketTxMeta useWW (txMetaScenarioF genesis)
         it "TxMetaScenarioG" $ bracketTxMeta useWW (txMetaScenarioG genesis)
-        it "TxMetaScenarioH" $ bracketTxMeta useWW (txMetaScenarioH pm genesis)
-        it "TxMetaScenarioI" $ bracketTxMeta useWW (txMetaScenarioI pm genesis)
-        it "TxMetaScenarioJ" $ bracketTxMeta useWW (txMetaScenarioJ pm genesis)
+        it "TxMetaScenarioH" $ bracketTxMeta useWW (txMetaScenarioH genesis)
+        it "TxMetaScenarioI" $ bracketTxMeta useWW (txMetaScenarioI genesis)
+        it "TxMetaScenarioJ" $ bracketTxMeta useWW (txMetaScenarioJ genesis)
 
     describe "Compare wallet kernel to pure model" $ do
       describe "Using hand-written inductive wallets, computes the expected block metadata for" $ do

--- a/wallet-new/test/unit/Test/Spec/TxMetaScenarios.hs
+++ b/wallet-new/test/unit/Test/Spec/TxMetaScenarios.hs
@@ -41,8 +41,8 @@ import           Pos.Util (withCompileInfo)
 
 import           Test.Hspec
 import           Test.Infrastructure.Genesis
-import           Test.Pos.Configuration (withDefConfiguration,
-                     withDefUpdateConfiguration, withProvidedMagicConfig)
+import           Test.Pos.Configuration (withDefUpdateConfiguration,
+                     withProvidedMagicConfig)
 import           UTxO.Context
 import           UTxO.DSL
 import           Wallet.Inductive
@@ -145,10 +145,9 @@ type TxScenarioRet h = (MockNodeStateParams, Inductive h Addr, PassiveWallet -> 
 
 -- | Scenario A
 -- Empty case
-txMetaScenarioA :: ProtocolMagic
-                   -> GenesisValues h Addr
+txMetaScenarioA :: GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioA pm GenesisValues{..} = (nodeStParams1 pm, ind, lengthCheck 0)
+txMetaScenarioA GenesisValues{..} = (nodeStParams1, ind, lengthCheck 0)
   where
     ind = Inductive {
           inductiveBoot   = boot
@@ -160,10 +159,9 @@ txMetaScenarioA pm GenesisValues{..} = (nodeStParams1 pm, ind, lengthCheck 0)
 -- | Scenario B
 -- A single pending payment.
 txMetaScenarioB :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioB pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioB genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = paymentWithChangeFromP0ToP1 genVals
     ind = Inductive {
@@ -182,10 +180,9 @@ txMetaScenarioB pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 -- | Scenario C
 -- A single pending payment and then confirmation.
 txMetaScenarioC :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioC pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioC genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = paymentWithChangeFromP0ToP1 genVals
     ind = Inductive {
@@ -205,10 +202,9 @@ txMetaScenarioC pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 -- | Scenario D
 -- Two confirmed payments from P0 to P1, using `change` addresses P0 and P0b respectively
 txMetaScenarioD :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioD pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioD genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     (t0,t1) = repeatPaymentWithChangeFromP0ToP1 genVals p0b
     ind = Inductive {
@@ -234,10 +230,9 @@ txMetaScenarioD pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 --
 -- This scenario exercises Rollback behaviour.
 txMetaScenarioE :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioE pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioE genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     (t0,t1) = repeatPaymentWithChangeFromP0ToP1 genVals p0b
     ind = Inductive {
@@ -264,10 +259,9 @@ txMetaScenarioE pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 -- A payment from P1 to P0's single address.
 -- This should create IncomingTransactions.
 txMetaScenarioF :: forall h. Hash h Addr
-                  => ProtocolMagic
-                  -> GenesisValues h Addr
+                  => GenesisValues h Addr
                   -> TxScenarioRet h
-txMetaScenarioF pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioF genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = paymentWithChangeFromP1ToP0 genVals
     ind = Inductive {
@@ -309,10 +303,9 @@ txMetaScenarioG genVals@GenesisValues{..} = (nodeStParams2, ind, check)
 -- A single pending payment to itself and then confirmation.
 -- This should be a Local Tx.
 txMetaScenarioH :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioH pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioH genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = paymentWithChangeFromP0ToP0 genVals
     ind = Inductive {
@@ -332,10 +325,9 @@ txMetaScenarioH pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 -- | Scenario I. This is like Scenario C with rollbacks.
 -- results should not change.
 txMetaScenarioI :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioI pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioI genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = paymentWithChangeFromP0ToP1 genVals
     ind = Inductive {
@@ -359,10 +351,9 @@ txMetaScenarioI pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
 -- | Scenario J
 -- A single payment with 4 outputs.
 txMetaScenarioJ :: forall h. Hash h Addr
-                   => ProtocolMagic
-                   -> GenesisValues h Addr
+                   => GenesisValues h Addr
                    -> TxScenarioRet h
-txMetaScenarioJ pm genVals@GenesisValues{..} = (nodeStParams1 pm, ind, check)
+txMetaScenarioJ genVals@GenesisValues{..} = (nodeStParams1, ind, check)
   where
     t0 = bigPaymentWithChange genVals
     ind = Inductive {
@@ -394,9 +385,8 @@ checkWithTxs check pw = do
       return $ fromRight (error ("Account not found")) eiTxs
     check txs
 
-nodeStParams1 :: ProtocolMagic -> MockNodeStateParams
-nodeStParams1 pm =
-  withProvidedMagicConfig pm $ \_ _ _ ->
+nodeStParams1 :: MockNodeStateParams
+nodeStParams1 =
     withDefUpdateConfiguration $
     withCompileInfo $
       MockNodeStateParams {
@@ -411,7 +401,6 @@ nodeStParams1 pm =
 
 nodeStParams2 :: MockNodeStateParams
 nodeStParams2 =
-  withDefConfiguration $ \_pm ->
     withDefUpdateConfiguration $
     withCompileInfo $
       MockNodeStateParams {

--- a/wallet-new/test/unit/Util/Buildable/Hspec.hs
+++ b/wallet-new/test/unit/Util/Buildable/Hspec.hs
@@ -22,6 +22,7 @@ module Util.Buildable.Hspec (
   , H.it
   , H.beforeAll
   , H.parallel
+  , H.runIO
   ) where
 
 import qualified Test.Hspec as H

--- a/wallet-new/test/unit/Util/Buildable/QuickCheck.hs
+++ b/wallet-new/test/unit/Util/Buildable/QuickCheck.hs
@@ -11,6 +11,8 @@ module Util.Buildable.QuickCheck (
   , QC.Gen
   , QC.conjoin
   , QC.choose
+  , QC.generate
+  , QC.arbitrary
   ) where
 
 import           Universum

--- a/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
@@ -28,6 +28,7 @@ import qualified Formatting.Buildable
 import           Pos.Chain.Txp (Utxo, formatUtxo)
 import           Pos.Core (Timestamp (..))
 import           Pos.Core.Chrono
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (EncryptedSecretKey, emptyPassphrase)
 
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
@@ -47,7 +48,7 @@ import           Cardano.Wallet.Kernel.Transactions (toMeta)
 
 import           Data.Validated
 import           Util.Buildable
-import           UTxO.Context (Addr)
+import           UTxO.Context (Addr, CardanoContext (..), TransCtxt (..))
 import           UTxO.DSL (Hash)
 import qualified UTxO.DSL as DSL
 import           UTxO.ToCardano.Interpreter
@@ -226,7 +227,9 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
                 -> TranslateT EquivalenceViolation m HD.HdAccountId
     walletBootT ctxt utxo = do
         let newRootId = HD.eskToHdRootId esk
-        let (Just defaultAddress) = Kernel.newHdAddress esk
+        nm <- asks (makeNetworkMagic . ccMagic . tcCardano)
+        let (Just defaultAddress) = Kernel.newHdAddress nm
+                                                        esk
                                                         emptyPassphrase
                                                         (Kernel.defaultHdAccountId newRootId)
                                                         (Kernel.defaultHdAddressId newRootId)

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -1,9 +1,11 @@
 -- | Wallet unit tests
+
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
 module Main (main) where
 
 import           Universum
 
-import           Formatting (build, sformat)
 import           Test.Hspec (Spec, describe, hspec, parallel)
 
 import           InputSelection.Evaluation (evalUsingGenData, evalUsingReplay)
@@ -11,10 +13,10 @@ import           InputSelection.Evaluation.Options (Command (..), evalCommand,
                      getEvalOptions)
 import           InputSelection.Evaluation.Replot (replot)
 import           Test.Pos.Util.Parallel.Parallelize (parallelizeAllCores)
-import           UTxO.Bootstrap (bootstrapTransaction)
-import           UTxO.Context (Addr, TransCtxt)
-import           UTxO.DSL (GivenHash, Transaction)
 import           UTxO.Translate (runTranslateNoErrors, withConfig)
+
+import           Pos.Crypto (ProtocolMagic (..), ProtocolMagicId (..),
+                     RequiresNetworkMagic (..))
 
 import qualified DeltaCompressionSpecs
 import qualified Test.Spec.Accounts
@@ -42,7 +44,9 @@ main = do
     case mEvalOptions of
       Nothing -> do
         -- _showContext
-        runTranslateNoErrors $ withConfig $ return $ hspec $ tests
+        -- TODO @intricate: Not sure how I should handle this usage of `ProtocolMagic`, tbh.
+        let pm = ProtocolMagic (ProtocolMagicId 1) RequiresNoMagic
+        runTranslateNoErrors pm $ withConfig $ return $ hspec $ tests
       Just evalOptions ->
         -- NOTE: The coin selection must be invoked with @eval@
         -- Run @wallet-unit-tests eval --help@ for details.
@@ -55,14 +59,14 @@ main = do
             replot evalOptions replotOpts
 
 -- | Debugging: show the translation context
-_showContext :: IO ()
-_showContext = do
-    putStrLn $ runTranslateNoErrors $ withConfig $
-      sformat build <$> ask
-    putStrLn $ runTranslateNoErrors $
-      let bootstrapTransaction' :: TransCtxt -> Transaction GivenHash Addr
-          bootstrapTransaction' = bootstrapTransaction
-      in sformat build . bootstrapTransaction' <$> ask
+-- _showContext :: IO ()
+-- _showContext = do
+--     putStrLn $ runTranslateNoErrors $ withConfig $
+--       sformat build <$> ask
+--     putStrLn $ runTranslateNoErrors $
+--       let bootstrapTransaction' :: TransCtxt -> Transaction GivenHash Addr
+--           bootstrapTransaction' = bootstrapTransaction
+--       in sformat build . bootstrapTransaction' <$> ask
 
 {-------------------------------------------------------------------------------
   Tests proper

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -1,7 +1,5 @@
 -- | Wallet unit tests
 
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
-
 module Main (main) where
 
 import           Universum
@@ -13,10 +11,6 @@ import           InputSelection.Evaluation.Options (Command (..), evalCommand,
                      getEvalOptions)
 import           InputSelection.Evaluation.Replot (replot)
 import           Test.Pos.Util.Parallel.Parallelize (parallelizeAllCores)
-import           UTxO.Translate (runTranslateNoErrors, withConfig)
-
-import           Pos.Crypto (ProtocolMagic (..), ProtocolMagicId (..),
-                     RequiresNetworkMagic (..))
 
 import qualified DeltaCompressionSpecs
 import qualified Test.Spec.Accounts

--- a/wallet-new/test/unit/WalletUnitTest.hs
+++ b/wallet-new/test/unit/WalletUnitTest.hs
@@ -44,9 +44,7 @@ main = do
     case mEvalOptions of
       Nothing -> do
         -- _showContext
-        -- TODO @intricate: Not sure how I should handle this usage of `ProtocolMagic`, tbh.
-        let pm = ProtocolMagic (ProtocolMagicId 1) RequiresNoMagic
-        runTranslateNoErrors pm $ withConfig $ return $ hspec $ tests
+        hspec $ tests
       Just evalOptions ->
         -- NOTE: The coin selection must be invoked with @eval@
         -- Run @wallet-unit-tests eval --help@ for details.

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
@@ -7,32 +7,45 @@ module Test.Pos.Wallet.Web.Methods.BackupDefaultAddressesSpec
 
 import           Universum
 
-import           Pos.Launcher (HasConfigurations)
+import           Test.Hspec (Spec, beforeAll_, describe, runIO)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess)
+import           Test.QuickCheck (arbitrary, generate)
+import           Test.QuickCheck.Monadic (pick)
 
+import           Pos.Chain.Genesis as Genesis (Config (..))
+import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
+import           Pos.Launcher (HasConfigurations)
 import           Pos.Util.Wlog (setupTestLogging)
 import           Pos.Wallet.Web.ClientTypes (CWallet (..))
 import           Pos.Wallet.Web.Methods.Restore (restoreWalletFromBackup)
-import           Test.Hspec (Spec, beforeAll_, describe)
-import           Test.Hspec.QuickCheck (modifyMaxSuccess)
-import           Test.Pos.Chain.Genesis.Dummy (dummyConfig)
-import           Test.Pos.Configuration (withDefConfigurations)
+
+import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty)
 import           Test.Pos.Wallet.Web.Mode (walletPropertySpec)
-import           Test.QuickCheck (Arbitrary (..))
-import           Test.QuickCheck.Monadic (pick)
 
 spec :: Spec
-spec = beforeAll_ setupTestLogging $
-            withDefConfigurations $ \_ _ _ ->
-                describe "restoreAddressFromWalletBackup" $ modifyMaxSuccess (const 10) $ do
-                    restoreWalletAddressFromBackupSpec
+spec = do
+    runWithMagic RequiresNoMagic
+    runWithMagic RequiresMagic
 
-restoreWalletAddressFromBackupSpec :: HasConfigurations => Spec
-restoreWalletAddressFromBackupSpec =
+runWithMagic :: RequiresNetworkMagic -> Spec
+runWithMagic rnm = do
+    pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
+    describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
+        specBody pm
+
+specBody :: ProtocolMagic -> Spec
+specBody pm = beforeAll_ setupTestLogging $
+    withProvidedMagicConfig pm $ \genesisConfig _ _ ->
+        describe "restoreAddressFromWalletBackup" $ modifyMaxSuccess (const 10) $ do
+            restoreWalletAddressFromBackupSpec genesisConfig
+
+restoreWalletAddressFromBackupSpec :: HasConfigurations => Genesis.Config -> Spec
+restoreWalletAddressFromBackupSpec genesisConfig =
     walletPropertySpec restoreWalletAddressFromBackupDesc $ do
         walletBackup   <- pick arbitrary
         restoredWallet <- lift
-            $ restoreWalletFromBackup dummyConfig walletBackup
+            $ restoreWalletFromBackup genesisConfig walletBackup
         let noOfAccounts = cwAccountsNumber restoredWallet
         assertProperty (noOfAccounts > 0) $ "Exported wallet has no accounts!"
   where

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/BackupDefaultAddressesSpec.hs
@@ -42,7 +42,7 @@ specBody pm = beforeAll_ setupTestLogging $
 
 restoreWalletAddressFromBackupSpec :: HasConfigurations => Genesis.Config -> Spec
 restoreWalletAddressFromBackupSpec genesisConfig =
-    walletPropertySpec restoreWalletAddressFromBackupDesc $ do
+    walletPropertySpec genesisConfig restoreWalletAddressFromBackupDesc $ do
         walletBackup   <- pick arbitrary
         restoredWallet <- lift
             $ restoreWalletFromBackup genesisConfig walletBackup

--- a/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Methods/PaymentSpec.hs
@@ -22,6 +22,7 @@ import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 import           Test.QuickCheck (arbitrary, choose, generate)
 import           Test.QuickCheck.Monadic (pick)
 
+import           Pos.Chain.Genesis as Genesis (Config (..))
 import           Pos.Chain.Txp (Tx (..), TxAux (..), TxFee (..),
                      TxpConfiguration, _TxOut)
 import           Pos.Chain.Update (bvdTxFeePolicy)
@@ -48,7 +49,6 @@ import           Pos.Wallet.Web.Util (decodeCTypeOrFail, getAccountAddrsOrThrow)
 import           Pos.Util.Servant (encodeCType)
 import           Pos.Util.Wlog (setupTestLogging)
 
-import           Test.Pos.Chain.Genesis.Dummy (dummyConfig, dummyGenesisData)
 import           Test.Pos.Configuration (withProvidedMagicConfig)
 import           Test.Pos.Util.QuickCheck.Property (assertProperty, expectedOne,
                      maybeStopProperty, splitWord, stopProperty)
@@ -65,18 +65,20 @@ deriving instance Eq CTx
 spec :: Spec
 spec = do
     runWithMagic RequiresNoMagic
-    runWithMagic RequiresMagic
+    -- Not running with `RequiresMagic` until `NetworkMagic` logic
+    -- has been fully implemented.
+    -- runWithMagic RequiresMagic
 
 runWithMagic :: RequiresNetworkMagic -> Spec
 runWithMagic rnm = beforeAll_ setupTestLogging $
     withCompileInfo $ do
         pm <- (\ident -> ProtocolMagic ident rnm) <$> runIO (generate arbitrary)
         describe ("(requiresNetworkMagic=" ++ show rnm ++ ")") $
-            withProvidedMagicConfig pm $ \_ txpConfig _ ->
+            withProvidedMagicConfig pm $ \genesisConfig txpConfig _ ->
                 describe "Wallet.Web.Methods.Payment" $ modifyMaxSuccess (const 10) $ do
                 describe "newPaymentBatch" $ do
-                    describe "Submitting a payment when restoring" (rejectPaymentIfRestoringSpec txpConfig)
-                    describe "One payment" (oneNewPaymentBatchSpec txpConfig)
+                    describe "Submitting a payment when restoring" (rejectPaymentIfRestoringSpec genesisConfig txpConfig)
+                    describe "One payment" (oneNewPaymentBatchSpec genesisConfig txpConfig)
 
 data PaymentFixture = PaymentFixture {
       pswd        :: PassPhrase
@@ -91,8 +93,8 @@ data PaymentFixture = PaymentFixture {
 }
 
 -- | Generic block of code to be reused across all the different payment specs.
-newPaymentFixture :: WalletProperty PaymentFixture
-newPaymentFixture = do
+newPaymentFixture :: Genesis.Config -> WalletProperty PaymentFixture
+newPaymentFixture genesisConfig = do
     passphrases <- importSomeWallets mostlyEmptyPassphrases
     let l = length passphrases
     destLen <- pick $ choose (1, l)
@@ -111,7 +113,7 @@ newPaymentFixture = do
     ws <- WS.askWalletSnapshot
     srcAddr <- getAddress ws srcAccId
     -- Dunno how to get account's balances without CAccModifier
-    initBalance <- getBalance dummyGenesisData srcAddr
+    initBalance <- getBalance (configGenesisData genesisConfig) srcAddr
     -- `div` 2 to leave money for tx fee
     let topBalance = unsafeGetCoin initBalance `div` 2
     coins <- pick $ map mkCoin <$> splitWord topBalance (fromIntegral destLen)
@@ -130,56 +132,59 @@ newPaymentFixture = do
 
 -- | Assess that if we try to submit a payment when the wallet is restoring,
 -- the backend prevents us from doing that.
-rejectPaymentIfRestoringSpec :: HasConfigurations => TxpConfiguration -> Spec
-rejectPaymentIfRestoringSpec txpConfig = walletPropertySpec "should fail with 403" $ do
-    PaymentFixture{..} <- newPaymentFixture
-    res <- lift $ try (newPaymentBatch dummyConfig txpConfig submitTxTestMode pswd batch)
-    liftIO $ shouldBe res (Left (err403 { errReasonPhrase = "Transaction creation is disabled when the wallet is restoring." }))
+rejectPaymentIfRestoringSpec :: HasConfigurations => Genesis.Config -> TxpConfiguration -> Spec
+rejectPaymentIfRestoringSpec genesisConfig txpConfig =
+    walletPropertySpec genesisConfig "should fail with 403" $ do
+        PaymentFixture{..} <- newPaymentFixture genesisConfig
+        res <- lift $ try (newPaymentBatch genesisConfig txpConfig submitTxTestMode pswd batch)
+        liftIO $ shouldBe res (Left (err403 { errReasonPhrase = "Transaction creation is disabled when the wallet is restoring." }))
 
 -- | Test one single, successful payment.
-oneNewPaymentBatchSpec :: HasConfigurations => TxpConfiguration -> Spec
-oneNewPaymentBatchSpec txpConfig = walletPropertySpec oneNewPaymentBatchDesc $ do
-    PaymentFixture{..} <- newPaymentFixture
+oneNewPaymentBatchSpec :: HasConfigurations => Genesis.Config -> TxpConfiguration -> Spec
+oneNewPaymentBatchSpec genesisConfig txpConfig =
+    walletPropertySpec genesisConfig oneNewPaymentBatchDesc $ do
+        PaymentFixture{..} <- newPaymentFixture genesisConfig
 
-    -- Force the wallet to be in a (fake) synced state
-    db <- WS.askWalletDB
-    randomSyncTip <- liftIO $ generate arbitrary
-    WS.setWalletSyncTip db walId randomSyncTip
+        -- Force the wallet to be in a (fake) synced state
+        db <- WS.askWalletDB
+        randomSyncTip <- liftIO $ generate arbitrary
+        WS.setWalletSyncTip db walId randomSyncTip
 
-    void $ lift $ newPaymentBatch dummyConfig txpConfig submitTxTestMode pswd batch
-    dstAddrs <- lift $ mapM decodeCTypeOrFail dstCAddrs
-    txLinearPolicy <- lift $ (bvdTxFeePolicy <$> gsAdoptedBVData) <&> \case
-        TxFeePolicyTxSizeLinear linear -> linear
-        _                              -> error "unknown fee policy"
-    txAux <- expectedOne "sent TxAux" =<< lift getSentTxs
-    TxFee fee <- lift (runExceptT $ txToLinearFee txLinearPolicy txAux) >>= \case
-        Left er -> stopProperty $ "Couldn't compute tx fee by tx, reason: " <> pretty er
-        Right x -> pure x
-    let outAddresses = map (fst . view _TxOut) $ toList $ _txOutputs $ taTx txAux
-    let changeAddrs = outAddresses \\ dstAddrs
-    assertProperty (length changeAddrs <= 1) $
-        "Expected at most one change address"
+        void $ lift $ newPaymentBatch genesisConfig txpConfig submitTxTestMode pswd batch
+        dstAddrs <- lift $ mapM decodeCTypeOrFail dstCAddrs
+        txLinearPolicy <- lift $ (bvdTxFeePolicy <$> gsAdoptedBVData) <&> \case
+            TxFeePolicyTxSizeLinear linear -> linear
+            _                              -> error "unknown fee policy"
+        txAux <- expectedOne "sent TxAux" =<< lift getSentTxs
+        TxFee fee <- lift (runExceptT $ txToLinearFee txLinearPolicy txAux) >>= \case
+            Left er -> stopProperty $ "Couldn't compute tx fee by tx, reason: " <> pretty er
+            Right x -> pure x
+        let outAddresses = map (fst . view _TxOut) $ toList $ _txOutputs $ taTx txAux
+        let changeAddrs = outAddresses \\ dstAddrs
+        assertProperty (length changeAddrs <= 1) $
+            "Expected at most one change address"
 
-    -- Validate balances
-    mapM_ (uncurry expectedAddrBalance) $ zip dstAddrs coins
-    when (policy == OptimizeForSecurity) $
-        expectedAddrBalance srcAddr (mkCoin 0)
-    changeBalance <- mkCoin . fromIntegral . sumCoins
-        <$> mapM (getBalance dummyGenesisData) changeAddrs
-    assertProperty (changeBalance <= initBalance `unsafeSubCoin` fee) $
-        "Minimal tx fee isn't satisfied"
+        -- Validate balances
+        let genesisData = configGenesisData genesisConfig
+        mapM_ (uncurry expectedAddrBalance) $ zip dstAddrs coins
+        when (policy == OptimizeForSecurity) $
+            expectedAddrBalance srcAddr (mkCoin 0)
+        changeBalance <- mkCoin . fromIntegral . sumCoins
+            <$> mapM (getBalance genesisData) changeAddrs
+        assertProperty (changeBalance <= initBalance `unsafeSubCoin` fee) $
+            "Minimal tx fee isn't satisfied"
 
-    ws' <- WS.askWalletSnapshot
-    -- Validate that tx meta was added when transaction was processed
-    forM_ (ordNub $ walId:dstWalIds) $ \wId -> do
-        txMetas <- maybeStopProperty "Wallet doesn't exist" (WS.getWalletTxHistory ws' wId)
-        void $ expectedOne "TxMeta for wallet" txMetas
+        ws' <- WS.askWalletSnapshot
+        -- Validate that tx meta was added when transaction was processed
+        forM_ (ordNub $ walId:dstWalIds) $ \wId -> do
+            txMetas <- maybeStopProperty "Wallet doesn't exist" (WS.getWalletTxHistory ws' wId)
+            void $ expectedOne "TxMeta for wallet" txMetas
 
-    -- Validate change and used address
-    -- TODO implement it when access
-    -- to these addresses will be provided considering mempool
-    -- expectedUserAddresses
-    -- expectedChangeAddresses
+        -- Validate change and used address
+        -- TODO implement it when access
+        -- to these addresses will be provided considering mempool
+        -- expectedUserAddresses
+        -- expectedChangeAddresses
   where
     oneNewPaymentBatchDesc =
         "Send money from one own address to multiple own addresses; " <>

--- a/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Tracking/SyncSpec.hs
@@ -53,7 +53,9 @@ import           Test.Pos.Wallet.Web.Util (importSomeWallets, wpGenBlocks)
 spec :: Spec
 spec = do
     runWithMagic RequiresNoMagic
-    runWithMagic RequiresMagic
+    -- Not running with `RequiresMagic` until `NetworkMagic` logic
+    -- has been fully implemented.
+    -- runWithMagic RequiresMagic
 
 runWithMagic :: RequiresNetworkMagic -> Spec
 runWithMagic rnm = do
@@ -76,7 +78,7 @@ specBody pm = beforeAll_ setupTestLogging $
           "Outgoing transaction from account to the same account."
 
 twoApplyTwoRollbacksSpec :: HasConfigurations => Genesis.Config -> Spec
-twoApplyTwoRollbacksSpec genesisConfig = walletPropertySpec twoApplyTwoRollbacksDesc $ do
+twoApplyTwoRollbacksSpec genesisConfig = walletPropertySpec genesisConfig twoApplyTwoRollbacksDesc $ do
     let protocolConstants = configProtocolConstants genesisConfig
         k                 = pcBlkSecurityParam protocolConstants
     -- During these tests we need to manually switch back to the old synchronous


### PR DESCRIPTION
## Description

"Split" the test-suites, for both `RequiresNoMagic` and `RequiresMagic` cases. Also, introduce arbitrary `ProtocolMagic`s (replace `dummyProtocolMagic` values). Since we hardcoded values in #3733, both splits should pass.

Motivation: in order to follow best practices of modifying tests & source code in separate PRs, today I factored out the testsuite modifications into a separate PR. We are PR'ing this before the full implementation of `NetworkMagic` is PR'ed, because we want to demonstrate that the tests can be split & parameterized by arbitrary `ProtocolMagic`s, without modifying source code, and still pass. Then, when we modify the source and pass the tests, we will have more confidence in a correct implementation.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-410

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.
^ there is no 1.3.1 section in the CHANGELOG, and this is dev work on a release branch, so I'm skipping this.

## Testing checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.