### PR TITLE
Fix Arbitrary instance for APIResponse

### DIFF
--- a/lib/src/Pos/Util/Servant.hs
+++ b/lib/src/Pos/Util/Servant.hs
@@ -971,7 +971,7 @@ data APIResponse a = APIResponse
 deriveJSON Aeson.defaultOptions ''APIResponse
 
 instance Arbitrary a => Arbitrary (APIResponse a) where
-    arbitrary = APIResponse <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = APIResponse <$> arbitrary <*> pure SuccessStatus <*> arbitrary
 
 instance ToJSON a => MimeRender OctetStream (APIResponse a) where
     mimeRender _ = encode


### PR DESCRIPTION
The APIResponse type isn't exactly right -- if we are returning a value
of type `APIResponse a`, that means we have successfully acquired a
value of type `a` to put in the record. So it doesn't make sense to
return an error status.

The arbitrary instance is modified to always return `SuccessStatus`.

## Linked issue

https://github.com/input-output-hk/cardano-wallet/pull/185

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
