### PR TITLE
[DEVOPS-1083] Nix documentation and refactor part III

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,28 +1,10 @@
 steps:
-  # - label: 'Acceptance Tests - mainnet - quick'
-  #   env:
-  #     CARDANO_STATE_DIR: "./state-acceptance-tests-mainnet-quick"
-  #   command: "$(nix-build -A acceptanceTests.mainnet.quick)"
-  #   timeout_in_minutes: 120
-
-  # - wait
-
   - label: 'Acceptance Tests - mainnet - full'
     command:
       - nix-build -A acceptanceTests.mainnet.full -o acceptance-tests-mainnet-full.sh
       - echo "+++ Syncing mainnet blockchain"
       - ./acceptance-tests-mainnet-full.sh
     timeout_in_minutes: 120
-
-  - wait
-
-  # - label: 'Acceptance Tests - testnet - quick'
-  #   env:
-  #     CARDANO_STATE_DIR: "./state-acceptance-tests-testnet-quick"
-  #   command: "$(nix-build -A acceptanceTests.testnet.quick)"
-  #   timeout_in_minutes: 120
-
-  # - wait
 
   - label: 'Acceptance Tests - testnet - full'
     command:

--- a/default.nix
+++ b/default.nix
@@ -247,9 +247,11 @@ let
 
     validateJson = self.callPackage ./tools/src/validate-json {};
 
-    # Add a shell attribute so that it can be built and cached by Hydra.
-    shell = import ./shell.nix { inherit system config pkgs; iohkPkgs = self; };
-
+    # Add a shell attributes so these can be built and cached by Hydra.
+    shells = {
+      cabal = import ./shell.nix { inherit system config pkgs; iohkPkgs = self; };
+      stack = import ./nix/stack-shell.nix { inherit system config pkgs; iohkPkgs = self; };
+    };
 
     ####################################################################
     # Version info

--- a/default.nix
+++ b/default.nix
@@ -226,6 +226,8 @@ let
       explorer = self.connect { inherit environment; executable = "explorer"; };
     });
 
