### PR TITLE
[DEVOPS-1177] Fix windows test (don't just delete files)

### DIFF
--- a/util/test/Test/Pos/Util/LogStructuredSpec.hs
+++ b/util/test/Test/Pos/Util/LogStructuredSpec.hs
@@ -8,7 +8,8 @@ import           Universum
 
 import           Data.Aeson (ToJSON (..))
 import qualified Data.HashMap.Strict as HM
-import           System.Directory (getCurrentDirectory, removeFile)
+import           System.Directory (doesFileExist, getCurrentDirectory,
+                     removeFile)
 import           Test.Hspec (Spec, describe, it)
 import           Test.Hspec.QuickCheck (modifyMaxSize, modifyMaxSuccess)
 import           Test.QuickCheck.Monadic (monadicIO)
@@ -99,5 +100,5 @@ spec = describe "Strucutured logging" $ do
                     contents <- readFile logFile
                     putStrLn contents
                     liftIO $ removeFile logFile
-                    liftIO $ removeFile "node.json"
+                    liftIO $ whenM (doesFileExist "node.json") (removeFile "node.json")
                 Nothing -> putStrLn ("JSON file NOT found:" :: Text)


### PR DESCRIPTION
This should fix
- nix-tools.tests.x86_64-pc-mingw32-cardano-sl-util.util-test.x86_64-linux

## Description

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
