### PR TITLE
[DEVOPS-1112] Staging application version

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14976,7 +14976,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
     applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 1
+      bvMinor: 2
       bvAlt: 0
 
 mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
@@ -14986,7 +14986,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
     applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 1
+      bvMinor: 2
       bvAlt: 0
 
 mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
@@ -14996,7 +14996,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
     applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
-      bvMinor: 1
+      bvMinor: 2
       bvAlt: 0
 
 ##############################################################################

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14973,7 +14973,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 17
+    applicationVersion: 16
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14973,7 +14973,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 16
+    applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14983,7 +14983,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 16
+    applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14993,7 +14993,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 16
+    applicationVersion: 17
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14955,7 +14955,7 @@ testnet_wallet_linux64: &testnet_wallet_linux64
 
 ##############################################################################
 ##                                                                          ##
-##   Staging config                                                         ##
+##   Mainnet dryrun config sample                                           ##
 ##                                                                          ##
 ##############################################################################
 
@@ -14968,7 +14968,10 @@ mainnet_dryrun_full: &mainnet_dryrun_full
         file: mainnet-genesis-dryrun-with-stakeholders.json
         hash: c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323
     requiresNetworkMagic: RequiresNoMagic
-  update: &staging_wallet_update
+
+mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
+  <<: *mainnet_dryrun_full
+  update:
     applicationName: csl-daedalus
     applicationVersion: 17
     lastKnownBlockVersion:
@@ -14976,14 +14979,25 @@ mainnet_dryrun_full: &mainnet_dryrun_full
       bvMinor: 1
       bvAlt: 0
 
-mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
-  <<: *mainnet_dryrun_full
-
 mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 16
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
 
 mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
+  update:
+    applicationName: csl-daedalus
+    applicationVersion: 16
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
 
 ##############################################################################
 ##                                                                          ##


### PR DESCRIPTION
## Description

Update the applicationVersion for the staging installers, but revert the part which changes the `lastKnownBlockVersion` for the staging cluster. This must be `0.2.0` not `0.1.0`.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1112
