### PR TITLE
[CSL-2526] update changes after covering remaining fees

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -44,6 +44,7 @@ module Cardano.Wallet.Kernel.CoinSelection.Generic (
   , coinSelOutputs
   , coinSelRemoveDust
   , coinSelPerGoal
+  , changesRemoveDust
     -- * Generalization over UTxO representations
   , StandardUtxo
   , PickFromUtxo(..)
@@ -384,8 +385,12 @@ coinSelOutputs cs = outVal (coinSelOutput cs) : coinSelChange cs
 coinSelRemoveDust :: CoinSelDom dom
                   => Value dom -> CoinSelResult dom -> CoinSelResult dom
 coinSelRemoveDust dust cs = cs {
-      coinSelChange = filter (> dust) (coinSelChange cs)
+      coinSelChange = changesRemoveDust dust (coinSelChange cs)
     }
+
+changesRemoveDust :: CoinSelDom dom
+                  => Value dom -> [Value dom] -> [Value dom]
+changesRemoveDust dust = filter (> dust)
 
 -- | Do coin selection per goal
 --

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Active.hs
@@ -195,7 +195,7 @@ setupPayment :: Monad m
                                )
 setupPayment policy grouping regulation payment = do
     rootId <- fromRootId wId
-    let opts   = (newOptions (Kernel.cardanoFee policy)) {
+    let opts   = (newOptions (Kernel.cardanoFee policy) (Kernel.cardanoFeeSanity policy)) {
                      csoExpenseRegulation = regulation
                    , csoInputGrouping     = grouping
                    }

--- a/wallet-new/test/unit/Test/Spec/GetTransactions.hs
+++ b/wallet-new/test/unit/Test/Spec/GetTransactions.hs
@@ -208,6 +208,8 @@ getAccountBalanceNow pw Fix{..} = do
 constantFee :: Word64 -> Int -> NonEmpty Coin -> Coin
 constantFee c _ _ = mkCoin c
 
+constantFeeCheck :: Word64 -> Coin -> Bool
+constantFeeCheck c c' = mkCoin c == c'
 
 spec :: Spec
 spec = do
@@ -482,7 +484,7 @@ spec = do
 
 payAux :: Kernel.ActiveWallet -> HdAccountId -> NonEmpty (Address, Coin) -> Word64 -> IO (Core.Tx, TxMeta)
 payAux aw hdAccountId payees fees = do
-    let opts = (newOptions (constantFee fees)) {
+    let opts = (newOptions (constantFee fees) (constantFeeCheck fees)) {
                           csoExpenseRegulation = SenderPaysFee
                         , csoInputGrouping = IgnoreGrouping
                         }

--- a/wallet-new/test/unit/Test/Spec/GetTransactions.hs
+++ b/wallet-new/test/unit/Test/Spec/GetTransactions.hs
@@ -56,6 +56,7 @@ import           Cardano.Wallet.Kernel.DB.TxMeta
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
 import           Cardano.Wallet.Kernel.Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
+import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as Node
 import qualified Cardano.Wallet.Kernel.PrefilterTx as Kernel
 import qualified Cardano.Wallet.Kernel.Read as Kernel
 import qualified Cardano.Wallet.Kernel.Transactions as Kernel
@@ -65,12 +66,13 @@ import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..),
                      walletPassiveLayer)
 import qualified Cardano.Wallet.WalletLayer as WalletLayer
 import qualified Cardano.Wallet.WalletLayer.Kernel.Accounts as Accounts
+import qualified Cardano.Wallet.WalletLayer.Kernel.Active as Active
 import qualified Cardano.Wallet.WalletLayer.Kernel.Conv as Kernel.Conv
 import           Cardano.Wallet.WalletLayer.Kernel.Transactions (toTransaction)
 
 import qualified Test.Spec.Addresses as Addresses
 import           Test.Spec.CoinSelection.Generators (InitialBalance (..),
-                     Pay (..), genUtxoWithAtLeast)
+                     Pay (..), genPayee, genUtxoWithAtLeast)
 import qualified Test.Spec.Fixture as Fixture
 import qualified Test.Spec.NewPayment as NewPayment
 import           TxMetaStorageSpecs (Isomorphic (..), genMeta)
@@ -145,6 +147,62 @@ prepareFixtures nm initialBalance = do
             , fixturePw = pw
         }
 
