### PR TITLE
[CBR-481/482] Add functionality for determining slot leaders during OBFT

### DIFF
--- a/chain/cardano-sl-chain.cabal
+++ b/chain/cardano-sl-chain.cabal
@@ -91,6 +91,7 @@ library
                        Pos.Chain.Txp.Undo
 
                        Pos.Chain.Lrc.Fts
+                       Pos.Chain.Lrc.OBFT
                        Pos.Chain.Lrc.Types
                        Pos.Chain.Lrc.Error
                        Pos.Chain.Lrc.Core

--- a/chain/cardano-sl-chain.cabal
+++ b/chain/cardano-sl-chain.cabal
@@ -254,6 +254,8 @@ test-suite chain-test
                        Test.Pos.Chain.Genesis.Gen
                        Test.Pos.Chain.Genesis.Json
                        Test.Pos.Chain.Lrc.FtsSpec
+                       Test.Pos.Chain.Lrc.ObftRoundRobinSpec
+                       Test.Pos.Chain.Lrc.StakeAndHolder
                        Test.Pos.Chain.Ssc.Arbitrary
                        Test.Pos.Chain.Ssc.Bi
                        Test.Pos.Chain.Ssc.CborSpec

--- a/chain/src/Pos/Chain/Genesis/Config.hs
+++ b/chain/src/Pos/Chain/Genesis/Config.hs
@@ -15,6 +15,7 @@ module Pos.Chain.Genesis.Config
        , configEpochSlots
        , configGeneratedSecretsThrow
        , configBootStakeholders
+       , configGenesisWStakeholders
        , configHeavyDelegation
        , configStartTime
        , configVssCerts
@@ -62,11 +63,11 @@ import           Pos.Chain.Genesis.ProtocolConstants
                      (GenesisProtocolConstants (..),
                      genesisProtocolConstantsToProtocolConstants)
 import           Pos.Chain.Genesis.Spec (GenesisSpec (..))
-import           Pos.Chain.Genesis.WStakeholders (GenesisWStakeholders)
+import           Pos.Chain.Genesis.WStakeholders (GenesisWStakeholders (..))
 import           Pos.Chain.Ssc.VssCertificatesMap (VssCertificatesMap)
 import           Pos.Chain.Txp.Tx (TxValidationRulesConfig)
 import           Pos.Chain.Update.BlockVersionData (BlockVersionData)
-import           Pos.Core.Common (BlockCount, SharedSeed)
+import           Pos.Core.Common (BlockCount, SharedSeed, StakeholderId)
 import           Pos.Core.ProtocolConstants (ProtocolConstants (..),
                      pcBlkSecurityParam, pcChainQualityThreshold, pcEpochSlots,
                      pcSlotSecurityParam, vssMaxTTL, vssMinTTL)
@@ -205,6 +206,10 @@ configGeneratedSecretsThrow =
 
 configBootStakeholders :: Config -> GenesisWStakeholders
 configBootStakeholders = gdBootStakeholders . configGenesisData
+
+configGenesisWStakeholders :: Config -> [StakeholderId]
+configGenesisWStakeholders =
+    keys . getGenesisWStakeholders . configBootStakeholders
 
 configHeavyDelegation :: Config -> GenesisDelegation
 configHeavyDelegation = gdHeavyDelegation . configGenesisData

--- a/chain/src/Pos/Chain/Lrc.hs
+++ b/chain/src/Pos/Chain/Lrc.hs
@@ -6,5 +6,6 @@ import           Pos.Chain.Lrc.Core as X
 import           Pos.Chain.Lrc.Error as X
 import           Pos.Chain.Lrc.Fts as X
 import           Pos.Chain.Lrc.Genesis as X
+import           Pos.Chain.Lrc.OBFT as X
 import           Pos.Chain.Lrc.RichmenComponent as X
 import           Pos.Chain.Lrc.Types as X

