### PR TITLE
[CO-432] Add foreign transaction to input and remove updateForeign

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/BListener.hs
@@ -45,7 +45,8 @@ import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import           Cardano.Wallet.Kernel.PrefilterTx (PrefilteredBlock (..),
                      prefilterBlock)
-import           Cardano.Wallet.Kernel.Read (getWalletCredentials)
+import           Cardano.Wallet.Kernel.Read (foreignPendingByAccount,
+                     getWalletCredentials, getWalletSnapshot)
 import           Cardano.Wallet.Kernel.Restore
 import qualified Cardano.Wallet.Kernel.Submission as Submission
 import           Cardano.Wallet.Kernel.Types (WalletId (..))
@@ -72,9 +73,10 @@ prefilterBlocks :: PassiveWallet
 prefilterBlocks pw bs = do
     let nm = makeNetworkMagic (pw ^. walletProtocolMagic)
     res <- getWalletCredentials pw
+    foreignPendings <- foreignPendingByAccount <$> getWalletSnapshot pw
     return $ case res of
          [] -> Nothing
-         xs -> Just $ map (\b -> first (b ^. rbContext,) $ prefilterBlock nm b xs) bs
+         xs -> Just $ map (\b -> first (b ^. rbContext,) $ prefilterBlock nm foreignPendings b xs) bs
 
 data BackfillFailed
     = SuccessorChanged BlockContext (Maybe BlockContext)

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/HdWallet/Read.hs
@@ -11,6 +11,7 @@ module Cardano.Wallet.Kernel.DB.HdWallet.Read (
   , addressesByRootId
   , addressesByAccountId
   , pendingByAccount
+  , foreignPendingByAccount
     -- | Simple lookups
   , lookupHdRootId
   , lookupHdAccountId
@@ -78,6 +79,14 @@ pendingByAccount = fmap aux . IxSet.toMap <$> view hdWalletsAccounts
   where
     aux :: HdAccount -> Pending
     aux acc = acc ^. hdAccountState . hdAccountStateCurrent cpPending
+
+-- | All pending foreign transactions in all accounts
+foreignPendingByAccount :: Query' e HdWallets (Map HdAccountId Pending)
+foreignPendingByAccount = fmap aux . IxSet.toMap <$> view hdWalletsAccounts
+  where
+    aux :: HdAccount -> Pending
+    aux acc = acc ^. hdAccountState . hdAccountStateCurrent cpForeign
+
 
 {-------------------------------------------------------------------------------
   Simple lookups

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/Read.hs
@@ -6,6 +6,7 @@ module Cardano.Wallet.Kernel.DB.Read (
   , addressesByRootId
   , addressesByAccountId
   , pendingByAccount
+  , foreignPendingByAccount
     -- | Lookups
   , lookupHdRootId
   , lookupHdAccountId
@@ -70,6 +71,9 @@ addressesByAccountId = liftNoErrorsHd1 HD.addressesByAccountId
 
 pendingByAccount :: DB -> Map HdAccountId Pending
 pendingByAccount = liftNoErrorsHd0 HD.pendingByAccount
+
+foreignPendingByAccount :: DB -> Map HdAccountId Pending
+foreignPendingByAccount = liftNoErrorsHd0 HD.foreignPendingByAccount
 
 lookupHdRootId :: DB -> HdRootId -> Either UnknownHdRoot HdRoot
 lookupHdRootId = liftHd1 HD.lookupHdRootId

--- a/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/PrefilterTx.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 module Cardano.Wallet.Kernel.PrefilterTx
@@ -43,6 +44,8 @@ import           Cardano.Wallet.Kernel.DB.InDb (InDb (..), fromDb)
 import           Cardano.Wallet.Kernel.DB.Resolved (ResolvedBlock,
                      ResolvedInput, ResolvedTx, rbContext, rbTxs,
                      resolvedToTxMeta, rtxInputs, rtxOutputs)
+import           Cardano.Wallet.Kernel.DB.Spec.Pending (Pending)
+import qualified Cardano.Wallet.Kernel.DB.Spec.Pending as Pending
 import           Cardano.Wallet.Kernel.DB.TxMeta.Types
 import           Cardano.Wallet.Kernel.Decrypt (WalletDecrCredentials,
                      eskToWalletDecrCredentials, selectOwnAddresses)
@@ -63,19 +66,22 @@ type AddrWithId = (HdAddressId,Address)
 -- the block that are relevant to the wallet.
 data PrefilteredBlock = PrefilteredBlock {
       -- | Relevant inputs
-      pfbInputs  :: !(Set TxIn)
+      pfbInputs        :: !(Set TxIn)
+
+      -- | Relevant foreign inputs
+    , pfbForeignInputs :: !(Set TxIn)
 
       -- | Relevant outputs
-    , pfbOutputs :: !Utxo
+    , pfbOutputs       :: !Utxo
 
       -- | all output addresses present in the Utxo
-    , pfbAddrs   :: ![AddrWithId]
+    , pfbAddrs         :: ![AddrWithId]
 
       -- | Prefiltered block metadata
-    , pfbMeta    :: !LocalBlockMeta
+    , pfbMeta          :: !LocalBlockMeta
 
       -- | Block context
-    , pfbContext :: !BlockContext
+    , pfbContext       :: !BlockContext
     }
 
 deriveSafeCopy 1 'base ''PrefilteredBlock
@@ -87,11 +93,12 @@ deriveSafeCopy 1 'base ''PrefilteredBlock
 -- relevance to that account
 emptyPrefilteredBlock :: BlockContext -> PrefilteredBlock
 emptyPrefilteredBlock context = PrefilteredBlock {
-      pfbInputs  = Set.empty
-    , pfbOutputs = Map.empty
-    , pfbAddrs   = []
-    , pfbMeta    = emptyLocalBlockMeta
-    , pfbContext = context
+      pfbInputs         = Set.empty
+    , pfbForeignInputs  = Set.empty
+    , pfbOutputs        = Map.empty
+    , pfbAddrs          = []
+    , pfbMeta           = emptyLocalBlockMeta
+    , pfbContext        = context
     }
 
 type WalletKey = (WalletId, WalletDecrCredentials)
@@ -164,13 +171,52 @@ prefilterTx wKey tx = ((prefInps',prefOuts'),metas)
 --
 -- NOTE: we can rely on a Monoidal fold here to combine the maps
 -- 'Map HdAccountId a' since the accounts will be unique accross wallet keys.
-prefilterTxForWallets :: [WalletKey]
-                      -> ResolvedTx
-                      -> ((Map HdAccountId (Set TxIn)
-                         , Map HdAccountId UtxoSummaryRaw)
-                         , [TxMeta])
-prefilterTxForWallets wKeys tx =
-    mconcat $ map ((flip prefilterTx) tx) wKeys
+-- The function decomposes a resolved block into input and output transactions and meta for given wallets
+-- In case of input transactions the two kinds are differentiated:
+-- (a) the input transactions belonging to some wallet
+-- (b) the foreign transactions.
+-- The foreign transactions are identified by picking the input transactions from the resolved one
+-- that happen to be in foreign pending set.
+prefilterTxForWallets
+    :: [WalletKey]
+    -> Map TxIn HdAccountId
+    -> ResolvedTx
+    -> ((Map HdAccountId (Set TxIn, Set TxIn)
+        , Map HdAccountId UtxoSummaryRaw)
+       , [TxMeta])
+prefilterTxForWallets wKeys foreignPendingByTransaction tx =
+    ((extend inputsE foreignInputsE, outputs),meta)
+  where
+    ((inputs,outputs),meta) = mconcat $ map ((flip prefilterTx) tx) wKeys
+
+    --NOTE: to find the foreign inputs in the transaction, we need to look at _all_ the inputs, since they will not be present in the prefiltered inputs
+    allInputs :: Set TxIn
+    allInputs = Set.fromList $ map fst $ toList (tx ^. rtxInputs  . fromDb)
+
+    foreignInputs :: Map HdAccountId (Set TxIn)
+    foreignInputs =
+        reindexByAccount $ Map.filterWithKey (\txin _ -> Set.member txin allInputs) foreignPendingByTransaction
+
+    inputsE, foreignInputsE :: Map HdAccountId (Set TxIn, Set TxIn)
+    inputsE = Map.map (, Set.empty) inputs
+    foreignInputsE =  Map.map (Set.empty,) foreignInputs
+
+    extend
+        :: Map HdAccountId (Set TxIn, Set TxIn)
+        -> Map HdAccountId (Set TxIn, Set TxIn)
+        -> Map HdAccountId (Set TxIn, Set TxIn)
+    extend inputs_ foreignInputs_ =
+        Map.unionWith (\inp fInp -> (fst inp, snd fInp)) inputs_ foreignInputs_
+
+    reindexByAccount
+        :: Map TxIn HdAccountId
+        -> Map HdAccountId (Set TxIn)
+    reindexByAccount byTxIn =
+        Map.fromListWith Set.union $ Map.elems $ Map.mapWithKey f byTxIn
+      where
+          f :: TxIn -> HdAccountId -> (HdAccountId, Set TxIn)
+          f txin accId = (accId, Set.singleton txin)
+
 
 -- | Prefilter inputs of a transaction
 prefilterInputs :: WalletKey
@@ -281,11 +327,13 @@ extendWithSummary (onlyOurInps,onlyOurOuts) utxoWithAddrId
 -- | Prefilter the transactions of a resolved block for the given wallets.
 --
 --   Returns prefiltered blocks indexed by HdAccountId.
-prefilterBlock :: NetworkMagic
-               -> ResolvedBlock
-               -> [(WalletId, EncryptedSecretKey)]
-               -> (Map HdAccountId PrefilteredBlock, [TxMeta])
-prefilterBlock nm block rawKeys =
+prefilterBlock
+    :: NetworkMagic
+    -> Map HdAccountId Pending
+    -> ResolvedBlock
+    -> [(WalletId, EncryptedSecretKey)]
+    -> (Map HdAccountId PrefilteredBlock, [TxMeta])
+prefilterBlock nm foreignPendingByAccount block rawKeys =
       (Map.fromList
     $ map (mkPrefBlock (block ^. rbContext) inpAll outAll)
     $ Set.toList accountIds
@@ -294,15 +342,18 @@ prefilterBlock nm block rawKeys =
     wKeys :: [WalletKey]
     wKeys = map toWalletKey rawKeys
 
-    inps :: [Map HdAccountId (Set TxIn)]
+    foreignPendingByTransaction :: Map TxIn HdAccountId
+    foreignPendingByTransaction = reindexByTransaction $ Map.map Pending.txIns foreignPendingByAccount
+
+    inps :: [Map HdAccountId (Set TxIn, Set TxIn)]
     outs :: [Map HdAccountId UtxoSummaryRaw]
-    (ios, conMetas) = unzip $ map (prefilterTxForWallets wKeys) (block ^. rbTxs)
+    (ios, conMetas) = unzip $ map (prefilterTxForWallets wKeys foreignPendingByTransaction) (block ^. rbTxs)
     (inps, outs) = unzip ios
     metas = concat conMetas
 
-    inpAll :: Map HdAccountId (Set TxIn)
+    inpAll :: Map HdAccountId (Set TxIn, Set TxIn)
     outAll :: Map HdAccountId UtxoSummaryRaw
-    inpAll = Map.unionsWith Set.union inps
+    inpAll = Map.unionsWith (\pair1 pair2 -> (Set.union (fst pair1) (fst pair2),Set.union (snd pair1) (fst pair2))) inps
     outAll = Map.unionsWith Map.union outs
 
     accountIds = Map.keysSet inpAll `Set.union` Map.keysSet outAll
@@ -310,17 +361,25 @@ prefilterBlock nm block rawKeys =
     toWalletKey :: (WalletId, EncryptedSecretKey) -> WalletKey
     toWalletKey (wid, esk) = (wid, eskToWalletDecrCredentials nm esk)
 
+    reindexByTransaction :: Map HdAccountId (Set TxIn) -> Map TxIn HdAccountId
+    reindexByTransaction byAccount = Map.fromList $ Set.toList $ Set.unions $ Map.elems $ Map.mapWithKey f byAccount
+        where
+            f :: HdAccountId -> Set TxIn -> Set (TxIn, HdAccountId)
+            f accId = Set.map (, accId)
+
+
 mkPrefBlock :: BlockContext
-            -> Map HdAccountId (Set TxIn)
+            -> Map HdAccountId (Set TxIn, Set TxIn)
             -> Map HdAccountId (Map TxIn (TxOutAux, AddressSummary))
             -> HdAccountId
             -> (HdAccountId, PrefilteredBlock)
 mkPrefBlock context inps outs accId = (accId, PrefilteredBlock {
-        pfbInputs  = inps'
-      , pfbOutputs = outs'
-      , pfbAddrs   = addrs''
-      , pfbMeta    = blockMeta'
-      , pfbContext = context
+        pfbInputs         = walletInps'
+      , pfbForeignInputs  = foreignInps'
+      , pfbOutputs        = outs'
+      , pfbAddrs          = addrs''
+      , pfbMeta           = blockMeta'
+      , pfbContext        = context
       })
     where
         fromAddrSummary :: AddressSummary -> AddrWithId
@@ -328,7 +387,12 @@ mkPrefBlock context inps outs accId = (accId, PrefilteredBlock {
 
         byAccountId accId'' def dict = fromMaybe def $ Map.lookup accId'' dict
 
-        inps'           =                  byAccountId accId Set.empty inps
+        walletInps = Map.map fst $
+                     Map.filter (not . Set.null . fst) inps
+        foreignInps = Map.map snd $
+                      Map.filter (not . Set.null . snd) inps
+        walletInps'           =                  byAccountId accId Set.empty walletInps
+        foreignInps'          =                  byAccountId accId Set.empty foreignInps
         (outs', addrs') = fromUtxoSummary (byAccountId accId Map.empty outs)
 
         addrs''    = nub $ map fromAddrSummary addrs'
@@ -406,8 +470,10 @@ instance Buildable PrefilteredBlock where
   build PrefilteredBlock{..} = bprint
     ( "PrefilteredBlock "
     % "{ inputs:  " % listJson
+    % "{ foreignInputs:  " % listJson
     % ", outputs: " % mapJson
     % "}"
     )
     (Set.toList pfbInputs)
+    (Set.toList pfbForeignInputs)
     pfbOutputs


### PR DESCRIPTION
## Description

At this moment prefiltering comes down to filtering out the relevant inputs and so the regular call to updatePending fails to see that the foreign transaction that got removed. Up till now we were looking at the outputs instead of the inputs not because of any fundamental difference between regular and foreign pending transactions, but rather because prefiltering is removing some information that we need and so we look at the outputs as a (somewhat poor) substitute instead. As a consequence we have `updatePending` and `updateForeign` removing corresponding inputs and outputs, respectively.

Here, the following changes are proposed:
1. We adopt lookup seeking one of our currently tracked foreign transaction to appear in the block's inputs, and if so, make sure it appears in the prefiltered block
(a) getters for foreign pending block are added
(b) in `prefilterTxForWallets` we search `inputs` for transactions that have the same id as the foreign transation in the respective pending set
(c) `PrefilteredBlock` is extended by `pfbForeignInputs` and populated if search of point 1b is successful 
(d) refactoring of `updatePending` in such a way that it works also with `pfbForeignInputs` and service both input and foreign input checkpoint
(e) update of both (wallet-new/src/Cardano/Wallet/Kernel/DB/Spec/Update.hs) - `applyBlock` and `applyBlockPartial` is done in the context of the change of point 1d 
2. `updateForeign` is removed
3. `updateUtxo` is changed in such a way that it includes rather `(Set.union pfbInputs pfbForeignInputs)` than `pfbInputs`

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-432

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
```
$ ./scripts/build/cardano-sl.sh wallet-new
$ nix-build -A walletIntegrationTests -o launch_integration_tests --arg useStackBinaries true
$ ./launch_integration_tests
```