+prepareUTxoFixtures :: NetworkMagic
+                    -> [Word64]
+                    -> Fixture.GenActiveWalletFixture Fix
+prepareUTxoFixtures nm coins = do
+    let (_, esk) = safeDeterministicKeyGen (B.pack $ replicate 32 0x42) mempty
+    let newRootId = eskToHdRootId nm esk
+    newRoot <- initHdRoot <$> pure newRootId
+                        <*> pure (WalletName "A wallet")
+                        <*> pure NoSpendingPassword
+                        <*> pure AssuranceLevelNormal
+                        <*> (InDb <$> pick arbitrary)
+
+    newAccountId <- HdAccountId newRootId <$> deriveIndex (pick . choose) HdAccountIx HardDerivation
+    utxo <- foldlM (\acc coin -> do
+            newIndex <- deriveIndex (pick . choose) HdAddressIx HardDerivation
+            txIn <- pick $ Core.TxInUtxo <$> arbitrary <*> arbitrary
+            let Just (addr, _) = deriveLvl2KeyPair nm
+                                                (IsBootstrapEraAddr True)
+                                                (ShouldCheckPassphrase True)
+                                                mempty
+                                                esk
+                                                (newAccountId ^. hdAccountIdIx . to getHdAccountIx)
+                                                (getHdAddressIx newIndex)
+            return $ M.insert txIn (TxOutAux (TxOut addr coin)) acc
+        ) M.empty (mkCoin <$> coins)
+    return $ \keystore aw -> do
+        let pw = Kernel.walletPassive aw
+        Keystore.insert (WalletIdHdRnd newRootId) esk keystore
+        let accounts         = Kernel.prefilterUtxo nm newRootId esk utxo
+            hdAccountId      = Kernel.defaultHdAccountId newRootId
+            (Just hdAddress) = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
+
+        void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)
+        return $ Fix {
+            fixtureHdRootId = newRootId
+          , fixtureHdRoot = newRoot
+          , fixtureAccountId = AccountIdHdRnd newAccountId
+          , fixtureESK = esk
+          , fixtureUtxo = utxo
+          }
+
+withUtxosFixture :: MonadIO m
+                => ProtocolMagic
+                -> [Word64]
+                -> (  Keystore.Keystore
+                    -> WalletLayer.ActiveWalletLayer m
+                    -> Kernel.ActiveWallet
+                    -> Fix
+                    -> IO a
+                    )
+                -> PropertyM IO a
+withUtxosFixture pm coins cc =
+    Fixture.withActiveWalletFixture pm (prepareUTxoFixtures nm coins) cc
+        where
+            nm = makeNetworkMagic pm
+
 withFixture :: MonadIO m
             => ProtocolMagic
             -> InitialBalance
@@ -214,6 +272,69 @@ constantFeeCheck c c' = mkCoin c == c'
 spec :: Spec
 spec = do
     describe "GetTransactions" $ do