--- a/chain/src/Pos/Chain/Lrc/OBFT.hs
+++ b/chain/src/Pos/Chain/Lrc/OBFT.hs
@@ -1,0 +1,55 @@
+module Pos.Chain.Lrc.OBFT
+        ( getSlotLeaderObftPure
+        , getEpochSlotLeaderScheduleObftPure
+        ) where
+
+import           Universum hiding (sort)
+
+import           Data.List.NonEmpty ((!!))
+import qualified Data.List.NonEmpty as NE (iterate, sort, take)
+
+import           Pos.Core (EpochIndex, FlatSlotId, LocalSlotIndex (..),
+                     SlotCount (..), SlotId (..), SlotLeaders, StakeholderId,
+                     flattenEpochOrSlot, slotIdSucc)
+
+-- | Selects the StakeholderId that matches the @SlotId@ index in a
+-- @SlotCount@-length epoch.
+getSlotLeaderObftPure
+    :: SlotId
+    -> SlotCount
+    -> NonEmpty StakeholderId
+    -> StakeholderId
+getSlotLeaderObftPure slotId slotCount stakeholders =
+    sortedStakeholders !! leaderIndex
+  where
+    -- Ensure the stakeholders are sorted
+    sortedStakeholders :: NonEmpty StakeholderId
+    sortedStakeholders = NE.sort stakeholders
+    --
+    leaderIndex :: Int
+    leaderIndex = (fromIntegral flatSlotId :: Int) `mod` (length stakeholders)
+    --
+    flatSlotId :: FlatSlotId
+    flatSlotId = flattenEpochOrSlot slotCount slotId
+
+-- | Selects @SlotCount@ StakeholderIds for the given epoch @EpochIndex@.
+getEpochSlotLeaderScheduleObftPure
+    :: EpochIndex
+    -> SlotCount
+    -> NonEmpty StakeholderId
+    -> SlotLeaders
+getEpochSlotLeaderScheduleObftPure epochIndex epochSlotCount stakeholders =
+    case nonEmpty slotLeaderSchedule of
+        Just sls -> sls
+        Nothing  -> error "getEpochSlotLeaderScheduleObftPure: Empty slot leader schedule"
+  where
+    slotLeaderSchedule =
+        map (\si -> getSlotLeaderObftPure si epochSlotCount stakeholders)
+            (NE.take (fromIntegral $ numEpochSlots)
+                     (NE.iterate (slotIdSucc epochSlotCount) startSlotId))
+    --
+    startSlotId :: SlotId
+    startSlotId = SlotId epochIndex (UnsafeLocalSlotIndex 0)
+    --
+    numEpochSlots :: Word64
+    numEpochSlots = getSlotCount $ epochSlotCount

--- a/chain/test/Test/Pos/Chain/Lrc/FtsSpec.hs
+++ b/chain/test/Test/Pos/Chain/Lrc/FtsSpec.hs
@@ -10,21 +10,19 @@ module Test.Pos.Chain.Lrc.FtsSpec
 
 import           Universum
 
-import           Data.List (scanl1)
-import qualified Data.Set as S (deleteFindMin, fromList)
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (Arbitrary (..), Property, choose,
-                     infiniteListOf, suchThat, (===))
+import           Test.QuickCheck (Arbitrary (..), Property, infiniteListOf,
+                     (===))
 
 import           Pos.Chain.Lrc (followTheSatoshi)
-import           Pos.Core (Coin, SharedSeed, StakeholderId, StakesList,
-                     addressHash, mkCoin, pcK, sumCoins, unsafeAddCoin,
-                     unsafeIntegerToCoin)
+import           Pos.Core (Coin, SharedSeed, StakeholderId, addressHash, pcK,
+                     sumCoins, unsafeIntegerToCoin)
 import           Pos.Crypto (PublicKey)
 
 import           Test.Pos.Chain.Genesis.Dummy (dummyEpochSlots,
                      dummyProtocolConstants)
+import           Test.Pos.Chain.Lrc.StakeAndHolder (StakeAndHolder (..))
 import           Test.Pos.Core.Arbitrary ()
 import           Test.Pos.Util.QuickCheck.Property (qcNotElem)
 
@@ -69,33 +67,6 @@ spec = do
   highStakeTolerance (pLen, present, chosen) =
     acceptable present (1 - (1 - highStake) ^ pLen)
       && acceptable chosen highStake
