### PR TITLE
[DEVOPS-1094] explorer frontend: hide footer in testnet mode

### DIFF
--- a/explorer/frontend/src/Explorer/View/Footer.purs
+++ b/explorer/frontend/src/Explorer/View/Footer.purs
@@ -13,7 +13,7 @@ import Explorer.I18n.Lenses (footer, fooCardanoOpenSource, fooCardanoHub
   , fooDaedalusPlatform, fooWhyCardano, fooCardanoRoadmap, fooCardanoReddit, fooCardanoCommunity
   , fooIOHK, fooIOHKBlog, fooIOHKYoutube, fooTwitter, fooProject, fooFoundation
   , fooLearnMore, fooProtocol) as I18nL
-import Explorer.Lenses.State (lang)
+import Explorer.Lenses.State (lang, testnet)
 import Explorer.Types.Actions (Action(..))
 import Explorer.Types.State (State)
 import Explorer.Util.Config (commitHash, version)
@@ -27,8 +27,10 @@ import Text.Smolder.Markup (text) as S
 
 footerView :: State -> P.HTML Action
 footerView state =
-    let lang' = state ^. lang in
-    S.div ! S.className "explorer-footer" $ do
+    let lang' = state ^. lang
+        footerHiddenClazz = if (state ^. testnet) then " hide" else ""
+    in
+    S.div ! S.className ("explorer-footer" <> footerHiddenClazz) $ do
         S.div ! S.className "explorer-footer__top" $ do
             S.div ! S.className "explorer-footer__container" $ do
                 S.div ! S.className "explorer-footer__top--content" $ do


### PR DESCRIPTION
## Description

If this is testnet explorer (i.e. the read "testnet" label is visible), then hide the site footer with a CSS class. This makes it look better when embedded in an iframe.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1094

## Type of change

- New feature, conditional on testnet mode.

## QA Steps

Look at the staging explorer and testnet explorer. The first should have a footer visible, the second not.
