### PR TITLE
[DEVOPS-1203] configuration.yaml: Bump applicationVersion

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14839,7 +14839,7 @@ mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14849,7 +14849,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14859,7 +14859,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14929,7 +14929,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 4
+    applicationVersion: 5
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0
@@ -14973,7 +14973,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14983,7 +14983,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14993,7 +14993,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2


### PR DESCRIPTION
## Description

Increase versions used by update system.

mainnet: 11 -> 12
staging: 18 -> 19
testnet: 4 -> 5

https://github.com/input-output-hk/internal-documentation/wiki/Daedalus-installer-history

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1203

## Type of change
- Configuration
