### PR TITLE
Reduce boilerplate for 'MeasuredIn' types

### DIFF
--- a/lib/src/Pos/Node/API.hs
+++ b/lib/src/Pos/Node/API.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE CPP             #-}
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE KindSignatures  #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TypeOperators              #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Pos.Node.API where
@@ -13,14 +15,13 @@ import           Control.Lens (At, Index, IxValue, at, ix, makePrisms, (?~))
 import           Data.Aeson
 import qualified Data.Aeson.Options as Aeson
 import           Data.Aeson.TH as A
-import           Data.Aeson.Types (Parser, Value (..), toJSONKeyText)
+import           Data.Aeson.Types (toJSONKeyText)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.Char as C
 import qualified Data.Map.Strict as Map
 import           Data.Swagger hiding (Example, example)
 import qualified Data.Swagger as S
 import           Data.Swagger.Declare (Declare, look)
-import qualified Data.Swagger.Internal
 import           Data.Swagger.Internal.Schema (GToSchema)
 import           Data.Swagger.Internal.TypeShape (GenericHasSimpleShape,
                      GenericShape)
@@ -47,7 +48,6 @@ import           Pos.Util.Example
 import           Pos.Util.Servant (APIResponse, CustomQueryFlag, Flaggable (..),
                      HasCustomQueryFlagDescription (..), Tags, ValidJSON)
 import           Pos.Util.UnitsOfMeasure
-import           Pos.Util.Util (aesonError)
 import           Serokell.Util.Text
 
 -- ToJSON/FromJSON instances for NodeId
@@ -100,50 +100,6 @@ genericSchemaDroppingPrefix prfx extraDoc proxy = do
 -- Helpers for writing instances for types with units
 --
 
--- Using a newtype wrapper might have been more elegant in some ways, but the
--- helpers need different amounts of information.
-
--- Convert to user-presentable text for the API
-unitToText :: UnitOfMeasure -> Text
-unitToText Bytes           = "bytes"
-unitToText LovelacePerByte = "Lovelace/byte"
-unitToText Lovelace        = "Lovelace"
-unitToText Seconds         = "seconds"
-unitToText Milliseconds    = "milliseconds"
-unitToText Microseconds    = "microseconds"
-unitToText Percentage100   = "percent"
-unitToText Blocks          = "blocks"
-unitToText BlocksPerSecond = "blocks/second"
-
-toJSONWithUnit :: ToJSON a => UnitOfMeasure -> a -> Value
-toJSONWithUnit u a =
-    object
-        [ "unit"     .= unitToText u
-        , "quantity" .= toJSON a
-        ]
-
--- This function ignores the unit, which might cause confusion.
-parseJSONQuantity :: FromJSON a => String -> Value -> Parser a
-parseJSONQuantity s = withObject s $ \o -> o .: "quantity"
-
--- assumes there is only one allowed unit
-toSchemaWithUnit :: (HasRequired b [a1], HasProperties b a2,
-                   Monoid b, Monoid a2, At a2, IsString a1, IsString (Index a2),
-                   ToSchema a3,
-                   HasType b (SwaggerType 'Data.Swagger.Internal.SwaggerKindSchema),
-                   IxValue a2 ~ Referenced Schema) =>
-                  UnitOfMeasure -> proxy a3 -> b
-toSchemaWithUnit unitOfMeasure a = (mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ toSchemaRef a
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ [String $ unitToText unitOfMeasure]
-                    )
-                ))
-
 data ForceNtpCheck
     = ForceNtpCheck
     | NoNtpCheck
@@ -166,8 +122,11 @@ forceNtpCheckDescription =
 
 
 -- | The different between the local time and the remote NTP server.
