### PR TITLE
[DEVOPS-1131] script-runner: runtime core node count configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Support for (unused) addresses batch import ([CO-448](https://iohk.myjetbrains.com/youtrack/issue/CO-448) [#4040](https://github.com/input-output-hk/cardano-sl/pull/4040))
+- Add `script-runner` tool to automate cluster-level testing ([DEVOPS-1131](https://iohk.myjetbrains.com/youtrack/v2/issue/devops-1131): [#3916](https://github.com/input-output-hk/cardano-sl/pull/3916) [#4057](https://github.com/input-output-hk/cardano-sl/pull/4057))
 
 
 ## Cardano SL 2.0.1

--- a/script-runner/common/NodeControl.hs
+++ b/script-runner/common/NodeControl.hs
@@ -36,7 +36,7 @@ import           Pos.Util.Wlog (logInfo, logWarning)
 import           System.Posix.Signals
 import           System.Process
 import           Types
-import           Universum hiding (on, state, when)
+import           Universum
 
 data NodeInfo = NodeInfo
             { niIndex       :: Integer
@@ -189,8 +189,8 @@ mutateConfigurationYaml filepath key mutator = do
     yaml = Y.encode newmap
   pure yaml
 
-createNodes :: Todo -> ScriptRunnerOptions -> PocMode ()
-createNodes todo opts = do
+createNodes :: ScriptRuntimeParams -> ScriptRunnerOptions -> PocMode ()
+createNodes srp opts = do
   topo <- view acTopology
   stateDir <- view acStatePath
   let
@@ -200,7 +200,8 @@ createNodes todo opts = do
   liftIO $ do
     BSL.writeFile (T.unpack path) (A.encode topo)
     keygen (cfg ^. CLI.configurationOptions_L)  stateDir
-  forM_ (range (0,todoCoreNodes todo - 1)) $ \node -> startNode (NodeInfo node Core stateDir path cfg)
+  forM_ (range (0, srpCoreNodes srp - 1)) $
+    \node -> startNode (NodeInfo (fromIntegral node) Core stateDir path cfg)
   forM_ (range (0,0)) $ \node -> startNode (NodeInfo node Relay stateDir path cfg)
 
 cleanupNodes :: PocMode ()

--- a/script-runner/common/Types.hs
+++ b/script-runner/common/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module Types (NodeHandle(..), NodeType(..), ScriptRunnerOptions(..), ScriptRunnerUIMode(..), srCommonNodeArgs, srPeers, srUiMode, Todo(..)) where
+module Types (NodeHandle(..), NodeType(..), ScriptRunnerOptions(..), ScriptRunnerUIMode(..), srCommonNodeArgs, srPeers, srUiMode, ScriptRuntimeParams(..)) where
 
 import           Control.Concurrent.Async.Lifted.Safe
 import           Control.Lens (makeLenses)
@@ -24,6 +24,6 @@ data ScriptRunnerOptions = ScriptRunnerOptions
 makeLenses ''ScriptRunnerOptions
 
 -- todo, extract this metadata out of the Configuration type
-data Todo = Todo {
-    todoCoreNodes :: Integer
+data ScriptRuntimeParams = ScriptRuntimeParams {
+    srpCoreNodes :: Integer
   } deriving Show

--- a/script-runner/stack-test
+++ b/script-runner/stack-test
@@ -20,15 +20,18 @@ LOGCFG=$(realpath ./log-config.yaml)
 TOPO=$(realpath ./topology-local.yaml)
 POLFILE=$(realpath ../scripts/policies/policy_script-runner.yaml)
 
-if [ -z "$ALT_MKTEMP" ]; then
-  T=$(mktemp -d -t . testrun-XXXXXX)
-else
+if [ -z $ALT_MKTEMP ]; then
+  # non-darwin
   T=$(mktemp -d -p . testrun-XXXXXX)
+else
+  # darwin
+  T=$(mktemp -d -t testrun)
 fi
 
+echo "Temp directory: $T"
 cd $T
 mkdir poc-state
 
 testcases --configuration-file $CFG --log-console-off --db-path poc-state/db --keyfile secret.key --log-config $LOGCFG --logs-prefix poc-state/logs --topology $TOPO --no-brickui --policies $POLFILE
 
-egrep -r --color=always "Processing of proposal|We'll request data for key Tagged|Ignoring data|Proposal .* is confirmed" relay-stdout-0
+egrep -r --color=always "Processing of proposal|We'll request data for key Tagged|Ignoring data|Proposal .* is confirmed" poc-state/relay-stdout-0


### PR DESCRIPTION
## Description

Pull the `richmen:` key-ed value from `lib/configuration.yaml` and
use that to determine the cluster size at runtime.

## Linked issue

https://iohk.myjetbrains.com/youtrack/v2/issue/devops-1131

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.
* Existing tests should handle this change.

## QA Steps
`./script-runner/stack-test test4.2`

## How to merge

Send the message `bors r+` to merge this PR. For more information, see [`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).