### PR TITLE
[CDEC-659] offline dns queries fixes

### DIFF
--- a/infra/src/Pos/Infra/Diffusion/Subscription/Dns.hs
+++ b/infra/src/Pos/Infra/Diffusion/Subscription/Dns.hs
@@ -51,7 +51,11 @@ dnsSubscriptionTarget logTrace timeoutError defaultPort addrs =
   where
 
     listTargets :: [NodeId] -> IO (Maybe (NodeId, SubscriptionTarget IO NodeId))
-    listTargets [] = getSubscriptionTarget (dnsSubscriptionTarget logTrace timeoutError defaultPort addrs)
+    listTargets [] = do
+      -- Wait 30s before another round; otherwise the node will exhaust
+      -- available opened file descriptors.
+      threadDelay 30000000
+      getSubscriptionTarget (dnsSubscriptionTarget logTrace timeoutError defaultPort addrs)
     listTargets (nodeId : nodeIds) = pure (Just (nodeId, SubscriptionTarget (listTargets nodeIds)))
 
     resolve :: IO [NodeId]

--- a/networking/src/Ntp/Util.hs
+++ b/networking/src/Ntp/Util.hs
@@ -151,7 +151,7 @@ resolveHost host = do
             }
     -- TBD why catch here? Why not let @'resolveHost'@ throw the exception?
     addrInfos <- Socket.getAddrInfo (Just hints) (Just host) Nothing
-                    `catch` (\(_ :: IOException) -> return [])
+                    `catch` (\(e :: IOException) -> logError (sformat ("getAddrInfo error: "%shown) e) >> return [])
 
     let maddr = getOption $ foldMap fn addrInfos
     case maddr of


### PR DESCRIPTION
## Description

This PR solves to problems, both when node starts without internet connection:
* dns queries reach a limit of open files: the rate in which `dnsSubscriptionTarget` runs is much higher than udp socket timeouts which would trigger closing the socket.  The solution is to retry resolving dns after a fixed 30s timeout after each unsuccessful loop.
* dns queries in the NtpClient did happen only on startup; now we retry after 30s

There are no tests, however this was easy to test manually and it fixes the original issue.

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/CDEC-659

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

Run a node with out internet connection.  Run `/api/v1/node-info?force_ntp_check` to see if it returns. Then connect to internet and query the `node-info` endpoint once again and see if the return value in `differenceFromNtpServer` is non null.

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
