### PR TITLE
[CBR-486] adjust fees when adding additional utxos for fees

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -434,7 +434,7 @@ estimateSize saa sta ins outs =
 --         here with some (hopefully) realistic values.
 estimateCardanoFee :: TxSizeLinear -> Int -> [Word64] -> Word64
 estimateCardanoFee linearFeePolicy ins outs
-    = round $ calculateTxSizeLinear linearFeePolicy
+    = ceiling $ calculateTxSizeLinear linearFeePolicy
             $ hi $ estimateSize boundAddrAttrSize boundTxAttrSize ins outs
 
 checkCardanoFeeSanity :: TxSizeLinear -> Coin -> Bool

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -12,6 +12,8 @@ module Cardano.Wallet.Kernel.CoinSelection.Generic (
   , Rounding(..)
   , Fee(..)
   , adjustFee
+  , feeSub
+  , unsafeFeeSub
   , unsafeFeeSum
   , utxoEntryVal
   , sizeOfEntries
@@ -153,6 +155,13 @@ newtype Fee dom = Fee { getFee :: Value dom }
 
 adjustFee :: (Value dom -> Value dom) -> Fee dom -> Fee dom
 adjustFee f = Fee . f . getFee
+
+feeSub :: CoinSelDom dom => Fee dom -> Fee dom -> Maybe (Fee dom)
+feeSub (Fee x) (Fee y) = Fee <$> valueSub x y
+
+unsafeFeeSub :: CoinSelDom dom => Fee dom -> Fee dom -> Fee dom
+unsafeFeeSub (Fee x) (Fee y) = Fee $ fromMaybe (error "unsafeFeeSub: underflow") $
+    valueSub x y
 
 unsafeFeeSum :: CoinSelDom dom => [Fee dom] -> Fee dom
 unsafeFeeSum = Fee . unsafeValueSum . map getFee


### PR DESCRIPTION
## Description

After the fix the fees are adjusted when many inputs are picked. The tx gets accepted by the node and socceedss (it also appear at the recipient's wallet). Most of the value below is fees as I sent a very small amount.

![adjusted-fees](https://user-images.githubusercontent.com/11467473/48546019-e9039300-e8cf-11e8-946f-d5c32444e99d.png)

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CBR-486

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

