### PR TITLE
[CBR-495] Fix inconsistent metadata store after deletion

### DIFF
--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta.hs
@@ -24,6 +24,7 @@ openMetaDB fp = do
           closeMetaDB   = withMVar lock ConcreteStorage.closeMetaDB
         , migrateMetaDB = withMVar lock ConcreteStorage.unsafeMigrateMetaDB
         , clearMetaDB   = withMVar lock ConcreteStorage.clearMetaDB
+        , deleteTxMetas = \w a   -> withMVar lock $ \c -> ConcreteStorage.deleteTxMetas c w a
         , getTxMeta     = \t w a -> withMVar lock $ \c -> ConcreteStorage.getTxMeta c t w a
         , putTxMeta     = \ t    -> withMVar lock $ \c -> ConcreteStorage.putTxMeta c t
         , putTxMetaT    = \ t    -> withMVar lock $ \c -> ConcreteStorage.putTxMetaT c t

--- a/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
+++ b/wallet-new/src/Cardano/Wallet/Kernel/DB/TxMeta/Types.hs
@@ -292,6 +292,7 @@ data MetaDBHandle = MetaDBHandle {
       closeMetaDB   :: IO ()
     , migrateMetaDB :: IO ()
     , clearMetaDB   :: IO ()
+    , deleteTxMetas :: Core.Address -> Maybe Word32 -> IO ()
     , getTxMeta     :: Txp.TxId -> Core.Address -> Word32 -> IO (Maybe TxMeta)
     , putTxMeta     :: TxMeta -> IO ()
     , putTxMetaT    :: TxMeta -> IO PutReturn


### PR DESCRIPTION
## Description

We store some information related to transaction in the metadata store (sqlite). However, when looking up transaction with metadata referring to wallet we don't know about, we fail with a not so friendly error "WalletNotFound" despite no wallet being given as part of the query.

This fix is actually two folds:

- It discards incoherent transactions fetched from the DB, if any,
  and shout a warning in the log. This is in order to make the system
  more resilient to conconcurrent calls while a wallet or account is
  being deleted (since metadata and accounts / wallets are stored in
  separated databases, we can't easily run both delete in a single
  transaction).

- It also deletes corresponding metadata when an account or a wallet
  is removed. This may cause extra damage? What if there are pending
  transactions when we delete the account or wallet.

## Linked issue

[CBR-495](https://iohk.myjetbrains.com/youtrack/issue/CBR-495)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

On input-output-hk/cardano-sl I've added the following integration tests:

```
    scenario "Reg#141: metadata become inconsistent after a wallet is deleted" $ do
        fixture <- setup $ defaultSetup
            & initialCoins .~ [14]

        response <- request $ Client.getTransactionIndexFilterSorts
            $- Nothing
            $- Nothing
            $- Nothing
            $- defaultPage
            $- defaultPerPage
            $- NoFilters
            $- NoSorts

        verify response
            [ expectSuccess
            ]

    scenario "Reg#141: metadata become inconsistent after an account is deleted" $ do
        fixture <- setup $ defaultSetup
            & initialCoins .~ [500000]

        request_ $ Client.postAccount
            $- fixture ^. wallet . walletId
            $- NewAccount
                noSpendingPassword
                "My Second Account"

        request_ $ Client.deleteAccount
            $- fixture ^. wallet . walletId
            $- defaultAccountId

        response <- request $ Client.getTransactionIndexFilterSorts
            $- Just (fixture ^. wallet . walletId)
            $- Nothing
            $- Nothing
            $- defaultPage
            $- defaultPerPage
            $- NoFilters
            $- NoSorts

        verify response
            [ expectSuccess
            ]
```

Both now passes. Beside, in case of future inconsistency like this in the DB, the whole endpoint won't fail but instead, inconsistent transactions will be discarded and a warning printed in the logs:

```
[cardano-sl.walletapi:Info:ThreadId 1201] [2018-12-08 15:05:49.40 UTC] 
GET Request #28
    :> api
    :> v1
    :> transactions
    :> 'wallet_id' field: -
    :> 'account_index' field: -
    :> 'address' field: -
    :> pagination: page=1, per_page=10
    :> filter_by: -
    :> sort_by: -
[cardano-sl.edge:Warning:ThreadId 1201] [2018-12-08 15:05:49.40 UTC] Inconsistent entry in the metadata store: UnknownHdAccountRoot HdRootId Ae2tdPwUPEZKUpTf4jDurpvX7fdUrmZvFPM56TAwihnBbAuyvMZ47NeHHdY
[cardano-sl.walletapi:Info:ThreadId 1201] [2018-12-08 15:05:49.40 UTC] 
    Response #28 OK 0.002410603s
```


## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
