### PR TITLE
Blockchain sync test: pass through nix build arguments

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,28 +1,10 @@
 steps:
-  # - label: 'Acceptance Tests - mainnet - quick'
-  #   env:
-  #     CARDANO_STATE_DIR: "./state-acceptance-tests-mainnet-quick"
-  #   command: "$(nix-build -A acceptanceTests.mainnet.quick)"
-  #   timeout_in_minutes: 120
-
-  # - wait
-
   - label: 'Acceptance Tests - mainnet - full'
     command:
       - nix-build -A acceptanceTests.mainnet.full -o acceptance-tests-mainnet-full.sh
       - echo "+++ Syncing mainnet blockchain"
       - ./acceptance-tests-mainnet-full.sh
     timeout_in_minutes: 120
-
-  - wait
-
-  # - label: 'Acceptance Tests - testnet - quick'
-  #   env:
-  #     CARDANO_STATE_DIR: "./state-acceptance-tests-testnet-quick"
-  #   command: "$(nix-build -A acceptanceTests.testnet.quick)"
-  #   timeout_in_minutes: 120
-
-  # - wait
 
   - label: 'Acceptance Tests - testnet - full'
     command:

--- a/default.nix
+++ b/default.nix
@@ -122,10 +122,10 @@ let
       testnet.explorer = mkDocker { environment = "testnet"; name = "explorer"; connectArgs = { executable = "explorer"; }; };
     };
     acceptanceTests = let