-
--- | Type used to generate random stakes and a 'PublicKey' that
--- doesn't have any stake.
---
--- Two necessarily different public keys are generated, as well as a list of
--- public keys who will be our other stakeholders. To guarantee a non-empty
--- stakes map, one of these public keys is inserted in the list, which is
--- converted to a set and then to a map.
-newtype StakeAndHolder = StakeAndHolder
-    { getNoStake :: (PublicKey, StakesList)
-    } deriving Show
-
-instance Arbitrary StakeAndHolder where
-    arbitrary = StakeAndHolder <$> do
-        pk1 <- arbitrary
-        pk2 <- arbitrary `suchThat` ((/=) pk1)
-        listPks <- do
-            n <- choose (2, 10)
-            replicateM n arbitrary
-        coins <- mkCoin <$> choose (1, 1000)
-        let setPks :: Set PublicKey
-            setPks = S.fromList $ pk1 : pk2 : listPks
-            (myPk, restPks) = S.deleteFindMin setPks
-            nRest = length restPks
-            values = scanl1 unsafeAddCoin $ replicate nRest coins
-            stakesList = map addressHash (toList restPks) `zip` values
-        return (myPk, stakesList)
 
 ftsListLength
     :: SharedSeed

--- a/chain/test/Test/Pos/Chain/Lrc/ObftRoundRobinSpec.hs
+++ b/chain/test/Test/Pos/Chain/Lrc/ObftRoundRobinSpec.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Specification of Pos.Chain.Lrc.OBFT (which is basically a pure
+-- version of 'Pos.DB.Lrc.OBFT').
+
+module Test.Pos.Chain.Lrc.ObftRoundRobinSpec
+       ( spec
+       ) where
+
+import           Universum hiding (sort)
+
+import           Data.List.NonEmpty (sort, (!!))
+import           Test.Hspec (Spec, describe)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import           Test.QuickCheck (Property, (===))
+
+import           Pos.Chain.Lrc (getEpochSlotLeaderScheduleObftPure,
+                     getSlotLeaderObftPure)
+import           Pos.Core (EpochIndex, SlotCount, SlotId, flattenEpochOrSlot)
+
+import           Test.Pos.Chain.Lrc.StakeAndHolder (StakeAndHolder (..))
+import           Test.Pos.Core.Arbitrary (genPositiveSlotCount)
+
+spec :: Spec
+spec = do
+  describe "Pos.Chain.Lrc.OBFT" $ do
+    describe "Round-robin" $ do
+        modifyMaxSuccess (const 10000) $ do
+            prop description_rrListLength
+                 (rrListLength <$> genPositiveSlotCount)
+            prop description_rrCorrectSlotLeader
+                 (rrCorrectSlotLeader <$> genPositiveSlotCount)
+ where
+  description_rrListLength =
+    "the amount of stakeholders is the same as the number of slots in an epoch"
+  description_rrCorrectSlotLeader =
+    "the correct slot leader is chosen given any epoch and slot"
+
+rrListLength
+    :: SlotCount
+    -> EpochIndex
+    -> StakeAndHolder
+    -> Property
+rrListLength epochSlotCount epochIndex (getNoStake -> (_, stakes)) = do
+    length (getEpochSlotLeaderScheduleObftPure epochIndex epochSlotCount stakeholders)
+        === fromIntegral epochSlotCount
+  where
+    stakeholders = case nonEmpty (map fst stakes) of
+        Just s  -> s
+        Nothing -> error "rrListLength: Empty list of stakeholders"
+
+rrCorrectSlotLeader
+    :: SlotCount
+    -> SlotId
+    -> StakeAndHolder
+    -> Property
+rrCorrectSlotLeader epochSlotCount slotId (getNoStake -> (_, stakes)) = do
+    actualSlotLeader === expectedSlotLeader
+  where
+    stakeholders = case nonEmpty (map fst stakes) of
+        Just s  -> s
+        Nothing -> error "rrCorrectSlotLeader: Empty list of stakeholders"
+    flatSlotId = flattenEpochOrSlot epochSlotCount slotId
+    expectedSlotLeaderIndex =
+        (fromIntegral flatSlotId :: Int) `mod` (length stakeholders)
+    expectedSlotLeader = (sort stakeholders) !! expectedSlotLeaderIndex
+    actualSlotLeader = getSlotLeaderObftPure slotId epochSlotCount stakeholders