+        prop "utxo fixture creates the correct balance" $ withMaxSuccess 10 $
+            monadicIO $ do
+                pm <- pick arbitrary
+                withUtxosFixture @IO pm [1,2,3] $ \_keystore _activeLayer aw f@Fix{..} -> do
+                    let pw = Kernel.walletPassive aw
+                    balance <- getAccountBalanceNow pw f
+                    balance `shouldBe` 6
+
+        prop "sanity tests checks" $ withMaxSuccess 10 $
+            monadicIO $ do
+                pm <- pick arbitrary
+                Fixture.withPassiveWalletFixture @IO pm (return $ \_ -> return ()) $ \_ _ pw _ -> do
+                    policy <- Node.getFeePolicy (pw ^. Kernel.walletNode)
+                    let checker = Kernel.cardanoFeeSanity policy . mkCoin
+                    checker 100 `shouldBe` False
+                    checker 155380 `shouldBe` False
+                    checker 155381 `shouldBe` True
+                    checker 213345 `shouldBe` True
+                    checker (2 * 155381) `shouldBe` True
+                    checker (2 * 155381 + 1) `shouldBe` False
+                    checker 755381 `shouldBe` False
+
+        prop "pay works normally for coin selection with additional utxos and changes" $ withMaxSuccess 10 $
+            monadicIO $ do
+                pm <- pick arbitrary
+                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin))
+                                <$> pick (genPayee mempty (PayLovelace 100))
+                withUtxosFixture @IO pm [300, 400, 500, 600, 5000000] $ \_keystore _activeLayer aw f@Fix{..} -> do
+                    let pw = Kernel.walletPassive aw
+                    -- get the balance before the payment
+                    coinsBefore <- getAccountBalanceNow pw f
+                    -- do the payment
+                    let (AccountIdHdRnd myAccountId) = fixtureAccountId
+                        src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
+                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ myAccountId ^. hdAccountIdIx)
+                        payment = V1.Payment src distr Nothing Nothing
+                    Right _ <- Active.pay aw emptyPassphrase PreferGrouping SenderPaysFee payment
+                    -- get the balance after the payment.
+                    coinsAfter <- getAccountBalanceNow pw f
+                    -- sanity check.
+                    policy <- Node.getFeePolicy (pw ^. Kernel.walletNode)
+                    let checker = Kernel.cardanoFeeSanity policy . mkCoin
+                    -- payment is very small so difference is almost equa to fees.
+                    coinsBefore - coinsAfter `shouldSatisfy` checker
+
+        prop "estimateFees looks sane for coin selection with additional utxos and changes" $ withMaxSuccess 10 $
+            monadicIO $ do
+                pm <- pick arbitrary
+                distr <- fmap (\(TxOut addr coin) -> V1.PaymentDistribution (V1.V1 addr) (V1.V1 coin))
+                                <$> pick (genPayee mempty (PayLovelace 100))
+                withUtxosFixture @IO pm [300, 400, 500, 600, 5000000] $ \_keystore _activeLayer aw Fix{..} -> do
+                    let pw = Kernel.walletPassive aw
+                    -- do the payment
+                    let (AccountIdHdRnd myAccountId) = fixtureAccountId
+                        src = V1.PaymentSource (Kernel.Conv.toRootId fixtureHdRootId)
+                                        (V1.unsafeMkAccountIndex $ getHdAccountIx $ myAccountId ^. hdAccountIdIx)
+                        payment = V1.Payment src distr Nothing Nothing
+                    Right c <- Active.estimateFees aw PreferGrouping SenderPaysFee payment
+                    -- sanity check.
+                    policy <- Node.getFeePolicy (pw ^. Kernel.walletNode)
+                    let checker = Kernel.cardanoFeeSanity policy
+                    c `shouldSatisfy` checker
+
         prop "scenario: Layer.CreateAddress -> TxMeta.putTxMeta -> Layer.getTransactions works properly." $ withMaxSuccess 5 $
             monadicIO $ do
                 testMetaSTB <- pick genMeta

--- a/wallet-new/test/unit/Test/Spec/NewPayment.hs
+++ b/wallet-new/test/unit/Test/Spec/NewPayment.hs
@@ -149,6 +149,9 @@ withFixture pm initialBalance toPay cc =
 constantFee :: Int -> NonEmpty Coin -> Coin
 constantFee _ _ = mkCoin 10
 
+constantFeeCheck :: Coin -> Bool
+constantFeeCheck c = c == mkCoin 10
+
 -- | Helper function to facilitate payments via the Layer or Servant.
 withPayment :: MonadIO n
             => ProtocolMagic
@@ -199,7 +202,7 @@ spec = describe "NewPayment" $ do
                 pm <- pick arbitrary
                 withFixture @IO pm (InitialADA 10000) (PayLovelace 10) $ \_ _ aw Fixture{..} -> do
                     policy <- Node.getFeePolicy (Kernel.walletPassive aw ^. Kernel.walletNode)
