### PR TITLE
Enable monitoring API (and corresponding doc) for all nodes in the cluster

### DIFF
--- a/cluster/app/prepare-environment/Main.hs
+++ b/cluster/app/prepare-environment/Main.hs
@@ -64,10 +64,10 @@ main = do
 
             case nodeType of
                 NodeCore -> do
-                    void (init genesis >> init topology >> init logger)
+                    void (init genesis >> init topology >> init logger >> init tls)
 
                 NodeRelay -> do
-                    void (init topology >> init logger)
+                    void (init topology >> init logger >> init tls)
 
                 NodeEdge -> do
                     void (init topology >> init logger >> init tls)


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

@parsonsmatt, this should unlock quite a few things for you to fix integration tests on `cardano-wallet`. Now, we generate a TLS environment for each node in the cluster, and they all start a monitoring api (and it's corresponding doc) using the generated certificates as an authentication mean.

This will have some rippling effects in `cardano-wallet` here:

https://github.com/input-output-hk/cardano-wallet/blob/develop/test/integration/Test/Integration/Framework/Cluster.hs#L75-L87

I'll leave that to you if that's okay :)

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [x] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

```
$ stack exec -- cardano-sl-cluster-demo
Cluster is starting (4 core(s), 1 relay(s), 1 edge(s))...
...core0 OK!
......address:       127.0.0.1:3000
......api address:   127.0.0.1:8080
......doc address:   127.0.0.1:8180
......system start:  1545335561
...core1 OK!
......address:       127.0.0.1:3001
......api address:   127.0.0.1:8081
......doc address:   127.0.0.1:8181
......system start:  1545335561
...core2 OK!
......address:       127.0.0.1:3002
......api address:   127.0.0.1:8082
......doc address:   127.0.0.1:8182
......system start:  1545335561
...core3 OK!
......address:       127.0.0.1:3003
......api address:   127.0.0.1:8083
......doc address:   127.0.0.1:8183
......system start:  1545335561
...relay OK!
......address:       127.0.0.1:3100
......api address:   127.0.0.1:8084
......doc address:   127.0.0.1:8184
......system start:  1545335561
...edge OK!
......api address:   127.0.0.1:8085
......doc address:   127.0.0.1:8185
......system start:  1545335561
Cluster is ready!
```

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
