### PR TITLE
release/2.0.0 [DEVOPS-1141] Set an ample maximum block size for epoch boundary blocks

### DIFF
--- a/chain/src/Pos/Chain/Block/Logic/Integrity.hs
+++ b/chain/src/Pos/Chain/Block/Logic/Integrity.hs
@@ -341,6 +341,9 @@ verifyBlocks genesisConfig curSlotId verifyNoUnknown bvd initLeaders = view _3 .
         let newLeaders = case blk of
                 Left genesisBlock -> genesisBlock ^. genBlockLeaders
                 Right _           -> leaders
+            blockMaxSize = case blk of
+                Left _  -> 2000000
+                Right _ -> bvdMaxBlockSize bvd
             vhp =
                 VerifyHeaderParams
                 { vhpPrevHeader = prevHeader
@@ -352,7 +355,7 @@ verifyBlocks genesisConfig curSlotId verifyNoUnknown bvd initLeaders = view _3 .
             vbp =
                 VerifyBlockParams
                 { vbpVerifyHeader = vhp
-                , vbpMaxSize = bvdMaxBlockSize bvd
+                , vbpMaxSize = blockMaxSize
                 , vbpVerifyNoUnknown = verifyNoUnknown
                 }
         in (newLeaders, Just $ getBlockHeader blk, res <> verifyBlock genesisConfig vbp blk)

--- a/lib/src/Pos/Communication/Limits.hs
+++ b/lib/src/Pos/Communication/Limits.hs
@@ -279,7 +279,7 @@ mlBlockHeader bvd = 1 + max (BlockHeaderGenesis <$> mlGenesisBlockHeader bvd)
                             (BlockHeaderMain    <$> mlMainBlockHeader bvd)
 
 mlGenesisBlock :: BlockVersionData -> Limit GenesisBlock
-mlGenesisBlock = Limit . fromIntegral . bvdMaxBlockSize
+mlGenesisBlock _ = Limit 2000000
 
 mlMainBlock :: BlockVersionData -> Limit MainBlock
 mlMainBlock = Limit . fromIntegral . bvdMaxBlockSize


### PR DESCRIPTION
## Description

This change ensures that, even if the maximum block size is reduced (and it is), the epoch boundary blocks (also called genesis blocks) are still allowed a higher maximum size.

This is a cherry-pick from #3864.

ChangeLog entry for this added in #3811.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1137
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1140
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1141

## Type of change

- Bug fix
- New feature
- Breaking change

## QA Steps

1. Wait for the next epoch after the maximum block size parameter has been reduced.
2. Check that nodes are still able to validate blocks.
