### PR TITLE
[RCD-42] log-configs/cluster.yaml: Include debug messages in json log

### DIFF
--- a/log-configs/cluster.yaml
+++ b/log-configs/cluster.yaml
@@ -6,13 +6,11 @@ rotation:
 
 loggerTree:
   severity: Debug+
-  files:
-    - node.log
 
   handlers:
     - { name: "JSON"
       , filepath: "node.json"
       , logsafety: SecretLogLevel
-      , severity: Info
+      , severity: Debug+
       , backend: FileJsonBE }
 


### PR DESCRIPTION
## Description

We need debug-level logging from nodes in the cluster.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/RCD-42

## Type of change

- Bug fix of configuration file.

## QA Steps
```
nix-build -A cardano-sl-node-static -o cardano-node
./cardano-node/bin/cardano-node-simple --address 127.0.0.1:3000 --listen 127.0.0.1:3000 --system-start `date +%s` --log-config log-configs/cluster.yaml --logs-prefix tmp/logs --db-path tmp/db --configuration-file lib/configuration.yaml --configuration-key mainnet_dryrun_full --topology scripts/bench/topology/topology.yaml --node-id node0
# check tmp/logs/node.json for sev: Debug
```