-newtype LocalTimeDifference = LocalTimeDifference (MeasuredIn 'Microseconds Integer)
-                            deriving (Show, Eq)
+newtype LocalTimeDifference =
+    LocalTimeDifference (MeasuredIn 'Microseconds Integer)
+    deriving stock (Show, Eq)
+    deriving newtype (ToJSON, FromJSON, BuildableSafeGen)
+deriveSafeBuildable ''LocalTimeDifference
 
 mkLocalTimeDifference :: Integer -> LocalTimeDifference
 mkLocalTimeDifference = LocalTimeDifference . MeasuredIn
@@ -175,34 +134,10 @@ mkLocalTimeDifference = LocalTimeDifference . MeasuredIn
 instance Arbitrary LocalTimeDifference where
     arbitrary = mkLocalTimeDifference <$> arbitrary
 
-instance ToJSON LocalTimeDifference where
-    toJSON (LocalTimeDifference (MeasuredIn w)) =
-        object [ "quantity" .= toJSON w
-               , "unit"     .= String "microseconds"
-               ]
-
-instance FromJSON LocalTimeDifference where
-    parseJSON = withObject "LocalTimeDifference" $ \sl -> mkLocalTimeDifference <$> sl .: "quantity"
-
 instance ToSchema LocalTimeDifference where
-    declareNamedSchema _ =
-        pure $ NamedSchema (Just "LocalTimeDifference") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["microseconds"]
-                    )
-                )
-
-deriveSafeBuildable ''LocalTimeDifference
-instance BuildableSafeGen LocalTimeDifference where
-    buildSafeGen _ (LocalTimeDifference (MeasuredIn w)) =
-        bprint (build%"μs") w
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Microseconds Integer)
+        pure $ NamedSchema (Just "LocalTimeDifference") s
 
 newtype TimeInfo
     = TimeInfo
@@ -230,15 +165,16 @@ instance BuildableSafeGen TimeInfo where
 
 deriveJSON Aeson.defaultOptions ''TimeInfo
 
-newtype SyncPercentage = SyncPercentage (MeasuredIn 'Percentage100 Word8)
-                     deriving (Show, Eq)
+newtype SyncPercentage
+    = SyncPercentage (MeasuredIn 'Percentage100 Word8)
+    deriving stock (Show, Eq, Ord)
+    deriving newtype (ToJSON, FromJSON, BuildableSafeGen)
+deriveSafeBuildable ''SyncPercentage
 
-mkSyncPercentage :: Word8 -> SyncPercentage
-mkSyncPercentage = SyncPercentage . MeasuredIn
-
-instance Ord SyncPercentage where
-    compare (SyncPercentage (MeasuredIn p1))
-            (SyncPercentage (MeasuredIn p2)) = compare p1 p2
+instance ToSchema SyncPercentage where
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Percentage100 Word8)
+        pure $ NamedSchema (Just "SyncPercentage") s
 
 instance Arbitrary SyncPercentage where
     arbitrary = mkSyncPercentage <$> choose (0, 100)
@@ -246,45 +182,20 @@ instance Arbitrary SyncPercentage where
 instance Example SyncPercentage where
     example = pure (SyncPercentage (MeasuredIn 14))
 
-instance ToJSON SyncPercentage where
-    toJSON (SyncPercentage (MeasuredIn w)) =
-        object [ "quantity" .= toJSON w
-               , "unit"     .= String "percent"
-               ]
-
-instance FromJSON SyncPercentage where
-    parseJSON = withObject "SyncPercentage" $ \sl -> mkSyncPercentage <$> sl .: "quantity"
-
-instance ToSchema SyncPercentage where
-    declareNamedSchema _ =
-        pure $ NamedSchema (Just "SyncPercentage") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity", "unit"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    & maximum_ .~ Just 100
-                    & minimum_ .~ Just 0
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["percent"]
-                    )
-                )
-
-deriveSafeBuildable ''SyncPercentage
-instance BuildableSafeGen SyncPercentage where
-    buildSafeGen _ (SyncPercentage (MeasuredIn w)) =
-        bprint (build%"%") w
+mkSyncPercentage :: Word8 -> SyncPercentage
+mkSyncPercentage = SyncPercentage . MeasuredIn
 
 
 -- | The absolute or relative height of the blockchain, measured in number
 -- of blocks.
