### PR TITLE
[RCD-48] explorer frontend: Update testnet link in footer

### DIFF
--- a/explorer/frontend/src/Explorer/View/Footer.purs
+++ b/explorer/frontend/src/Explorer/View/Footer.purs
@@ -143,7 +143,7 @@ navItemsLeft lang =
       , link: "https://cardanoroadmap.com"
       }
     , { label: translate (I18nL.footer <<< I18nL.fooCardanoTestnet) lang
-      , link: "https://tada.iohk.io"
+      , link: "https://testnet.iohkdev.io"
       }
     , { label: translate (I18nL.footer <<< I18nL.fooCardanoSource) lang
       , link: "https://github.com/input-output-hk/cardano-sl"


### PR DESCRIPTION
## Description

The testnet link was using an old URL.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/RCD-48

## Type of change
- Bug fix

## QA Steps
- Look at footer links on http://cardano-explorer.awstest.iohkdev.io/ (staging) or https://cardanoexplorer.com (mainnet) and check testnet.
