### PR TITLE
[CBR-481/482] Add ObftConsensusStrictness data type

### DIFF
--- a/chain/src/Pos/Chain/Update/BlockVersionData.hs
+++ b/chain/src/Pos/Chain/Update/BlockVersionData.hs
@@ -3,6 +3,7 @@
 module Pos.Chain.Update.BlockVersionData
        ( BlockVersionData (..)
        , isBootstrapEraBVD
+       , ObftConsensusStrictness (..)
        , ConsensusEra (..)
        , consensusEraBVD
        ) where
@@ -130,14 +131,19 @@ isBootstrapEraBVD adoptedBVD = isBootstrapEra (bvdUnlockStakeEpoch adoptedBVD)
 obftEraFlagValue :: EpochIndex
 obftEraFlagValue = EpochIndex 9999999999999999999
 
-data ConsensusEra = Original | OBFT
-    deriving (Show)
+data ObftConsensusStrictness = ObftStrict | ObftLenient
+    deriving (Eq, Show, Generic)
+
+instance NFData ObftConsensusStrictness
+
+data ConsensusEra = Original | OBFT ObftConsensusStrictness
+    deriving (Eq, Show, Generic)
 
 -- | This function uses the repurposed field `bvdUnlockStakeEpoch` to
 -- tell us whether we are in the Original or OBFT consensus eras.
 consensusEraBVD :: BlockVersionData -> ConsensusEra
 consensusEraBVD bvd = if obftEraFlagValue == bvdUnlockStakeEpoch bvd
-                         then OBFT
+                         then OBFT ObftLenient
                          else Original
 
 deriveSimpleBi ''BlockVersionData [

--- a/chain/test/Test/Pos/Chain/Update/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Update/Arbitrary.hs
@@ -15,10 +15,12 @@ import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
 import           Pos.Chain.Update (BlockVersion (..), BlockVersionData (..),
-                     BlockVersionModifier, SoftforkRule (..), SystemTag (..),
-                     UpdateData (..), UpdatePayload (..), UpdateProposal,
-                     UpdateProposalToSign (..), UpdateVote (..),
-                     VoteState (..), mkUpdateProposalWSign, mkUpdateVote)
+                     BlockVersionModifier, ConsensusEra,
+                     ObftConsensusStrictness, SoftforkRule (..),
+                     SystemTag (..), UpdateData (..), UpdatePayload (..),
+                     UpdateProposal, UpdateProposalToSign (..),
+                     UpdateVote (..), VoteState (..), mkUpdateProposalWSign,
+                     mkUpdateVote)
 import           Pos.Core.Attributes (mkAttributes)
 import           Pos.Crypto (ProtocolMagic, fakeSigner)
 
@@ -41,6 +43,14 @@ instance Arbitrary BlockVersion where
     shrink = genericShrink
 
 instance Arbitrary BlockVersionModifier where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ConsensusEra where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ObftConsensusStrictness where
     arbitrary = genericArbitrary
     shrink = genericShrink
 


### PR DESCRIPTION
## Description

Adds a data type, `ObftConsensusStrictness` which will be utilized in `OBFT` block validation. 

- `ObftStrict` implies that we will validate blocks strictly according to the round-robin slot leader schedule.
- `ObftLenient` implies that we will follow the more lax rules under which any valid slot leader is able to mint a block given that `blocksMintedByLeaderInLastK < k * t` where `t` is some constant such that `1/5 <= t <= 1/4`.

## Linked issues

https://iohk.myjetbrains.com/youtrack/issue/CBR-481
https://iohk.myjetbrains.com/youtrack/issue/CBR-482

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.