-newtype BlockchainHeight = BlockchainHeight (MeasuredIn 'Blocks Core.BlockCount)
-                         deriving (Show, Eq)
+newtype BlockchainHeight =
+    BlockchainHeight (MeasuredIn 'Blocks Word64)
+    deriving stock (Show, Eq)
+    deriving newtype (ToJSON, FromJSON, BuildableSafeGen)
+deriveSafeBuildable ''BlockchainHeight
 
 mkBlockchainHeight :: Core.BlockCount -> BlockchainHeight
-mkBlockchainHeight = BlockchainHeight . MeasuredIn
+mkBlockchainHeight (Core.BlockCount n) = BlockchainHeight $ MeasuredIn n
 
 instance Arbitrary BlockchainHeight where
     arbitrary =
@@ -292,38 +203,11 @@ instance Arbitrary BlockchainHeight where
 
 instance Example BlockchainHeight
 
-instance ToJSON BlockchainHeight where
-    toJSON (BlockchainHeight (MeasuredIn w)) =
-        object
-            [ "quantity" .= toJSON (Core.getBlockCount w)
-            , "unit"     .= String "blocks"
-            ]
-
-instance FromJSON BlockchainHeight where
-    parseJSON = withObject "BlockchainHeight" $ \sl ->
-        mkBlockchainHeight . Core.BlockCount <$> sl .: "quantity"
-
 instance ToSchema BlockchainHeight where
-    declareNamedSchema _ =
-        pure $ NamedSchema (Just "BlockchainHeight") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    & maximum_ .~ Just (fromIntegral (maxBound :: Word64))
-                    & minimum_ .~ Just (fromIntegral (minBound :: Word64))
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["blocks"]
-                    )
-                )
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Blocks Word64)
+        pure $ NamedSchema (Just "BlockchainHeight") s
 
-deriveSafeBuildable ''BlockchainHeight
-instance BuildableSafeGen BlockchainHeight where
-    buildSafeGen _ (BlockchainHeight (MeasuredIn w)) =
-        bprint (build%" blocks") w
 
 
 -- | The @dynamic@ information for this node.
@@ -445,81 +329,37 @@ instance (Buildable a, Buildable b) => Buildable (a, b) where
 
 -- | How many milliseconds a slot lasts for.
 newtype SlotDuration = SlotDuration (MeasuredIn 'Milliseconds Word)
-    deriving (Show, Eq)
+    deriving stock (Show, Eq)
+    deriving newtype (ToJSON, FromJSON, BuildableSafeGen)
+deriveSafeBuildable ''SlotDuration
 
-mkSlotDuration :: Word -> SlotDuration
-mkSlotDuration = SlotDuration . MeasuredIn
+instance ToSchema SlotDuration where
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Milliseconds Word)
+        pure $ NamedSchema (Just "SlotDuration") s
 
 instance Arbitrary SlotDuration where
     arbitrary = mkSlotDuration <$> choose (0, 100)
 
-instance ToJSON SlotDuration where
-    toJSON (SlotDuration (MeasuredIn w)) = toJSONWithUnit Milliseconds w
+mkSlotDuration :: Word -> SlotDuration
+mkSlotDuration = SlotDuration . MeasuredIn
 