-      acceptanceTest = pkgs.callPackage ./scripts/test/acceptance;
+      acceptanceTest = args: pkgs.callPackage ./scripts/test/acceptance (args // { inherit gitrev forceDontCheck; });
       mkTest = { environment, ...}: {
-        full  = acceptanceTest { inherit environment gitrev; resume = false; };
-        quick = acceptanceTest { inherit environment gitrev; resume = true; };
+        full  = acceptanceTest { inherit environment; resume = false; };
+        quick = acceptanceTest { inherit environment; resume = true; };
       };
     in localLib.forEnvironments mkTest;
 

--- a/default.nix
+++ b/default.nix
@@ -56,7 +56,7 @@ let
   other = rec {
     inherit pkgs;
     testlist = innerClosePropagation [] [ cardanoPkgs.cardano-sl ];
-    walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev useStackBinaries; };
+    walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev forceDontCheck useStackBinaries; };
     validateJson = pkgs.callPackage ./tools/src/validate-json {};
     demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster {
       inherit gitrev useStackBinaries;

--- a/default.nix
+++ b/default.nix
@@ -59,11 +59,11 @@ let
     walletIntegrationTests = pkgs.callPackage ./scripts/test/wallet/integration { inherit gitrev forceDontCheck useStackBinaries; };
     validateJson = pkgs.callPackage ./tools/src/validate-json {};
     demoCluster = pkgs.callPackage ./scripts/launch/demo-cluster {
-      inherit gitrev useStackBinaries;
+      inherit gitrev useStackBinaries forceDontCheck;
       iohkPkgs = cardanoPkgs;
     };
     demoClusterLaunchGenesis = pkgs.callPackage ./scripts/launch/demo-cluster {
-      inherit gitrev useStackBinaries;
+      inherit gitrev useStackBinaries forceDontCheck;
       iohkPkgs = cardanoPkgs;
       launchGenesis = true;
       configurationKey = "testnet_full";

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -42,7 +42,7 @@ let
   } else {
     environment = "demo";
   };
-  demoWallet = pkgs.callPackage ./../connect-to-cluster ({ inherit gitrev useStackBinaries; debug = false; } // walletEnvironment // walletConfig);
+  demoWallet = pkgs.callPackage ./../connect-to-cluster ({ inherit gitrev useStackBinaries forceDontCheck; debug = false; } // walletEnvironment // walletConfig);
   ifWallet = optionalString (runWallet);
   ifKeepAlive = optionalString (keepAlive);
   src = ./../../..;

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -8,9 +8,10 @@
 , numImportedWallets ? 11
 , assetLockAddresses ? []
 , system ? builtins.currentSystem
-, iohkPkgs ? import ./../../.. { inherit config system gitrev; }
+, iohkPkgs ? import ./../../.. { inherit config system gitrev forceDontCheck; }
 , pkgs ? iohkPkgs.pkgs
 , gitrev ? localLib.commitIdFromGitRepo ./../../../.git
+, forceDontCheck ? false
 , ghcRuntimeArgs ? "-N2 -qg -A1m -I0 -T"
 , additionalNodeArgs ? ""
 , keepAlive ? true

--- a/scripts/test/acceptance/default.nix
+++ b/scripts/test/acceptance/default.nix
@@ -1,8 +1,9 @@
-{ localLib ? import ./../../../lib.nix
+{ localLib ? import ../../../lib.nix
 , config ? {}
 , system ? builtins.currentSystem
 , pkgs ? import localLib.fetchNixPkgs { inherit system config; }
 , gitrev ? localLib.commitIdFromGitRepo ../../../.git
+, forceDontCheck ? false
 , stateDir ? localLib.maybeEnv "CARDANO_STATE_DIR" "./state-acceptance-test-${environment}"
 , environment ? "mainnet"
 , resume ? true
@@ -11,14 +12,14 @@
 with localLib;
 
 let
-  iohkPkgs = import ./../../.. { inherit config system pkgs gitrev; };
+  iohkPkgs = import ../../.. { inherit config system pkgs gitrev forceDontCheck; };
 
   cardanoDeps = with iohkPkgs; [ cardano-sl-tools cardano-sl-wallet-new ];
   demoClusterDeps = with pkgs; [ jq coreutils curl gnused openssl time ];
   allDeps =  demoClusterDeps ++ cardanoDeps;
 
   wallet = pkgs.callPackage ../../launch/connect-to-cluster {
-    inherit gitrev stateDir environment;
+    inherit gitrev stateDir environment forceDontCheck;
 
     # This will limit heap size to 1GB, along with the usual RTS options.
     ghcRuntimeArgs = "-N2 -qg -A1m -I0 -T -M1G";

--- a/scripts/test/wallet/integration/default.nix
+++ b/scripts/test/wallet/integration/default.nix
@@ -7,6 +7,7 @@
 , gitrev ? "123456" # Dummy git revision to prevent mass rebuilds
 , ghcRuntimeArgs ? "-N2 -qg -A1m -I0 -T"
 , additionalNodeArgs ? ""
+, forceDontCheck ? false
 , useStackBinaries ? false
 }:
 
@@ -18,14 +19,14 @@ let
   integrationTestDeps = with pkgs; [ gnugrep ];
   allDeps = integrationTestDeps ++ (optionals (!useStackBinaries ) cardanoDeps);
   demo-cluster = iohkPkgs.demoCluster.override {
-    inherit gitrev numCoreNodes stateDir useStackBinaries;
+    inherit gitrev forceDontCheck numCoreNodes stateDir useStackBinaries;
     keepAlive = false;
     assetLockAddresses = [ "DdzFFzCqrhswMWoTiWaqXUDZJuYUx63qB6Aq8rbVbhFbc8NWqhpZkC7Lhn5eVA7kWf4JwKvJ9PqQF78AewMCzDZLabkzm99rFzpNDKp5" ];
   };
   executables =  {
     integration-test = "${iohkPkgs.cardano-sl-wallet-new}/bin/wal-integr-test";
   };
-  iohkPkgs = import ./../../../.. { inherit config system pkgs gitrev; };
+  iohkPkgs = import ./../../../.. { inherit config system pkgs gitrev forceDontCheck; };
 in pkgs.writeScript "integration-tests" ''
   #!${pkgs.stdenv.shell}
   export PATH=${pkgs.lib.makeBinPath allDeps}:$PATH


### PR DESCRIPTION
## Description

Nix build arguments such as `forceDontCheck` were not getting passed through to the `acceptanceTests`.

Also the nightly mainnet and testnet sync tests should be run in parallel.

## Type of change
- Build system and dev environment

## QA Steps
```
nix-build --arg forceDontCheck true -A acceptanceTests.mainnet.full -o acceptance-test-no-tests
nix-build -A acceptanceTests.mainnet.full -o acceptance-test
```
