### PR TITLE
[CBR-420] Avoid writing to acid-state log

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17301,6 +17301,7 @@ license = stdenv.lib.licenses.mit;
 , silently
 , stdenv
 , stm
+, stm-chans
 , string-conv
 , tabl
 , tar
@@ -17407,6 +17408,7 @@ safe-exceptions
 serokell-util
 silently
 stm
+stm-chans
 tabl
 tar
 text

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -46,6 +46,7 @@ executable dbgen
                      , network-transport-tcp >= 0.6
                      , optparse-generic
                      , stm
+                     , stm-chans
                      , text
                      , time
                      , time-units

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -12,7 +12,7 @@ module Main where
 
 import           Universum
 
-import           Control.Concurrent.STM (newTQueueIO)
+import           Control.Concurrent.STM.TBQueue (newTBQueueIO)
 import           Data.Default (def)
 import           Data.Maybe (isJust)
 import           Data.Time.Units (fromMicroseconds)
@@ -143,7 +143,7 @@ walletRunner
 walletRunner genesisConfig txpConfig confOpts dbs publicKeyPath secretKeyPath ws act = do
     wwmc <- WalletWebModeContext <$> pure ws
                                  <*> newTVarIO def
-                                 <*> liftIO newTQueueIO
+                                 <*> liftIO (newTBQueueIO 64)
                                  <*> newRealModeContext genesisConfig txpConfig dbs confOpts publicKeyPath secretKeyPath
     runReaderT act wwmc
 

--- a/wallet-new/src/Cardano/Wallet/LegacyAction.hs
+++ b/wallet-new/src/Cardano/Wallet/LegacyAction.hs
@@ -2,7 +2,7 @@ module Cardano.Wallet.LegacyAction(actionWithWallet) where
 
 import           Universum
 
-import           Control.Concurrent.STM (newTQueueIO)
+import           Control.Concurrent.STM (newTBQueueIO)
 
 import           Ntp.Client (NtpConfiguration, NtpStatus, ntpClientSettings,
                      withNtpClient)
@@ -48,7 +48,7 @@ actionWithWallet wArgs@WalletBackendParams {..} genesisConfig walletConfig txpCo
     logInfo "[Attention] Software is built with the wallet backend"
     bracketWalletWebDB (walletDbPath walletDbOptions) (walletRebuildDb walletDbOptions) $ \db ->
         bracketWalletWS $ \conn -> do
-            syncQueue <- liftIO newTQueueIO
+            syncQueue <- liftIO $ newTBQueueIO 64
             ntpStatus <- withNtpClient (ntpClientSettings ntpConfig)
             runWRealMode genesisConfig txpConfig db conn syncQueue nodeRes (mainAction ntpStatus)
   where

--- a/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Sync.hs
@@ -42,7 +42,7 @@ module Pos.Wallet.Web.Tracking.Sync
 
 import           Universum hiding (id)
 
-import           Control.Concurrent.STM (readTQueue)
+import           Control.Concurrent.STM (readTBQueue)
 import           Control.Exception.Safe (handleAny)
 import           Control.Lens (to)
 import           Control.Monad.Except (MonadError (throwError))
@@ -119,7 +119,7 @@ processSyncRequest
     -> SyncQueue
     -> m ()
 processSyncRequest genesisConfig syncQueue = do
-    newRequest <- atomically (readTQueue syncQueue)
+    newRequest <- atomically (readTBQueue syncQueue)
     syncWalletWithBlockchain genesisConfig newRequest
         >>= either processSyncError (const (logSuccess newRequest))
     processSyncRequest genesisConfig syncQueue

--- a/wallet/src/Pos/Wallet/Web/Tracking/Types.hs
+++ b/wallet/src/Pos/Wallet/Web/Tracking/Types.hs
@@ -15,7 +15,7 @@ module Pos.Wallet.Web.Tracking.Types
 
 import           Universum
 
-import           Control.Concurrent.STM (TQueue, writeTQueue)
+import           Control.Concurrent.STM (TBQueue, writeTBQueue)
 
 import           Pos.DB.Class (MonadDBRead (..))
 import           Pos.Infra.Slotting (MonadSlotsData)
@@ -48,7 +48,7 @@ type WalletTrackingEnv ctx m =
 
 -- | A 'SyncQueue' is a bounded queue where we store incoming 'SyncRequest', and
 -- we process them asynchronously.
-type SyncQueue = TQueue SyncRequest
+type SyncQueue = TBQueue SyncRequest
 
 -- | A 'SyncRequest' model the interaction the user (or more generally the system)
 -- has with the wallet.
@@ -105,5 +105,5 @@ submitSyncRequest :: ( MonadIO m
                      , HasLens SyncQueue ctx SyncQueue
                      ) => SyncRequest -> m ()
 submitSyncRequest syncRequest = do
-    requestQueue <- view (lensOf @(TQueue SyncRequest))
-    atomically $ writeTQueue requestQueue syncRequest
+    requestQueue <- view (lensOf @(TBQueue SyncRequest))
+    atomically $ writeTBQueue requestQueue syncRequest

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -215,7 +215,7 @@ initWalletTestContext WalletTestParams {..} callback =
                 wtcConnectedPeers <- ConnectedPeers <$> STM.newTVarIO mempty
                 wtcLastKnownHeader <- STM.newTVarIO Nothing
                 wtcSentTxs <- STM.newTVarIO mempty
-                wtcSyncQueue <- STM.newTQueueIO
+                wtcSyncQueue <- STM.newTBQueueIO 64
                 wtcSlottingStateVar <- mkSimpleSlottingStateVar dummyEpochSlots
                 pure WalletTestContext {..}
             callback wtc


### PR DESCRIPTION
When there are no wallets configured (for instance, during a cold sync), we can
safely skip applying any blocks.