### PR TITLE
[CO-412] Sqlite error during test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ wallet-new/test/golden/*.txt.new
 
 # cardano-state-* for wallet data
 cardano-state-*
-state-*
+/state-*
 
 # exchange topology file
 exchange-topology.yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -260,6 +260,8 @@ extra-deps:
 - hspec-core-2.5.1
 - hspec-discover-2.5.1
 
+- quickcheck-state-machine-0.4.2
+
 # Graphics stuff not found on stackage.
 - Chart-diagrams-1.8.3
 - graphviz-2999.19.0.0

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -558,8 +558,7 @@ test-suite wallet-unit-tests
                     , random
                     , time
 
--- set this to test-suite
-executable wallet-sm-tests
+test-suite wallet-sm-tests
   ghc-options:        -Wall -O2 -threaded
   type:               exitcode-stdio-1.0
   main-is:            Spec.hs

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -558,6 +558,65 @@ test-suite wallet-unit-tests
                     , random
                     , time
 
+-- set this to test-suite
+executable wallet-sm-tests
+  ghc-options:        -Wall -O2 -threaded
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  other-modules:      TicketDispenser
+                      Wallet
+  default-language:   Haskell2010
+  default-extensions: BangPatterns
+                      ConstraintKinds
+                      DeriveGeneric
+                      FlexibleContexts
+                      FlexibleInstances
+                      GADTs
+                      InstanceSigs
+                      LambdaCase
+                      MultiParamTypeClasses
+                      MultiWayIf
+                      NoImplicitPrelude
+                      OverloadedStrings
+                      RankNTypes
+                      RecordWildCards
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TypeFamilies
+  other-extensions:   DeriveAnyClass
+                      GeneralizedNewtypeDeriving
+                      UndecidableInstances
+  hs-source-dirs:     test/state-machine
+
+  build-depends:      acid-state
+                    , base
+                    , cardano-sl-wallet
+                    , cardano-sl-wallet-new
+                    , cardano-sl-infra
+                    , cardano-sl-chain
+                    , cardano-sl-util
+                    , monad-control
+                    , stm
+                    , bytestring
+                    , hspec
+                    , hspec-core
+                    , mtl
+                    , QuickCheck
+                    , quickcheck-instances
+                    , quickcheck-state-machine
+                    , tree-diff
+                    -- TODO: filelock and strict can be removed after TicketDispenser is removed
+                    , filelock
+                    , strict
+                    , tasty
+                    , tasty-quickcheck
+                    , text
+                    , universum
+                    , vector
+                    , directory
+                    , filepath
+                    , random
+
 test-suite wallet-new-specs
   ghc-options:      -Wall -O2 -threaded -rtsopts
   type:             exitcode-stdio-1.0

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -597,6 +597,7 @@ executable wallet-sm-tests
                     , cardano-sl-infra
                     , cardano-sl-chain
                     , cardano-sl-util
+                    , cardano-sl-core
                     , monad-control
                     , stm
                     , bytestring
@@ -618,6 +619,43 @@ executable wallet-sm-tests
                     , directory
                     , filepath
                     , random
+                    , time-units
+
+executable wallet-reset-error
+  ghc-options:        -Wall -O2 -threaded
+  type:               exitcode-stdio-1.0
+  main-is:            Main.hs
+  default-language:   Haskell2010
+  default-extensions: BangPatterns
+                      ConstraintKinds
+                      DeriveGeneric
+                      FlexibleContexts
+                      FlexibleInstances
+                      GADTs
+                      InstanceSigs
+                      LambdaCase
+                      MultiParamTypeClasses
+                      MultiWayIf
+                      NoImplicitPrelude
+                      OverloadedStrings
+                      RankNTypes
+                      RecordWildCards
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TypeFamilies
+  other-extensions:   DeriveAnyClass
+                      GeneralizedNewtypeDeriving
+                      UndecidableInstances
+  hs-source-dirs:     test/reset-error
+
+  build-depends:      base
+                    --, cardano-sl-wallet
+                    , cardano-sl-wallet-new
+                    , cardano-sl-infra
+                    --, cardano-sl-chain
+                    , cardano-sl-util
+                    , QuickCheck
+                    , universum
 
 test-suite wallet-new-specs
   ghc-options:      -Wall -O2 -threaded -rtsopts

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -558,7 +558,10 @@ test-suite wallet-unit-tests
                     , random
                     , time
 
-test-suite wallet-sm-tests
+-- NOTE: my ghci (akegalj) doesn't like when this is test-suite
+-- "executable" will be changed to "test-suite" when development
+-- is nearly over
+executable wallet-sm-tests
   ghc-options:        -Wall -O2 -threaded
   type:               exitcode-stdio-1.0
   main-is:            Spec.hs

--- a/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
@@ -1,4 +1,3 @@
-
 module Cardano.Wallet.API.Types.UnitOfMeasure where
 
 import           Universum
@@ -17,6 +16,6 @@ data UnitOfMeasure =
     | Blocks
     -- | Number of blocks per second.
     | BlocksPerSecond
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
 
-data MeasuredIn (a :: UnitOfMeasure) b = MeasuredIn b deriving (Eq, Show)
+data MeasuredIn (a :: UnitOfMeasure) b = MeasuredIn b deriving (Eq, Show, Generic)

--- a/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
+++ b/wallet-new/src/Cardano/Wallet/API/Types/UnitOfMeasure.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Cardano.Wallet.API.Types.UnitOfMeasure where
 
 import           Universum

--- a/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/API/V1/Types.hs
@@ -294,7 +294,7 @@ optsADTCamelCase = defaultOptions
 -- General rules for serialisation:
 --
 -- 1. Never define an instance on the inner type 'a'. Do it only on 'V1 a'.
-newtype V1 a = V1 a deriving (Eq, Ord)
+newtype V1 a = V1 a deriving (Eq, Ord, Generic)
 
 -- | Unwrap the 'V1' newtype to give the underlying type.
 unV1 :: V1 a -> a
@@ -468,7 +468,7 @@ type WalletName = Text
 data AssuranceLevel =
     NormalAssurance
   | StrictAssurance
-  deriving (Eq, Ord, Show, Enum, Bounded)
+  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 instance Arbitrary AssuranceLevel where
     arbitrary = elements [minBound .. maxBound]
@@ -817,7 +817,7 @@ instance BuildableSafeGen WalletUpdate where
 
 -- | The sync progress with the blockchain.
 newtype SyncPercentage = SyncPercentage (MeasuredIn 'Percentage100 Word8)
-                     deriving (Show, Eq)
+                     deriving (Show, Eq, Generic)
 
 mkSyncPercentage :: Word8 -> SyncPercentage
 mkSyncPercentage = SyncPercentage . MeasuredIn
@@ -866,7 +866,7 @@ instance BuildableSafeGen SyncPercentage where
 
 
 newtype EstimatedCompletionTime = EstimatedCompletionTime (MeasuredIn 'Milliseconds Word)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 mkEstimatedCompletionTime :: Word -> EstimatedCompletionTime
 mkEstimatedCompletionTime = EstimatedCompletionTime . MeasuredIn
@@ -913,7 +913,7 @@ instance ToSchema EstimatedCompletionTime where
 
 
 newtype SyncThroughput = SyncThroughput (MeasuredIn 'BlocksPerSecond OldStorage.SyncThroughput)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 mkSyncThroughput :: Core.BlockCount -> SyncThroughput
 mkSyncThroughput = SyncThroughput . MeasuredIn . OldStorage.SyncThroughput
@@ -1008,7 +1008,7 @@ data SyncState =
     -- ^ Restoring from seed or from backup.
     | Synced
     -- ^ Following the blockchain.
-    deriving (Eq, Show, Ord)
+    deriving (Eq, Show, Ord, Generic)
 
 instance ToJSON SyncState where
     toJSON ss = object [ "tag"  .= toJSON (renderAsTag ss)

--- a/wallet-new/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer.hs
@@ -71,6 +71,7 @@ import           Cardano.Wallet.WalletLayer.Kernel.Conv (InvalidRedemptionCode)
 data CreateWallet =
     CreateWallet NewWallet
   | ImportWalletFromESK EncryptedSecretKey (Maybe SpendingPassword)
+  deriving (Show)
 
 data CreateWalletError =
     CreateWalletError Kernel.CreateWalletError

--- a/wallet-new/test/reset-error/Main.hs
+++ b/wallet-new/test/reset-error/Main.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Main (main) where
+
+import           Universum
+
+import           Pos.Infra.InjectFail (mkFInjects)
+import           Pos.Util.Wlog (Severity)
+
+import qualified Cardano.Wallet.API.V1.Types as V1
+import qualified Cardano.Wallet.Kernel as Kernel
+import qualified Cardano.Wallet.Kernel.BIP39 as BIP39
+import           Cardano.Wallet.Kernel.Internal (PassiveWallet)
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
+import           Cardano.Wallet.Kernel.NodeStateAdaptor (mockNodeStateDef)
+import qualified Cardano.Wallet.WalletLayer as WL
+import qualified Cardano.Wallet.WalletLayer.Kernel as WL
+
+import           Test.QuickCheck (Gen, arbitrary, frequency, generate)
+
+withWalletLayer
+          :: (WL.PassiveWalletLayer IO -> PassiveWallet -> IO a)
+          -> IO a
+withWalletLayer cc = do
+    Keystore.bracketTestKeystore $ \keystore -> do
+        mockFInjects <- mkFInjects mempty
+        WL.bracketPassiveWallet
+            Kernel.UseInMemory
+            devNull
+            keystore
+            mockNodeStateDef
+            mockFInjects
+            cc
+  where
+    devNull :: Severity -> Text -> IO ()
+    devNull _ _ = return ()
+
+genNewWalletRq :: Gen V1.NewWallet
+genNewWalletRq = do
+    spendingPassword <- frequency [(20, pure Nothing), (80, Just <$> arbitrary)]
+    assuranceLevel   <- arbitrary
+    walletName       <- arbitrary
+    mnemonic <- arbitrary @(BIP39.Mnemonic 12)
+    return $ V1.NewWallet (V1.BackupPhrase mnemonic)
+                          spendingPassword
+                          assuranceLevel
+                          walletName
+                          V1.CreateWallet
+
+main :: IO ()
+main = withWalletLayer $ \pwl _ -> do
+    WL.resetWalletState pwl
+    void $ WL.createWallet pwl . WL.CreateWallet =<< generate genNewWalletRq
+    void $ WL.getWallets pwl

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -7,7 +7,7 @@ import           Universum
 import           GHC.Conc (getNumProcessors, setNumCapabilities)
 import           Test.Hspec (Spec, after, around, before, describe, hspec, it,
                      parallel)
-import           Test.QuickCheck (expectFailure, withMaxSuccess)
+import           Test.QuickCheck (expectFailure, once, withMaxSuccess)
 
 import           TicketDispenser
 import           Wallet
@@ -27,8 +27,9 @@ tests =
         -- TODO: test wallet layer which is not in memory. Maybe there are race condition bugs when we are using filesystem persisted db instead of in-memory one
         around (withWalletLayer . curry) $ do
             describe "Wallet" $ do
-                it "sequential" $ withMaxSuccess 100 . prop_wallet
---                it "parallel" $ withMaxSuccess 3 . prop_walletParallel
+                it "normal postcondition failure" $ withMaxSuccess 10 . prop_fail
+                it "sqlite postcondition failure?" $ withMaxSuccess 100 . prop_wallet
+--                it "parallel" $ withMaxSuccess 30 . prop_walletParallel
 
 ------------------------------------------------------------------------
 

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
+import           Universum
+
+import           Test.Hspec (Spec, after, around, before, describe, hspec, it,
+                     parallel)
+import           Test.QuickCheck (expectFailure, withMaxSuccess)
+
+import           TicketDispenser
+import           Wallet
+
+------------------------------------------------------------------------
+
+tests :: Spec
+tests =
+    describe "Tests" $ parallel $ do
+        -- NOTE: ticket dispenser example is provided by quickcheck-state-machine lib
+        -- This serves as an reference example. It will be removed
+        before setupLock $ after cleanupLock $ do
+            describe "Ticket dispenser" $ do
+                it "sequential" $ prop_ticketDispenser
+                it "parallel with exclusive lock" $ withMaxSuccess 30 . prop_ticketDispenserParallelOK
+                it "parallel with shared lock" $ expectFailure . prop_ticketDispenserParallelBad
+        around (withWalletLayer . curry) $ do
+            describe "Wallet" $ do
+                it "sequential" $ prop_wallet
+                it "parallel" $ withMaxSuccess 2 . prop_walletParallel
+
+------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+    -- TODO: enable more cores
+    -- parallelizeAllCores
+    hspec tests

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -38,5 +38,5 @@ parallelizeAllCores = getNumProcessors >>= setNumCapabilities
 
 main :: IO ()
 main = do
-    parallelizeAllCores
+--    parallelizeAllCores
     hspec tests

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -25,10 +25,10 @@ tests =
 --                it "parallel with exclusive lock" $ withMaxSuccess 30 . prop_ticketDispenserParallelOK
 --                it "parallel with shared lock" $ expectFailure . prop_ticketDispenserParallelBad
         -- TODO: test wallet layer which is not in memory. Maybe there are race condition bugs when we are using filesystem persisted db instead of in-memory one
-        around (withWalletLayer . curry) $ do
+        -- around (withWalletLayer . curry) $ do
             describe "Wallet" $ do
-                it "normal postcondition failure" $ withMaxSuccess 100 . prop_fail
-                it "sqlite postcondition failure?" $ withMaxSuccess 100 . prop_wallet
+                it "normal postcondition failure" $ withMaxSuccess 100 $ prop_fail
+                it "sqlite postcondition failure?" $ withMaxSuccess 100 $ prop_wallet
 --                it "parallel" $ withMaxSuccess 30 . prop_walletParallel
 
 ------------------------------------------------------------------------

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 import           Universum
 
+import           GHC.Conc (getNumProcessors, setNumCapabilities)
 import           Test.Hspec (Spec, after, around, before, describe, hspec, it,
                      parallel)
 import           Test.QuickCheck (expectFailure, withMaxSuccess)
@@ -23,15 +24,19 @@ tests =
                 it "sequential" $ prop_ticketDispenser
                 it "parallel with exclusive lock" $ withMaxSuccess 30 . prop_ticketDispenserParallelOK
                 it "parallel with shared lock" $ expectFailure . prop_ticketDispenserParallelBad
+        -- TODO: test wallet layer which is not in memory. Maybe there are race condition bugs when we are using filesystem persisted db instead of in-memory one
         around (withWalletLayer . curry) $ do
             describe "Wallet" $ do
-                it "sequential" $ prop_wallet
-                it "parallel" $ withMaxSuccess 2 . prop_walletParallel
+                it "sequential" $ withMaxSuccess 30 . prop_wallet
+                it "parallel" $ withMaxSuccess 3 . prop_walletParallel
 
 ------------------------------------------------------------------------
 
+-- TODO: factor out functionality from Parallel.Parallelize module into a lib and reuse
+parallelizeAllCores :: IO ()
+parallelizeAllCores = getNumProcessors >>= setNumCapabilities
+
 main :: IO ()
 main = do
-    -- TODO: enable more cores
-    -- parallelizeAllCores
+    parallelizeAllCores
     hspec tests

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -27,7 +27,7 @@ tests =
         -- TODO: test wallet layer which is not in memory. Maybe there are race condition bugs when we are using filesystem persisted db instead of in-memory one
         around (withWalletLayer . curry) $ do
             describe "Wallet" $ do
-                it "normal postcondition failure" $ withMaxSuccess 10 . prop_fail
+                it "normal postcondition failure" $ withMaxSuccess 100 . prop_fail
                 it "sqlite postcondition failure?" $ withMaxSuccess 100 . prop_wallet
 --                it "parallel" $ withMaxSuccess 30 . prop_walletParallel
 

--- a/wallet-new/test/state-machine/Spec.hs
+++ b/wallet-new/test/state-machine/Spec.hs
@@ -19,16 +19,16 @@ tests =
     describe "Tests" $ parallel $ do
         -- NOTE: ticket dispenser example is provided by quickcheck-state-machine lib
         -- This serves as an reference example. It will be removed
-        before setupLock $ after cleanupLock $ do
-            describe "Ticket dispenser" $ do
-                it "sequential" $ prop_ticketDispenser
-                it "parallel with exclusive lock" $ withMaxSuccess 30 . prop_ticketDispenserParallelOK
-                it "parallel with shared lock" $ expectFailure . prop_ticketDispenserParallelBad
+--        before setupLock $ after cleanupLock $ do
+--            describe "Ticket dispenser" $ do
+--                it "sequential" $ prop_ticketDispenser
+--                it "parallel with exclusive lock" $ withMaxSuccess 30 . prop_ticketDispenserParallelOK
+--                it "parallel with shared lock" $ expectFailure . prop_ticketDispenserParallelBad
         -- TODO: test wallet layer which is not in memory. Maybe there are race condition bugs when we are using filesystem persisted db instead of in-memory one
         around (withWalletLayer . curry) $ do
             describe "Wallet" $ do
-                it "sequential" $ withMaxSuccess 30 . prop_wallet
-                it "parallel" $ withMaxSuccess 3 . prop_walletParallel
+                it "sequential" $ withMaxSuccess 100 . prop_wallet
+--                it "parallel" $ withMaxSuccess 3 . prop_walletParallel
 
 ------------------------------------------------------------------------
 

--- a/wallet-new/test/state-machine/TicketDispenser.hs
+++ b/wallet-new/test/state-machine/TicketDispenser.hs
@@ -148,9 +148,9 @@ semantics se (tdb, tlock) cmd = case cmd of
     return ResetOk
 
 mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
-mock (Model Nothing)  TakeTicket = error "mock: TakeTicket"
-mock (Model (Just n)) TakeTicket = GotTicket <$> pure n
-mock _                Reset      = pure ResetOk
+-- mock (Model Nothing)  TakeTicket = error "mock: TakeTicket"
+-- mock (Model (Just n)) TakeTicket = GotTicket <$> pure n
+mock _                _      = pure ResetOk
 
 ------------------------------------------------------------------------
 

--- a/wallet-new/test/state-machine/TicketDispenser.hs
+++ b/wallet-new/test/state-machine/TicketDispenser.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TemplateHaskell     #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  TicketDispenser
+-- Copyright   :  (C) 2017, ATS Advanced Telematic Systems GmbH
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  Stevan Andjelkovic <stevan.andjelkovic@here.com>
+-- Stability   :  provisional
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module contains a specification of a simple ticket dispenser.
+--
+-----------------------------------------------------------------------------
+
+module TicketDispenser
+  ( prop_ticketDispenser
+  , prop_ticketDispenserParallel
+  , prop_ticketDispenserParallelOK
+  , prop_ticketDispenserParallelBad
+  , withDbLock
+  , setupLock
+  , cleanupLock
+  )
+  where
+
+import           Control.Exception (IOException, catch)
+import           Data.TreeDiff (ToExpr)
+import           GHC.Generics (Generic, Generic1)
+import           Prelude hiding (readFile)
+import           System.Directory (createDirectoryIfMissing,
+                     getTemporaryDirectory, removeFile)
+import           System.FileLock (SharedExclusive (..), lockFile, unlockFile)
+import           System.FilePath ((</>))
+import           System.IO (hClose, openTempFile)
+import           System.IO.Strict (readFile)
+import           Test.QuickCheck (Gen, Property, frequency, (===))
+import           Test.QuickCheck.Monadic (monadicIO)
+
+import           Test.StateMachine
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+------------------------------------------------------------------------
+
+-- The actions of the ticket dispenser are:
+
+data Action (r :: * -> *)
+  = TakeTicket
+  | Reset
+  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+
+data Response (r :: * -> *)
+  = GotTicket Int
+  | ResetOk
+  deriving (Show, Generic1, Rank2.Foldable)
+
+-- Which correspond to taking a ticket and getting the next number, and
+-- resetting the number counter of the dispenser.
+
+------------------------------------------------------------------------
+
+-- The dispenser has to be reset before use, hence the maybe integer.
+
+newtype Model (r :: * -> *) = Model (Maybe Int)
+  deriving (Eq, Show, Generic)
+
+deriving instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model Nothing
+
+preconditions :: Model Symbolic -> Action Symbolic -> Logic
+preconditions (Model Nothing)  TakeTicket = Bot
+preconditions (Model (Just _)) TakeTicket = Top
+preconditions _                Reset      = Top
+
+transitions :: Model r -> Action r -> Response r -> Model r
+transitions (Model m) cmd _ = case cmd of
+  TakeTicket -> Model (succ <$> m)
+  Reset      -> Model (Just 0)
+
+postconditions :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
+postconditions (Model m) TakeTicket (GotTicket n) = Just n .== (succ <$> m)
+postconditions _         Reset      ResetOk       = Top
+postconditions _         _          _             = error "postconditions"
+
+------------------------------------------------------------------------
+
+-- With stateful generation we ensure that the dispenser is reset before
+-- use.
+
+generator :: Model Symbolic -> Gen (Action Symbolic)
+generator _ = frequency
+  [ (1, pure Reset)
+  , (4, pure TakeTicket)
+  ]
+
+shrinker :: Action Symbolic -> [Action Symbolic]
+shrinker _ = []
+
+------------------------------------------------------------------------
+
+-- We will implement the dispenser using a simple database file which
+-- stores the next number. A file lock is used to allow concurrent use.
+
+semantics
+  :: SharedExclusive                       -- ^ Indicates if the file
+                                           -- lock should be shared
+                                           -- between threads or if it
+                                           -- should be exclusive.
+                                           -- Sharing it could cause
+                                           -- race conditions.
+
+  -> (FilePath, FilePath)                  -- ^ File paths to the
+                                           -- database storing the
+                                           -- ticket counter and the
+                                           -- file lock used for
+                                           -- synchronisation.
+
+  -> Action Concrete
+
+  -> IO (Response Concrete)
+
+semantics se (tdb, tlock) cmd = case cmd of
+  TakeTicket -> do
+    lock <- lockFile tlock se
+    i <- read <$> readFile tdb
+      `catch` (\(_ :: IOException) -> return "-1")
+    writeFile tdb (show (i + 1))
+      `catch` (\(_ :: IOException) -> return ())
+    unlockFile lock
+    return (GotTicket (i + 1))
+  Reset      -> do
+    lock <- lockFile tlock se
+    writeFile tdb (show (0 :: Integer))
+      `catch` (\(_ :: IOException) -> return ())
+    unlockFile lock
+    return ResetOk
+
+mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
+mock (Model Nothing)  TakeTicket = error "mock: TakeTicket"
+mock (Model (Just n)) TakeTicket = GotTicket <$> pure n
+mock _                Reset      = pure ResetOk
+
+------------------------------------------------------------------------
+
+type DbLock = (FilePath, FilePath)
+
+setupLock :: IO DbLock
+setupLock = do
+  tmp <- getTemporaryDirectory
+  let tmpTD = tmp </> "ticket-dispenser"
+  createDirectoryIfMissing True tmpTD
+  (tdb,   dbh)   <- openTempFile tmpTD "ticket-dispenser.db"
+  hClose dbh
+  (tlock, lockh) <- openTempFile tmpTD "ticket-dispenser.lock"
+  hClose lockh
+  return (tdb, tlock)
+
+cleanupLock :: DbLock -> IO ()
+cleanupLock (tdb, tlock) = do
+  removeFile tdb
+  removeFile tlock
+
+withDbLock :: (DbLock -> IO ()) -> IO ()
+withDbLock run = do
+  lock <- setupLock
+  run lock
+  cleanupLock lock
+
+sm :: SharedExclusive -> DbLock -> StateMachine Model Action IO Response
+sm se files = StateMachine
+  initModel transitions preconditions postconditions
+  Nothing generator Nothing shrinker (semantics se files) mock
+
+-- Sequentially the model is consistent (even though the lock is
+-- shared).
+
+prop_ticketDispenser :: DbLock -> Property
+prop_ticketDispenser files = forAllCommands sm' Nothing $ \cmds -> monadicIO $ do
+  (hist, _, res) <- runCommands sm' cmds
+  prettyCommands sm' hist $
+    checkCommandNames cmds (res === Ok)
+  where
+    sm' = sm Shared files
+
+prop_ticketDispenserParallel :: SharedExclusive -> DbLock -> Property
+prop_ticketDispenserParallel se files =
+  forAllParallelCommands sm' $ \cmds -> monadicIO $
+    prettyParallelCommands cmds =<< runParallelCommandsNTimes 100 sm' cmds
+  where
+    sm' = sm se files
+
+-- So long as the file locks are exclusive, i.e. not shared, the
+-- parallel property passes.
+prop_ticketDispenserParallelOK :: DbLock -> Property
+prop_ticketDispenserParallelOK = prop_ticketDispenserParallel Exclusive
+
+prop_ticketDispenserParallelBad :: DbLock -> Property
+prop_ticketDispenserParallelBad = prop_ticketDispenserParallel Shared

--- a/wallet-new/test/state-machine/Wallet.hs
+++ b/wallet-new/test/state-machine/Wallet.hs
@@ -83,14 +83,13 @@ initModel = Model
 
 -- If you need more fine grained distribution, use preconditions
 preconditions :: Model Symbolic -> Action Symbolic -> Logic
-preconditions _ ResetWalletA      = Top
+preconditions _ _      = Top
 
 transitions :: Model r -> Action r -> Response r -> Model r
-transitions _ cmd res = case cmd of
-    ResetWalletA -> Model
+transitions _ _ _ = Model
 
 postconditions :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
-postconditions _ ResetWalletA ResetWalletR                          = Bot
+postconditions _ _ _ = Bot
 
 ------------------------------------------------------------------------
 
@@ -133,7 +132,7 @@ withWalletLayer cc = do
 -- NOTE: I (akegalj) was not sure how library exactly uses mock so there is an explanation here https://github.com/advancedtelematic/quickcheck-state-machine/issues/236#issuecomment-431858389
 -- NOTE: `mock` is not used in a current quickcheck-state-machine-0.4.2 so in practice we could leave it out. Its still in an experimental phase and there is a possibility it will be added in future versions of this library, so we won't leave it out just yet
 mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
-mock _ ResetWalletA      = pure ResetWalletR
+mock _ _      = pure ResetWalletR
 
 ------------------------------------------------------------------------
 

--- a/wallet-new/test/state-machine/Wallet.hs
+++ b/wallet-new/test/state-machine/Wallet.hs
@@ -16,7 +16,6 @@
 
 module Wallet
   ( prop_wallet
-  , prop_walletParallel
   , prop_fail
   , withWalletLayer
   )
@@ -108,6 +107,7 @@ shrinker _ = []
 semantics :: WL.PassiveWalletLayer IO -> PassiveWallet -> Action Concrete -> IO (Response Concrete)
 semantics pwl _ cmd = case cmd of
     ResetWalletA -> do
+        -- Error seems to be goone if line bellow is removed?
         WL.resetWalletState pwl
         return ResetWalletR
 
@@ -193,13 +193,5 @@ prop_wallet (pwl, pw) = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
     (hist, _, res) <- runCommands sm cmds
     prettyCommands sm hist $
         checkCommandNames cmds (res === Ok)
-  where
-    sm = stateMachine pwl pw
-
-prop_walletParallel :: (WL.PassiveWalletLayer IO, PassiveWallet) -> Property
-prop_walletParallel (pwl, pw) =
-  forAllParallelCommands sm $ \cmds -> monadicIO $
-    -- TODO: fix quickcheck with state machine pretty printer output (works well with tasty)
-    prettyParallelCommands cmds =<< runParallelCommandsNTimes 100 sm cmds
   where
     sm = stateMachine pwl pw

--- a/wallet-new/test/state-machine/Wallet.hs
+++ b/wallet-new/test/state-machine/Wallet.hs
@@ -195,6 +195,8 @@ genNewWalletRq = do
                           V1.CreateWallet
 
 generator :: Model Symbolic -> Gen (Action Symbolic)
+-- if wallet has not been reset, then we should first reset it!
+generator (Model _ False) = pure ResetWalletA
 generator Model{..} = frequency
     [ (1, pure ResetWalletA)
     , (5, CreateWalletA . WL.CreateWallet <$> genNewWalletRq)

--- a/wallet-new/test/state-machine/Wallet.hs
+++ b/wallet-new/test/state-machine/Wallet.hs
@@ -40,6 +40,7 @@ import qualified Cardano.Wallet.Kernel.BIP39 as BIP39
 import           Cardano.Wallet.Kernel.Internal (PassiveWallet)
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
 import           Cardano.Wallet.Kernel.NodeStateAdaptor (mockNodeStateDef)
+import qualified Cardano.Wallet.Kernel.Wallets as Kernel
 import qualified Cardano.Wallet.WalletLayer as WL
 import qualified Cardano.Wallet.WalletLayer.Kernel as WL.Kernel
 
@@ -184,8 +185,8 @@ withWalletLayer cc = do
     devNull _ _ = return ()
 
 mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
-mock _ _      = pure ResetWalletR
--- mock _ (CreateWalletA _) = pure $ ResetWalletR -- seems like `mock` is only used as a counter
+mock _ ResetWalletA      = pure ResetWalletR
+mock _ (CreateWalletA _) = pure $ CreateWalletR (Left $ WL.CreateWalletError Kernel.CreateWalletDefaultAddressDerivationFailed)
 
 ------------------------------------------------------------------------
 

--- a/wallet-new/test/state-machine/Wallet.hs
+++ b/wallet-new/test/state-machine/Wallet.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TemplateHaskell     #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Wallet
+  ( prop_wallet
+  , prop_walletParallel
+  , withWalletLayer
+  )
+  where
+
+import           Universum hiding (elem)
+
+import           Data.Time.Units (Microsecond, toMicroseconds)
+import           Data.TreeDiff (ToExpr (toExpr))
+import           GHC.Generics (Generic, Generic1)
+import           Test.QuickCheck (Gen, Property, arbitrary, frequency, (===))
+import           Test.QuickCheck.Monadic (monadicIO)
+
+import           Test.StateMachine
+import           Test.StateMachine.Types (StateMachine)
+
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+import           Cardano.Wallet.API.Types.UnitOfMeasure (MeasuredIn (..),
+                     UnitOfMeasure (..))
+import qualified Cardano.Wallet.API.V1.Types as V1
+import qualified Cardano.Wallet.Kernel as Kernel
+import qualified Cardano.Wallet.Kernel.BIP39 as BIP39
+import           Cardano.Wallet.Kernel.Internal (PassiveWallet)
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
+import           Cardano.Wallet.Kernel.NodeStateAdaptor (mockNodeStateDef)
+import qualified Cardano.Wallet.WalletLayer as WL
+import qualified Cardano.Wallet.WalletLayer.Kernel as WL.Kernel
+
+import qualified Pos.Core as Core
+import           Pos.Infra.InjectFail (mkFInjects)
+import           Pos.Util.Wlog (Severity)
+import qualified Pos.Wallet.Web.State.Storage as OldStorage
+
+
+------------------------------------------------------------------------
+
+-- Wallet actions
+
+data Action (r :: * -> *)
+    = ResetWalletA
+    | CreateWalletA WL.CreateWallet
+    deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+
+data Response (r :: * -> *)
+    = ResetWalletR
+    | CreateWalletR (Either WL.CreateWalletError V1.Wallet)
+    deriving (Show, Generic1, Rank2.Foldable)
+
+
+------------------------------------------------------------------------
+
+-- Wallet state
+
+-- TODO: should we put PassiveWallet reference into the model?
+-- this is how CircurlarBufer.hs does it - it saves a spec and uses
+-- a spec to check real state
+data Model (r :: * -> *) = Model
+    { mWallets :: [V1.Wallet]
+    }
+    deriving (Eq, Show, Generic)
+
+-- TODO: can we make this shorter and derive only necessary things
+-- FIXME: orphan instances
+-- NOTE: this is use for diffing datatypes for pretty printer
+deriving instance ToExpr (V1.V1 Core.Timestamp)
+deriving instance ToExpr Core.Coin
+deriving instance ToExpr Core.Timestamp
+deriving instance ToExpr (V1.V1 Core.Coin)
+deriving instance ToExpr V1.Wallet
+deriving instance ToExpr V1.WalletId
+deriving instance ToExpr V1.AssuranceLevel
+deriving instance ToExpr V1.SyncState
+deriving instance ToExpr V1.WalletType
+deriving instance ToExpr V1.SyncProgress
+deriving instance ToExpr V1.SyncPercentage
+deriving instance ToExpr V1.SyncThroughput
+deriving instance ToExpr OldStorage.SyncThroughput
+deriving instance ToExpr V1.EstimatedCompletionTime
+deriving instance ToExpr Core.BlockCount
+deriving instance ToExpr (MeasuredIn 'Milliseconds Word)
+deriving instance ToExpr (MeasuredIn 'BlocksPerSecond Word)
+deriving instance ToExpr (MeasuredIn 'Percentage100 Word8)
+deriving instance ToExpr (MeasuredIn 'BlocksPerSecond OldStorage.SyncThroughput)
+instance ToExpr Microsecond where
+    toExpr = toExpr . toMicroseconds
+deriving instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model []
+
+preconditions :: Model Symbolic -> Action Symbolic -> Logic
+preconditions _ ResetWalletA      = Top
+preconditions _ (CreateWalletA _) = Top
+
+transitions :: Model r -> Action r -> Response r -> Model r
+transitions model@Model{..} cmd res = case cmd of
+    ResetWalletA -> initModel
+    CreateWalletA _ ->
+        case res of
+            CreateWalletR (Left _) -> model
+            CreateWalletR (Right wallet) -> model { mWallets = wallet : mWallets } -- TODO: use lenses
+            _ -> error "This transition should not be reached!"
+
+postconditions :: Model Concrete -> Action Concrete -> Response Concrete -> Logic
+postconditions _ ResetWalletA ResetWalletR                          = Top
+ -- TODO: pissibly check that wallet wasn't added
+ -- check that ratio of errors is normal/expected
+postconditions _ (CreateWalletA _) (CreateWalletR (Left _)) = Top
+-- TODO: check that wallet request and wallet response contain same attributes
+postconditions Model{..} (CreateWalletA _) (CreateWalletR (Right wallet)) =  Top -- wallet `elem` mWallets
+postconditions _ _ _ =  error "This postcondition should not be reached!"
+
+------------------------------------------------------------------------
+
+-- Action generator
+
+-- TODO: reuse the one from wallet-new/test/unit/Test/Spec/Wallets.hs
+genNewWalletRq :: Gen V1.NewWallet
+genNewWalletRq = do
+    spendingPassword <- frequency [(20, pure Nothing), (80, Just <$> arbitrary)]
+    assuranceLevel   <- arbitrary
+    walletName       <- arbitrary
+    mnemonic <- arbitrary @(BIP39.Mnemonic 12)
+    return $ V1.NewWallet (V1.BackupPhrase mnemonic)
+                          spendingPassword
+                          assuranceLevel
+                          walletName
+                          V1.CreateWallet
+
+generator :: Model Symbolic -> Gen (Action Symbolic)
+generator _ = frequency
+    [ (1, pure ResetWalletA)
+    , (5, CreateWalletA . WL.CreateWallet <$> genNewWalletRq)
+    -- TODO: add generator for importing wallet from secret key
+    ]
+
+shrinker :: Action Symbolic -> [Action Symbolic]
+shrinker _ = []
+
+-- ------------------------------------------------------------------------
+--
+semantics :: WL.PassiveWalletLayer IO -> PassiveWallet -> Action Concrete -> IO (Response Concrete)
+semantics pwl _ cmd = case cmd of
+    ResetWalletA -> do
+        -- TODO: check how it will behave if exception is raised here!
+        WL.resetWalletState pwl
+        return ResetWalletR
+    CreateWalletA cw -> CreateWalletR <$> WL.createWallet pwl cw
+
+-- TODO: reuse withLayer function defined in wallet-new/test/unit/Test/Spec/Fixture.hs
+withWalletLayer
+          :: (WL.PassiveWalletLayer IO -> PassiveWallet -> IO a)
+          -> IO a
+withWalletLayer cc = do
+    Keystore.bracketTestKeystore $ \keystore -> do
+        -- TODO: can we use fault injection in wallet to test expected failure cases?
+        mockFInjects <- mkFInjects mempty
+        WL.Kernel.bracketPassiveWallet
+            Kernel.UseInMemory
+            devNull
+            keystore
+            mockNodeStateDef
+            mockFInjects
+            cc
+  where
+    devNull :: Severity -> Text -> IO ()
+    devNull _ _ = return ()
+
+mock :: Model Symbolic -> Action Symbolic -> GenSym (Response Symbolic)
+mock _ _      = pure ResetWalletR
+-- mock _ (CreateWalletA _) = pure $ ResetWalletR -- seems like `mock` is only used as a counter
+
+------------------------------------------------------------------------
+
+-- TODO: model invariant?
+-- TODO: model distribution?
+stateMachine :: WL.PassiveWalletLayer IO -> PassiveWallet -> StateMachine Model Action IO Response
+stateMachine pwl pw =
+    StateMachine
+        initModel
+        transitions
+        preconditions
+        postconditions
+        Nothing
+        generator
+        Nothing
+        shrinker
+        (semantics pwl pw)
+        mock
+
+prop_wallet :: (WL.PassiveWalletLayer IO, PassiveWallet) -> Property
+prop_wallet (pwl, pw) = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
+    (hist, _, res) <- runCommands sm cmds
+    prettyCommands sm hist $
+        checkCommandNames cmds (res === Ok)
+  where
+    sm = stateMachine pwl pw
+
+prop_walletParallel :: (WL.PassiveWalletLayer IO, PassiveWallet) -> Property
+prop_walletParallel (pwl, pw) =
+  forAllParallelCommands sm $ \cmds -> monadicIO $
+    -- TODO: fix quickcheck with state machine pretty printer output (works well with tasty)
+    prettyParallelCommands cmds =<< runParallelCommandsNTimes 100 sm cmds
+  where
+    sm = stateMachine pwl pw

--- a/wallet/src/Pos/Wallet/Web/State/Storage.hs
+++ b/wallet/src/Pos/Wallet/Web/State/Storage.hs
@@ -266,7 +266,7 @@ instance NFData SyncStatistics where
 -- during the syncing process, to provide better estimate to the frontend
 -- on how much time the restoration/syncing progress is going to take.
 newtype SyncThroughput = SyncThroughput BlockCount
-     deriving (Eq, Ord, Show, NFData)
+     deriving (Eq, Ord, Show, NFData, Generic)
 
 zeroThroughput :: SyncThroughput
 zeroThroughput = SyncThroughput (BlockCount 0)


### PR DESCRIPTION
## Description

have a look at https://github.com/input-output-hk/cardano-sl/compare/akegalj/CO-414/test-sm-reset-state...akegalj/co-412/sqlite-error?expand=1#diff-3b681d025c5691ef4161a3e2d29ebea3R260
```
-- forAllCommands is using shrinking. When test fail with `postcondition _ GetWalletsA _ = Bot`
-- shrinking is going to start doing its job and I will get the report:
--
--        uncaught exception: SQLError
--        SQLite3 returned ErrorMisuse while attempting to perform prepare "BEGIN TRANSACTION": bad parameter or other API misuse
--        (after 7 tests and 1 shrink)
--          Commands { unCommands = [ Command ResetWalletA (fromList []) ] }
--
-- where I would expect the report similar to the one from prop_fail which looks like:
--
--        Falsifiable (after 1 test):
--          PostconditionFailed "BotC" /= Ok
--
-- is this problem in forAllCommands ? Or is it a problem in wallet backend?
-- or is it a problem with hunit, where we are doing all actions within the bracket
-- `around (withWalletLayer . curry)` (see Spec.hs)? Maybe hunit closed the db handle
-- before forAllCommands finished (if it forked into different thread)?
--
-- note that I have isolated wallet within binary wallet-reset-error (in wallet-new/cardano-sl-wallet-new.cabal)
-- and this binary works well (showcasing that reset wallet is actually working correctly).
-- So my primary suspect is `forAllCommands` (from quickcheck-state-machine) and/or `around` (from hspec)
```

you can compile it with 
```
stack build --ghc-options="-Wwarn +RTS -A256m -n2m -RTS" --jobs=2 --no-run-tests --no-run-benchmarks --fast  cardano-sl-wallet-new:wallet-sm-tests
```

and run it with
```
stack exec -- wallet-sm-tests
```

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
