### PR TITLE
[CO-436] Change integration tests way of confirming transactions

### DIFF
--- a/wallet-new/integration/RandomStateWalk.hs
+++ b/wallet-new/integration/RandomStateWalk.hs
@@ -32,7 +32,6 @@ import           Test.QuickCheck (arbitrary, choose, elements, frequency,
 import           Test.QuickCheck.Monadic (PropertyM, monadic, monadicIO, pick,
                      pre, run, stop)
 import           Test.QuickCheck.Property (Property, ioProperty, rejected)
-import           Text.Show.Pretty (ppShow)
 
 import           Cardano.Wallet.API.Response (WalletResponse (..))
 import           Cardano.Wallet.API.V1.Migration.Types (migrate)
@@ -751,12 +750,6 @@ initialWalletState wc = do
     return WalletState {..}
   where
     fromResp = (either throwM (pure . wrData) =<<)
-
-log :: MonadIO m => Text -> m ()
-log = putStrLn . mappend "[TEST-LOG] "
-
-ppShowT :: Show a => a -> Text
-ppShowT = fromString . ppShow
 
 walletIdIsNotGenesis
     :: (Monad m,

--- a/wallet-new/integration/Util.hs
+++ b/wallet-new/integration/Util.hs
@@ -14,6 +14,7 @@ import           Test.Hspec.QuickCheck (prop)
 import           Test.QuickCheck (arbitrary, generate, withMaxSuccess)
 import           Test.QuickCheck.Monadic (PropertyM, monadicIO)
 import           Test.QuickCheck.Property (Testable)
+import           Text.Show.Pretty (ppShow)
 
 import qualified Pos.Chain.Txp as Txp
 
@@ -169,6 +170,12 @@ noLongerThan action maxWaitingTime = do
     case res of
         Left _  -> return Nothing
         Right a -> return $ Just a
+
+log :: MonadIO m => Text -> m ()
+log = putStrLn . mappend "[TEST-LOG] "
+
+ppShowT :: Show a => a -> Text
+ppShowT = fromString . ppShow
 
 
 -- | Output for @Text@.


### PR DESCRIPTION
## Description

Here we are switching in a enterprise of confirming the transaction into looking at the status of the transaction. The current tests rely on the confirmation number, which is not correct. The only reason those tests don't fail entirely at this moment is because there is an implicit ordering at the creation_time of the tx. So when the tests take the first tx of the list and check on it, this happens to be the correct tx. But this is very unreliable.

In a nutshell we demand that the transaction's status is either `InNewestBlocks` or  `Persisted`

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-436

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
```
nix-build -A walletIntegrationTests -o launch_integration_tests --arg useStackBinaries true
./launch_integration_tests
```

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
