### PR TITLE
[DEVOPS-1097] resolved ambiguous types

### DIFF
--- a/core/src/Pos/Core/Conc.hs
+++ b/core/src/Pos/Core/Conc.hs
@@ -34,7 +34,6 @@ import           UnliftIO.Async (async, cancel, concurrently, forConcurrently,
 import           UnliftIO.MVar (modifyMVar, newMVar)
 
 import           Pos.Util (realTime)
-import           Pos.Util.Wlog (HasLoggerName (..))
 
 currentTime :: MonadIO m => m Microsecond
 currentTime = liftIO realTime
@@ -68,7 +67,3 @@ newSharedAtomic = newMVar
 
 modifySharedAtomic :: MonadUnliftIO m => MVar a -> (a -> m (a, b)) -> m b
 modifySharedAtomic = modifyMVar
-
-instance HasLoggerName IO where
-    askLoggerName = return "*production*"
-    modifyLoggerName = const id

--- a/lib/src/Pos/Util/UserSecret.hs
+++ b/lib/src/Pos/Util/UserSecret.hs
@@ -236,7 +236,7 @@ ensureModeIs600 :: MonadMaybeLog m => FilePath -> m ()
 #ifdef POSIX
 ensureModeIs600 path = do
     accessMode <- getAccessMode path
-    unless (accessMode == mode600) $ do
+    unless (accessMode == mode600) $ liftIO $ do
         logWarning $
             sformat ("Key file at "%build%" has access mode "%oct%" instead of 600. Fixing it automatically.")
             path accessMode

--- a/lib/src/Pos/Util/UserSecret.hs
+++ b/lib/src/Pos/Util/UserSecret.hs
@@ -37,7 +37,6 @@ module Pos.Util.UserSecret
        , writeUserSecretRelease
 
        , UserSecretDecodingError (..)
-       , ensureModeIs600
        -- * Internal API
        , writeRaw
        ) where
@@ -230,20 +229,15 @@ getAccessMode path = do
 -- | Set mode 600 on a given file, regardless of its current mode.
 setMode600 :: (MonadIO m) => FilePath -> m ()
 setMode600 path = liftIO $ PSX.setFileMode path mode600
-#endif
 
 ensureModeIs600 :: MonadMaybeLog m => FilePath -> m ()
-#ifdef POSIX
 ensureModeIs600 path = do
     accessMode <- getAccessMode path
-    unless (accessMode == mode600) $ liftIO $ do
+    unless (accessMode == mode600) $ do
         logWarning $
             sformat ("Key file at "%build%" has access mode "%oct%" instead of 600. Fixing it automatically.")
             path accessMode
         setMode600 path
-#else
-ensureModeIs600 _ = do
-    pure ()
 #endif
 
 -- | Create user secret file at the given path, but only when one doesn't

--- a/util/src/Pos/Util/Wlog/Compatibility.hs
+++ b/util/src/Pos/Util/Wlog/Compatibility.hs
@@ -161,6 +161,10 @@ class HasLoggerName m where
                            => (LoggerName -> LoggerName) -> m a -> m a
   modifyLoggerName f = hoist (modifyLoggerName f)
 
+instance HasLoggerName IO where
+    askLoggerName    = pure "*production*"
+    modifyLoggerName = const id
+
 instance (Monad m, HasLoggerName m) => HasLoggerName (StateT a m)
 instance (Monad m, HasLoggerName m) => HasLoggerName (StateLazy.StateT a m)
 instance (Monad m, HasLoggerName m) => HasLoggerName (ReaderT a m)


### PR DESCRIPTION
## Description

resolved ambiguous type; the logging message was looping inifinitely and never delivered.

## Linked issue

DEVOPS-1097

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps

these steps should be done in the root directory of where `cardano-sl` was checkout:

1.) compilation: `nix-build -A connectScripts.mainnet.wallet --arg forceDontCheck true --cores 0 --max-jobs 4`
2.) create file: `default-wallet.key` with permissions e.g. 755: `chmod 755 default-wallet.key`
3.) run in one terminal: `./result`
4.) run in another terminal: `curl -v https://localhost:8090/api/internal/import-wallet -k --cert state-wallet-mainnet/tls/client/client.crt --key state-wallet-mainnet/tls/client/client.key -d '{"filePath":"<<enter absolute path to >>/default-wallet.key"}' -H 'Content-Type: application/json'`

## Screenshots (if available)
a log entry appears similar to this one:
```
[cardano-sl.*production*:Warning:ThreadId 389] [2018-10-18 08:05:36.70 UTC] Key file at <<path>>/cardano-sl.git/default-wallet.key has access mode 755 instead of 600. Fixing it automatically.
```