### PR TITLE
[DEVOPS-1091] CI: Push wallet docker images to hub.docker.com

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,3 +18,11 @@ steps:
     command: "git submodule update --init --recursive ; rm -rf test-state ; nix-shell node-ipc/shell.nix --run 'node node-ipc/server.js'"
     agents:
       system: x86_64-linux
+
+  - label: 'Docker image build and push to hub'
+    command:
+      - "nix-build scripts/ci/docker-build-push --argstr dockerHubRepoName inputoutput/cardano-sl -o docker-build-push"
+      - "./docker-build-push"
+    agents:
+      system: x86_64-linux
+    branches: "master develop release/* devops-1091-docker-hub"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 # CHANGELOG
 
-## Cardano SL 2.0.0
+## Cardano SL vNext
 
+### Features
+
+### Fixes
+
+### Improvements
+
+- #### Docker images published to Docker Hub
+
+  Docker images are now available at
+  [hub.docker.com](https://hub.docker.com/r/inputoutput/cardano-sl/).
+
+  Users who build their own Docker images: please be aware that the
+  image tags now look like `cardano-sl:2.1.0-mainnet-wallet`.
+
+
+## Cardano SL 2.0.0
 
 ### Features
 

--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-auxx
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - Auxx
 description:         Cardano SL - Auxx
 license:             MIT

--- a/binary/cardano-sl-binary.cabal
+++ b/binary/cardano-sl-binary.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-binary
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - binary serialization
 description:         This package defines a type class for binary serialization,
                      helpers and instances.

--- a/binary/test/cardano-sl-binary-test.cabal
+++ b/binary/test/cardano-sl-binary-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-binary-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - binary serializarion (tests)
 description:         This package contains test helpers for cardano-sl-binary.
 license:             MIT

--- a/chain/cardano-sl-chain.cabal
+++ b/chain/cardano-sl-chain.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-chain
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - transaction processing
 description:         Cardano SL - transaction processing
 license:             MIT

--- a/chain/test/cardano-sl-chain-test.cabal
+++ b/chain/test/cardano-sl-chain-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-chain-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - arbitrary instances for cardano-sl-chain
 description:         Cardano SL - arbitrary instances for cardano-sl-chain
 license:             MIT

--- a/client/cardano-sl-client.cabal
+++ b/client/cardano-sl-client.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-client
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL client modules
 description:         Cardano SL client modules
 license:             MIT

--- a/cluster/cardano-sl-cluster.cabal
+++ b/cluster/cardano-sl-cluster.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-cluster
-version:             2.0.0
+version:             2.1.0
 synopsis:            Utilities to generate and run cluster of nodes
 description:         See README
 homepage:            https://github.com/input-output-hk/cardano-sl/cluster/README.md

--- a/core/cardano-sl-core.cabal
+++ b/core/cardano-sl-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-core
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - core
 description:         Cardano SL - core
 license:             MIT

--- a/core/test/cardano-sl-core-test.cabal
+++ b/core/test/cardano-sl-core-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-core-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - core functionality (tests)
 description:         QuickCheck Arbitrary instances for the Cardano SL core
                      functionality.

--- a/crypto/cardano-sl-crypto.cabal
+++ b/crypto/cardano-sl-crypto.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-crypto
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - cryptography primitives
 description:         This package contains cryptography primitives used in Cardano SL.
 license:             MIT

--- a/crypto/test/cardano-sl-crypto-test.cabal
+++ b/crypto/test/cardano-sl-crypto-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-crypto-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - arbitrary instances for cardano-sl-crypto
 description:         This package contains arbitrary instances for the cryptography primitives used in Cardano SL.
 license:             MIT

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-db
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - basic DB interfaces
 description:         Cardano SL - basic DB interfaces
 license:             MIT

--- a/db/test/cardano-sl-db-test.cabal
+++ b/db/test/cardano-sl-db-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-db-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - arbitrary instances for cardano-sl-db
 description:         Cardano SL - arbitrary instances for cardano-sl-db
 license:             MIT

--- a/default.nix
+++ b/default.nix
@@ -154,7 +154,10 @@ let
 
     dockerImages = let
       build = args: self.callPackage ./nix/docker.nix ({
-        inherit (self.cardanoPackages) cardano-sl-node-static;
+        inherit (self.cardanoPackages)
+          cardano-sl-node-static
+          cardano-wallet-static
+          cardano-sl-explorer-static;
       } // args);
       makeDockerImage = { environment, ...}:
         build { inherit environment; } // {
@@ -232,7 +235,9 @@ let
     demoCluster = self.callPackage ./scripts/launch/demo-cluster {
       inherit useStackBinaries;
       inherit (self.cardanoPackages)
-        cardano-sl cardano-sl-cluster cardano-wallet;
+        cardano-sl
+        cardano-sl-cluster
+        cardano-wallet;
     };
 
     ####################################################################

--- a/docs/exchange-onboarding.md
+++ b/docs/exchange-onboarding.md
@@ -181,15 +181,16 @@ container and import the image run
 
     docker load < $(nix-build --no-out-link -A dockerImages.mainnet.wallet)
 
-This will create an image `cardano-container-mainnet:latest`
-(or `cardano-container-staging:latest` for testnet)
+This will create an image `cardano-sl:X.Y.Z-mainnet-wallet` (or
+`cardano-sl:X.Y.Z-testnet-wallet` for testnet), where `X.Y.Z` is the
+Cardano SL version.
 
 After this image is built, it can be used like any other docker image being pushed
 into a registry and pulled down using your preferred docker orchestration tool.
 
 The image can be ran using the following:
 
-    docker run --name cardano-mainnet-wallet --rm -it -p 127.0.0.1:8090:8090 -p 127.0.0.1:8000:8000 -v state-wallet-mainnet:/wallet cardano-container-mainnet:latest
+    docker run --name cardano-mainnet-wallet --rm -it -p 127.0.0.1:8090:8090 -p 127.0.0.1:8000:8000 -v state-wallet-mainnet:/wallet cardano-sl:X.Y.Z-mainnet-wallet
 
 The above command will create a docker volume named `state-wallet-mainnet` and will mount
 that to /wallet. Note: if no volume is mounted to `/wallet` the container startup

--- a/explorer/cardano-sl-explorer.cabal
+++ b/explorer/cardano-sl-explorer.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-explorer
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano explorer
 description:         Please see README.md
 license:             MIT

--- a/faucet/cardano-sl-faucet.cabal
+++ b/faucet/cardano-sl-faucet.cabal
@@ -1,5 +1,5 @@
 name:           cardano-sl-faucet
-version:        2.0.0
+version:        2.1.0
 description:    Cardano SL - faucet
 license:        MIT
 author:         Ben Ford

--- a/generator/cardano-sl-generator.cabal
+++ b/generator/cardano-sl-generator.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-generator
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - arbitrary data generation
 description:         Cardano SL - arbitrary data generation
 license:             MIT

--- a/infra/cardano-sl-infra.cabal
+++ b/infra/cardano-sl-infra.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-infra
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - infrastructural
 description:         Cardano SL - infrastructural
 license:             MIT

--- a/infra/test/cardano-sl-infra-test.cabal
+++ b/infra/test/cardano-sl-infra-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-infra-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - generators for cardano-sl-infra
 description:         This package contains generators for the infrastructural data types used in Cardano SL.
 license:             MIT

--- a/lib/cardano-sl.cabal
+++ b/lib/cardano-sl.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL main implementation
 description:         Please see README.md
 license:             MIT

--- a/mnemonic/cardano-sl-mnemonic.cabal
+++ b/mnemonic/cardano-sl-mnemonic.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-mnemonic
-version:             2.0.0
+version:             2.1.0
 synopsis:            TODO
 description:         See README
 homepage:            https://github.com/input-output-hk/cardano-sl/mnemonic/README.md

--- a/networking/cardano-sl-networking.cabal
+++ b/networking/cardano-sl-networking.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-networking
-version:             2.0.0
+version:             2.1.0
 license:             MIT
 license-file:        LICENSE
 category:            Network

--- a/nix/.stack.nix/cardano-sl-auxx.nix
+++ b/nix/.stack.nix/cardano-sl-auxx.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-auxx";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-binary-test.nix
+++ b/nix/.stack.nix/cardano-sl-binary-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-binary-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-binary.nix
+++ b/nix/.stack.nix/cardano-sl-binary.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-binary";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-chain-test.nix
+++ b/nix/.stack.nix/cardano-sl-chain-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-chain-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-chain.nix
+++ b/nix/.stack.nix/cardano-sl-chain.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-chain";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-client.nix
+++ b/nix/.stack.nix/cardano-sl-client.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-client";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2017 IOHK";

--- a/nix/.stack.nix/cardano-sl-cluster.nix
+++ b/nix/.stack.nix/cardano-sl-cluster.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-cluster";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-core-test.nix
+++ b/nix/.stack.nix/cardano-sl-core-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-core-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-core.nix
+++ b/nix/.stack.nix/cardano-sl-core.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-core";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-crypto-test.nix
+++ b/nix/.stack.nix/cardano-sl-crypto-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-crypto-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-crypto.nix
+++ b/nix/.stack.nix/cardano-sl-crypto.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-crypto";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-db-test.nix
+++ b/nix/.stack.nix/cardano-sl-db-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-db-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-db.nix
+++ b/nix/.stack.nix/cardano-sl-db.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-db";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-explorer.nix
+++ b/nix/.stack.nix/cardano-sl-explorer.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-explorer";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2017 IOHK";

--- a/nix/.stack.nix/cardano-sl-faucet.nix
+++ b/nix/.stack.nix/cardano-sl-faucet.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-faucet";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-generator.nix
+++ b/nix/.stack.nix/cardano-sl-generator.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-generator";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2017 IOHK";

--- a/nix/.stack.nix/cardano-sl-infra-test.nix
+++ b/nix/.stack.nix/cardano-sl-infra-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-infra-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-infra.nix
+++ b/nix/.stack.nix/cardano-sl-infra.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-infra";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-mnemonic.nix
+++ b/nix/.stack.nix/cardano-sl-mnemonic.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-mnemonic";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-networking.nix
+++ b/nix/.stack.nix/cardano-sl-networking.nix
@@ -11,7 +11,7 @@
       specVersion = "1.20";
       identifier = {
         name = "cardano-sl-networking";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "";

--- a/nix/.stack.nix/cardano-sl-node-ipc.nix
+++ b/nix/.stack.nix/cardano-sl-node-ipc.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-node-ipc";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "";

--- a/nix/.stack.nix/cardano-sl-node.nix
+++ b/nix/.stack.nix/cardano-sl-node.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-node";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-tools-post-mortem.nix
+++ b/nix/.stack.nix/cardano-sl-tools-post-mortem.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-tools-post-mortem";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-tools.nix
+++ b/nix/.stack.nix/cardano-sl-tools.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-tools";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-util-test.nix
+++ b/nix/.stack.nix/cardano-sl-util-test.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-util-test";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-util.nix
+++ b/nix/.stack.nix/cardano-sl-util.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-util";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-sl-utxo.nix
+++ b/nix/.stack.nix/cardano-sl-utxo.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-utxo";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2017-2018 IOHK";

--- a/nix/.stack.nix/cardano-sl-x509.nix
+++ b/nix/.stack.nix/cardano-sl-x509.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl-x509";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/.stack.nix/cardano-sl.nix
+++ b/nix/.stack.nix/cardano-sl.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-sl";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2016 IOHK";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet";
-        version = "2.0.0";
+        version = "2.1.0";
       };
       license = "MIT";
       copyright = "2018 IOHK";

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,24 +1,39 @@
 { writeScriptBin, dockerTools
 
 , glibcLocales, iana-etc, openssl, bashInteractive, coreutils, utillinux, iproute, iputils, curl, socat
-, cardano-sl-node-static, cardano-sl-config, version
+, cardano-sl-node-static, cardano-wallet-static, cardano-sl-explorer-static
+, cardano-sl-config, version
 
-, environment ? "mainnet"
-, type ? null
+# Connect script function.
 , connect
+# Additional arguments to supply to connect script function.
 , connectArgs ? {}
+
+# Used to generate the docker image names
+, repoName ? "cardano-sl"
+
+# Configure start script to use this network.
+, environment ? "mainnet"
+
+# Specialize start script command to one of
+# wallet (default if null), explorer, node.
+, type ? null
 }:
 
-# assertOneOf "type" type [ "wallet" "explorer" "node" ];
+assert builtins.elem type [ null "wallet" "explorer" "node" ];
+
+with import ../lib.nix;
 
 let
-  localLib = import ../lib.nix;
+  useConfigVolume = environment == "demo";
   connectToCluster = connect ({
     inherit environment;
     stateDir = "/wallet/${environment}";
     walletListen = "0.0.0.0:8090";
     walletDocListen = "0.0.0.0:8091";
     ekgListen = "0.0.0.0:8000";
+  } // optionalAttrs useConfigVolume {
+    topologyFile = "/config/topology.yaml";
   } // connectArgs);
 
   startScriptConnect = name: args: writeScriptBin "cardano-start-${name}" ''
@@ -27,37 +42,71 @@ let
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     if [ ! -d /wallet ]; then
       echo '/wallet volume not mounted, you need to create one with `docker volume create` and pass the correct -v flag to `docker run`'
-    exit 1
-    fi
-    cd /wallet
-    exec ${connectToCluster.override args}
-  '';
-  confKey = localLib.environments.${environment}.confKey;
-  startScripts = [
-    (startScriptConnect "wallet" {})
-    (startScriptConnect "explorer" { executable = "explorer"; })
-    (writeScriptBin "cardano-start-node" ''
-      #!/bin/sh
-      set -euo pipefail
-
-      export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
-      if [ ! -d /state ]; then
-        echo '/state volume not mounted, you need to create one with `docker volume create` and pass the correct -v flag to `docker run`'
       exit 1
+    fi
 
-      cd /state
-      node_args="--db-path /state/db --rebuild-db --listen 0.0.0.0:3000 --json-log /state/logs/node.json --logs-prefix /state/logs --log-config /state/logs/log-config-node.yaml --metrics +RTS -N2 -qg -A1m -I0 -T -RTS --configuration-file ${cardano-sl-config}/lib/configuration.yaml --configuration-key ${confKey}"
+    ${optionalString useConfigVolume ''
+    if [ ! -f /config/topology.yaml ]; then
+      echo '/config/topology.yaml does not exist.'
+      echo 'You need to bind-mount a config directory to'
+      echo 'the /config volume (the -v flag to `docker run`)'
+      exit 2
+    fi
+    ''}
 
-      exec ${cardano-sl-node-static}/bin/cardano-node-simple $node_args "$@"
-    '')
-  ];
-  
-in dockerTools.buildImage {
-  name = "cardano-sl";
-  tag = "${version}${if (type != null) then "-" + type else ""}-${environment}";
-  contents = [ iana-etc openssl bashInteractive coreutils utillinux iproute iputils curl socat ]
-   ++ startScripts;
-  config = {
+    cd /wallet
+    exec ${connectToCluster.override args}${optionalString useConfigVolume " --runtime-args \"$RUNTIME_ARGS\""}
+  '';
+  confKey = environments.${environment}.confKey;
+
+  startScriptNode = writeScriptBin "cardano-start-node" ''
+    #!/bin/sh
+    set -euo pipefail
+
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
+    if [ ! -d /state ]; then
+      echo '/state volume not mounted, you need to create one with `docker volume create` and pass the correct -v flag to `docker run`'
+    exit 1
+
+    cd /state
+    node_args="--db-path /state/db --rebuild-db --listen 0.0.0.0:3000 --json-log /state/logs/node.json --logs-prefix /state/logs --log-config /state/logs/log-config-node.yaml --metrics +RTS -N2 -qg -A1m -I0 -T -RTS --configuration-file ${cardano-sl-config}/lib/configuration.yaml --configuration-key ${confKey}"
+
+    exec ${cardano-sl-node-static}/bin/cardano-node-simple $node_args "$@"
+  '';
+
+  # Layer of tools which aren't going to change much between versions.
+  baseImage = dockerTools.buildImage {
+    name = "${repoName}-env";
+    contents = [ iana-etc openssl bashInteractive coreutils utillinux iproute iputils curl socat ];
+  };
+
+  # Adds cardano-sl packages to image: core node, wallet, explorer, config.
+  cardanoSLImage = dockerTools.buildImage {
+    name = repoName;
+    tag = version;
+    fromImage = baseImage;
+    contents = [
+      cardano-wallet-static
+      cardano-sl-node-static
+      cardano-sl-explorer-static
+      cardano-sl-config
+    ];
+  };
+
+  # Adds start scripts for the environment.
+  environmentImage = dockerTools.buildImage {
+    name = repoName;
+    tag = "${version}-${environment}";
+    fromImage = cardanoSLImage;
+    contents = [
+      (startScriptConnect "wallet" { executable = "wallet"; })
+      (startScriptConnect "explorer" { executable = "explorer"; })
+      startScriptNode
+    ];
+    config = mkConfig null;
+  };
+
+  mkConfig = type: {
     Cmd = [ "cardano-start-${if (type != null) then type else "wallet"}" ];
     ExposedPorts = {
       "3000/tcp" = {}; # protocol
@@ -66,5 +115,15 @@ in dockerTools.buildImage {
       "8100/tcp" = {}; # explorer api
       "8000/tcp" = {}; # ekg
     };
+  } // optionalAttrs useConfigVolume {
+    Env = [ "RUNTIME_ARGS=" ];
   };
-}
+
+in
+  # Final image, possibly specialized to a certain node type.
+  dockerTools.buildImage {
+    name = repoName;
+    tag = "${version}-${environment}${if (type != null) then "-" + type else ""}";
+    fromImage = environmentImage;
+    config = mkConfig type;
+  } // { inherit version; }

--- a/node-ipc/cardano-sl-node-ipc.cabal
+++ b/node-ipc/cardano-sl-node-ipc.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-node-ipc
-version:             2.0.0
+version:             2.1.0
 license:             MIT
 license-file:        LICENSE
 author:              Michael Bishop

--- a/node/cardano-sl-node.cabal
+++ b/node/cardano-sl-node.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-node
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL simple node executable
 description:         Provides a 'cardano-node-simple' executable which can
                      connect to the Cardano network and act as a full node

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13579,7 +13579,7 @@ license = stdenv.lib.licenses.bsd3;
 mkDerivation {
 
 pname = "cardano-sl";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../lib;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -13824,7 +13824,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-auxx";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../auxx;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -13968,7 +13968,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-binary";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../binary;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14067,7 +14067,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-binary-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../binary/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14174,7 +14174,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-chain";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../chain;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14334,7 +14334,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-chain-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../chain/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14414,7 +14414,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-client";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../client;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14515,7 +14515,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-cluster";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../cluster;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14652,7 +14652,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-core";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../core;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14778,7 +14778,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-core-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../core/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14859,7 +14859,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-crypto";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../crypto;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -14950,7 +14950,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-crypto-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../crypto/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15032,7 +15032,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-db";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../db;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15127,7 +15127,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-db-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../db/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15226,7 +15226,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-explorer";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../explorer;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15412,7 +15412,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-faucet";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../faucet;
 isLibrary = true;
 isExecutable = true;
@@ -15542,7 +15542,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-generator";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../generator;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15734,7 +15734,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-infra";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../infra;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -15860,7 +15860,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-infra-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../infra/test;
 libraryHaskellDepends = [
 async
@@ -15920,7 +15920,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-mnemonic";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../mnemonic;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16022,7 +16022,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-networking";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../networking;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16165,7 +16165,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-node";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../node;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16261,7 +16261,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-node-ipc";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../node-ipc;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16342,7 +16342,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-tools";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../tools;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16461,7 +16461,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-tools-post-mortem";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../tools/post-mortem;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16568,7 +16568,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-util";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../util;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16697,7 +16697,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-util-test";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../util/test;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16774,7 +16774,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-utxo";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../utxo;
 libraryHaskellDepends = [
 base
@@ -16836,7 +16836,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-sl-x509";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../x509;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"
@@ -16989,7 +16989,7 @@ license = stdenv.lib.licenses.mit;
 mkDerivation {
 
 pname = "cardano-wallet";
-version = "2.0.0";
+version = "2.1.0";
 src = ./../wallet;
 configureFlags = [
 "--ghc-option=-fwarn-redundant-constraints"

--- a/scripts/ci/docker-build-push/default.nix
+++ b/scripts/ci/docker-build-push/default.nix
@@ -1,0 +1,56 @@
+# This script will load nix-built docker images of cardano-sl wallet
+# into the Docker daemon (must be running), and then push to the
+# Docker Hub. Credentials for the hub must already be installed with
+# "docker login".
+
+let
+  localLib = import ../../../lib.nix;
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, iohkPkgs ? import ../../.. { inherit config system; }
+, pkgs ? iohkPkgs.pkgs
+, hostPkgs ? import <nixpkgs> { inherit config system; }
+, dockerHubRepoName ? null
+}:
+
+with hostPkgs;
+with hostPkgs.lib;
+
+let
+  imageTypes = ["wallet" "explorer" "node"];
+  images = concatLists (attrValues (localLib.forEnvironments ({ environment, ...}:
+    let genericImage = iohkPkgs.dockerImages.${environment};
+    in [ genericImage ] ++ map (type: genericImage.${type}) imageTypes)));
+
+in
+  writeScript "docker-build-push" (''
+    #!${stdenv.shell}
+
+    set -euo pipefail
+
+    export PATH=${lib.makeBinPath [ docker gnused ]}
+
+    ${if dockerHubRepoName == null then ''
+    reponame=cardano-sl
+    username="$(docker info | sed '/Username:/!d;s/.* //')"
+    fullrepo="$username/$reponame"
+    '' else ''
+    fullrepo="${dockerHubRepoName}"
+    ''}
+
+  '' + concatMapStringsSep "\n" (image: ''
+    echo "Loading ${image}"
+    branch="''${BUILDKITE_BRANCH:-}"
+    if [[ "$branch" = master ]] || [[ "$branch" = release/* ]]; then
+      tag="${image.imageTag}"
+    else
+      tag="$(echo ${image.imageTag} | sed -e s/${image.version}/develop/)"
+    fi
+    tagged="$fullrepo:$tag"
+    docker load -i "${image}"
+    if [ "$tagged" != "${image.imageName}:${image.imageTag}" ]; then
+      docker tag "${image.imageName}:${image.imageTag}" "$tagged"
+    fi
+    docker push "$tagged"
+  '') images)

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -159,6 +159,21 @@ in writeScript "${executable}-connect-to-${environment}" ''
   ln -sf ${curlScript} ${stateDir}/curl
   ''}
 
+  # If disableClientAuth is null then use DEMO_NO_CLIENT_AUTH at runtime.
+  # Any non-empty value means disable it.
+  # The DEMO_NO_CLIENT_AUTH variable is used by the demo cluster.
+  ${if disableClientAuth == null then ''
+    if [ -n "''${DEMO_NO_CLIENT_AUTH:-}" ]; then
+      CLIENT_AUTH_ARGS="--no-client-auth"
+    else
+      CLIENT_AUTH_ARGS=""
+    fi
+  '' else if disableClientAuth then ''
+    CLIENT_AUTH_ARGS="--no-client-auth"
+  '' else ''
+    CLIENT_AUTH_ARGS=""
+  ''}
+
   exec ${executables.${executable}}                                                    \
     ${configurationArgs}                                                               \
     ${ ifWallet "--tlscert ${stateDir}/tls/server/server.crt"}                         \
@@ -170,7 +185,7 @@ in writeScript "${executable}-connect-to-${environment}" ''
     --db-path "${stateDir}/db"   ${extraParams}                                        \
     ${ ifWallet "--wallet-db-path '${stateDir}/wallet-db' ${walletDataLayer}"}         \
     ${ ifDebug "--wallet-debug"}                                                       \
-    ${ ifDisableClientAuth "--no-client-auth"}                                         \
+    $CLIENT_AUTH_ARGS                                                                  \
     --keyfile ${stateDir}/secret.key                                                   \
     ${ ifWallet "--wallet-address ${walletListen}" }                                   \
     ${ ifWallet "--wallet-doc-address ${walletDocListen}" }                            \

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-tools
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - Tools
 description:         Cardano SL - Tools
 license:             MIT

--- a/tools/post-mortem/cardano-sl-tools-post-mortem.cabal
+++ b/tools/post-mortem/cardano-sl-tools-post-mortem.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-tools-post-mortem
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - post-mortem tool
 description:         Cardano SL - post-mortem tool
 license:             MIT

--- a/util/cardano-sl-util.cabal
+++ b/util/cardano-sl-util.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-util
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - general utilities
 description:         This package contains utility functions not specific
                      to Cardano SL which extend 3rd party libraries or implement

--- a/util/test/cardano-sl-util-test.cabal
+++ b/util/test/cardano-sl-util-test.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-util-test
-version:             2.0.0
+version:             2.1.0
 synopsis:            Cardano SL - general utilities (tests)
 description:         QuickCheck Arbitrary instances for the Cardano SL general
                      utilities package.

--- a/utxo/cardano-sl-utxo.cabal
+++ b/utxo/cardano-sl-utxo.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-utxo
-version:             2.0.0
+version:             2.1.0
 synopsis:            Abstract definitions of UTxO based accounting
 -- description:
 homepage:            https://github.com/input-output-hk/cardano-sl/#readme

--- a/wallet/cardano-wallet.cabal
+++ b/wallet/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2.0.0
+version:             2.1.0
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/x509/cardano-sl-x509.cabal
+++ b/x509/cardano-sl-x509.cabal
@@ -1,5 +1,5 @@
 name:                cardano-sl-x509
-version:             2.0.0
+version:             2.1.0
 synopsis:            Tool-suite for generating x509 certificates specialized for RSA with SHA-256
 description:         See README
 homepage:            https://github.com/input-output-hk/cardano-sl/x509/README.md


### PR DESCRIPTION
## Description

- Adds CI pipeline which uploads the docker images to docker hub.

- The demo cluster doesn't work in docker due to #3778. I have removed the demo cluster docker image.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1091

## Type of change
- Build scripts

## Builds on Docker Hub

https://hub.docker.com/r/inputoutput/cardano-sl/

## QA Steps

- Check that the buildkite pipeline works.

### Mainnet wallet
```
docker volume create wallet_mainnet
docker run -p 9090:8090 -v wallet_mainnet:/wallet inputoutput/cardano-sl:2.1.0-mainnet-wallet
curl --insecure https://localhost:9090/api/v1/node-info
```
