### PR TITLE
[DEVOPS-1172] faucet: Use OptimizeForHighThroughput grouping policy

### DIFF
--- a/faucet/cardano-sl-faucet.cabal
+++ b/faucet/cardano-sl-faucet.cabal
@@ -1,7 +1,3 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
 name:           cardano-sl-faucet
 version:        2.0.0
 description:    Cardano SL - faucet
@@ -22,6 +18,7 @@ library
                     , aeson-pretty
                     , base16-bytestring
                     , bytestring
+                    , cardano-sl-client
                     , cardano-sl-core
                     , cardano-sl-crypto
                     , cardano-sl-chain

--- a/faucet/src/Cardano/WalletClient.hs
+++ b/faucet/src/Cardano/WalletClient.hs
@@ -21,7 +21,7 @@ import qualified Data.ByteArray as BA
 import           Data.ByteString (ByteString)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Text.Strict.Lens (utf8)
-import           Pos.Client.Txp.Util (InputSelectionPolicy(..))
+import           Pos.Client.Txp.Util (InputSelectionPolicy (..))
 import           Pos.Core (Address (..), Coin (..))
 import           Pos.Crypto.Signing (PassPhrase)
 import           System.Random

--- a/faucet/src/Cardano/WalletClient.hs
+++ b/faucet/src/Cardano/WalletClient.hs
@@ -21,6 +21,7 @@ import qualified Data.ByteArray as BA
 import           Data.ByteString (ByteString)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Text.Strict.Lens (utf8)
+import           Pos.Client.Txp.Util (InputSelectionPolicy(..))
 import           Pos.Core (Address (..), Coin (..))
 import           Pos.Crypto.Signing (PassPhrase)
 import           System.Random
@@ -49,7 +50,8 @@ withdraw addr = withSublogger "WalletClient.withdraw" $ do
     q <- view feWithdrawalQ
     let paymentDist = (V1.PaymentDistribution addr coin :| [])
         sp =  spendingPassword <&> view (re utf8 . to hashPwd . to V1)
-        payment = Payment paymentSource paymentDist Nothing sp
+        gp = Just (V1 OptimizeForHighThroughput)
+        payment = Payment paymentSource paymentDist gp sp
     eRes <- liftIO $ sendToQueue q payment
     case eRes of
         Left e -> do

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16543,6 +16543,7 @@ license = stdenv.lib.licenses.mit;
 , base16-bytestring
 , bytestring
 , cardano-sl-chain
+, cardano-sl-client
 , cardano-sl-core
 , cardano-sl-crypto
 , cardano-sl-infra
@@ -16610,6 +16611,7 @@ base
 base16-bytestring
 bytestring
 cardano-sl-chain
+cardano-sl-client
 cardano-sl-core
 cardano-sl-crypto
 cardano-sl-util


### PR DESCRIPTION
## Description

Fix faucet withdrawals which occasionally fail due to unavailable UTxO.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1172

## Type of change
- Bug fix in faucet -- i.e. testnet only.

## Testing

This is done with a local build with a faucet connected to the local Daedalus wallet.

- [x] Successful withdrawals with a local faucet and wallet.
- [x] Withdrawal transaction does not result in grouping of UTxO. See [transaction in explorer](https://cardano-explorer.cardano-testnet.iohkdev.io/tx/e0e98ca0dc62717dd9ba2d662f66ea78be944d4a6f72903f842e8fb0c7f2bca5)