+    # Produces a script which starts a cluster of core nodes and a
+    # relay, then connects an edge node (wallet) to it.
     demoCluster = self.callPackage ./scripts/launch/demo-cluster {
       inherit useStackBinaries;
       inherit (self.cardanoPackages)

--- a/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
+++ b/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md
@@ -170,7 +170,7 @@ cabal 2.0.0.1 which doesn't work.
 
 Enter the `nix-shell`:
 
-    [nix-shell:~/cardano-sl]$ nix-shell -A forCabal
+    [nix-shell:~/cardano-sl]$ nix-shell
 
 Then build all cardano-sl packages:
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -71,27 +71,29 @@ cache and nothing built locally.
    You can tell if the cache works by finding an output store path on
    [a Hydra build](https://hydra.iohk.io/job/serokell/cardano-sl/cardano-sl.x86_64-linux/latest#tabs-details),
    and then running `nix-store --realize PATH`. For example:
-   
+
    ```
    nix-store --realize /nix/store/ivapcjym0ar5mdx3jyf1p6d3m2zzmajn-cardano-sl-1.3.0
    ```
 
-   If this doesn't work, review the your settings with:
-   
+   If this doesn't work, review your settings with:
+
    ```
    nix show-config | egrep '(subst|keys)'
    ```
 
-2. If building from `cardano-sl`, check for extra files in package sub
-   directories. Run `git clean -nd` to see what to delete.
+2. Check for extra files in package sub-directories. Run `git clean
+   -nd` to see what to delete.
 
-   Common things which defeat the cache are things like benchmark results.
+   Common things which defeat the cache are things like benchmark
+   results or files left behind after running tests.
+
    Run `git clean -ndX` to see what else to delete.
 
 ### Multi User Nix Installation
 
 You can tell if Nix is installed in multi user mode by checking the
-ownership of `/nix/store`. The owner:group should be `root:nixbld`.
+ownership of `/nix/store`. The `owner:group` should be `root:nixbld`.
 
 Additionally, the `nix-daemon` service will be running in a multi user
 Nix installation.
@@ -100,7 +102,7 @@ Nix installation.
 ### How to update the `src.json` files
 
 We pin versions to exact revisions and put these revisions, and their
-SHA256 hash into little json files. To recalculate the hash, use
+SHA-256 hash into little json files. To recalculate the hash, use
 `nix-prefetch-git` according to
 [this procedure](https://github.com/input-output-hk/internal-documentation/wiki/Daedalus#q-how-to-change-cardano-sl-version-for-daedalus).
 

--- a/explorer/frontend/default.nix
+++ b/explorer/frontend/default.nix
@@ -3,7 +3,7 @@
 , cardano-sl-explorer, gitrev
 }:
 
-with (import ../../lib.nix);
+with import ../../lib.nix;
 
 let
   src = cleanSourceWith {

--- a/nix/overlays/benchmark.nix
+++ b/nix/overlays/benchmark.nix
@@ -1,6 +1,6 @@
 { pkgs }:
 
-with (import ../../lib.nix);
+with import ../../lib.nix;
 
 self: super: {
   mkDerivation = args: super.mkDerivation (args // optionalAttrs (isCardanoSL args.pname) {

--- a/nix/overlays/faster-build.nix
+++ b/nix/overlays/faster-build.nix
@@ -3,7 +3,7 @@
 
 { pkgs }:
 
-with (import ../../lib.nix);
+with import ../../lib.nix;
 
 self: super: {
   mkDerivation = args: super.mkDerivation (args // optionalAttrs (isCardanoSL args.pname) {

--- a/nix/overlays/required.nix
+++ b/nix/overlays/required.nix
@@ -2,7 +2,7 @@
 
 with pkgs.haskell.lib;
 
-with (import ../../lib.nix);
+with import ../../lib.nix;
 
 let
   addRealTimeTestLogs = drv: overrideCabal drv (attrs: {

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,0 +1,22 @@
+# This is the derivation used by "stack --nix".
+# It provides the system dependencies required for a stack build.
+{ system ? builtins.currentSystem
+, config ? {}
+, iohkPkgs ? import ./.. {inherit config system; }
+, pkgs ? iohkPkgs.pkgs
+}:
+with pkgs;
+
+haskell.lib.buildStackProject {
+  inherit (haskell.packages.ghc822) ghc;
+  name = "cardano-sl-stack-env";
+
+  buildInputs = [
+    zlib openssh autoreconfHook openssl
+    gmp rocksdb git bsdiff ncurses lzma
+    perl bash
+  ] ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
+
+  phases = ["nobuildPhase"];
+  nobuildPhase = "mkdir -p $out";
+}

--- a/release.nix
+++ b/release.nix
@@ -64,7 +64,8 @@ let
     cardano-sl-wallet-new = supportedSystems;
     cardano-sl-x509 = supportedSystems;
     daedalus-bridge = supportedSystems;
-    shell = supportedSystems;
+    shells.cabal = supportedSystems;
+    shells.stack = supportedSystems;
     stack2nix = supportedSystems;
   } skipPackages;
   platforms' = removeAttrs {

--- a/scripts/launch/connect-to-cluster/default.nix
+++ b/scripts/launch/connect-to-cluster/default.nix
@@ -1,4 +1,4 @@
-with (import ./../../../lib.nix);
+with import ../../../lib.nix;
 
 { stdenv, writeText, writeScript
 

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -1,4 +1,4 @@
-with (import ./../../../lib.nix);
+with import ../../../lib.nix;
 
 { stdenv, runCommand, writeText, writeScript
 , jq, coreutils, curl, gnused, openssl

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -44,7 +44,7 @@ let
     '';
 
 in writeScript "demo-cluster" ''
-  #!${stdenv.shell}
+  #!${stdenv.shell} -e
   export PATH=${stdenv.lib.makeBinPath allDeps}:$PATH
   export DEMO_STATE_DIR=${stateDir}
   export DEMO_CONFIGURATION_FILE=${configFiles}/configuration.yaml

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -118,7 +118,11 @@ in writeScript "demo-cluster" ''
     fi
   ''}
   ${ifKeepAlive ''
-    echo "The demo cluster has started and will stop when you exit with Ctrl-C. Log files are in ${stateDir}/logs."
+    echo "The demo cluster has started and will stop when you exit with Ctrl-C."
+    echo "Log files are in ${stateDir}/logs."
+    ${ifWallet ''
+    echo "Use ${stateDir}/curl to make requests to the wallet."
+    ''}
     sleep infinity
   ''}
 ''

--- a/scripts/launch/demo-cluster/default.nix
+++ b/scripts/launch/demo-cluster/default.nix
@@ -43,6 +43,12 @@ let
       cp -vi ${cardano-sl.src + "/mainnet-genesis.json"} mainnet-genesis.json
     '';
 
+  prepareGenesis = callPackage ../../prepare-genesis {
+    inherit numCoreNodes stateDir;
+    configurationKey = "testnet_full";
+    configurationKeyLaunch = "testnet_launch";
+  };
+
 in writeScript "demo-cluster" ''
   #!${stdenv.shell} -e
   export PATH=${stdenv.lib.makeBinPath allDeps}:$PATH

--- a/scripts/prepare-genesis/default.nix
+++ b/scripts/prepare-genesis/default.nix
@@ -1,4 +1,4 @@
-with (import ./../../lib.nix);
+with import ./../../lib.nix;
 
 { stdenv, writeScript, writeScriptBin
 , jq, coreutils, gnused, haskell, haskellPackages

--- a/scripts/prepare-genesis/default.nix
+++ b/scripts/prepare-genesis/default.nix
@@ -1,22 +1,28 @@
+# This create a builder script which generates new genesis data using
+# cardano-keygen.  It creates an new configuration.yaml with the
+# correct hash of the genesis data.
 with import ./../../lib.nix;
 
 { stdenv, writeScript, writeScriptBin
-, jq, coreutils, gnused, haskell, haskellPackages
-
+, python3, jq, coreutils, gnused, haskell, haskellPackages
 , cardano-sl, cardano-sl-tools
 
-## Options
-, stateDir ? localLib.maybeEnv "CARDANO_STATE_DIR" "./state-demo"
+# System start time parameter (UNIX time), or 0 to use the current time.
 , systemStart ? 0
+
+# The configuration section to update with new genesis data.
 , configurationKey ? "testnet_full"
+
+# The configuration section to use for creating the genesis data.
 , configurationKeyLaunch ? "testnet_launch"
+
+# Corresponds to "richmen" setting in configuration.yaml
 , numCoreNodes ? 7
 }:
 
-
 let
   yaml2json = haskell.lib.disableCabalFlag haskellPackages.yaml "no-exe";
-  genesisTools = [ yaml2json jq coreutils gnused cardano-sl-tools ];
+  genesisTools = [ yaml2json jq python3 coreutils gnused cardano-sl-tools ];
   configSource = cardano-sl.src + "/configuration.yaml";
 
 in
@@ -24,9 +30,14 @@ in
     #!${stdenv.shell}
     set -euo pipefail
 
-    export PATH=${makeBinPath genesisTools}
-    src=${configSource}
-    out=$1
+    export PATH="${makeBinPath genesisTools}"
+    src="${configSource}"
+    out="${1-}"
+
+    if [ -z "$out" ]; then
+      echo "usage: $0 OUTDIR"
+      exit 1
+    fi
 
     mkdir -p $out
     sed -e 's/richmen:.*/richmen: ${toString numCoreNodes}/g' $src > $out/configuration-launch.yaml

--- a/scripts/test/acceptance/default.nix
+++ b/scripts/test/acceptance/default.nix
@@ -1,4 +1,4 @@
-with (import ./../../../lib.nix);
+with import ../../../lib.nix;
 
 { stdenv, writeScript
 , jq, coreutils, curl, gnused, openssl, time

--- a/scripts/test/wallet/integration/default.nix
+++ b/scripts/test/wallet/integration/default.nix
@@ -1,4 +1,4 @@
-with (import ./../../../../lib.nix);
+with import ../../../../lib.nix;
 
 { stdenv, writeScript, gnugrep
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -211,7 +211,7 @@ packages:
   extra-dep: true
 
 nix:
-  shell-file: shell.nix
+  shell-file: nix/stack-shell.nix
 
 extra-deps:
 # Needed to fix an issue with CTX_INIT failing to build on newer openssl


### PR DESCRIPTION
## Description

Continues on from #3761 and #3760.

* Salvage a commit with a buildkite fix from #3757.
* Allow `shell.nix` to work for `cabal new-build` by moving the `stack --nix` shell to `nix/stack-shell.nix`.
* Documentation and comments.
* Bring back `demoClusterLaunchGenesis` and fix it.
* In the connect scripts, add a helper script which wraps curl, to make wallet API requests easier.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1083

## Type of change
- Refactors and documentation.
- Build system and dev environment.
