### PR TITLE
[RCD-38] [develop] Fix "GeneratedSecrets missing" error

### DIFF
--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -162,14 +162,14 @@ main = do
         $ withConfigurations Nothing Nothing False koConfigurationOptions
         $ \genesisConfig _ _ _ -> do
               logInfo "Processing command"
-              generatedSecrets <- configGeneratedSecretsThrow genesisConfig
               case koCommand of
                   RearrangeMask msk  -> rearrange msk
                   GenerateKey   path -> genPrimaryKey path
                   GenerateVss   path -> genVssCert genesisConfig path
                   ReadKey       path -> readKey path
                   DumpAvvmSeeds opts -> dumpAvvmSeeds opts
-                  GenerateKeysBySpec gkbg ->
+                  GenerateKeysBySpec gkbg -> do
+                      generatedSecrets <- configGeneratedSecretsThrow genesisConfig
                       generateKeysByGenesis generatedSecrets gkbg
                   DumpGenesisData dgdPath dgdCanonical -> dumpGenesisData
                       (configGenesisData genesisConfig)


### PR DESCRIPTION
## Description

NOTE: This is the same exact change as #3812, but `cherry-pick`ed over to `develop`.

An error, `GeneratedSecrets missing from Genesis.Config`, is thrown when trying to make use of the `cardano-keygen` tool.

It was found that we attempt to extract a `Maybe GeneratedSecrets` from the config (and throw if it is `Nothing`) before we even know which command was specified by the user. Because the `configGeneratedSecrets` field is always set to `Nothing` in the `GCSrc` case, the error will always be thrown whenever trying to make use of `cardano-keygen` with a config which makes use of a `GCSrc`.

Therefore, the solution would be that, since `GeneratedSecrets` is only required for the `generate-keys-by-spec` command, we should *only* attempt to extract `GeneratedSecrets` in the `GenerateKeysBySpec` case. This also means that the `generate-keys-by-spec` command can only be used with a config which makes use of a `GCSpec`.

## Linked issue

[https://iohk.myjetbrains.com/youtrack/issue/RCD-38](https://iohk.myjetbrains.com/youtrack/issue/RCD-38)
## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->
