### PR TITLE
[DEVOPS-1146] Add heap profile chart to nightly sync test

### DIFF
--- a/scripts/test/acceptance/default.nix
+++ b/scripts/test/acceptance/default.nix
@@ -47,7 +47,7 @@ in
     ''}
     mkdir -p ${stateDir}/logs
 
-    trap "stop_wallet" INT TERM
+    trap "stop_wallet" INT TERM EXIT
 
     ${utf8LocaleSetting}
     echo Launching wallet node: ${wallet}


### PR DESCRIPTION
## Description

Adds GHC heap profiling plot to the Buildkite nightly sync test.

There is only one heap profile which includes both the sync and wallet restore phases together.
It is fairly easy to distinguish the phases on the charts. If the sync and restore phases must be in separate charts then this can be done.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1146

## Type of change
- Tests
