### PR TITLE
[CO-407] Remove legacy-wallet dependency from new wallet Migration

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Keystore.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.Kernel.Keystore (
     -- * Deleting values
     , delete
     -- * Queries on a keystore
+    , getKeys
     , lookup
     -- * Tests handy functions
     , bracketTestKeystore
@@ -267,6 +268,11 @@ lookup nm wId (Keystore ks) =
 lookupKey :: NetworkMagic -> UserSecret -> WalletId -> Maybe EncryptedSecretKey
 lookupKey nm us (WalletIdHdRnd walletId) =
     Data.List.find (\k -> eskToHdRootId nm k == walletId) (us ^. usKeys)
+
+-- | Return all Keystore 'usKeys'
+getKeys :: Keystore -> IO [EncryptedSecretKey]
+getKeys (Keystore ks) =
+    Strict.withMVar ks $ \(InternalStorage us) -> return $ us ^. usKeys
 
 {-------------------------------------------------------------------------------
   Deleting things from the keystore

--- a/wallet-new/src/Cardano/Wallet/Kernel/Migration.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Migration.hs
@@ -2,8 +2,6 @@ module Cardano.Wallet.Kernel.Migration (migrateLegacyDataLayer) where
 
 import           Universum
 
-import           Control.Lens.TH
-import qualified Data.HashMap.Strict as HM
 import           Data.Text (pack)
 import           Data.Time (defaultTimeLocale, formatTime, getCurrentTime,
                      iso8601DateFormat)
@@ -12,141 +10,21 @@ import           System.Directory (doesDirectoryExist, makeAbsolute, renamePath)
 import           Formatting ((%))
 import qualified Formatting as F
 
-import qualified Pos.Core as Core
 import           Pos.Core.NetworkMagic (makeNetworkMagic)
+import           Pos.Crypto (EncryptedSecretKey)
 import           Pos.Util.Wlog (Severity (..))
-import qualified Pos.Wallet.Web.ClientTypes as WebTypes
-import qualified Pos.Wallet.Web.State.Storage as WS
-
-import           Pos.Wallet.Web.State.Acidic (closeState, openState)
-import           Pos.Wallet.Web.State.State (getWalletSnapshot)
 
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.DB.HdWallet as HD
-import           Cardano.Wallet.Kernel.DB.InDb (InDb (InDb))
 import qualified Cardano.Wallet.Kernel.Internal as Kernel
 import           Cardano.Wallet.Kernel.Keystore as Keystore
 import           Cardano.Wallet.Kernel.Restore (restoreWallet)
-import           Cardano.Wallet.Kernel.Types
 
 {-------------------------------------------------------------------------------
-  Pure helper functions for migration. This include only data that are not
-  derivable from the blockchain.
+  Pure helper functions for migration.
 -------------------------------------------------------------------------------}
 
--- | An heuristic confidence score of whether or not a spending password was
--- set for this wallet.
--- Note how is not possible to reconstruct this information
--- reliably, because the legacy wallet never stored if this wallet was
--- spending-password-protected, it only stored the creation time and the
--- last time the password was changed. However, when creating a wallet, they
--- did set the lastUpdate == dateCreated, so it's not possible to distinguish
--- between the case where the user set the password at creation time and
--- never changed it or the case where the user never set the password at all.
-data Confidence =
-    HasSpendingPasswordUnknown
-  -- ^ This happens because there is no real way to judge if the user set
-  -- a spending password or not, especially because if the user @did@ set a
-  -- spending password right at the start, there will be no way of reconstructing
-  -- this from the legacy storage. Unfortunately, this is the case most users
-  -- fall into.
-  | ProbablyHasSpendingPassword
-  -- ^ Ihis is when the users later changed their password.
-  -- In principle they could set it to be empty (so we still cannot be sure),
-  -- but this is unlikely (and disallowed by the frontend).
-
-data MigrationMetadata = MigrationMetadata {
-    _mmHdRootId            :: HD.HdRootId
-  , _mmAssuranceLevel      :: HD.AssuranceLevel
-  , _mmWalletName          :: HD.WalletName
-  , _mmDefaultAddress      :: Core.Address
-  -- ^ A default Address which will be used during restoration. It's a trick
-  -- to avoid having the user insert the @spending password@ during migration,
-  -- which would complicate things sensibly.
-  , _mmHasSpendingPassword :: Bool
-  }
-
-makeLenses ''MigrationMetadata
-
-data MetadataUnavailable = NotEnoughData
-
--- | Obtain any interesting metadata necessary to migrate a wallet from
--- the legacy 'WS.WalletStorage'.
-metadataFromWalletStorage :: WS.WalletStorage
-                          -> [Either MetadataUnavailable MigrationMetadata]
-metadataFromWalletStorage ws =
-    let allWalletInfos = HM.toList (WS._wsWalletInfos ws)
-    in map extract allWalletInfos
-  where
-      extract :: (WebTypes.CId (WebTypes.Wal), WS.WalletInfo)
-              -> Either MetadataUnavailable MigrationMetadata
-      extract (wId, wInfo) =
-          MigrationMetadata <$> extractHdRootId wId
-                            <*> extractAssuranceLevel wInfo
-                            <*> extractWalletName wInfo
-                            <*> extractAddress (wId, wInfo)
-                            <*> extractHasSpendingPassword wInfo
-
-      extractHdRootId :: WebTypes.CId (WebTypes.Wal)
-                      -> Either MetadataUnavailable HD.HdRootId
-      extractHdRootId cwalId = do
-          let (WebTypes.CId (WebTypes.CHash t)) = cwalId
-          rootAddr <- first (const NotEnoughData) (Core.decodeTextAddress t)
-          pure . HD.HdRootId . InDb $ rootAddr
-
-      extractAssuranceLevel :: WS.WalletInfo
-                            -> Either MetadataUnavailable HD.AssuranceLevel
-      extractAssuranceLevel wi = do
-          let wMeta = WS._wiMeta wi :: WebTypes.CWalletMeta
-          pure $ case WebTypes.cwAssurance wMeta of
-                     WebTypes.CWAStrict -> HD.AssuranceLevelStrict
-                     WebTypes.CWANormal -> HD.AssuranceLevelNormal
-
-      extractWalletName :: WS.WalletInfo
-                        -> Either MetadataUnavailable HD.WalletName
-      extractWalletName wi = do
-          let wMeta = WS._wiMeta wi :: WebTypes.CWalletMeta
-          pure $ HD.WalletName (WebTypes.cwName wMeta)
-
-      extractHasSpendingPassword :: WS.WalletInfo
-                                 -> Either MetadataUnavailable Bool
-      extractHasSpendingPassword wi = do
-          let confidence = case WS._wiPassphraseLU wi == WS._wiCreationTime wi of
-                                True  -> HasSpendingPasswordUnknown
-                                False -> ProbablyHasSpendingPassword
-              -- Our best guess whether or not this wallet has the spending password.
-              -- currently we always yield True, but we can tweak these values if
-              -- our assumptions reveal not to be correct (or if we can fine tune
-              -- our heuristic).
-              bestGuess = case confidence of
-                               HasSpendingPasswordUnknown  -> True
-                               ProbablyHasSpendingPassword -> True
-          pure bestGuess
-
-      extractAddress :: (WebTypes.CId (WebTypes.Wal), WS.WalletInfo)
-                     -> Either MetadataUnavailable Core.Address
-      extractAddress (cwalId, _) =
-        findSuitableAddress cwalId (HM.toList (WS._wsAccountInfos ws))
-
-      findSuitableAddress :: WebTypes.CId (WebTypes.Wal)
-                          -> [(WebTypes.AccountId, WS.AccountInfo)]
-                          -> Either MetadataUnavailable Core.Address
-      findSuitableAddress _ [] = Left NotEnoughData
-      findSuitableAddress cwalId ((WebTypes.AccountId aiWId _index, acc) : xs)
-          | aiWId /= cwalId = findSuitableAddress cwalId xs
-          | otherwise =
-              -- NOTE: In principle, we might want to pick an unused address,
-              -- to make the whole restoration process cleaner. However, not
-              -- only would this come with a O(n * log(n)) lookup rather than
-              -- just a linear scan, but it wouldn't be that useful: considering
-              -- that Daedalus never creates unused addresses automatically, the
-              -- actual chances of finding an unused one would be pretty slim.
-              case HM.keys . WS._aiAddresses $ acc of
-                   []    -> findSuitableAddress cwalId xs
-                   (a:_) -> Right a
-
-
--- | Tries to check the existence of the DB at 'FilePath'. It first tries to
+--- | Tries to check the existence of the DB at 'FilePath'. It first tries to
 -- check for the input 'FilePath' as-it-is. If this fails, it tries to check
 -- for absolute path.
 -- This is sometimes necessary if the DB path is given with paths like
@@ -162,24 +40,36 @@ resolveDbPath fp = do
              absExist <- doesDirectoryExist absPath
              return $ if absExist then Just absPath else Nothing
 
--- | Migrates the wallet database created with the legacy data layer onto the
--- new format. It does that by extract the metadata not deriveable from the
--- blockchain first, and then kicking-off the async restoration process.
+--- | Move the legacy database into a backup directory.
+moveLegacyDB :: FilePath -> IO FilePath
+moveLegacyDB filepath = do
+    now <- getCurrentTime
+    let backupPath =  filepath
+                   <> "-backup-"
+                   <> formatTime defaultTimeLocale (iso8601DateFormat (Just "%H_%M_%S")) now
+    renamePath filepath backupPath
+    return backupPath
+
+-- | Migrates all wallets present in the Keystore by restoring each wallet from
+-- its encrypted secret key. Since the spending password is not available, we
+-- cannot create a default address for new wallets. This has the effect that
+-- the user won't be able to rely on transacting with a default address
+-- while restoration is in progress.
 --
 -- When @forced@ is False we are lenient in logging any error and continuing
 -- rather than crashing the node. The rationale is that if
--- we live the node running, we would give the user a chance
+-- we leave the node running, we would give the user a chance
 -- to submit a bug report from the Daedalus interface.
 --
 -- However when @forced@ is True the migration is a all-or-nothing.
--- If anything fails (e.g. wallet decoding, resotartion etc) the node crashes.
+-- If anything fails the node crashes.
 migrateLegacyDataLayer :: Kernel.PassiveWallet
                        -> FilePath
                        -> Bool
                        -> IO ()
 migrateLegacyDataLayer pw unresolvedDbPath forced = do
-    let logMsg = pw ^. Kernel.walletLogMessage
-    logMsg Info "Starting acid state migration"
+    logMsg Info "Starting wallet(s) migration"
+
     resolved <- resolveDbPath unresolvedDbPath
     case resolved of
        Nothing -> -- We assume no migration is needed and we move along
@@ -190,95 +80,55 @@ migrateLegacyDataLayer pw unresolvedDbPath forced = do
                 False -> do
                     logMsg Info $ "No legacy DB at " <> pack unresolvedDbPath <> ", migration is not needed."
        Just legacyDbPath -> do
-           bracketLegacyDB legacyDbPath $ \st -> do
-                let  (unavailable, available) = partitionEithers (metadataFromWalletStorage st)
-                     unavailableLen = length unavailable
-                     availableLen   = length available
+           wKeys <- Keystore.getKeys (pw ^. Kernel.walletKeystore)
+           mapM_ (restore pw forced) wKeys
 
-                when (unavailableLen > 0) $ do
-                    let msg = show unavailableLen
-                              <> " out of "
-                              <> show (unavailableLen + availableLen)
-                              <> " wallets failed to be converted into the metadata "
-                              <> "information needed for migration."
-                    case forced of
-                        True -> do
-                            logMsg Error $ "Migration failed! " <> msg
-                            exitFailure
-                        False -> do
-                            logMsg Error msg
+           -- asynchronous restoration still runs at this point.
+           logMsg Info $ "Migration succeeded, restoration of migrated wallets in progress..."
 
-                when (availableLen > 0) $ do
-                    logMsg Info $ "Found "
-                        <> show availableLen
-                        <> " rootAddress(es) to migrate."
-
-                mapM_ (restore pw forced) available
-
-           -- Now that we have closed the DB, we can move the directory
+           -- Now we can move the directory
            backupPath <- moveLegacyDB legacyDbPath
 
            -- asynchronous restoration still runs at this point.
            logMsg Info $ "acid state migration succeeded. Old db backup can be found at " <> pack backupPath
-
+    where
+        logMsg = pw ^. Kernel.walletLogMessage
 
 restore :: Kernel.PassiveWallet
         -> Bool
-        -> MigrationMetadata
+        -> EncryptedSecretKey
         -> IO ()
-restore pw forced metadata = do
-    let nm       = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
-        logMsg   = pw ^. Kernel.walletLogMessage
-        keystore = pw ^. Kernel.walletKeystore
-        wId      = WalletIdHdRnd (metadata ^. mmHdRootId)
-    mEsk <- Keystore.lookup nm wId keystore
-    case mEsk of
-        Just esk -> do
-            res <- restoreWallet pw
-                                 (metadata ^. mmHasSpendingPassword)
-                                 (metadata ^. mmDefaultAddress)
-                                 (metadata ^. mmWalletName)
-                                 (metadata ^. mmAssuranceLevel)
-                                 esk
-            case res of
-                 Right (restoredRoot, balance) -> do
-                     let msg = "Migrating " % F.build
-                                % " with balance " % F.build
-                     logMsg Info (F.sformat msg restoredRoot balance)
-                 Left err -> do
-                     let errMsg = "Couldn't migrate " % F.build
-                                % " due to : " % F.build % "."
-                         msg = F.sformat errMsg wId err
-                     case forced of
-                        False -> logMsg Error msg
-                        True  -> do
-                            logMsg Error ("Migration failed! " <> msg <> " You are advised to delete the newly created db and try again.")
-                            exitFailure
-        Nothing -> do
-            let errMsg = "Couldn't migrate " % F.build
-                       % " : the key was not found in the keystore."
-                msg = F.sformat errMsg wId
-            case forced of
+restore pw forced esk = do
+    let logMsg = pw ^. Kernel.walletLogMessage
+        nm     = makeNetworkMagic (pw ^. Kernel.walletProtocolMagic)
+        rootId = HD.eskToHdRootId nm esk
+
+    let -- DEFAULTS for wallet restoration
+        -- we don't have a spending password during migration
+        hasSpendingPassword   = False
+        -- we cannot derive an address without a spending password
+        defaultAddress        = Nothing
+        defaultWalletName     = HD.WalletName "<Migrated Wallet>"
+        defaultAssuranceLevel = HD.AssuranceLevelStrict
+
+    res <- restoreWallet pw
+                         hasSpendingPassword
+                         defaultAddress
+                         defaultWalletName
+                         defaultAssuranceLevel
+                         esk
+
+    case res of
+         Right (restoredRoot, balance) -> do
+             let msg = "Migrating " % F.build
+                        % " with balance " % F.build
+             logMsg Info (F.sformat msg restoredRoot balance)
+         Left err -> do
+             let errMsg = "Couldn't migrate " % F.build
+                        % " due to : " % F.build % "."
+                 msg = F.sformat errMsg rootId err
+             case forced of
                 False -> logMsg Error msg
                 True  -> do
                     logMsg Error ("Migration failed! " <> msg <> " You are advised to delete the newly created db and try again.")
                     exitFailure
-
--- PRECONDITION: The 'FilePath' should exist. This is checked at the call site.
-bracketLegacyDB :: FilePath -> (WS.WalletStorage -> IO a) -> IO a
-bracketLegacyDB legacyDbPath withWalletStorage =
-    bracket (openState False legacyDbPath)
-            closeState
-            -- Apparently hlint thinks this is more readable, heh.
-            (getWalletSnapshot >=> withWalletStorage)
-
--- | Move the legacy database into a backup directory.
-moveLegacyDB :: FilePath -> IO FilePath
-moveLegacyDB filepath = do
-    now <- getCurrentTime
-    let backupPath =  filepath
-                   <> "-backup-"
-                   <> formatTime defaultTimeLocale (iso8601DateFormat (Just "%H_%M_%S")) now
-    renamePath filepath backupPath
-    return backupPath
-

--- a/wallet-new/src/Cardano/Wallet/Kernel/Restore.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/Restore.hs
@@ -91,7 +91,7 @@ import           Pos.Util.Trace (Severity (Error))
 -- background thread that will asynchronously restore the wallet history.
 --
 -- Wallet initialization parameters match those of 'createWalletHdRnd'
--- NOTE: We pass in a fresh 'Address' which will be used to initialise the
+-- NOTE: We pass in an optional fresh 'Address' which will be used to initialise the
 -- companion 'HdAccount' this wallet will be created with. The reason why
 -- we do this is that, if we were to use the 'PassPhrase' directly, it would
 -- have been impossible for upstream code dealing with migrations to call
@@ -102,8 +102,8 @@ import           Pos.Util.Trace (Severity (Error))
 restoreWallet :: Kernel.PassiveWallet
               -> Bool
               -- ^ Did this wallet have a spending password set?
-              -> Core.Address
-              -- ^ The stock address to use for the companion 'HdAccount'.
+              -> Maybe Core.Address
+              -- ^ An optional stock address to use for the companion 'HdAccount'.
               -> HD.WalletName
               -> HD.AssuranceLevel
               -> EncryptedSecretKey

--- a/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
+++ b/wallet-new/src/Cardano/Wallet/WalletLayer/Kernel/Wallets.hs
@@ -128,7 +128,7 @@ createWallet wallet newWalletRequest = liftIO $ do
                     restoreWallet
                       wallet
                       (pwd /= emptyPassphrase)
-                      (hdAddress ^. HD.hdAddressAddress . fromDb)
+                      (Just (hdAddress ^. HD.hdAddressAddress . fromDb))
                       (HD.WalletName walletName)
                       hdAssuranceLevel
                       esk

--- a/wallet-new/test/unit/Test/Spec/Addresses.hs
+++ b/wallet-new/test/unit/Test/Spec/Addresses.hs
@@ -83,8 +83,8 @@ prepareFixtures nm = do
                           <*> (InDb <$> pick arbitrary)
     newAccountId <- HdAccountId newRootId <$> deriveIndex (pick . choose) HdAccountIx HardDerivation
     let accounts = M.singleton newAccountId mempty
-        hdAccountId      = Kernel.defaultHdAccountId newRootId
-        (Just hdAddress) = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
+        hdAccountId = Kernel.defaultHdAccountId newRootId
+        hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 
     return $ \pw -> do
         void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)

--- a/wallet-new/test/unit/Test/Spec/GetTransactions.hs
+++ b/wallet-new/test/unit/Test/Spec/GetTransactions.hs
@@ -137,9 +137,9 @@ prepareFixtures nm initialBalance = do
         forM_ fixt $ \Fix{..} -> do
             liftIO $ Keystore.insert (WalletIdHdRnd fixtureHdRootId) fixtureESK keystore
 
-            let accounts         = Kernel.prefilterUtxo nm fixtureHdRootId fixtureESK fixtureUtxo
-                hdAccountId      = Kernel.defaultHdAccountId fixtureHdRootId
-                (Just hdAddress) = Kernel.defaultHdAddress nm fixtureESK emptyPassphrase fixtureHdRootId
+            let accounts    = Kernel.prefilterUtxo nm fixtureHdRootId fixtureESK fixtureUtxo
+                hdAccountId = Kernel.defaultHdAccountId fixtureHdRootId
+                hdAddress   = Kernel.defaultHdAddress nm fixtureESK emptyPassphrase fixtureHdRootId
 
             void $ liftIO $ update (pw ^. wallets) (CreateHdWallet fixtureHdRoot hdAccountId hdAddress accounts)
         return $ Fixture {
@@ -175,9 +175,9 @@ prepareUTxoFixtures nm coins = do
     return $ \keystore aw -> do
         let pw = Kernel.walletPassive aw
         Keystore.insert (WalletIdHdRnd newRootId) esk keystore
-        let accounts         = Kernel.prefilterUtxo nm newRootId esk utxo
-            hdAccountId      = Kernel.defaultHdAccountId newRootId
-            (Just hdAddress) = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
+        let accounts    = Kernel.prefilterUtxo nm newRootId esk utxo
+            hdAccountId = Kernel.defaultHdAccountId newRootId
+            hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 
         void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)
         return $ Fix {

--- a/wallet-new/test/unit/Test/Spec/NewPayment.hs
+++ b/wallet-new/test/unit/Test/Spec/NewPayment.hs
@@ -116,9 +116,9 @@ prepareFixtures nm initialBalance toPay = do
         liftIO $ Keystore.insert (WalletIdHdRnd newRootId) esk keystore
         let pw = Kernel.walletPassive aw
 
-        let accounts         = Kernel.prefilterUtxo nm newRootId esk utxo'
-            hdAccountId      = Kernel.defaultHdAccountId newRootId
-            (Just hdAddress) = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
+        let accounts    = Kernel.prefilterUtxo nm newRootId esk utxo'
+            hdAccountId = Kernel.defaultHdAccountId newRootId
+            hdAddress   = Kernel.defaultHdAddress nm esk emptyPassphrase newRootId
 
         void $ liftIO $ update (pw ^. wallets) (CreateHdWallet newRoot hdAccountId hdAddress accounts)
         return $ Fixture {

--- a/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
+++ b/wallet-new/test/unit/Wallet/Inductive/Cardano.hs
@@ -237,7 +237,7 @@ equivalentT useWW activeWallet esk = \mkWallet w ->
           Kernel.createWalletHdRnd
             passiveWallet
             False
-            (defaultAddress ^. HD.hdAddressAddress . fromDb)
+            (Just (defaultAddress ^. HD.hdAddressAddress . fromDb))
             walletName
             assuranceLevel
             esk


### PR DESCRIPTION
## Description

This PR changes the wallet migration code in order to remove the last dependency on the legacy wallet.

In order to achieve this, the following changes were made to wallet migration:

* previously, we extracted metadata from the legacy DB for the purposes of migration. This included migrating a "default address" for each migrated wallets
* instead of migrating from the legacy db, we now migrate all wallets that have an encrypted secret key in the wallet Keystore
* however, this does not give us the wallet spending password, which prevents us from being able to create a default address for each migrated wallet
* the solution is to remove the invariant that new wallets be created/restored with a default address (and instead make the address optional)
* existing code paths that create/restore wallets can still create and provide a default address, while the migration code can omit the address for migration

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CO-407

## Type of change
- [X] 🛠 New feature (non-breaking change which adds functionality)
- [X] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc

## Testing checklist
- [X] All new and existing tests passed.

## QA Steps

Re-test wallet migration
