### PR TITLE
Nightly tests: Only run tests on Linux

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,14 +1,18 @@
 steps:
-  - label: 'Acceptance Tests - mainnet - full'
+  - label: 'Acceptance Tests - mainnet'
     command:
       - nix-build -A acceptanceTests.mainnet.full -o acceptance-tests-mainnet-full.sh
       - echo "+++ Syncing mainnet blockchain"
       - ./acceptance-tests-mainnet-full.sh
     timeout_in_minutes: 120
+    agents:
+      system: x86_64-linux
 
-  - label: 'Acceptance Tests - testnet - full'
+  - label: 'Acceptance Tests - testnet'
     command:
       - nix-build -A acceptanceTests.testnet.full -o acceptance-tests-testnet-full.sh
       - echo "+++ Syncing testnet blockchain"
       - ./acceptance-tests-testnet-full.sh
-    timeout_in_minutes: 60
+    timeout_in_minutes: 120
+    agents:
+      system: x86_64-linux


### PR DESCRIPTION
## Description

Will get more consistent results.

Avoids the problem where the nightly test run starts but the macOS builds from Hydra aren't yet ready, and so the buildkite agent needs to build for itself.

Other tests are still executed on macOS as part of normal builds.

## Linked issue

None

## Type of change

- Buildkite pipeline tweak