-                    let opts = (newOptions (Kernel.cardanoFee policy)) {
+                    let opts = (newOptions (Kernel.cardanoFee policy) (Kernel.cardanoFeeSanity policy)) {
                                csoExpenseRegulation = SenderPaysFee
                              , csoInputGrouping     = IgnoreGrouping
                              }
@@ -217,7 +220,7 @@ spec = describe "NewPayment" $ do
                 pm <- pick arbitrary
                 withFixture @IO pm (InitialADA 10000) (PayADA 1) $ \_ _ aw Fixture{..} -> do
                     policy <- Node.getFeePolicy (Kernel.walletPassive aw ^. Kernel.walletNode)
-                    let opts = (newOptions (Kernel.cardanoFee policy)) {
+                    let opts = (newOptions (Kernel.cardanoFee policy) (Kernel.cardanoFeeSanity policy)) {
                                csoExpenseRegulation = ReceiverPaysFee
                              , csoInputGrouping     = IgnoreGrouping
                              }
@@ -261,7 +264,7 @@ spec = describe "NewPayment" $ do
                 monadicIO $ do
                     pm <- pick arbitrary
                     withFixture @IO pm (InitialADA 10000) (PayADA 1) $ \_ _ aw Fixture{..} -> do
-                        let opts = (newOptions constantFee) {
+                        let opts = (newOptions constantFee constantFeeCheck) {
                                    csoExpenseRegulation = SenderPaysFee
                                  , csoInputGrouping     = IgnoreGrouping
                                  }
@@ -281,7 +284,7 @@ spec = describe "NewPayment" $ do
                 monadicIO $ do
                     pm <- pick arbitrary
                     withFixture @IO pm (InitialADA 10000) (PayADA 1) $ \_ _ aw Fixture{..} -> do
-                        let opts = (newOptions constantFee) {
+                        let opts = (newOptions constantFee constantFeeCheck) {
                                    csoExpenseRegulation = SenderPaysFee
                                  , csoInputGrouping     = IgnoreGrouping
                                  }
@@ -302,7 +305,7 @@ spec = describe "NewPayment" $ do
                     pm <- pick arbitrary
                     withFixture @IO pm (InitialADA 10000) (PayADA 1) $ \_ _ aw Fixture{..} -> do
                         policy <- Node.getFeePolicy (Kernel.walletPassive aw ^. Kernel.walletNode)
-                        let opts = (newOptions (Kernel.cardanoFee policy)) {
+                        let opts = (newOptions (Kernel.cardanoFee policy) (Kernel.cardanoFeeSanity policy)) {
                                    csoExpenseRegulation = SenderPaysFee
                                  , csoInputGrouping     = IgnoreGrouping
                                  }


### PR DESCRIPTION
## Description

This pr tries to fix a bug on coin and fee selection, which was reported by QA.
The bug was caused because in some cases some changes were not included in the transaction, resulting in huge fees.

The CoinSelection works in many different stages:
- first given some payees, some inputs are selected which cover the expenses (fees are ignored for now). Changes are computed at this stage.
- then fees are computed and we reduce changes to cover the fees. If they are enough, we are done.
- if not new inputs are selected. 

The problem is that these additional inputs (last step) which cover the fees, may not be entirely consumed for the fees: we need to return what's left as change.

TODO:
- [x] Decide exactly how these changes will be returned: Do we create new additional change outputs or do we distribute them to the existing changes? If we decide the latter, do we need to equally distribute the additional change to all existing one, or just give everything to one of them? 
UPDATE: we split additional changes to existing change outputs. We do this in FromGeneric module (instead of the Generic or Fees) for 2 reason: in this module change outputs are flatten to a list (instead of list of lists) and also it is less polymorphic, which means we can directly use divide function from Core.
- [ ] Another issue is the additional fees that we may need to pay for these additional utxos and changes. This issue becomes too complex.
- [x] Add a sanity check after the coin selection, which reports an internal error if fees are not within a reasonable range.
- [ ] check `round` vs `ceiling` in the use of `calculateTxSizeLinear`.
- [x] add unit tests

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CSL-2526

## QA Steps
Here are some steps to reproduce the bug with tome good probabilities:
- Create a wallet. 
- send 1 tx with amount > 1 ADA to it.
- send 2 txs with ammount in [100..1000] Lovelace to it.
- try to send < 100 Lovelace from it.

After trying the last step with different amounts and addresses, at some point the bug will appear and fees will be > 1 ADA.

The bug appears in these cases because the inputs in [100..1000] are enough to cover the <100 tx, but not enough to cover the fees. So an additional input needs to be selected. If we are "lucky" this input will be the > 1 ADA in which case we will have huge fees (without the fix).

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Screenshots (if available)

before
![bad](https://user-images.githubusercontent.com/11467473/47898973-c8275080-de80-11e8-89c6-26090193a0fc.png)

after
![good](https://user-images.githubusercontent.com/11467473/47898979-ce1d3180-de80-11e8-8027-e944955015ae.png)
