### PR TITLE
[CBR-475] adds MVar for any sqlite-operation

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18422,6 +18422,7 @@ x509-store
 testHaskellDepends = [
 acid-state
 aeson
+async
 base
 bytestring
 cardano-crypto

--- a/wallet-new/cardano-sl-wallet-new.cabal
+++ b/wallet-new/cardano-sl-wallet-new.cabal
@@ -506,6 +506,7 @@ test-suite wallet-unit-tests
   hs-source-dirs:     server test/unit
 
   build-depends:      acid-state
+                    , async
                     , base
                     , bytestring
                     , cardano-crypto

--- a/wallet-new/test/unit/TxMetaStorageSpecs.hs
+++ b/wallet-new/test/unit/TxMetaStorageSpecs.hs
@@ -11,8 +11,8 @@ import           Universum
 
 import qualified Cardano.Wallet.Kernel.DB.Sqlite as SQlite
 import           Cardano.Wallet.Kernel.DB.TxMeta
-import           Control.Exception.Safe (bracket)
 import           Control.Concurrent.Async
+import           Control.Exception.Safe (bracket)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set

--- a/wallet-new/test/unit/TxMetaStorageSpecs.hs
+++ b/wallet-new/test/unit/TxMetaStorageSpecs.hs
@@ -201,8 +201,7 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWriteWithNoOp meta0 hdl
                 t1 <- async $ threadWriteWithNoOp meta1 hdl
-                _ <- waitAny [t0, t1]
-                return ()
+                traverse_ wait [t0, t1]
 
         it "synchronized with 2 write workers and no-ops: correct count" $ withMaxSuccess 5 $  monadicIO $ do
             -- beware of the big data.
@@ -212,10 +211,9 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWriteWithNoOp meta0 hdl
                 t1 <- async $ threadWriteWithNoOp meta1 hdl
-                _ <- waitAny [t0, t1]
+                traverse_ wait [t0, t1]
                 (ls, _count) <- getTxMetas hdl (Offset 0) (Limit 300) Everything Nothing NoFilterOp NoFilterOp Nothing
                 length ls `shouldBe` 200
-                return ()
 
         it "synchronized with 2 write workers" $ withMaxSuccess 5 $  monadicIO $ do
             -- beware of the big data.
@@ -225,8 +223,7 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWrite meta0 hdl
                 t1 <- async $ threadWrite meta1 hdl
-                _ <- waitAny [t0, t1]
-                return ()
+                traverse_ wait [t0, t1]
 
         it "synchronized with 2 write workers: correct count" $ withMaxSuccess 5 $  monadicIO $ do
             -- beware of the big data.
@@ -236,10 +233,9 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWrite meta0 hdl
                 t1 <- async $ threadWrite meta1 hdl
-                _ <- waitAny [t0, t1]
+                traverse_ wait [t0, t1]
                 (ls, _count) <- getTxMetas hdl (Offset 0) (Limit 300) Everything Nothing NoFilterOp NoFilterOp Nothing
                 length ls `shouldBe` 200
-                return ()
 
         it "synchronized 1 write and 1 read workers" $ withMaxSuccess 5 $  monadicIO $ do
             -- beware of the big data.
@@ -248,8 +244,7 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWriteWithNoOp metas hdl
                 t1 <- async $ threadRead 2000 hdl
-                _ <- waitAny [t0, t1]
-                return ()
+                traverse_ wait [t0, t1]
 
         it "synchronized 1 write and 1 read workers: correct count" $ withMaxSuccess 5 $  monadicIO $ do
             -- beware of the big data.
@@ -258,10 +253,9 @@ txMetaStorageSpecs = do
             run $ withTemporaryDb $ \hdl -> do
                 t0 <- async $ threadWriteWithNoOp metas hdl
                 t1 <- async $ threadRead 200 hdl
-                _ <- waitAny [t0, t1]
+                traverse_ wait [t0, t1]
                 (ls, _count) <- getTxMetas hdl (Offset 0) (Limit 300) Everything Nothing NoFilterOp NoFilterOp Nothing
                 length ls `shouldBe` 200
-                return ()
 
     describe "SQlite transactions" $ do
         it "throws an exception when tx with double spending" $ monadicIO $ do


### PR DESCRIPTION
## Description

Multithreading at SQlite is not the greatest. The intermediate libraries we use make things slightly worse. We already suffer from 2 known issues: 
- unexpected exceptions because of race conditions (https://github.com/IreneKnapp/direct-sqlite/issues/77). This can make things like this not pattern match
`Left (Sqlite.SQLConstraintError Sqlite.Unique "tx_metas_outputs.meta_id, tx_metas_outputs.output_index")` because we get the wrong exception and the node crashes with:
```
StorageFailure (SQLOtherError SQLite3 returned ErrorConstraint while attempting to perform step: not an error)
cardano-node: StorageFailure (SQLOtherError SQLite3 returned ErrorConstraint while attempting to perform step: not an error)
```

- `withTransaction` is not multithreaded. If 2 threads (which for example restore/sync at the same time) tries to use it, the node may crash. I tried this:
```
thread0 conn = 
    forM_ [1..5000] $ \n -> do
        withTransaction conn (return ())

thread1 conn = 
    forM_ [1..5000] $ \n -> do
        withTransaction conn (return ())
```
and I get different results like:
`SQLite3 returned ErrorError while attempting to perform step: not an error`
`SQLite3 returned ErrorError while attempting to perform step: cannot start a transaction within a transaction`
so even trying to handle the IS_BUSY error, we may get the wrong error because of the previous isssue!


Given the above and despite as cruel as it is, I think we should use our own MVars and use mutually exclusive uses of the connection.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
