### PR TITLE
[CBR-477] flush logs before applications exit

### DIFF
--- a/generator/app/VerificationBench.hs
+++ b/generator/app/VerificationBench.hs
@@ -44,7 +44,7 @@ import           Pos.Util.CompileInfo (withCompileInfo)
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration)
 import           Pos.Util.Util (realTime)
 import           Pos.Util.Wlog (LoggerConfig, Severity (Debug), logError,
-                     logInfo, setupLogging)
+                     logInfo, removeAllHandlers, setupLogging')
 
 import           Test.Pos.Block.Logic.Mode (BlockTestMode, TestParams (..),
                      runBlockTestMode)
@@ -185,7 +185,7 @@ readBlocks path = do
 
 main :: IO ()
 main = do
-    setupLogging "verification-bench" loggerConfig
+    lh <- setupLogging' "verification-bench" loggerConfig
     args <- Opts.execParser
         $ Opts.info
             (benchArgsParser <**> Opts.helper)
@@ -262,6 +262,7 @@ main = do
                     when (errno > 0) $ do
                         logError $ sformat ("Verification/Application errors ("%shown%"):") errno
                         traverse_ (logError . show) errs
+    removeAllHandlers lh
     where
         loggerConfig :: LoggerConfig
         loggerConfig = defaultInteractiveConfiguration Debug

--- a/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
+++ b/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
@@ -43,7 +43,8 @@ import           Pos.Launcher.Configuration (ConfigurationOptions (..),
 import           Pos.Util.CompileInfo (withCompileInfo)
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration)
 import           Pos.Util.Util (realTime)
