### PR TITLE
[DEVOPS-1121] explorer: add testnet URL to CORS origin whitelist

### DIFF
--- a/explorer/src/Pos/Explorer/Socket/App.hs
+++ b/explorer/src/Pos/Explorer/Socket/App.hs
@@ -146,6 +146,7 @@ notifierServer notifierSettings connVar = do
             [ "https://cardanoexplorer.com"
             , "https://explorer.iohkdev.io"
             , "http://cardano-explorer.cardano-mainnet.iohk.io"
+            , "https://cardano-explorer.cardano-testnet.iohkdev.io"
             , "http://localhost:3100"
             ]
 


### PR DESCRIPTION
## Description

Configure explorer to accept the testnet URL as a valid "origin" for requests.
This fixes the realtime updates.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1121

## Type of change
- Bug fix of configuration
