### PR TITLE
[RCD-45] & [RCD-44] Review fee calculation entirely

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -70,6 +70,7 @@ instance IsValue Core.Coin where
                                    else a `Core.unsafeSubCoin` b
   valueRatio  = \  a b -> coinToDouble a / coinToDouble b
   valueAdjust = \r d a -> coinFromDouble r (d * coinToDouble a)
+  valueDiv    = divCoin
 
 instance CoinSelDom Cardano where
   type    Input     Cardano = Core.TxIn
@@ -191,14 +192,6 @@ feeOptions CoinSelectionOptions{..} = FeeOptions{
 type PickUtxo m = forall e. Core.Coin  -- ^ Fee to still cover
                -> CoinSelT Core.Utxo e m (Maybe (Core.TxIn, Core.TxOutAux))
 
-data CoinSelFinalResult = CoinSelFinalResult {
-      csrInputs  :: NonEmpty (Core.TxIn, Core.TxOutAux)
-      -- ^ Picked inputs
-    , csrOutputs :: NonEmpty Core.TxOutAux
-      -- ^ Picked outputs
-    , csrChange  :: [Core.Coin]
-    }
-
 -- | Run coin selection
 --
 -- NOTE: Final UTxO is /not/ returned: coin selection runs /outside/ any wallet
@@ -215,8 +208,8 @@ runCoinSelT :: forall m. Monad m
             -> (forall utxo. PickFromUtxo utxo
                   => NonEmpty (Output (Dom utxo))
                   -> CoinSelT utxo CoinSelHardErr m [CoinSelResult (Dom utxo)])
-            -> CoinSelPolicy Core.Utxo m CoinSelFinalResult
-runCoinSelT opts pickUtxo policy (NE.sortBy (flip (comparing outVal)) -> request) utxo = do
+            -> CoinSelPolicy Core.Utxo m (CoinSelFinalResult Cardano)
+runCoinSelT opts pickUtxo policy (NE.sortBy (flip (comparing outVal)) -> request) =
     -- NOTE: we sort the payees by output value, to maximise our chances of succees.
     -- In particular, let's consider a scenario where:
     --
@@ -233,44 +226,9 @@ runCoinSelT opts pickUtxo policy (NE.sortBy (flip (comparing outVal)) -> request
     --
     -- Therefore, just always considering them in order from large to small
     -- is probably a good idea.
-    mSelection <- unwrapCoinSelT policy' utxo
-    case mSelection of
-      Left err -> return (Left err)
-      Right ((css, additionalUtxo, additionalChange), _utxo') -> do
-        let inps = concatMap selectedEntries
-                     (additionalUtxo : map coinSelInputs css)
-            outs = map coinSelOutput css
-            changesWithDust = splitChange additionalChange $ concatMap coinSelChange css
-        let allInps = case inps of
-                        []   -> error "runCoinSelT: empty list of inputs"
-                        i:is -> i :| is
-            originalOuts = case outs of
-                               []   -> error "runCoinSelT: empty list of outputs"
-                               o:os -> o :| os
-            changes = changesRemoveDust (csoDustThreshold opts) changesWithDust
-        return . Right $ CoinSelFinalResult allInps
-                                            originalOuts
-                                            changes
+    evalCoinSelT policy'
   where
-    -- we should have (x + (sum ls) = sum result), but this check could overflow.
-    splitChange :: Value Cardano -> [Value Cardano] -> [Value Cardano]
-    splitChange = go
-        where
-          go remaining [] = [remaining]
-              -- we only create new change if for whatever reason there is none already
-              -- or if is some overflow happens when we try to add.
-          go remaining [a] = case valueAdd remaining a of
-              Just newChange -> [newChange]
-              Nothing        -> [a, remaining]
-          go remaining ls@(a : as) =
-            let piece = divCoin remaining (length ls)
-                newRemaining = unsafeValueSub remaining piece -- unsafe because of div.
-            in case valueAdd piece a of
-                Just newChange -> newChange : go newRemaining as
-                Nothing        -> a : go remaining as
-
-    policy' :: CoinSelT Core.Utxo CoinSelHardErr m
-                 ([CoinSelResult Cardano], SelectedUtxo Cardano, Value Cardano)
+    policy' :: CoinSelT Core.Utxo CoinSelHardErr m (CoinSelFinalResult Cardano)
     policy' = do
         mapM_ validateOutput request
         css <- intInputGrouping (csoInputGrouping opts)
@@ -346,7 +304,7 @@ validateOutput out =
 random :: forall m. MonadRandom m
        => CoinSelectionOptions
        -> Word64          -- ^ Maximum number of inputs
-       -> CoinSelPolicy Core.Utxo m CoinSelFinalResult
+       -> CoinSelPolicy Core.Utxo m (CoinSelFinalResult Cardano)
 random opts maxInps =
       runCoinSelT opts pickUtxo
     $ Random.random Random.PrivacyModeOn maxInps . NE.toList
@@ -361,7 +319,7 @@ random opts maxInps =
 largestFirst :: forall m. Monad m
              => CoinSelectionOptions
              -> Word64
-             -> CoinSelPolicy Core.Utxo m CoinSelFinalResult
+             -> CoinSelPolicy Core.Utxo m (CoinSelFinalResult Cardano)
 largestFirst opts maxInps =
       runCoinSelT opts pickUtxo
     $ LargestFirst.largestFirst maxInps . NE.toList

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -392,8 +392,8 @@ estimateSize saa sta ins outs =
 --         here with some (hopefully) realistic values.
 estimateCardanoFee :: TxSizeLinear -> Int -> [Word64] -> Word64
 estimateCardanoFee linearFeePolicy ins outs
-    = round $ calculateTxSizeLinear linearFeePolicy
-            $ hi $ estimateSize boundAddrAttrSize boundTxAttrSize ins outs
+    = ceiling $ calculateTxSizeLinear linearFeePolicy
+              $ hi $ estimateSize boundAddrAttrSize boundTxAttrSize ins outs
 
 checkCardanoFeeSanity :: TxSizeLinear -> Coin -> Bool
 checkCardanoFeeSanity linearFeePolicy fees =

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/FromGeneric.hs
@@ -172,8 +172,9 @@ newOptions estimateFee check = CoinSelectionOptions {
     }
 
 feeOptions :: CoinSelectionOptions -> FeeOptions Cardano
-feeOptions CoinSelectionOptions{..} = FeeOptions{
-      foExpenseRegulation = csoExpenseRegulation
+feeOptions CoinSelectionOptions{..} = FeeOptions
+    { foExpenseRegulation = csoExpenseRegulation
+    , foDustThreshold = csoDustThreshold
     , foEstimate = \numInputs outputs ->
                       case outputs of
                         []   -> error "feeOptions: empty list"

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Kernel.CoinSelection.Generic (
   , mapCoinSelErr
   , mapCoinSelUtxo
   , unwrapCoinSelT
+  , evalCoinSelT
   , wrapCoinSelT
     -- * Errors
   , CoinSelHardErr(..)
@@ -91,6 +92,7 @@ class Ord v => IsValue v where
   valueDist   :: v -> v -> v                         -- ^ @|a - b|@
   valueRatio  :: v -> v -> Double                    -- ^ @a / b@
   valueAdjust :: Rounding -> Double -> v -> Maybe v  -- ^ @a * b@
+  valueDiv    :: v -> Int -> v                       -- ^ @a / k@
 
 class ( Ord (Input dom)
       , IsValue (Value dom)
@@ -245,6 +247,10 @@ mapCoinSelUtxo inj proj act = wrapCoinSelT $ \st ->
 -- | Unwrap the 'CoinSelT' stack
 unwrapCoinSelT :: CoinSelT utxo e m a -> utxo -> m (Either e (a, utxo))
 unwrapCoinSelT act = runExceptT . runStrictStateT (unCoinSelT act)
+
+-- | Unwrap the 'CoinSelT' stack, only getting the resulting selection
+evalCoinSelT :: Monad m => CoinSelT utxo e m a -> utxo -> m (Either e a)
+evalCoinSelT act = runExceptT . evalStrictStateT (unCoinSelT act)
 
 -- | Inverse of 'unwrapCoinSelT'
 wrapCoinSelT :: Monad m

--- a/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic/Fees.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/CoinSelection/Generic/Fees.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Cardano.Wallet.Kernel.CoinSelection.Generic.Fees (
-    ExpenseRegulation(..)
-  , FeeOptions(..)
-  , adjustForFees
-  ) where
+module Cardano.Wallet.Kernel.CoinSelection.Generic.Fees
+    ( ExpenseRegulation(..)
+    , FeeOptions(..)
+    , CoinSelFinalResult(..)
+    , adjustForFees
+    ) where
 
 import           Universum
 
@@ -35,107 +36,167 @@ data FeeOptions dom = FeeOptions {
     , foExpenseRegulation :: ExpenseRegulation
     }
 
+data CoinSelFinalResult dom = CoinSelFinalResult
+    { csrInputs  :: NonEmpty (UtxoEntry dom)
+    -- ^ Picked inputs
+    , csrOutputs :: NonEmpty (Output dom)
+    -- ^ Picked outputs
+    , csrChange  :: [Value dom]
+    -- ^ Resulting changes
+    }
+
+type PickUtxo m utxo
+    =  Value (Dom utxo)
+    -> CoinSelT utxo CoinSelHardErr m (Maybe (UtxoEntry (Dom utxo)))
+
 -- | Given the coin selection result from a policy run, adjust the outputs
 -- for fees, potentially returning additional inputs that we need to cover
 -- all fees.
-adjustForFees :: forall utxo m. (CoinSelDom (Dom utxo), Monad m)
-              => FeeOptions (Dom utxo)
-              -> (Value (Dom utxo) ->
-                   CoinSelT utxo CoinSelHardErr m (Maybe (UtxoEntry (Dom utxo))))
-              -> [CoinSelResult (Dom utxo)]
-              -> CoinSelT utxo CoinSelHardErr m
-                   ([CoinSelResult (Dom utxo)], SelectedUtxo (Dom utxo), Value (Dom utxo))
+adjustForFees
+    :: forall utxo m. (CoinSelDom (Dom utxo), Monad m)
+    => FeeOptions (Dom utxo)
+    -> PickUtxo m utxo
+    -> [CoinSelResult (Dom utxo)]
+    -> CoinSelT utxo CoinSelHardErr m (CoinSelFinalResult (Dom utxo))
 adjustForFees feeOptions pickUtxo css = do
-    case foExpenseRegulation feeOptions of
-      ReceiverPaysFee -> coinSelLiftExcept $
-        (, emptySelection, valueZero) <$> receiverPaysFee upperBound css
-      SenderPaysFee ->
-        senderPaysFee pickUtxo upperBound css
-  where
-    upperBound = feeUpperBound feeOptions css
+    let inps = concatMap (selectedEntries . coinSelInputs) css
+    let outs = map coinSelOutput css
+    let chgs = concatMap coinSelChange css
+
+    (inps', outs', chgs') <-
+        case foExpenseRegulation feeOptions of
+          ReceiverPaysFee ->
+            coinSelLiftExcept $ receiverPaysFee feeOptions inps outs chgs
+
+          SenderPaysFee ->
+            senderPaysFee pickUtxo feeOptions inps outs chgs
+
+    let neInps = case inps' of
+            []   -> error "adjustForFees: empty list of inputs"
+            i:is -> i :| is
+
+    let neOuts = case outs' of
+            []   -> error "adjustForFees: empty list of outputs"
+            o:os -> o :| os
+
+    return $ CoinSelFinalResult neInps neOuts chgs'
+
 
 {-------------------------------------------------------------------------------
   Receiver pays fee
 -------------------------------------------------------------------------------}
 
-receiverPaysFee :: forall dom. CoinSelDom dom
-                => Fee dom
-                -> [CoinSelResult dom]
-                -> Except CoinSelHardErr [CoinSelResult dom]
-receiverPaysFee totalFee =
-    mapM go . divvyFee (outVal . coinSelRequest) totalFee
+receiverPaysFee
+    :: forall dom. CoinSelDom dom
+    => FeeOptions dom
+    -> [UtxoEntry dom]
+    -> [Output dom]
+    -> [Value dom]
+    -> Except CoinSelHardErr ([UtxoEntry dom], [Output dom], [Value dom])
+receiverPaysFee feeOptions inps outs chgs = do
+    let totalFee = feeUpperBound feeOptions inps outs chgs
+    outs' <- mapM go . divvyFee outVal totalFee $ outs
+    return (inps, outs', chgs)
   where
-    go :: (Fee dom, CoinSelResult dom)
-       -> Except CoinSelHardErr (CoinSelResult dom)
-    go (fee, cs) =
-        case outSubFee fee (coinSelRequest cs) of
+    go
+        :: (Fee dom, Output dom)
+        -> Except CoinSelHardErr (Output dom)
+    go (fee, out) =
+        case outSubFee fee out of
           Just newOut ->
-            return $ cs { coinSelOutput = newOut }
+            return newOut
           Nothing ->
             throwError $
-              CoinSelHardErrOutputCannotCoverFee (pretty (coinSelRequest cs)) (pretty fee)
+              CoinSelHardErrOutputCannotCoverFee (pretty out) (pretty fee)
 
 {-------------------------------------------------------------------------------
   Sender pays fee
 -------------------------------------------------------------------------------}
 
-senderPaysFee :: (Monad m, CoinSelDom (Dom utxo))
-              => (Value (Dom utxo) ->
-                   CoinSelT utxo CoinSelHardErr m (Maybe (UtxoEntry (Dom utxo))))
-              -> Fee (Dom utxo)
-              -> [CoinSelResult (Dom utxo)]
-              -> CoinSelT utxo CoinSelHardErr m
-                   ([CoinSelResult (Dom utxo)], SelectedUtxo (Dom utxo), Value (Dom utxo))
-senderPaysFee pickUtxo totalFee css = do
-    let (css', remainingFee) = feeFromChange totalFee css
-    (additionalUtxo, additionalChange) <- coverRemainingFee pickUtxo remainingFee
-    return (css', additionalUtxo, additionalChange)
+senderPaysFee
+    :: (Monad m, CoinSelDom (Dom utxo))
+    => PickUtxo m utxo
+    -> FeeOptions (Dom utxo)
+    -> [UtxoEntry (Dom utxo)]
+    -> [Output (Dom utxo)]
+    -> [Value (Dom utxo)]
+    -> CoinSelT utxo CoinSelHardErr m ([UtxoEntry (Dom utxo)], [Output (Dom utxo)], [Value (Dom utxo)])
+senderPaysFee pickUtxo feeOptions = go
+  where
+    go inps outs chgs = do
+        -- 1/
+        -- We compute fees using all inputs, outputs and changes since
+        -- all of them have an influence on the fee calculation.
+        let fee = feeUpperBound feeOptions inps outs chgs
 
-coverRemainingFee :: forall utxo m. (Monad m, CoinSelDom (Dom utxo))
-                  => (Value (Dom utxo) -> CoinSelT utxo CoinSelHardErr m (Maybe (UtxoEntry (Dom utxo))))
-                  -> Fee (Dom utxo)
-                  -> CoinSelT utxo CoinSelHardErr m (SelectedUtxo (Dom utxo), Value (Dom utxo))
+        -- 2/
+        -- We try to cover fee with the available change by substracting equally
+        -- across all inputs. There's no fairness in that in the case of a
+        -- multi-account transaction. Everyone pays the same part.
+        let (chgs', remainingFee) = reduceChangeOutputs fee chgs
+        if getFee remainingFee == valueZero then
+            -- 3.1/
+            -- Should the change cover the fee, we're done.
+            return (inps, outs, chgs')
+
+            -- 3.2/
+            -- Otherwise, we need an extra entries from the available utxo to
+            -- cover what's left. Note that this entry may increase our change
+            -- because we may not consume it entirely. So we will just split
+            -- the extra change across all changes possibly increasing the
+            -- number of change outputs (if there was none, or if increasing
+            -- a change value causes an overflow).
+            --
+            -- Because selecting a new input increases the fee, we need to
+            -- re-run the algorithm with this new elements and using the initial
+            -- change plus the extra change brought up by this entry and see if
+            -- we can now correctly cover fee.
+        else do
+            extraUtxo <- coverRemainingFee pickUtxo remainingFee
+            let inps' = selectedEntries extraUtxo
+            let extraChange = selectedBalance extraUtxo
+            go (inps <> inps') outs (splitChange extraChange chgs)
+
+
+coverRemainingFee
+    :: forall utxo m. (Monad m, CoinSelDom (Dom utxo))
+    => PickUtxo m utxo
+    -> Fee (Dom utxo)
+    -> CoinSelT utxo CoinSelHardErr m (SelectedUtxo (Dom utxo))
 coverRemainingFee pickUtxo fee = go emptySelection
   where
     go :: SelectedUtxo (Dom utxo)
-       -> CoinSelT utxo CoinSelHardErr m (SelectedUtxo (Dom utxo), Value (Dom utxo))
+       -> CoinSelT utxo CoinSelHardErr m (SelectedUtxo (Dom utxo))
     go !acc
       | selectedBalance acc >= getFee fee =
-          return (acc, unsafeValueSub (selectedBalance acc) (getFee fee))
+          return acc
       | otherwise = do
           mio <- (pickUtxo $ unsafeValueSub (getFee fee) (selectedBalance acc))
           io  <- maybe (throwError CoinSelHardErrCannotCoverFee) return mio
           go (select io acc)
 
--- | Attempt to pay the fee from change outputs, returning any fee remaining
---
--- NOTE: For sender pays fees, distributing the fee proportionally over the
--- outputs is not strictly necessary (fairness is not a concern): we could just
--- use the change of the first output to cover the entire fee (if sufficiently
--- large). Doing it proportionally however has the benefit that the fee
--- adjustment doesn't change the payment:change ratio too much, which may be
--- important for the correct operation of the coin selection policy.
---
--- NOTE: This does mean that /if/ the policy generates small outputs with
--- very large corresponding change outputs, we may not make optional use of
--- those change outputs and perhaps unnecessarily add additional UTxO entries.
--- However, in most cases the policy cares about the output:change ratio,
--- so we stick with this approach nonetheless.
-feeFromChange :: forall dom. CoinSelDom dom
-              => Fee dom
-              -> [CoinSelResult dom]
-              -> ([CoinSelResult dom], Fee dom)
-feeFromChange totalFee =
-    bimap identity unsafeFeeSum
-    . unzip
-    . map go
-    . divvyFee (outVal . coinSelRequest) totalFee
-  where
-    -- | Adjust the change output, returning any fee remaining
-    go :: (Fee dom, CoinSelResult dom) -> (CoinSelResult dom, Fee dom)
-    go (fee, cs) =
-        let (change', fee') = reduceChangeOutputs fee (coinSelChange cs)
-        in (cs { coinSelChange = change' }, fee')
+
+-- we should have (x + (sum ls) = sum result), but this check could overflow.
+splitChange
+    :: forall dom. (CoinSelDom dom)
+    => Value dom
+    -> [Value dom]
+    -> [Value dom]
+splitChange = go
+    where
+      go remaining [] = [remaining]
+          -- we only create new change if for whatever reason there is none already
+          -- or if is some overflow happens when we try to add.
+      go remaining [a] = case valueAdd remaining a of
+          Just newChange -> [newChange]
+          Nothing        -> [a, remaining]
+      go remaining ls@(a : as) =
+        let piece = valueDiv remaining (length ls)
+            newRemaining = unsafeValueSub remaining piece -- unsafe because of div.
+        in case valueAdd piece a of
+            Just newChange -> newChange : go newRemaining as
+            Nothing        -> a : go remaining as
+
 
 -- | Reduce the given change outputs by the total fee, returning the remainig
 -- change outputs if any are left, or the remaining fee otherwise
@@ -167,13 +228,19 @@ reduceChangeOutputs totalFee cs =
   Auxiliary
 -------------------------------------------------------------------------------}
 
-feeUpperBound :: CoinSelDom dom
-              => FeeOptions dom -> [CoinSelResult dom] -> Fee dom
-feeUpperBound FeeOptions{..} css =
+feeUpperBound
+    :: forall dom. (CoinSelDom dom)
+    => FeeOptions dom
+    -> [UtxoEntry dom]
+    -> [Output dom]
+    -> [Value dom]
+    -> Fee dom
+feeUpperBound FeeOptions{..} inps outs chgs =
     foEstimate numInputs outputs
   where
-    numInputs = fromIntegral $ sum (map (sizeToWord . coinSelInputSize) css)
-    outputs   = concatMap coinSelOutputs css
+    numInputs = fromIntegral $ sizeToWord $ selectedSize $ foldr' select emptySelection inps
+    outputs = map outVal outs <> chgs
+
 
 -- | divvy fee across outputs, discarding zero-output if any. Returns `Nothing`
 -- when there's no more outputs after filtering, in which case, we just can't

--- a/wallet-new/test/unit/InputSelection/FromGeneric.hs
+++ b/wallet-new/test/unit/InputSelection/FromGeneric.hs
@@ -46,6 +46,7 @@ instance IsValue (SafeValue h a) where
   valueDist   = safeDist
   valueRatio  = safeRatio
   valueAdjust = safeAdjust
+  valueDiv    = safeDiv
 
 instance (DSL.Hash h a, Buildable a) => CoinSelDom (DSL h a) where
   type    Input     (DSL h a) = DSL.Input  h a
@@ -108,6 +109,10 @@ safeDist (Value x) (Value y) =
 safeRatio :: SafeValue h a -> SafeValue h a -> Double
 safeRatio (Value x) (Value y) =
     fromIntegral x / fromIntegral y
+
+safeDiv :: SafeValue h a  -> Int -> SafeValue h a
+safeDiv (Value x) k =
+    Value (x `div` fromIntegral k)
 
 -- TODO: check for underflow/overflow
 safeAdjust :: Rounding -> Double -> SafeValue h a -> Maybe (SafeValue h a)

--- a/wallet-new/test/unit/Test/Spec/CoinSelection.hs
+++ b/wallet-new/test/unit/Test/Spec/CoinSelection.hs
@@ -41,9 +41,8 @@ import           Cardano.Wallet.Kernel.CoinSelection (CoinSelFinalResult (..),
                      CoinSelectionOptions (..), ExpenseRegulation (..),
                      InputGrouping (..), estimateMaxTxInputsExplicitBounds,
                      largestFirst, newOptions, random)
-import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
-                     (estimateCardanoFee,
-                     estimateHardMaxTxInputsExplicitBounds)
+import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric (Cardano,
+                     estimateCardanoFee, estimateHardMaxTxInputsExplicitBounds)
 import           Cardano.Wallet.Kernel.Transactions (mkStdTx)
 import           Cardano.Wallet.Kernel.Util.Core (paymentAmount, utxoBalance,
                      utxoRestrictToInputs)
@@ -464,7 +463,7 @@ encodedSize = fromBytes . fromIntegral . LBS.length . toLazyByteString . encode
 
 type Policy = CoinSelectionOptions
            -> Word64
-           -> CoinSelPolicy Core.Utxo Gen CoinSelFinalResult
+           -> CoinSelPolicy Core.Utxo Gen (CoinSelFinalResult Cardano)
 
 type RunResult = ( Core.Utxo
                  , NonEmpty Core.TxOut


### PR DESCRIPTION
## Description

So, basically, by conflating a bit the selected entries and changes, a
lot of things become easier.  At the price of one thing: fairness.

The previous code was splitting fee across change proportionally to
inputs.  So here, I just split the fee across all changes, regardless of
the input.

One could see it as another type of fairness :upside_down_face: ...  But
that's also a lot simpler to handle, because we can just manipulate all
inputs and all changes directly and compute fee for those directly.


## Linked issue

[RCD-45](https://iohk.myjetbrains.com/youtrack/issue/RCD-45)
[RCD-44](https://iohk.myjetbrains.com/youtrack/issue/RCD-44)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

```
Wallet unit tests
  Coin selection policies unit tests
    largestFirst
      one payee, SenderPaysFee, fee = 0
        +++ OK, passed 1000 tests.
      one payee, ReceiverPaysFee, fee = 0
        +++ OK, passed 1000 tests.
      multiple payees, SenderPaysFee, fee = 0
        +++ OK, passed 1000 tests.
      multiple payees, ReceiverPaysFee, fee = 0
        +++ OK, passed 1000 tests.
      one payee, SenderPaysFee, fee = 1 Lovelace
        +++ OK, passed 1000 tests.
      one payee, ReceiverPaysFee, fee = 1 Lovelace
        +++ OK, passed 1000 tests.
      multiple payees, SenderPaysFee, fee = 1 Lovelace
        +++ OK, passed 1000 tests.
      multiple payees, ReceiverPaysFee, fee = 1 Lovelace
        +++ OK, passed 1000 tests.
    random
      one payee, SenderPaysFee, fee = 0
        +++ OK, passed 2000 tests.
      one payee, ReceiverPaysFee, fee = 0
        +++ OK, passed 2000 tests.
      multiple payees, SenderPaysFee, fee = 0
        +++ OK, passed 2000 tests.
      multiple payees, ReceiverPaysFee, fee = 0
        +++ OK, passed 2000 tests.
      one payee, SenderPaysFee, fee = 1 Lovelace
        +++ OK, passed 2000 tests.
      multiple payees, SenderPaysFee, fee = 1 Lovelace
        +++ OK, passed 2000 tests.
      one payee, ReceiverPaysFee, fee = linear
        +++ OK, passed 2000 tests.
      multiple payees, ReceiverPaysFee, fee = linear
        +++ OK, passed 2000 tests.
      one payee, SenderPaysFee, fee = cardano
        +++ OK, passed 2000 tests.
      multiple payees, SenderPaysFee, fee = cardano
        +++ OK, passed 2000 tests.
      one payee, ReceiverPaysFee, fee = cardano
        +++ OK, passed 2000 tests.
      multiple payees, ReceiverPaysFee, fee = cardano
        +++ OK, passed 2000 tests.
    Expected failures
      Paying a redeem address should always be rejected
        +++ OK, passed 2000 tests.
      Paying somebody not having enough money should fail
        +++ OK, passed 2000 tests.
      Restricting too much the number of inputs results in an hard error for a single payee
        +++ OK, passed 2000 tests.
      Restricting too much the number of inputs results in an hard error for multiple payees
        +++ OK, passed 2000 tests.
    Fiddly Addresses
      multiple payees, SenderPaysFee, fee = cardano
        +++ OK, passed 200 tests.
      multiple payees, ReceiverPaysFee, fee = cardano
        +++ OK, passed 200 tests.
    Input Grouping
      Require grouping, fee = 0, one big group depletes the Utxo completely
        +++ OK, passed 2000 tests.
      Require grouping, fee = cardano, one big group depletes the Utxo completely
        +++ OK, passed 2000 tests.
      Require grouping, fee = 0, several groups allows the payment to be fullfilled
        +++ OK, passed 2000 tests.
      Prefer grouping, fee = 0
        +++ OK, passed 2000 tests.
      IgnoreGrouping, fee = 0 must not deplete the utxo
        +++ OK, passed 2000 tests.
    Estimating the maximum number of inputs
      estimateMaxTxInputs yields a lower bound.
        +++ OK, passed 100 tests.
      estimateMaxTxInputs yields a relatively tight bound.
        +++ OK, passed 100 tests.
      estimateHardMaxTxInputs is close to estimateMaxTxInputs.
        +++ OK, passed 1000 tests.

Finished in 123.3834 seconds
34 examples, 0 failures
```


## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
