### PR TITLE
[DEVOPS-1203] configuration.yaml: Bump applicationVersion

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14984,7 +14984,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 19
+    applicationVersion: 20
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14994,7 +14994,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 19
+    applicationVersion: 20
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -15004,7 +15004,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 19
+    applicationVersion: 20
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14945,7 +14945,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 6
+    applicationVersion: 7
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14945,7 +14945,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 5
+    applicationVersion: 6
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0
@@ -14984,7 +14984,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 20
+    applicationVersion: 21
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14994,7 +14994,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 20
+    applicationVersion: 21
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -15004,7 +15004,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 20
+    applicationVersion: 21
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14945,7 +14945,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 7
+    applicationVersion: 8
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14851,7 +14851,7 @@ mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14861,7 +14861,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14871,7 +14871,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 11
+    applicationVersion: 12
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14945,7 +14945,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 4
+    applicationVersion: 5
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0
@@ -14984,7 +14984,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14994,7 +14994,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -15004,7 +15004,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 18
+    applicationVersion: 19
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14851,7 +14851,7 @@ mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 12
+    applicationVersion: 13
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14861,7 +14861,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 12
+    applicationVersion: 13
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14871,7 +14871,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 12
+    applicationVersion: 13
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1


### PR DESCRIPTION
## Description

These are cherry-picks of applicationVersion bumps from the release branch, plus an increment of mainnet to the next un-proposed version.

https://github.com/input-output-hk/internal-documentation/wiki/Daedalus-installer-history

## Linked issue

https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1203

## Type of change
- Configuration