--- a/chain/test/Test/Pos/Chain/Lrc/StakeAndHolder.hs
+++ b/chain/test/Test/Pos/Chain/Lrc/StakeAndHolder.hs
@@ -1,0 +1,41 @@
+module Test.Pos.Chain.Lrc.StakeAndHolder
+       ( StakeAndHolder (..)
+       ) where
+
+import           Universum
+
+import           Data.List (scanl1)
+import qualified Data.Set as S (deleteFindMin, fromList)
+import           Test.QuickCheck (Arbitrary (..), choose, suchThat)
+
+import           Pos.Core (StakesList, addressHash, mkCoin, unsafeAddCoin)
+import           Pos.Crypto (PublicKey)
+
+import           Test.Pos.Core.Arbitrary ()
+
+-- | Type used to generate random stakes and a 'PublicKey' that
+-- doesn't have any stake.
+--
+-- Two necessarily different public keys are generated, as well as a list of
+-- public keys who will be our other stakeholders. To guarantee a non-empty
+-- stakes map, one of these public keys is inserted in the list, which is
+-- converted to a set and then to a map.
+newtype StakeAndHolder = StakeAndHolder
+    { getNoStake :: (PublicKey, StakesList)
+    } deriving Show
+
+instance Arbitrary StakeAndHolder where
+    arbitrary = StakeAndHolder <$> do
+        pk1 <- arbitrary
+        pk2 <- arbitrary `suchThat` ((/=) pk1)
+        listPks <- do
+            n <- choose (2, 10)
+            replicateM n arbitrary
+        coins <- mkCoin <$> choose (1, 1000)
+        let setPks :: Set PublicKey
+            setPks = S.fromList $ pk1 : pk2 : listPks
+            (myPk, restPks) = S.deleteFindMin setPks
+            nRest = length restPks
+            values = scanl1 unsafeAddCoin $ replicate nRest coins
+            stakesList = map addressHash (toList restPks) `zip` values
+        return (myPk, stakesList)

--- a/core/test/Test/Pos/Core/Arbitrary.hs
+++ b/core/test/Test/Pos/Core/Arbitrary.hs
@@ -20,6 +20,7 @@ module Test.Pos.Core.Arbitrary
        , UnreasonableEoS (..)
 
        , genAddress
+       , genPositiveSlotCount
        , genSlotId
        , genLocalSlotIndex
        ) where
@@ -98,6 +99,12 @@ deriving instance Arbitrary ChainDifficulty
 ----------------------------------------------------------------------------
 
 deriving instance Arbitrary SlotCount
+
+genPositiveSlotCount :: Gen SlotCount
+genPositiveSlotCount = do
+    let upperBound = 5000 -- no specific reason for using 5000
+    x <- choose (1, upperBound)
+    pure $ SlotCount x
 
 maxReasonableEpoch :: Integral a => a
 maxReasonableEpoch = 5 * 1000 * 1000 * 1000 * 1000  -- 5 * 10^12, because why not

--- a/db/cardano-sl-db.cabal
+++ b/db/cardano-sl-db.cabal
@@ -39,6 +39,7 @@ library
                        Pos.DB.Txp.Utxo
 
                        Pos.DB.Lrc
+                       Pos.DB.Lrc.OBFT
                        Pos.DB.Delegation
                        Pos.DB.Ssc
                        Pos.DB.Ssc.SecretStorage

--- a/db/src/Pos/DB/Lrc/Consumer/Delegation.hs
+++ b/db/src/Pos/DB/Lrc/Consumer/Delegation.hs
@@ -13,10 +13,15 @@ module Pos.DB.Lrc.Consumer.Delegation
        -- * Functions for getting richmen
        , getDlgRichmen
        , tryGetDlgRichmen
+       , getDlgRichmenObft
        ) where
 
 import           Universum
 