-instance FromJSON SlotDuration where
-    parseJSON v = mkSlotDuration <$> parseJSONQuantity "SlotDuration" v
-
-instance ToSchema SlotDuration where
-    declareNamedSchema _ =
-        pure $ NamedSchema (Just "SlotDuration") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["milliseconds"]
-                    )
-                )
-
-deriveSafeBuildable ''SlotDuration
-instance BuildableSafeGen SlotDuration where
-    buildSafeGen _ (SlotDuration (MeasuredIn w)) =
-        bprint (build%"ms") w
 
 newtype MaxTxSize = MaxTxSize (MeasuredIn 'Bytes Word)
-    deriving (Show, Eq)
+    deriving stock (Show, Eq)
+    deriving newtype (ToJSON, FromJSON, BuildableSafeGen)
+deriveSafeBuildable ''MaxTxSize
 
-instance ToJSON MaxTxSize where
-    toJSON (MaxTxSize (MeasuredIn s)) =
-        object
-            [ "quantity" .= toJSON s
-            , "unit"     .= String "bytes"
-            ]
-
-instance FromJSON MaxTxSize where
-    parseJSON = withObject "MaxTxSize" $ \o ->
-        mkMaxTxSize <$> o .: "quantity"
-
-mkMaxTxSize :: Word -> MaxTxSize
-mkMaxTxSize = MaxTxSize . MeasuredIn
+instance ToSchema MaxTxSize where
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Bytes Word)
+        pure $ NamedSchema (Just "MaxTxSize") s
 
 instance Arbitrary MaxTxSize where
     arbitrary = mkMaxTxSize <$> arbitrary
 
-deriveSafeBuildable ''MaxTxSize
-instance BuildableSafeGen MaxTxSize where
-    buildSafeGen _ (MaxTxSize (MeasuredIn w)) =
-        bprint (build%"bytes") w
-
-instance ToSchema MaxTxSize where
-    declareNamedSchema _ = do
-        pure $ NamedSchema (Just "MaxTxSize") $ mempty
-            & type_ .~ SwaggerObject
-            & required .~ ["quantity"]
-            & properties .~ (mempty
-                & at "quantity" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerNumber
-                    & minimum_ .~ (Just 0)
-                    )
-                & at "unit" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["bytes"]
-                    )
-                )
-
+mkMaxTxSize :: Word -> MaxTxSize
+mkMaxTxSize = MaxTxSize . MeasuredIn
 
 
 -- | This deceptively-simple newtype is a wrapper to virtually @all@ the types exposed as
@@ -682,51 +522,52 @@ instance FromJSON (V1 Core.SlotId) where
 instance Arbitrary (V1 Core.SlotId) where
     arbitrary = fmap V1 arbitrary
 
+data TxFeePolicy = TxFeePolicy
+    { tfpA :: MeasuredIn 'LovelacePerByte Core.Coeff
+    , tfpB :: MeasuredIn 'Lovelace Core.Coeff
+    } deriving (Eq, Ord, Show, Generic)
 
+fromCorePolicy :: Core.TxSizeLinear -> TxFeePolicy
+fromCorePolicy (Core.TxSizeLinear a b) =
+    TxFeePolicy (MeasuredIn a) (MeasuredIn b)
 
-instance Arbitrary (V1 Core.TxFeePolicy) where
-    arbitrary = fmap V1 (arbitrary `suchThat` predicate)
+deriveJSON Aeson.defaultOptions ''TxFeePolicy
+
+instance Arbitrary TxFeePolicy where
+    arbitrary = fmap fromCorePolicy' (arbitrary `suchThat` predicate)
       where
-        -- Don't generate unknown feepolicies
+        fromCorePolicy' = \case
+            Core.TxFeePolicyTxSizeLinear a -> fromCorePolicy a
+            _ -> error "Arbitrary TxFeePolicy: Just generated a non-linear fee policy?"
         predicate (Core.TxFeePolicyTxSizeLinear  _) = True
         predicate (Core.TxFeePolicyUnknown _ _)     = False
 
-instance ToJSON (V1 Core.TxFeePolicy) where
-    toJSON (V1 p) =
-        object $ case p of
-            Core.TxFeePolicyTxSizeLinear (Core.TxSizeLinear a b) ->
-                [ "tag" .= ("linear" :: String)
-                , "a" .= toJSONWithUnit LovelacePerByte a
-                , "b" .= toJSONWithUnit Lovelace b
-                ]
-            Core.TxFeePolicyUnknown _ _ ->
-                [ "tag" .= ("unknown" :: String)
-                ]
+instance Example TxFeePolicy
 