-import           Pos.Util.Wlog (Severity (Debug), setupLogging)
+import           Pos.Util.Wlog (Severity (Debug), removeAllHandlers,
+                     setupLogging')
 
 import           Test.Pos.Block.Logic.Emulation (runEmulation, sudoLiftIO)
 import           Test.Pos.Block.Logic.Mode (BlockTestContext, BlockTestMode,
@@ -226,7 +227,7 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp = env (runBlockTestMode gen
 runBenchmark :: IO ()
 runBenchmark = do
     let loggerConfig = defaultInteractiveConfiguration Debug
-    setupLogging "verifyBenchmark" loggerConfig
+    lh <- setupLogging' "verifyBenchmark" loggerConfig
     startTime <- realTime
     let cfo = defaultConfigurationOptions
             { cfoFilePath = "../lib/configuration.yaml"
@@ -250,3 +251,4 @@ runBenchmark = do
                         [ verifyBlocksBenchmark genesisConfig secretKeys tp ctx
                         , verifyHeaderBenchmark genesisConfig secretKeys tp
                         ]
+    removeAllHandlers lh

--- a/lib/src/Pos/Launcher/Resource.hs
+++ b/lib/src/Pos/Launcher/Resource.hs
@@ -66,11 +66,12 @@ import           Pos.Launcher.Mode (InitMode, InitModeContext (..), runInitMode)
 import           Pos.Launcher.Param (BaseParams (..), LoggingParams (..),
                      NodeParams (..))
 import           Pos.Util (bracketWithLogging, newInitFuture)
+import           Pos.Util.Log.Internal (LoggingHandler)
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration,
                      isWritingToConsole, lcLoggerTree, ltHandlers)
 import           Pos.Util.Wlog (LoggerConfig (..), Severity (..), WithLogger,
                      logDebug, logInfo, parseLoggerConfig, removeAllHandlers,
-                     setupLogging)
+                     setupLogging')
 
 #ifdef linux_HOST_OS
 import qualified Pos.Util.Wlog as Logger
@@ -251,12 +252,12 @@ getRealLoggerConfig LoggingParams{..} = do
                       -- add output to the console with severity filter >= Info
         Just False -> lcLoggerTree . ltHandlers %~ filter (not . isWritingToConsole)
 
-setupLoggers :: MonadIO m => Text -> LoggingParams -> m ()
-setupLoggers cfoKey params = setupLogging cfoKey =<< getRealLoggerConfig params
+setupLoggers :: MonadIO m => Text -> LoggingParams -> m LoggingHandler
+setupLoggers cfoKey params = setupLogging' cfoKey =<< getRealLoggerConfig params
 
 -- | RAII for Logging.
 loggerBracket :: Text -> LoggingParams -> IO a -> IO a
-loggerBracket cfoKey lp = bracket_ (setupLoggers cfoKey lp) removeAllHandlers
+loggerBracket cfoKey lp action = bracket (setupLoggers cfoKey lp) removeAllHandlers (const action)
 
 ----------------------------------------------------------------------------
 -- NodeContext

--- a/networking/bench/LogReader/Main.hs
+++ b/networking/bench/LogReader/Main.hs
@@ -28,7 +28,8 @@ import           Bench.Network.Commons (LogMessage (..), MeasureEvent (..),
                      logMessageParser, measureInfoParser)
 import           LogReaderOptions (Args (..), argsParser)
 import           Pos.Util.Trace (Severity (..), Trace, traceWith, wlogTrace)
-import           Pos.Util.Wlog (centiUtcTimeF, productionB, setupLogging)
+import           Pos.Util.Wlog (centiUtcTimeF, productionB, removeAllHandlers,
+                     setupLogging')
 
 
 type Measures = M.Map MsgId (Payload, [(MeasureEvent, Timestamp)])
@@ -116,8 +117,9 @@ getOptions = (\(a, ()) -> a) <$> simpleOptions
 
 main :: IO ()
 main = do
-    setupLogging (Just centiUtcTimeF) productionB
+    lh <- setupLogging' (Just centiUtcTimeF) productionB
     let logTrace = wlogTrace mempty
     Args{..} <- liftIO getOptions
     measures <- foldrM (analyze logTrace) M.empty inputFiles
     printMeasures resultFile measures
+    removeAllHandlers lh

--- a/networking/bench/Receiver/Main.hs
+++ b/networking/bench/Receiver/Main.hs
@@ -28,6 +28,7 @@ import           Node (ConversationActions (..), Listener (..), NodeAction (..),
                      simpleNodeEndPoint)
 import           Node.Message.Binary (binaryPacking)
 import           Pos.Util.Trace (Severity (..), Trace, wlogTrace)
+import           Pos.Util.Wlog (removeAllHandlers)
 import           ReceiverOptions (Args (..), argsParser)
 
 main :: IO ()
@@ -40,7 +41,7 @@ main = do
             argsParser
             empty
 
-    loadLogConfig logsPrefix logConfig
+    lh <- loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
     transport <- do
@@ -54,6 +55,7 @@ main = do
     node logTrace (simpleNodeEndPoint transport) (const noReceiveDelay) (const noReceiveDelay) prng binaryPacking () defaultNodeEnvironment $ \_ ->
         NodeAction (const [pingListener noPong]) $ \_ -> do
             threadDelay (duration * 1000000)
+    removeAllHandlers lh
   where
 
     logTrace :: Trace IO (Severity, Text)

--- a/networking/bench/Sender/Main.hs
+++ b/networking/bench/Sender/Main.hs
@@ -34,6 +34,7 @@ import           Node (Conversation (..), ConversationActions (..), Node (Node),
 import           Node.Internal (NodeId (..))
 import           Node.Message.Binary (binaryPacking)
 import           Pos.Util.Trace (Severity (..), wlogTrace)
+import           Pos.Util.Wlog (removeAllHandlers)
 
 import           Bench.Network.Commons (MeasureEvent (..), Payload (..),
                      Ping (..), Pong (..), loadLogConfig, logMeasure)
@@ -57,7 +58,7 @@ main = do
             argsParser
             empty
 
-    loadLogConfig logsPrefix logConfig
+    lh <- loadLogConfig logsPrefix logConfig
     setLocaleEncoding utf8
 
     transport <- do
@@ -89,6 +90,7 @@ main = do
                         forM_ drones stopDrone
 
     action
+    removeAllHandlers lh
 
   where
 

--- a/networking/src/Bench/Network/Commons.hs
+++ b/networking/src/Bench/Network/Commons.hs
@@ -45,11 +45,12 @@ import           Prelude hiding (takeWhile)
 
 import           Node (Message (..))
 import           Pos.Util (realTime)
+import           Pos.Util.Log.Internal (LoggingHandler)
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration,
                      lcLoggerTree, ltMinSeverity, ltNamedSeverity)
 import           Pos.Util.Trace (Trace, traceWith)
 import           Pos.Util.Wlog (LoggerConfig (..), Severity (..),
-                     parseLoggerConfig, setLogPrefix, setupLogging)
+                     parseLoggerConfig, setLogPrefix, setupLogging')
 
 -- * Transfered data types
 
@@ -100,13 +101,13 @@ defaultLogConfig =
     lc0 & lcLoggerTree .~ newlt
 
 
-loadLogConfig :: MonadIO m => Maybe FilePath -> Maybe FilePath -> m ()
+loadLogConfig :: MonadIO m => Maybe FilePath -> Maybe FilePath -> m LoggingHandler
 loadLogConfig logsPrefix configFile = do
     lc1 <- case configFile of
         Nothing  -> return defaultLogConfig
         Just lc0 -> parseLoggerConfig lc0
     lc <- liftIO $ setLogPrefix logsPrefix lc1
-    setupLogging "bench" lc
+    setupLogging' "bench" lc
 
 
 -- * Logging & parsing

--- a/networking/test/Test/Network/Broadcast/OutboundQueueSpec.hs
+++ b/networking/test/Test/Network/Broadcast/OutboundQueueSpec.hs
@@ -25,7 +25,6 @@ import           Test.QuickCheck (Gen, Property, choose, forAll, ioProperty,
                      property, suchThat, (===))
 import qualified Test.QuickCheck as QC
 
-import           Pos.Util.Wlog
 
 arbitraryNodeType :: Gen NodeType
 arbitraryNodeType = QC.elements [minBound .. maxBound]
@@ -81,7 +80,6 @@ arbitraryPeers genNid genNodeType = do
 -- "outbound queue".
 testInFlight :: IO Bool
 testInFlight = do
-    removeAllHandlers
 
     -- Set up some test nodes
     allNodes <- do

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -26,12 +26,13 @@ import           Pos.Crypto (EncryptedSecretKey (..), SecretKey (..),
                      VssKeyPair, fullPublicKeyF, hashHexF, noPassEncrypt,
                      redeemPkB64F, toPublic, toVssPublicKey)
 import           Pos.Launcher (dumpGenesisData, withConfigurations)
+import qualified Pos.Util.Log as Log
 import           Pos.Util.Log.LoggerConfig (defaultInteractiveConfiguration)
 import           Pos.Util.UserSecret (readUserSecret, takeUserSecret, usKeys,
                      usPrimKey, usVss, usWallet, writeUserSecretRelease,
                      wusRootKey)
 import           Pos.Util.Wlog (Severity (Debug), WithLogger, logInfo,
-                     setupLogging, usingLoggerName)
+                     setupLogging', usingLoggerName)
 
 import           Dump (dumpFakeAvvmSeed, dumpGeneratedGenesisData,
                      dumpRichSecrets)
@@ -156,7 +157,7 @@ genVssCert genesisConfig path = do
 main :: IO ()
 main = do
     KeygenOptions {..} <- getKeygenOptions
-    setupLogging "keygen" $ defaultInteractiveConfiguration Debug
+    lh <- setupLogging' "keygen" $ defaultInteractiveConfiguration Debug
     usingLoggerName "keygen"
         $ withConfigurations Nothing Nothing False koConfigurationOptions
         $ \genesisConfig _ _ _ -> do
@@ -174,3 +175,4 @@ main = do
                       (configGenesisData genesisConfig)
                       dgdCanonical
                       dgdPath
+    Log.closeLogScribes lh

--- a/tools/src/launcher/Main.hs
+++ b/tools/src/launcher/Main.hs
@@ -91,8 +91,8 @@ import           Pos.Util.Log.LoggerConfig (BackendKind (..), LogHandler (..),
                      lcBasePath, lcLoggerTree, ltHandlers, ltMinSeverity,
                      retrieveLogFiles)
 import           Pos.Util.Wlog (LoggerNameBox (..), Severity (Info), logError,
-                     logInfo, logNotice, logWarning, setupLogging,
-                     usingLoggerName)
+                     logInfo, logNotice, logWarning, removeAllHandlers,
+                     setupLogging', usingLoggerName)
 
 import           Pos.Tools.Launcher.Environment (substituteEnvVarsValue)
 import           Pos.Tools.Launcher.Logging (reportErrorDefault)
@@ -308,7 +308,7 @@ main =
             case loNodeLogConfig of
                 Nothing -> loNodeArgs
                 Just lc -> loNodeArgs ++ ["--log-config", toText lc]
-    setupLogging (cfoKey loConfiguration) $
+    lh <- setupLogging' (cfoKey loConfiguration) $
         defaultInteractiveConfiguration Info
             & lcBasePath .~ launcherLogsPrefix
             & lcLoggerTree %~ case launcherLogsPrefix of
@@ -355,6 +355,7 @@ main =
                     (UpdaterData loUpdaterPath loUpdaterArgs loUpdateWindowsRunner loUpdateArchive)
                     lo
                 logNotice "Finished clientScenario"
+    removeAllHandlers lh
   where
     -- We propagate some options to the node executable, because
     -- we almost certainly want to use the same configuration and

--- a/util/src/Pos/Util/Wlog.hs
+++ b/util/src/Pos/Util/Wlog.hs
@@ -15,6 +15,7 @@ module Pos.Util.Wlog
         , runNamedPureLog
           -- * Setup
         , setupLogging
+        , setupLogging'
         , setupTestLogging
           -- * Logging functions
         , logDebug
@@ -59,5 +60,5 @@ import           Pos.Util.Wlog.Compatibility (CanLog (..), HasLoggerName (..),
                      logInfo, logMCond, logMessage, logNotice, logWarning,
                      productionB, removeAllHandlers, retrieveLogContent,
                      runNamedPureLog, setLoggerName, setupLogging,
-                     setupTestLogging, usingLoggerName)
+                     setupLogging', setupTestLogging, usingLoggerName)
 

--- a/util/src/Pos/Util/Wlog/Compatibility.hs
+++ b/util/src/Pos/Util/Wlog/Compatibility.hs
@@ -291,8 +291,8 @@ centiUtcTimeF utc =
     tsformat = "%F %T%2Q %Z"
 
 -- do nothing, logs are closed by finalizers
-removeAllHandlers :: IO ()
-removeAllHandlers = pure ()
+removeAllHandlers :: LoggingHandler -> IO ()
+removeAllHandlers = Log.closeLogScribes
 
 -- Safe and structured logging.
 


### PR DESCRIPTION
## Description

Logging does some buffering which was not flushed to the backends when node or tools exited.
Now there is an explicit flush of the queues and all outputs will be closed.

## Linked issue

CBR-477

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps

verify output is complete: e.g. in tool `cardano-keygen`

## Screenshots (if available)

sync-test with the node containing the changes in Launcher/Resource.hs, when Ctrl-C'ed:
```
[cardano-sl.*production*:Debug:ThreadId 9760] [2018-10-31 12:12:38.37 UTC] Rolling: verifying
[cardano-sl.diffusion.outboundqueue.self:Warning:ThreadId 9801] [2018-10-31 12:12:38.43 UTC] sending MsgRequestBlocks (fromList [NodeId 13.229.245.242:3000:0]) to NodeId 13.229.245.242:3000:0 failed with AsyncCancelled :: SomeException
[cardano-sl.node:Error:ThreadId 9770] [2018-10-31 12:12:38.43 UTC] stopping the wallet submission layer...
[cardano-sl.diffusion:Error:ThreadId 9738] [2018-10-31 12:12:38.43 UTC] stopping with exception AsyncCancelled
[cardano-sl.node:Error:ThreadId 4] [2018-10-31 12:12:38.45 UTC] logException: user interrupt
```