+import           Data.HashSet (fromList)
+
+import           Pos.Chain.Genesis (configGenesisWStakeholders)
+import           Pos.Chain.Genesis as Genesis (Config (..))
 import           Pos.Chain.Lrc (RichmenComponent (..), RichmenSet)
 import           Pos.Chain.Update (BlockVersionData (..))
 import           Pos.Core (EpochIndex)
@@ -70,3 +75,10 @@ getDlgRichmen genesisBvd fname epoch = lrcActionOnEpochReason
 tryGetDlgRichmen
     :: MonadDBRead m => BlockVersionData -> EpochIndex -> m (Maybe RichmenSet)
 tryGetDlgRichmen = getRichmen . dlgRichmenComponent
+
+-- | For OBFT, we retrieve the genesis stakeholders and classify them as the
+-- "richmen". We don't perform any LRC operations here.
+getDlgRichmenObft
+    :: Genesis.Config
+    -> RichmenSet
+getDlgRichmenObft = fromList . configGenesisWStakeholders

--- a/db/src/Pos/DB/Lrc/OBFT.hs
+++ b/db/src/Pos/DB/Lrc/OBFT.hs
@@ -1,16 +1,16 @@
 module Pos.DB.Lrc.OBFT
        ( getSlotLeaderObft
+       , getEpochSlotLeaderScheduleObft
        ) where
 
 import           Universum
 
-import qualified Data.Map as M (toList)
 import           Pos.Chain.Delegation (ProxySKBlockInfo)
-import           Pos.Chain.Genesis (GenesisData (..), GenesisWStakeholders (..))
+import           Pos.Chain.Genesis (configGenesisWStakeholders)
 import qualified Pos.Chain.Genesis as Genesis (Config (..))
-import           Pos.Core (FlatSlotId, SlotId, StakeholderId, addressHash,
-                     flattenEpochOrSlot, pcEpochSlots)
-import           Pos.Crypto (ProxySecretKey (..))
+import           Pos.Core (EpochIndex, FlatSlotId, LocalSlotIndex (..),
+                     SlotCount (..), SlotId (..), SlotLeaders, StakeholderId,
+                     flattenEpochOrSlot, pcEpochSlots, slotIdSucc)
 import           Pos.DB (MonadDBRead)
 import           Pos.DB.Delegation (getDlgTransPsk)
 
@@ -19,28 +19,18 @@ import           UnliftIO (MonadUnliftIO)
 
 -- | This function selects the current slot leaders by obtaining the
 -- genesis stakeholders, then tracing them through the delegation
--- mapping. If a genesis stakeholder delegated to another stakeholder,
--- we return the delegatee's id. If the genesis stakeholder did not
--- delegate, we return their id.
+-- mapping.
 getSlotLeaderObft
     :: (MonadDBRead m, MonadUnliftIO m)
     => Genesis.Config -> SlotId -> m (StakeholderId, ProxySKBlockInfo)
 getSlotLeaderObft genesisConfig si = do
     mDlg <- getDlgTransPsk currentSlotGenesisSId
-    case mDlg of
-        Just (_, UnsafeProxySecretKey { pskDelegatePk = delegateePk }) ->
-            pure ((addressHash delegateePk), (swap <$> mDlg))
-        Nothing -> pure (currentSlotGenesisSId, Nothing)
+    pure (currentSlotGenesisSId, (swap <$> mDlg))
   where
     -- We assume here that the genesis bootstrap stakeholders list
     -- is nonempty
     stakeholders :: [StakeholderId]
-    stakeholders = sort $
-                    map fst $
-                    M.toList $
-                    getGenesisWStakeholders $
-                    gdBootStakeholders $
-                    Genesis.configGenesisData genesisConfig
+    stakeholders = sort $ configGenesisWStakeholders genesisConfig
     --
     flatSlotId :: FlatSlotId
     flatSlotId =
@@ -53,3 +43,21 @@ getSlotLeaderObft genesisConfig si = do
     --
     currentSlotGenesisSId :: StakeholderId
     currentSlotGenesisSId = stakeholders !! leaderIndex