-instance FromJSON (V1 Core.TxFeePolicy) where
-    parseJSON j = V1 <$> (withObject "TxFeePolicy" $ \o -> do
-        (tag :: String) <- o .: "tag"
-        case tag of
-            "linear" -> do
-                a <- (o .: "a") >>= parseJSONQuantity "Coeff"
-                b <- (o .: "b") >>= parseJSONQuantity "Coeff"
-                return $ Core.TxFeePolicyTxSizeLinear $ Core.TxSizeLinear a b
-            _ ->
-                aesonError "TxFeePolicy: unknown policy name") j
-
-instance ToSchema (V1 Core.TxFeePolicy) where
+instance ToSchema TxFeePolicy where
     declareNamedSchema _ = do
-        pure $ NamedSchema (Just "Core.TxFeePolicy") $ mempty
+        -- NOTE
+        -- Not using 'genericSchemaDroppingPrefix' here because there
+        -- seems to be a bug where the base shema of 'b' would override the base
+        -- schema of 'a'; So, having the right descriptions for the wrong unit
+        -- for 'a'. It's kinda weird and I don't have time to look further to
+        -- fix this ATM ¯\_(ツ)_/¯
+        NamedSchema _ a <- declareNamedSchema $ Proxy @(MeasuredIn 'LovelacePerByte Double)
+        NamedSchema _ b <- declareNamedSchema $ Proxy @(MeasuredIn 'Lovelace Double)
+        pure $ NamedSchema (Just "TxFeePolicy") $ mempty
             & type_ .~ SwaggerObject
-            & required .~ ["tag"]
+            & required .~ ["a", "b"]
             & properties .~ (mempty
-                & at "tag" ?~ (Inline $ mempty
-                    & type_ .~ SwaggerString
-                    & enum_ ?~ ["linear", "unknown"]
-                    )
-                & at "a" ?~ (Inline $ toSchemaWithUnit LovelacePerByte (Proxy @Double))
-                & at "b" ?~ (Inline $ toSchemaWithUnit Lovelace (Proxy @Double))
+                & at "a" ?~ Inline (a & description ?~ "Slope of the linear curve")
+                & at "b" ?~ Inline (b & description ?~ "Intercept of the linear curve")
                 )
+
+deriveSafeBuildable ''TxFeePolicy
+instance BuildableSafeGen TxFeePolicy where
+    buildSafeGen _ (TxFeePolicy a b) = bprint
+        ( "( a = " % build % ", b = " % build % " )")
+        a
+        b
 
 instance Arbitrary (V1 Core.SlotCount) where
     arbitrary = fmap V1 arbitrary
@@ -736,8 +577,6 @@ instance ToSchema (V1 Core.SlotCount) where
         pure $ NamedSchema (Just "V1Core.SlotCount") $ mempty
             & type_ .~ SwaggerNumber
             & minimum_ .~ Just 0
-
-
 
 instance ToJSON (V1 Core.SlotCount) where
     toJSON (V1 (Core.SlotCount c)) = toJSON c
@@ -758,7 +597,7 @@ data NodeSettings = NodeSettings
     , setProjectVersion    :: !(V1 Version)
     , setGitRevision       :: !Text
     , setMaxTxSize         :: !MaxTxSize
-    , setFeePolicy         :: !(V1 Core.TxFeePolicy)
+    , setFeePolicy         :: !TxFeePolicy
     , setSecurityParameter :: !SecurityParameter
     } deriving (Show, Eq, Generic)
 

--- a/lib/src/Pos/Node/API.hs
+++ b/lib/src/Pos/Node/API.hs
@@ -165,6 +165,15 @@ instance BuildableSafeGen TimeInfo where
 
 deriveJSON Aeson.defaultOptions ''TimeInfo
 
+data Percent -- No concrete type needed, this is just for the Swagger schema
+
+instance ToSchema Percent where
+    declareNamedSchema _ = do
+        NamedSchema _ s <- declareNamedSchema $ Proxy @Word
+        pure $ NamedSchema (Just "Percent") $ s
+            & minimum_ ?~ 0
+            & maximum_ ?~ 100
+
 newtype SyncPercentage
     = SyncPercentage (MeasuredIn 'Percentage100 Word8)
     deriving stock (Show, Eq, Ord)
@@ -173,7 +182,7 @@ deriveSafeBuildable ''SyncPercentage
 
 instance ToSchema SyncPercentage where
     declareNamedSchema _ = do
-        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Percentage100 Word8)
+        NamedSchema _ s <- declareNamedSchema $ Proxy @(MeasuredIn 'Percentage100 Percent)
         pure $ NamedSchema (Just "SyncPercentage") s
 
 instance Arbitrary SyncPercentage where

--- a/lib/src/Pos/Util/UnitsOfMeasure.hs
+++ b/lib/src/Pos/Util/UnitsOfMeasure.hs
@@ -1,9 +1,25 @@
 {-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE KindSignatures #-}
 
-module Pos.Util.UnitsOfMeasure where
+module Pos.Util.UnitsOfMeasure
+    ( UnitOfMeasure (..)
+    , MeasuredIn(..)
+    ) where
 
+import           Control.Lens (at, (?~))
+import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object,
+                     withObject, (.:), (.=))
+import qualified Data.Text.Lazy as T
+import qualified Data.Text.Lazy.Builder as B
+import           Formatting ((%))
+import qualified Formatting as F
+import           Formatting.Buildable (Buildable (..))
+import           Pos.Core.Util.LogSafe (BuildableSafeGen (..))
 import           Universum
+
+import           Data.Swagger (NamedSchema (..), Referenced (..),
+                     SwaggerType (..), ToSchema (..), enum_, properties,
+                     required, type_)
 
 -- | A finite sum type representing time units we might want to show to
 -- clients. The idea is that whenever we have a quantity represeting some
@@ -22,6 +38,79 @@ data UnitOfMeasure =
     | Bytes
     | Lovelace
     | LovelacePerByte
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
-data MeasuredIn (a :: UnitOfMeasure) b = MeasuredIn b deriving (Eq, Show)
+instance Buildable UnitOfMeasure where
+    build = \case
+        Bytes           -> "bytes"
+        LovelacePerByte -> "lovelace/byte"
+        Lovelace        -> "lovelace"
+        Seconds         -> "seconds"
+        Milliseconds    -> "milliseconds"
+        Microseconds    -> "microseconds"
+        Percentage100   -> "percent"
+        Blocks          -> "blocks"
+        BlocksPerSecond -> "blocks/second"
+
+instance ToJSON UnitOfMeasure where
+    toJSON = String . T.toStrict . B.toLazyText . build
+
+-- | Represent data with a given unit of measure
+data MeasuredIn (u :: UnitOfMeasure) a
+    = MeasuredIn a
+    deriving (Show, Eq, Ord)
+
+instance (Demote u, Buildable a) => BuildableSafeGen (MeasuredIn u a) where
+    buildSafeGen _ = build
+
+instance (Demote u, Buildable a) => Buildable (MeasuredIn u a) where
+    build (MeasuredIn a) = F.bprint
+        (F.build % " " % F.build)
+        a
+        (demote $ Proxy @u)
+
+instance (Demote u, ToJSON a) => ToJSON (MeasuredIn u a) where
+    toJSON (MeasuredIn a) = object
+        [ "unit"     .= demote (Proxy @u)
+        , "quantity" .= toJSON a
+        ]
+
+instance (Demote u, FromJSON a) => FromJSON (MeasuredIn u a) where
+    parseJSON = withObject "MeasuredIn" $ \o -> do
+        verifyUnit =<< o .: "unit"
+        MeasuredIn <$> o .: "quantity"
+      where
+        verifyUnit = \case
+            u@(String _) | u == toJSON (demote $ Proxy @u) -> pure ()
+            _ -> mempty
+
+instance (Demote u, ToSchema a) => ToSchema (MeasuredIn u a) where
+    declareNamedSchema _ = do
+        NamedSchema _ schema <- declareNamedSchema (Proxy @a)
+        pure $ NamedSchema (Just "MeasuredIn") $ mempty
+            & type_ .~ SwaggerObject
+            & required .~ ["quantity", "unit"]
+            & properties .~ (mempty
+                & at "quantity" ?~ Inline schema
+                & at "unit" ?~ (Inline $ mempty
+                    & type_ .~ SwaggerString
+                    & enum_ ?~ [toJSON $ demote $ Proxy @u]
+                    )
+                )
+
+--
+-- Internal
+--
+
+-- | Bring a type back to the world of value (invert of promote)
+class Demote (u :: UnitOfMeasure) where
+    demote :: Proxy u -> UnitOfMeasure
+instance Demote 'Bytes           where demote _ = Bytes
+instance Demote 'LovelacePerByte where demote _ = LovelacePerByte
+instance Demote 'Lovelace        where demote _ = Lovelace
+instance Demote 'Seconds         where demote _ = Seconds
+instance Demote 'Milliseconds    where demote _ = Milliseconds
+instance Demote 'Microseconds    where demote _ = Microseconds
+instance Demote 'Percentage100   where demote _ = Percentage100
+instance Demote 'Blocks          where demote _ = Blocks
+instance Demote 'BlocksPerSecond where demote _ = BlocksPerSecond

--- a/lib/src/Pos/Util/UnitsOfMeasure.hs
+++ b/lib/src/Pos/Util/UnitsOfMeasure.hs
@@ -80,9 +80,15 @@ instance (Demote u, FromJSON a) => FromJSON (MeasuredIn u a) where
         verifyUnit =<< o .: "unit"
         MeasuredIn <$> o .: "quantity"
       where
+        unitS = toString $ T.toStrict $ B.toLazyText $ build $ demote $ Proxy @u
         verifyUnit = \case
-            u@(String _) | u == toJSON (demote $ Proxy @u) -> pure ()
-            _ -> mempty
+            u@(String _) | u == toJSON (demote $ Proxy @u) ->
+                pure ()
+            _ ->
+                fail
+                $  "failed to parse quantified value. Expected value in '"
+                <> unitS <> "' but got something else. e.g.: "
+                <> "{ \"unit\": \"" <> unitS <> "\", \"quantity\": ...}"
 
 instance (Demote u, ToSchema a) => ToSchema (MeasuredIn u a) where
     declareNamedSchema _ = do

--- a/node/src/Cardano/Node/API.hs
+++ b/node/src/Cardano/Node/API.hs
@@ -259,10 +259,11 @@ getNodeSettings compileInfo updateConfiguration timestamp slottingVar ns = do
 
     slotId            <- liftIO $ getTipSlotId ns
     maxTxSize         <- liftIO $ getMaxTxSize ns
-    feePolicy         <- liftIO $ getFeePolicy ns
     securityParameter <- liftIO $ getSecurityParameter ns
     slotCount         <- liftIO $ getSlotCount ns
-
+    feePolicy         <- liftIO $ getFeePolicy ns >>= \case
+        Core.TxFeePolicyTxSizeLinear a -> return a
+        _ -> fail "getNodeSettings: Unsupported / Unknown fee policy."
 
     pure $ single NodeSettings
         { setSlotDuration =
@@ -278,7 +279,7 @@ getNodeSettings compileInfo updateConfiguration timestamp slottingVar ns = do
         , setMaxTxSize =
             mkMaxTxSize $ fromIntegral $ maxTxSize
         , setFeePolicy =
-            V1 feePolicy
+            fromCorePolicy feePolicy
         , setSecurityParameter =
              securityParameter
         , setSlotCount =

--- a/wallet/test/unit/API/MarshallingSpec.hs
+++ b/wallet/test/unit/API/MarshallingSpec.hs
@@ -34,7 +34,7 @@ import qualified Pos.Chain.Update as Core
 import qualified Pos.Core as Core
 import qualified Pos.Core.Attributes as Core
 import qualified Pos.Crypto as Core
-import           Pos.Node.API (SecurityParameter, SlotDuration)
+import qualified Pos.Node.API as Node
 
 import           Test.Pos.Chain.Block.Arbitrary ()
 import           Test.Pos.Core.Arbitrary ()
@@ -58,11 +58,12 @@ spec = describe "Marshalling & Unmarshalling" $ do
         aesonRoundtripProp @BackupPhrase Proxy
         aesonRoundtripProp @Redemption Proxy
         aesonRoundtripProp @(V1 Core.SoftwareVersion) Proxy
+        aesonRoundtripProp @(V1 Version) Proxy
         aesonRoundtripProp @(V1 Core.SlotId) Proxy
         aesonRoundtripProp @(V1 Core.SlotCount) Proxy
-        aesonRoundtripProp @SecurityParameter Proxy
-        aesonRoundtripProp @SlotDuration Proxy
-        aesonRoundtripProp @(V1 Core.TxFeePolicy) Proxy
+        aesonRoundtripProp @Node.SecurityParameter Proxy
+        aesonRoundtripProp @Node.SlotDuration Proxy
+        aesonRoundtripProp @Node.TxFeePolicy Proxy
         aesonRoundtripProp @Byte Proxy
         aesonRoundtripProp @NodeSettings Proxy
         aesonRoundtripProp @Payment Proxy


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

This leverages generics and type-classes to avoid re-writing the same stuff
all other the place. It provides an easy way to give unit for existing types
in the API.

In the meantime, I've also slightly refactored the TxFeePolicy to remove the 'tag' in favor of
allowing only linear fee to be returned. This is less flexible but that's also not something
we're likely to change in the next ... years or so.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [?] All new and existing tests passed. 

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

#### curl -k --cert ... https://localhost:8080/api/v1/node-settings

```json
{
  "slotId": {
    "slot": 8,
    "epoch": 2
  },
  "slotDuration": {
    "quantity": 7000,
    "unit": "milliseconds"
  },
  "slotCount": 20,
  "softwareInfo": {
    "version": 0,
    "applicationName": "cardano-sl"
  },
  "projectVersion": "2.0.0",
  "gitRevision": "1e04867bdb15e3642789e38860b0d253132d372a",
  "maxTxSize": {
    "quantity": 4096,
    "unit": "bytes"
  },
  "feePolicy": {
    "a": {
      "quantity": 155381,
      "unit": "lovelace/byte"
    },
    "b": {
      "quantity": 43.946,
      "unit": "lovelace"
    }
  },
  "securityParameter": 2
}
```

#### curl -k --cert ... https://localhost:8080/api/v1/node-info

```json
{
  "syncProgress": {
    "quantity": 100,
    "unit": "percent"
  },
  "blockchainHeight": {
    "quantity": 51,
    "unit": "blocks"
  },
  "localBlockchainHeight": {
    "quantity": 51,
    "unit": "blocks"
  },
  "localTimeInformation": {
    "differenceFromNtpServer": {
      "quantity": 2461,
      "unit": "microseconds"
    }
  },
  "subscriptionStatus": {}
}
```


## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

#### Schema for `/api/v1/node-settings`

![image](https://user-images.githubusercontent.com/5680256/51120355-2ecbd180-1815-11e9-86f3-b2361f1c36d7.png)

![image](https://user-images.githubusercontent.com/5680256/51120385-3b502a00-1815-11e9-9f15-80e80af69c0d.png)

#### Schema for `/api/v1/node-info`

![image](https://user-images.githubusercontent.com/5680256/51120314-1956a780-1815-11e9-9fc7-040d7dd37cec.png)


## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
