### PR TITLE
[DEVOPS-1091] demo cluster: fix wallet base url when listening on 0.0.0.0

### DIFF
--- a/cluster/src/Cardano/Cluster/Util.hs
+++ b/cluster/src/Cardano/Cluster/Util.hs
@@ -366,9 +366,15 @@ ntwrkAddrToString (host, port) =
 
 ntwrkAddrToBaseUrl :: NetworkAddress -> BaseUrl
 ntwrkAddrToBaseUrl (host, port) =
-    BaseUrl Https (B8.unpack host) (fromIntegral port) mempty
-
+    BaseUrl Https (fromHostListen host) (fromIntegral port) mempty
+  where
+    -- Converts the host part of a NetworkAddress to a String,
+    -- translating the wildcard listen address to localhost.
+    fromHostListen :: B8.ByteString -> String
+    fromHostListen h = case B8.unpack h of
+        "0.0.0.0" -> "127.0.0.1"
+        host'     -> host'
 
 ntwrkAddrToNodeAddr :: NetworkAddress -> NodeAddr a
-ntwrkAddrToNodeAddr (addr, port) =
-    NodeAddrExact (unsafeIPFromString $ B8.unpack addr) (Just port)
+ntwrkAddrToNodeAddr (host, port) =
+    NodeAddrExact (unsafeIPFromString $ B8.unpack host) (Just port)


### PR DESCRIPTION
## Description

Listening on all interfaces (designated by listen address 0.0.0.0) is currently not supported in `cluster`.

This fixes the problem for the wallet. If the wallet listen address is 0.0.0.0, then it will connect to the wallet using 127.0.0.1 rather than failing.

I am so far unable to make the correct tweak so that core nodes and relays will listen on all interfaces but connect to each other with 127.0.0.1.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1091

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## QA Steps

```
DEMO_STATE_DIR=$(pwd)/state-cluster DEMO_NO_CLIENT_AUTH=True DEMO_WALLET_ADDRESS=0.0.0.0:9090
curl --insecure https://localhost:9090/api/v1/node-info
```