+
+-- | Generates the full slot leader schedule for an epoch (10*k slots long).
+getEpochSlotLeaderScheduleObft
+    :: (MonadDBRead m, MonadUnliftIO m)
+    => Genesis.Config -> EpochIndex -> m SlotLeaders
+getEpochSlotLeaderScheduleObft genesisConfig ei = do
+    leaders <-
+        map fst
+            <$> mapM (getSlotLeaderObft genesisConfig)
+                     (take (fromIntegral $ epochSlotCount)
+                           (iterate (slotIdSucc epochSlots) startSlotId))
+    case nonEmpty leaders of
+        Just l  -> pure l
+        Nothing -> error "getEpochSlotLeaderScheduleObft: Empty list of leaders"
+  where
+    startSlotId = SlotId ei (UnsafeLocalSlotIndex 0)
+    epochSlots = pcEpochSlots (Genesis.configProtocolConstants genesisConfig)
+    epochSlotCount = getSlotCount $ epochSlots

--- a/db/src/Pos/DB/Lrc/OBFT.hs
+++ b/db/src/Pos/DB/Lrc/OBFT.hs
@@ -1,0 +1,55 @@
+module Pos.DB.Lrc.OBFT
+       ( getSlotLeaderObft
+       ) where
+
+import           Universum
+
+import qualified Data.Map as M (toList)
+import           Pos.Chain.Delegation (ProxySKBlockInfo)
+import           Pos.Chain.Genesis (GenesisData (..), GenesisWStakeholders (..))
+import qualified Pos.Chain.Genesis as Genesis (Config (..))
+import           Pos.Core (FlatSlotId, SlotId, StakeholderId, addressHash,
+                     flattenEpochOrSlot, pcEpochSlots)
+import           Pos.Crypto (ProxySecretKey (..))
+import           Pos.DB (MonadDBRead)
+import           Pos.DB.Delegation (getDlgTransPsk)
+
+import           Data.List ((!!))
+import           UnliftIO (MonadUnliftIO)
+
+-- | This function selects the current slot leaders by obtaining the
+-- genesis stakeholders, then tracing them through the delegation
+-- mapping. If a genesis stakeholder delegated to another stakeholder,
+-- we return the delegatee's id. If the genesis stakeholder did not
+-- delegate, we return their id.
+getSlotLeaderObft
+    :: (MonadDBRead m, MonadUnliftIO m)
+    => Genesis.Config -> SlotId -> m (StakeholderId, ProxySKBlockInfo)
+getSlotLeaderObft genesisConfig si = do
+    mDlg <- getDlgTransPsk currentSlotGenesisSId
+    case mDlg of
+        Just (_, UnsafeProxySecretKey { pskDelegatePk = delegateePk }) ->
+            pure ((addressHash delegateePk), (swap <$> mDlg))
+        Nothing -> pure (currentSlotGenesisSId, Nothing)
+  where
+    -- We assume here that the genesis bootstrap stakeholders list
+    -- is nonempty
+    stakeholders :: [StakeholderId]
+    stakeholders = sort $
+                    map fst $
+                    M.toList $
+                    getGenesisWStakeholders $
+                    gdBootStakeholders $
+                    Genesis.configGenesisData genesisConfig
+    --
+    flatSlotId :: FlatSlotId
+    flatSlotId =
+        flattenEpochOrSlot (pcEpochSlots (Genesis.configProtocolConstants
+                                              genesisConfig))
+                           si
+    --
+    leaderIndex :: Int
+    leaderIndex = (fromIntegral flatSlotId :: Int) `mod` (length stakeholders)
+    --
+    currentSlotGenesisSId :: StakeholderId
+    currentSlotGenesisSId = stakeholders !! leaderIndex


### PR DESCRIPTION
## Description

Adds functionality for determining slot leaders and richmen during the OBFT era. Also adds a test `ObftRoundRobinSpec` which introduces a couple of property tests pertaining to the OBFT round-robin slot leader schedule. 

_Note: This PR does not actually modify block generation or validation code. It only introduces the functions which will be utilized in upcoming PRs._

## Linked issues

https://iohk.myjetbrains.com/youtrack/issue/CBR-481
https://iohk.myjetbrains.com/youtrack/issue/CBR-482

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [~] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.