### PR TITLE
[DEVOPS-1109] cli argument to inhibit console log: --log-console-off

### DIFF
--- a/lib/src/Pos/Client/CLI/Options.hs
+++ b/lib/src/Pos/Client/CLI/Options.hs
@@ -38,6 +38,7 @@ import           Pos.Launcher.Configuration (ConfigurationOptions (..))
 data CommonArgs = CommonArgs
     { logConfig            :: !(Maybe FilePath)
     , logPrefix            :: !(Maybe FilePath)
+    , logConsoleOff        :: !Bool
     , reportServers        :: ![Text]
     , updateServers        :: ![Text]
     , configurationOptions :: !ConfigurationOptions
@@ -47,6 +48,7 @@ commonArgsParser :: Opt.Parser CommonArgs
 commonArgsParser = do
     logConfig <- optionalLogConfig
     logPrefix <- optionalLogPrefix
+    logConsoleOff <- optionalLogConsoleOff
     reportServers <- reportServersOption
     updateServers <- updateServersOption
     configurationOptions <- configurationOptionsParser
@@ -114,8 +116,14 @@ optionalLogConfig =
 
 optionalLogPrefix :: Opt.Parser (Maybe String)
 optionalLogPrefix =
-    optional $ Opt.strOption $
+    Opt.optional $ Opt.strOption $
         templateParser "logs-prefix" "FILEPATH" "Prefix to logger output path."
+
+optionalLogConsoleOff :: Opt.Parser Bool
+optionalLogConsoleOff =
+    Opt.switch $
+        Opt.long "log-console-off" <>
+        Opt.help "Inhibit logging to the console."
 
 optionalJSONPath :: Opt.Parser (Maybe FilePath)
 optionalJSONPath =

--- a/lib/src/Pos/Client/CLI/Params.hs
+++ b/lib/src/Pos/Client/CLI/Params.hs
@@ -38,7 +38,7 @@ loggingParams defaultName CommonNodeArgs{..} =
     { lpHandlerPrefix = logPrefix commonArgs
     , lpConfigPath    = logConfig commonArgs
     , lpDefaultName   = defaultName
-    , lpConsoleLog    = Nothing -- no override by default
+    , lpConsoleLog    = Just (not $ logConsoleOff commonArgs)
     }
 
 getBaseParams :: LoggerName -> CommonNodeArgs -> BaseParams

--- a/tools/src/dbgen/Main.hs
+++ b/tools/src/dbgen/Main.hs
@@ -94,6 +94,7 @@ newRealModeContext genesisConfig txpConfig dbs confOpts publicKeyPath secretKeyP
          , commonArgs             = CommonArgs {
                logConfig            = Nothing
              , logPrefix            = Nothing
+             , logConsoleOff        = True
              , reportServers        = mempty
              , updateServers        = mempty
              , configurationOptions = confOpts

--- a/util/src/Pos/Util/Log/Scribes.hs
+++ b/util/src/Pos/Util/Log/Scribes.hs
@@ -97,7 +97,6 @@ mkFileScribe rot sevfilter fdesc formatter colorize s v = do
                   let tdiff' = round $ diffUTCTime rottime (_itemTime item)
                   if bytes' < 0 || tdiff' < (0 :: Integer)
                      then do   -- log file rotation
-                        putStrLn $ "rotate! bytes=" ++ (show bytes') ++ " tdiff=" ++ (show tdiff')
                         hClose hdl
                         (hdl2, bytes2, rottime2) <- evalRotator rot fdesc
                         return (hdl2, bytes2, rottime2)


### PR DESCRIPTION
Signed-off-by: Alexander Diemand <codieplusplus@apax.net>

## Description

flag to turn off logging to the console.

PR for Daedalus: https://github.com/input-output-hk/daedalus/pull/1144
(adds the flag `--log-console-off` to the installer which writes it to the `launcher-config.yaml`)

## Linked issue

DEVOPS-1109

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps

start a node with `--log-console-off` and verify that no message is printed on the console.
