### PR TITLE
[CBR-481] Implement OBFT block validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 ### Features
 
 - Support for (unused) addresses batch import ([CO-448](https://iohk.myjetbrains.com/youtrack/issue/CO-448) [#4040](https://github.com/input-output-hk/cardano-sl/pull/4040))
-- Add `script-runner` tool to automate cluster-level testing ([DEVOPS-1131](https://iohk.myjetbrains.com/youtrack/v2/issue/devops-1131): [#3916](https://github.com/input-output-hk/cardano-sl/pull/3916) [#4057](https://github.com/input-output-hk/cardano-sl/pull/4057) [#4061](https://github.com/input-output-hk/cardano-sl/pull/4061))
+
+- Add `script-runner` tool to automate cluster-level testing ([DEVOPS-1131](https://iohk.myjetbrains.com/youtrack/v2/issue/devops-1131): [#3916](https://github.com/input-output-hk/cardano-sl/pull/3916) [#4057](https://github.com/input-output-hk/cardano-sl/pull/4057))
 
 - Node Monitoring API: nodes now serve their own settings and info via a web server via a `/api/v1/node-settings` and `/api/v1/node-info` (still proxied by the wallet backend) ([#110](https://github.com/input-output-hk/cardano-wallet/issues/110))
   - Set up scaffolding for node API [#3788](https://github.com/input-output-hk/cardano-sl/pull/3788)
@@ -35,6 +36,11 @@
     - `feePolicy`: The fee policy, in flat Lovelace and variable Lovelace/byte
     - `securityParameter`: The consensus security parameter (usually referred as `k` in the papers)
 
+- Implement block creation and validation for the OBFT `ConsensusEra`.
+    - Adapt epoch consolidation functionality for OBFT ([CBR-497](https://iohk.myjetbrains.com/youtrack/issue/CBR-497) [#3966](https://github.com/input-output-hk/cardano-sl/pull/3966))
+    - Extend `LastBlkSlots` data type and storage for OBFT ([CBR-499](https://iohk.myjetbrains.com/youtrack/issue/CBR-499) [#4003](https://github.com/input-output-hk/cardano-sl/pull/4003) [#4052](https://github.com/input-output-hk/cardano-sl/pull/4052))
+    - Disable SSC during OBFT. ([CBR-490](https://iohk.myjetbrains.com/youtrack/issue/CBR-490) [#4026](https://github.com/input-output-hk/cardano-sl/pull/4026))
+    - Implement OBFT block validation ([CBR-481](https://iohk.myjetbrains.com/youtrack/issue/CBR-481) [#4018](https://github.com/input-output-hk/cardano-sl/pull/4018) [#4029](https://github.com/input-output-hk/cardano-sl/pull/4029) [#4059](https://github.com/input-output-hk/cardano-sl/pull/4059))
 
 ### Improvements
 

--- a/chain/src/Pos/Chain/Block/Logic/Integrity.hs
+++ b/chain/src/Pos/Chain/Block/Logic/Integrity.hs
@@ -83,6 +83,8 @@ verifyFromEither :: Text -> Either Text b -> VerificationRes
 verifyFromEither txt (Left reason) = verifyGeneric [(False, txt <> ": " <> reason)]
 verifyFromEither txt (Right _)     = verifyGeneric [(True, txt)]
 
+{-# ANN verifyHeader ("HLint: ignore Reduce duplication" :: Text) #-}
+
 -- CHECK: @verifyHeader
 -- | Check some predicates (determined by 'VerifyHeaderParams') about
 -- 'BlockHeader'.

--- a/chain/src/Pos/Chain/Block/Slog/Types.hs
+++ b/chain/src/Pos/Chain/Block/Slog/Types.hs
@@ -46,6 +46,8 @@ instance Buildable LastSlotInfo where
         bprint ( "LastSlotInfo "% int %" "% string)
             i (take 16 . BS.unpack . B16.encode $ CC.xpubPublicKey pk)
 
+instance NFData LastSlotInfo
+
 -- | This type contains 'FlatSlotId's of the blocks whose depth is
 -- less than 'blkSecurityParam'. 'FlatSlotId' is chosen in favor of
 -- 'SlotId', because the main use case is chain quality calculation,

--- a/chain/src/Pos/Chain/Block/Slog/Types.hs
+++ b/chain/src/Pos/Chain/Block/Slog/Types.hs
@@ -5,6 +5,8 @@ module Pos.Chain.Block.Slog.Types
        , LastSlotInfo (..)
        , noLastBlkSlots
 
+       , ConsensusEraLeaders (..)
+
        , SlogGState (..)
        , HasSlogGState (..)
 
@@ -27,8 +29,9 @@ import qualified Formatting.Buildable as Buildable
 import           System.Metrics.Label (Label)
 
 import           Pos.Binary.Class (Cons (..), Field (..), deriveSimpleBi)
-import           Pos.Core (ChainDifficulty, EpochIndex, FlatSlotId,
-                     LocalSlotIndex, SlotCount, slotIdF, unflattenSlotId)
+import           Pos.Core (BlockCount, ChainDifficulty, EpochIndex, FlatSlotId,
+                     LocalSlotIndex, SlotCount, SlotLeaders, StakeholderId,
+                     slotIdF, unflattenSlotId)
 import           Pos.Core.Chrono (OldestFirst (..))
 import           Pos.Core.Reporting (MetricMonitorState)
 import           Pos.Crypto (PublicKey (..))
@@ -59,6 +62,10 @@ type LastBlkSlots = OldestFirst [] LastSlotInfo
 
 noLastBlkSlots :: LastBlkSlots
 noLastBlkSlots = OldestFirst []
+
+data ConsensusEraLeaders = OriginalLeaders SlotLeaders
+                         | ObftStrictLeaders SlotLeaders
+                         | ObftLenientLeaders (Set StakeholderId) BlockCount LastBlkSlots
 
 -- | In-memory representation of Slog (aka BlockExtra) part of
 -- GState. Note that it contains only part of BlockExtra.

--- a/chain/src/Pos/Chain/Block/Slog/Types.hs
+++ b/chain/src/Pos/Chain/Block/Slog/Types.hs
@@ -66,6 +66,9 @@ noLastBlkSlots = OldestFirst []
 data ConsensusEraLeaders = OriginalLeaders SlotLeaders
                          | ObftStrictLeaders SlotLeaders
                          | ObftLenientLeaders (Set StakeholderId) BlockCount LastBlkSlots
+                         deriving (Eq, Show, Generic)
+
+instance NFData ConsensusEraLeaders
 
 -- | In-memory representation of Slog (aka BlockExtra) part of
 -- GState. Note that it contains only part of BlockExtra.

--- a/chain/src/Pos/Chain/Update/BlockVersionData.hs
+++ b/chain/src/Pos/Chain/Update/BlockVersionData.hs
@@ -140,6 +140,8 @@ instance NFData ObftConsensusStrictness
 data ConsensusEra = Original | OBFT ObftConsensusStrictness
     deriving (Eq, Show, Generic)
 
+instance NFData ConsensusEra
+
 -- | This function uses the repurposed field `bvdUnlockStakeEpoch` to
 -- tell us whether we are in the Original or OBFT consensus eras.
 consensusEraBVD :: BlockVersionData -> ConsensusEra

--- a/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
@@ -467,6 +467,7 @@ genHeaderAndParams pm era = do
             , Block.vhpMaxSize = Just (biSize header)
             , Block.vhpVerifyNoUnknown = not hasUnknownAttributes
             , Block.vhpConsensusEra = era
+            , Block.vhpLastBlkSlotsAndK = Nothing
             }
     return . HAndP $ (params, header)
 

--- a/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
@@ -26,8 +26,8 @@ import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable as Buildable
 import qualified Prelude
 import           System.Random (Random, mkStdGen, randomR)
-import           Test.QuickCheck (Arbitrary (..), Gen, choose, suchThat,
-                     vectorOf)
+import           Test.QuickCheck (Arbitrary (..), Gen, choose, elements,
+                     suchThat, vectorOf)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
@@ -36,6 +36,7 @@ import           Pos.Chain.Block (HeaderHash, mkMainBlock, mkMainBlockExplicit)
 import qualified Pos.Chain.Block as Block
 import qualified Pos.Chain.Delegation as Core
 import           Pos.Chain.Genesis (GenesisHash (..))
+import           Pos.Chain.Update (ConsensusEra (..))
 import           Pos.Core (localSlotIndexMaxBound, localSlotIndexMinBound)
 import qualified Pos.Core as Core
 import           Pos.Core.Attributes (areAttributesKnown)
@@ -409,6 +410,7 @@ genHeaderAndParams pm = do
     -- the header chain. This ensures different parts of it are chosen
     -- each time.
     skip <- choose (0, num - 1)
+    era <- genConsensusEra
     let atMost2HeadersAndLeaders = take 2 $ drop skip headers
         (prev, header) =
             case atMost2HeadersAndLeaders of
@@ -457,6 +459,7 @@ genHeaderAndParams pm = do
             , Block.vhpLeaders = nonEmpty $ map Core.addressHash thisHeadersEpoch
             , Block.vhpMaxSize = Just (biSize header)
             , Block.vhpVerifyNoUnknown = not hasUnknownAttributes
+            , Block.vhpConsensusEra = era
             }
     return . HAndP $ (params, header)
 
@@ -466,3 +469,9 @@ genHeaderAndParams pm = do
 -- list.
 instance Arbitrary HeaderAndParams where
     arbitrary = arbitrary >>= genHeaderAndParams
+
+-- TODO mhueschen | decide: should we generate both?
+genConsensusEra :: Gen ConsensusEra
+genConsensusEra = do
+    obftStrictness <- arbitrary
+    elements [Original, OBFT obftStrictness]

--- a/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
@@ -26,8 +26,8 @@ import           Formatting (bprint, build, (%))
 import qualified Formatting.Buildable as Buildable
 import qualified Prelude
 import           System.Random (Random, mkStdGen, randomR)
-import           Test.QuickCheck (Arbitrary (..), Gen, choose, elements,
-                     suchThat, vectorOf)
+import           Test.QuickCheck (Arbitrary (..), Gen, choose, suchThat,
+                     vectorOf)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary,
                      genericShrink)
 
@@ -281,6 +281,7 @@ instance Show BlockHeaderList where
 --     genesis kind.
 recursiveHeaderGen
     :: ProtocolMagic
+    -> ConsensusEra
     -> GenesisHash
     -> Bool -- ^ Whether to create genesis block before creating main block for 0th slot
     -> [Either SecretKey (SecretKey, SecretKey)]
@@ -288,20 +289,21 @@ recursiveHeaderGen
     -> [Block.BlockHeader]
     -> Gen [Block.BlockHeader]
 recursiveHeaderGen pm
+                   era
                    gHash
                    genesis
                    (eitherOfLeader : leaders)
                    (Core.SlotId{..} : rest)
                    blockchain
-    | genesis && Core.getSlotIndex siSlot == 0 = do
+    | genesis && era == Original && Core.getSlotIndex siSlot == 0 = do
           gBody <- arbitrary
           let pHeader = maybe (Left gHash) Right ((fmap fst . uncons) blockchain)
               gHeader = Block.BlockHeaderGenesis $ Block.mkGenesisHeader pm pHeader siEpoch gBody
           mHeader <- genMainHeader (Just gHeader)
-          recursiveHeaderGen pm gHash True leaders rest (mHeader : gHeader : blockchain)
+          recursiveHeaderGen pm era gHash True leaders rest (mHeader : gHeader : blockchain)
     | otherwise = do
           curHeader <- genMainHeader ((fmap fst . uncons) blockchain)
-          recursiveHeaderGen pm gHash True leaders rest (curHeader : blockchain)
+          recursiveHeaderGen pm era gHash True leaders rest (curHeader : blockchain)
   where
     genMainHeader prevHeader = do
         body <- arbitrary
@@ -319,8 +321,8 @@ recursiveHeaderGen pm
                     in (delegateSK, Just proxy)
         pure $ Block.BlockHeaderMain $
             Block.mkMainHeader pm (maybe (Left gHash) Right prevHeader) slotId leader proxySK body extraHData
-recursiveHeaderGen _ _ _ [] _ b = return b
-recursiveHeaderGen _ _ _ _ [] b = return b
+recursiveHeaderGen _ _ _ _ [] _ b = return b
+recursiveHeaderGen _ _ _ _ _ [] b = return b
 
 
 -- | Maximum start epoch in block header verification tests
@@ -349,25 +351,30 @@ bhlEpochs = 2
 -- Note that a leader is generated for each slot.
 -- (Not exactly a leader - see previous comment)
 instance Arbitrary BlockHeaderList where
-    arbitrary = arbitrary >>= genStubbedBHL
+    arbitrary = do
+        pm <- arbitrary
+        era <- arbitrary
+        genStubbedBHL pm era
 
 genStubbedBHL
     :: ProtocolMagic
+    -> ConsensusEra
     -> Gen BlockHeaderList
-genStubbedBHL pm = do
+genStubbedBHL pm era = do
     incompleteEpochSize <- choose (1, dummyEpochSlots - 1)
     let slot = Core.SlotId 0 localSlotIndexMinBound
-    generateBHL pm dummyGenesisHash True slot (dummyEpochSlots * bhlEpochs + incompleteEpochSize)
+    generateBHL pm era dummyGenesisHash True slot (dummyEpochSlots * bhlEpochs + incompleteEpochSize)
 
 generateBHL
     :: ProtocolMagic
+    -> ConsensusEra
     -> GenesisHash
     -> Bool         -- ^ Whether to create genesis block before creating main
                     --    block for 0th slot
     -> Core.SlotId     -- ^ Start slot
     -> Core.SlotCount  -- ^ Slot count
     -> Gen BlockHeaderList
-generateBHL pm gHash createInitGenesis startSlot slotCount = BHL <$> do
+generateBHL pm era gHash createInitGenesis startSlot slotCount = BHL <$> do
     let correctLeaderGen :: Gen (Either SecretKey (SecretKey, SecretKey))
         correctLeaderGen =
             -- We don't want to create blocks with self-signed psks
@@ -383,6 +390,7 @@ generateBHL pm gHash createInitGenesis startSlot slotCount = BHL <$> do
     (, actualLeaders) <$>
         recursiveHeaderGen
             pm
+            era
             gHash
             createInitGenesis
             leadersList
@@ -398,19 +406,18 @@ newtype HeaderAndParams = HAndP
     { getHAndP :: (Block.VerifyHeaderParams, Block.BlockHeader)
     } deriving (Eq, Show)
 
-genHeaderAndParams :: ProtocolMagic -> Gen HeaderAndParams
-genHeaderAndParams pm = do
+genHeaderAndParams :: ProtocolMagic -> ConsensusEra -> Gen HeaderAndParams
+genHeaderAndParams pm era = do
     -- This integer is used as a seed to randomly choose a slot down below
     seed <- arbitrary :: Gen Int
     startSlot <- Core.SlotId <$> choose (0, bhlMaxStartingEpoch) <*> arbitrary
     (headers, leaders) <- first reverse . getHeaderList <$>
-        (generateBHL pm dummyGenesisHash True startSlot =<< choose (1, 2))
+        (generateBHL pm era dummyGenesisHash True startSlot =<< choose (1, 2))
     let num = length headers
     -- 'skip' is the random number of headers that should be skipped in
     -- the header chain. This ensures different parts of it are chosen
     -- each time.
     skip <- choose (0, num - 1)
-    era <- genConsensusEra
     let atMost2HeadersAndLeaders = take 2 $ drop skip headers
         (prev, header) =
             case atMost2HeadersAndLeaders of
@@ -468,10 +475,7 @@ genHeaderAndParams pm = do
 -- type, so it is used here and at most 3 blocks are taken from the generated
 -- list.
 instance Arbitrary HeaderAndParams where
-    arbitrary = arbitrary >>= genHeaderAndParams
-
--- TODO mhueschen | decide: should we generate both?
-genConsensusEra :: Gen ConsensusEra
-genConsensusEra = do
-    obftStrictness <- arbitrary
-    elements [Original, OBFT obftStrictness]
+    arbitrary = do
+        pm <- arbitrary
+        era <- arbitrary
+        genHeaderAndParams pm era

--- a/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
+++ b/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
@@ -27,7 +27,7 @@ import           Pos.Chain.Block (BlockHeader (..), BlockSignature (..),
 import qualified Pos.Chain.Block as Block
 import           Pos.Chain.Delegation (HeavyDlgIndex (..))
 import           Pos.Chain.Genesis (GenesisHash (..))
-import           Pos.Chain.Update (ConsensusEra)
+import           Pos.Chain.Update (ConsensusEra (..))
 import           Pos.Core (EpochIndex (..), SlotId (..), difficultyL)
 import           Pos.Core.Attributes (mkAttributes)
 import           Pos.Core.Chrono (NewestFirst (..))
@@ -157,16 +157,16 @@ mainHeaderFormation pm prevHeader slotId signer body extra =
 -- GenesisBlock ∪ MainBlock
 ----------------------------------------------------------------------------
 
-validateGoodMainHeader :: ProtocolMagic -> Gen Bool
-validateGoodMainHeader pm = do
-    (BT.getHAndP -> (params, header)) <- BT.genHeaderAndParams pm
+validateGoodMainHeader :: ProtocolMagic -> ConsensusEra -> Gen Bool
+validateGoodMainHeader pm era = do
+    (BT.getHAndP -> (params, header)) <- BT.genHeaderAndParams pm era
     pure $ isVerSuccess $ Block.verifyHeader pm params header
 
 -- FIXME should sharpen this test to ensure that it fails with the expected
 -- reason.
-validateBadProtocolMagicMainHeader :: ProtocolMagic -> Gen Bool
-validateBadProtocolMagicMainHeader pm = do
-    (BT.getHAndP -> (params, header)) <- BT.genHeaderAndParams pm
+validateBadProtocolMagicMainHeader :: ProtocolMagic -> ConsensusEra -> Gen Bool
+validateBadProtocolMagicMainHeader pm era = do
+    (BT.getHAndP -> (params, header)) <- BT.genHeaderAndParams pm era
     let protocolMagicId' = ProtocolMagicId (getProtocolMagic pm + 1)
         header' = case header of
             BlockHeaderGenesis h -> BlockHeaderGenesis (h & gbhProtocolMagicId .~ protocolMagicId')
@@ -175,5 +175,5 @@ validateBadProtocolMagicMainHeader pm = do
 
 validateGoodHeaderChain :: ProtocolMagic -> ConsensusEra -> Gen Bool
 validateGoodHeaderChain pm era = do
-    BT.BHL (l, _) <- BT.genStubbedBHL pm
+    BT.BHL (l, _) <- BT.genStubbedBHL pm era
     pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing (NewestFirst l)

--- a/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
+++ b/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
@@ -27,6 +27,7 @@ import           Pos.Chain.Block (BlockHeader (..), BlockSignature (..),
 import qualified Pos.Chain.Block as Block
 import           Pos.Chain.Delegation (HeavyDlgIndex (..))
 import           Pos.Chain.Genesis (GenesisHash (..))
+import           Pos.Chain.Update (ConsensusEra)
 import           Pos.Core (EpochIndex (..), SlotId (..), difficultyL)
 import           Pos.Core.Attributes (mkAttributes)
 import           Pos.Core.Chrono (NewestFirst (..))
@@ -65,9 +66,10 @@ spec = describe "Block properties" $ modifyMaxSuccess (min 20) $ do
     emptyHeaderChain
         :: NewestFirst [] BlockHeader
         -> ProtocolMagic
+        -> ConsensusEra
         -> Bool
-    emptyHeaderChain l pm =
-        isVerSuccess $ Block.verifyHeaders pm Nothing l
+    emptyHeaderChain l pm era =
+        isVerSuccess $ Block.verifyHeaders pm era Nothing l
 
 -- | Both of the following tests are boilerplate - they use `mkGenericHeader` to create
 -- headers and then compare these with manually built headers.
@@ -171,7 +173,7 @@ validateBadProtocolMagicMainHeader pm = do
             BlockHeaderMain h    -> BlockHeaderMain    (h & gbhProtocolMagicId .~ protocolMagicId')
     pure $ not $ isVerSuccess $ Block.verifyHeader pm params header'
 
-validateGoodHeaderChain :: ProtocolMagic -> Gen Bool
-validateGoodHeaderChain pm = do
+validateGoodHeaderChain :: ProtocolMagic -> ConsensusEra -> Gen Bool
+validateGoodHeaderChain pm era = do
     BT.BHL (l, _) <- BT.genStubbedBHL pm
-    pure $ isVerSuccess $ Block.verifyHeaders pm Nothing (NewestFirst l)
+    pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing (NewestFirst l)

--- a/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
+++ b/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
@@ -69,7 +69,7 @@ spec = describe "Block properties" $ modifyMaxSuccess (min 20) $ do
         -> ConsensusEra
         -> Bool
     emptyHeaderChain l pm era =
-        isVerSuccess $ Block.verifyHeaders pm era Nothing l
+        isVerSuccess $ Block.verifyHeaders pm era Nothing Nothing l
 
 -- | Both of the following tests are boilerplate - they use `mkGenericHeader` to create
 -- headers and then compare these with manually built headers.
@@ -176,4 +176,4 @@ validateBadProtocolMagicMainHeader pm era = do
 validateGoodHeaderChain :: ProtocolMagic -> ConsensusEra -> Gen Bool
 validateGoodHeaderChain pm era = do
     BT.BHL (l, _) <- BT.genStubbedBHL pm era
-    pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing (NewestFirst l)
+    pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing Nothing (NewestFirst l)

--- a/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
+++ b/chain/test/Test/Pos/Chain/Block/BlockSpec.hs
@@ -69,7 +69,7 @@ spec = describe "Block properties" $ modifyMaxSuccess (min 20) $ do
         -> ConsensusEra
         -> Bool
     emptyHeaderChain l pm era =
-        isVerSuccess $ Block.verifyHeaders pm era Nothing Nothing l
+        isVerSuccess $ Block.verifyHeaders pm era Nothing l
 
 -- | Both of the following tests are boilerplate - they use `mkGenericHeader` to create
 -- headers and then compare these with manually built headers.
@@ -176,4 +176,4 @@ validateBadProtocolMagicMainHeader pm era = do
 validateGoodHeaderChain :: ProtocolMagic -> ConsensusEra -> Gen Bool
 validateGoodHeaderChain pm era = do
     BT.BHL (l, _) <- BT.genStubbedBHL pm era
-    pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing Nothing (NewestFirst l)
+    pure $ isVerSuccess $ Block.verifyHeaders pm era Nothing (NewestFirst l)

--- a/db/src/Pos/DB/BatchOp.hs
+++ b/db/src/Pos/DB/BatchOp.hs
@@ -5,6 +5,7 @@
 
 module Pos.DB.BatchOp
        ( RocksBatchOp (..)
+       , EmptyBatchOp
        , SomeBatchOp (..)
        , SomePrettyBatchOp (..)
        , dbWriteBatch'

--- a/db/src/Pos/DB/Block/Logic/Creation.hs
+++ b/db/src/Pos/DB/Block/Logic/Creation.hs
@@ -36,8 +36,9 @@ import           Pos.Chain.Ssc (MonadSscMem, SscPayload, defaultSscPayload,
                      stripSscPayload)
 import           Pos.Chain.Txp (TxAux (..), TxpConfiguration, emptyTxPayload,
                      mkTxPayload)
-import           Pos.Chain.Update (UpdateConfiguration, UpdatePayload (..),
-                     curSoftwareVersion, lastKnownBlockVersion)
+import           Pos.Chain.Update (ConsensusEra (..), UpdateConfiguration,
+                     UpdatePayload (..), curSoftwareVersion,
+                     lastKnownBlockVersion)
 import           Pos.Core (BlockCount, EpochIndex, EpochOrSlot (..),
                      SlotId (..), epochIndexL, flattenSlotId, getEpochOrSlot,
                      kChainQualityThreshold, kEpochSlots,
@@ -66,8 +67,8 @@ import qualified Pos.DB.Lrc as LrcDB
 import           Pos.DB.Ssc (sscGetLocalPayload, sscResetLocal)
 import           Pos.DB.Txp (MempoolExt, MonadTxpLocal (..), MonadTxpMem,
                      clearTxpMemPool, txGetPayload, withTxpLocalData)
-import           Pos.DB.Update (UpdateContext, clearUSMemPool, getMaxBlockSize,
-                     usCanCreateBlock, usPreparePayload)
+import           Pos.DB.Update (UpdateContext, clearUSMemPool, getConsensusEra,
+                     getMaxBlockSize, usCanCreateBlock, usPreparePayload)
 import           Pos.Util (_neHead)
 import           Pos.Util.Util (HasLens (..), HasLens')
 import           Pos.Util.Wlog (WithLogger, logDebug)
@@ -296,8 +297,11 @@ canCreateBlock k sId tipHeader =
             throwError "this software is obsolete and can't create block"
         unless (EpochOrSlot (Right sId) > tipEOS) $
             throwError "slot id is not greater than one from the tip block"
-        unless (tipHeader ^. epochIndexL == siEpoch sId) $
-            throwError "we don't know genesis block for this epoch"
+        era <- getConsensusEra
+        case era of
+            Original -> unless (tipHeader ^. epochIndexL == siEpoch sId) $
+                throwError "we don't know genesis block for this epoch"
+            OBFT _ -> pass
         let flatSId = flattenSlotId (kEpochSlots k) sId
         -- Small heuristic: let's not check chain quality during the
         -- first quarter of the 0-th epoch, because during this time

--- a/db/src/Pos/DB/Block/Logic/Header.hs
+++ b/db/src/Pos/DB/Block/Logic/Header.hs
@@ -114,6 +114,8 @@ classifyNewHeader genesisConfig (BlockHeaderMain header) = fmap (either identity
                 OBFT _ -> pure $
                           getEpochSlotLeaderScheduleObft genesisConfig
                                                          (siEpoch newHeaderSlot)
+            lastBlkSlots <- GS.getLastSlots
+            let k = configBlkSecurityParam genesisConfig
             let vhp =
                     VerifyHeaderParams
                     { vhpPrevHeader = Just tipHeader
@@ -129,6 +131,7 @@ classifyNewHeader genesisConfig (BlockHeaderMain header) = fmap (either identity
                     , vhpMaxSize = Just maxBlockHeaderSize
                     , vhpVerifyNoUnknown = False
                     , vhpConsensusEra = era
+                    , vhpLastBlkSlotsAndK = Just (lastBlkSlots, k)
                     }
             let pm = configProtocolMagic genesisConfig
             case verifyHeader pm vhp (BlockHeaderMain header) of

--- a/db/src/Pos/DB/Block/Logic/Internal.hs
+++ b/db/src/Pos/DB/Block/Logic/Internal.hs
@@ -44,14 +44,15 @@ import           Pos.Chain.Genesis as Genesis (Config (..),
                      configEpochSlots)
 import           Pos.Chain.Ssc (HasSscConfiguration, MonadSscMem, SscBlock)
 import           Pos.Chain.Txp (TxpConfiguration, mkLiveTxValidationRules)
-import           Pos.Chain.Update (PollModifier)
+import           Pos.Chain.Update (ConsensusEra (..), PollModifier)
 import           Pos.Core (epochIndexL)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
 import           Pos.Core.Exception (assertionFailed)
 import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Core.Reporting (MonadReporting)
 import           Pos.Core.Slotting (epochOrSlotToEpochIndex, getEpochOrSlot)
-import           Pos.DB (MonadDB, MonadDBRead, MonadGState, SomeBatchOp (..))
+import           Pos.DB (EmptyBatchOp, MonadDB, MonadDBRead, MonadGState,
+                     SomeBatchOp (..))
 import           Pos.DB.Block.BListener (MonadBListener)
 import           Pos.DB.Block.GState.SanityCheck (sanityCheckDB)
 import           Pos.DB.Block.Slog.Context (slogRollbackLastSlots)
@@ -67,8 +68,8 @@ import           Pos.DB.Ssc (sscApplyBlocks, sscNormalize, sscRollbackBlocks)
 import           Pos.DB.Txp.MemState (MonadTxpLocal (..))
 import           Pos.DB.Txp.Settings (TxpBlock, TxpBlund,
                      TxpGlobalSettings (..))
-import           Pos.DB.Update (UpdateBlock, UpdateContext, usApplyBlocks,
-                     usNormalize, usRollbackBlocks)
+import           Pos.DB.Update (UpdateBlock, UpdateContext, getConsensusEra,
+                     usApplyBlocks, usNormalize, usRollbackBlocks)
 import           Pos.Util (Some (..), spanSafe)
 import           Pos.Util.Util (HasLens', lensOf)
 
@@ -137,10 +138,13 @@ normalizeMempool genesisConfig txpConfig = do
     -- We normalize all mempools except the delegation one.
     -- That's because delegation mempool normalization is harder and is done
     -- within block application.
+    era <- getConsensusEra
+    case era of
+        Original -> sscNormalize genesisConfig
+        OBFT _   -> pass -- We don't perform SSC operations during the OBFT era
     currentEpoch <- epochOrSlotToEpochIndex . getEpochOrSlot <$> getTipHeader
     let txValRulesConfig = configTxValRules $ genesisConfig
         txValRules = mkLiveTxValidationRules currentEpoch txValRulesConfig
-    sscNormalize genesisConfig
     txpNormalize genesisConfig txValRules txpConfig
     usNormalize (configBlockVersionData genesisConfig)
 
@@ -203,9 +207,15 @@ applyBlocksDbUnsafeDo genesisConfig scb blunds pModifier = do
     usBatch <- SomeBatchOp <$> usApplyBlocks genesisConfig (map toUpdateBlock blocks) pModifier
     delegateBatch <- SomeBatchOp <$> dlgApplyBlocks (map toDlgBlund blunds)
     txpBatch <- tgsApplyBlocks $ map toTxpBlund blunds
-    sscBatch <- SomeBatchOp <$>
-        -- TODO: pass not only 'Nothing'
-        sscApplyBlocks genesisConfig (map toSscBlock blocks) Nothing
+    era <- getConsensusEra
+    sscBatch <- case era of
+        Original -> do
+            -- TODO: pass not only 'Nothing'
+            res <- sscApplyBlocks genesisConfig (map toSscBlock blocks) Nothing
+            pure (SomeBatchOp res)
+        OBFT _ -> do
+            -- We don't perform SSC operations during the OBFT era
+            pure $ SomeBatchOp ([] :: [EmptyBatchOp])
     GS.writeBatchGState
         [ delegateBatch
         , usBatch

--- a/db/src/Pos/DB/Block/Logic/VAR.hs
+++ b/db/src/Pos/DB/Block/Logic/VAR.hs
@@ -29,7 +29,8 @@ import           Pos.Chain.Block (ApplyBlocksException (..), Block, Blund,
                      VerifyBlocksException (..), headerHashG, prevBlockL)
 import           Pos.Chain.Genesis as Genesis (Config (..), configEpochSlots)
 import           Pos.Chain.Txp (TxpConfiguration)
-import           Pos.Chain.Update (PollModifier, UpdateConfiguration)
+import           Pos.Chain.Update (ConsensusEra (..), PollModifier,
+                     UpdateConfiguration)
 import           Pos.Core (epochIndexL)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..),
                      toNewestFirst, toOldestFirst)
@@ -48,7 +49,7 @@ import qualified Pos.DB.GState.Common as GS (getTip)
 import           Pos.DB.Ssc (sscVerifyBlocks)
 import           Pos.DB.Txp.Settings
                      (TxpGlobalSettings (TxpGlobalSettings, tgsVerifyBlocks))
-import           Pos.DB.Update (getAdoptedBV, usVerifyBlocks)
+import           Pos.DB.Update (getAdoptedBV, getConsensusEra, usVerifyBlocks)
 import           Pos.Util (neZipWith4, spanSafe, _neHead)
 import           Pos.Util.Util (HasLens (..))
 import           Pos.Util.Wlog (logDebug)
@@ -97,8 +98,11 @@ verifyBlocksPrefix genesisConfig currentSlot blocks = runExceptT $ do
     -- 'decode'.
     slogUndos <- withExceptT VerifyBlocksError $
         ExceptT $ slogVerifyBlocks genesisConfig currentSlot blocks
-    _ <- withExceptT (VerifyBlocksError . pretty) $
-        ExceptT $ sscVerifyBlocks genesisConfig (map toSscBlock blocks)
+    era <- getConsensusEra
+    case era of
+        Original -> void $ withExceptT (VerifyBlocksError . pretty) $
+                        ExceptT $ sscVerifyBlocks genesisConfig (map toSscBlock blocks)
+        OBFT _   -> pass -- We don't perform SSC operations during the OBFT era
     TxpGlobalSettings {..} <- view (lensOf @TxpGlobalSettings)
     txUndo <- withExceptT (VerifyBlocksError . pretty) $
         ExceptT $ tgsVerifyBlocks dataMustBeKnown $ map toTxpBlock blocks

--- a/db/src/Pos/DB/Delegation/Logic/VAR.hs
+++ b/db/src/Pos/DB/Delegation/Logic/VAR.hs
@@ -37,7 +37,7 @@ import           Pos.Chain.Delegation (CedeModifier (..), DlgBlund,
 import           Pos.Chain.Genesis as Genesis (Config (..),
                      configBlockVersionData)
 import           Pos.Chain.Lrc (RichmenSet)
-import           Pos.Chain.Update (BlockVersionData)
+import           Pos.Chain.Update (BlockVersionData, ConsensusEra (..))
 import           Pos.Core (EpochIndex (..), StakeholderId, addressHash,
                      epochIndexL, siEpoch)
 import           Pos.Core.Chrono (NE, NewestFirst (..), OldestFirst (..))
@@ -55,7 +55,8 @@ import           Pos.DB.Delegation.Logic.Common (DelegationError (..),
 import           Pos.DB.Delegation.Logic.Mempool (clearDlgMemPoolAction,
                      deleteFromDlgMemPool, processProxySKHeavyInternal)
 import qualified Pos.DB.GState.Common as GS
-import           Pos.DB.Lrc (HasLrcContext, getDlgRichmen)
+import           Pos.DB.Lrc (HasLrcContext, getDlgRichmen, getDlgRichmenObft)
+import           Pos.DB.Update (getConsensusEra)
 import           Pos.Util (getKeys, _neHead)
 import           Pos.Util.Wlog (WithLogger, logDebug)
 
@@ -333,7 +334,10 @@ dlgVerifyBlocks ::
     -> OldestFirst NE Block
     -> ExceptT Text m (OldestFirst NE DlgUndo)
 dlgVerifyBlocks genesisConfig blocks = do
-    richmen <- lift $ getDlgRichmen genesisBvd "dlgVerifyBlocks" headEpoch
+    era <- getConsensusEra
+    richmen <- lift $ case era of
+        Original -> getDlgRichmen genesisBvd "dlgVerifyBlocks" headEpoch
+        OBFT _   -> pure $ getDlgRichmenObft genesisConfig
     hoist (evalMapCede emptyCedeModifier) $ mapM (verifyBlock richmen) blocks
   where
     genesisBvd = configBlockVersionData genesisConfig

--- a/db/src/Pos/DB/Update/Logic/Global.hs
+++ b/db/src/Pos/DB/Update/Logic/Global.hs
@@ -19,7 +19,8 @@ import           UnliftIO (MonadUnliftIO)
 
 import           Pos.Chain.Block (ComponentBlock (..), headerHashG,
                      headerLeaderKeyL, headerSlotL)
-import           Pos.Chain.Genesis as Genesis (Config, configBlkSecurityParam)
+import           Pos.Chain.Genesis as Genesis (Config (..),
+                     configBlkSecurityParam)
 import           Pos.Chain.Update (ApplicationName, BlockVersion,
                      BlockVersionData, BlockVersionState,
                      ConfirmedProposalState, MonadPoll, NumSoftwareVersion,

--- a/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
+++ b/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
@@ -212,6 +212,7 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp =
                 , vhpMaxSize = Nothing
                 , vhpVerifyNoUnknown = False
                 , vhpConsensusEra = Original
+                , vhpLastBlkSlotsAndK = Nothing
                 }
         let !params = VerifyBlockParams
                 { vbpVerifyHeader = verifyHeaderParams

--- a/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
+++ b/generator/bench/Bench/Pos/Criterion/Block/Logic.hs
@@ -22,7 +22,8 @@ import           Pos.Chain.Genesis as Genesis (Config (..),
                      TestnetBalanceOptions (..), configBlockVersionData,
                      configBootStakeholders, configEpochSlots,
                      configGeneratedSecretsThrow, gsSecretKeys)
-import           Pos.Chain.Update (BlockVersionData (..), updateConfiguration)
+import           Pos.Chain.Update (BlockVersionData (..), ConsensusEra (..),
+                     updateConfiguration)
 import           Pos.Core.Chrono (NE, OldestFirst (..), nonEmptyNewestFirst)
 import           Pos.Core.Common (BlockCount (..), unsafeCoinPortionFromDouble)
 import           Pos.Core.NetworkMagic (makeNetworkMagic)
@@ -210,6 +211,7 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp =
                 , vhpLeaders = Just leaders
                 , vhpMaxSize = Nothing
                 , vhpVerifyNoUnknown = False
+                , vhpConsensusEra = Original
                 }
         let !params = VerifyBlockParams
                 { vbpVerifyHeader = verifyHeaderParams
@@ -223,7 +225,7 @@ verifyHeaderBenchmark !genesisConfig !secretKeys !tp =
         nf isVerSuccess $ verifyHeader pm params header
 
     benchBlockVerification ~(block, params) =
-        nf isVerSuccess $ verifyBlock genesisConfig dummyTxValRules params block
+        nf isVerSuccess $ verifyBlock genesisConfig Original dummyTxValRules params block
 
 
 runBenchmark :: IO ()

--- a/lib/src/Pos/Network/Block/Logic.hs
+++ b/lib/src/Pos/Network/Block/Logic.hs
@@ -151,9 +151,8 @@ handleUnsolicitedHeader genesisConfig header nodeId = do
             logDebug $ sformat alternativeFormat hHash
             addHeaderToBlockRequestQueue nodeId header False
         CHUseless reason -> logDebug $ sformat uselessFormat hHash reason
-        CHInvalid _ -> do
-            logWarning $ sformat ("handleUnsolicited: header "%shortHashF%
-                                " is invalid") hHash
+        CHInvalid reason -> do
+            logWarning $ sformat invalidFormat hHash reason
             pass -- TODO: ban node for sending invalid block.
   where
     hHash = headerHash header
@@ -165,6 +164,9 @@ handleUnsolicitedHeader genesisConfig header nodeId = do
         " potentially represents good alternative chain, will process"
     uselessFormat =
         "Header " %shortHashF%" is useless for the following reason: " %stext
+    invalidFormat =
+        "handleUnsolicitedHeader: header " %shortHashF%
+        " is invalid for the following reason: " %stext
 
 ----------------------------------------------------------------------------
 -- Putting things into request queue

--- a/utxo/src/UTxO/Translate.hs
+++ b/utxo/src/UTxO/Translate.hs
@@ -209,10 +209,11 @@ verify ma = withConfig $ do
 --   split the chain into epochs and validate each epoch individually
 verifyBlocksPrefix
   :: forall e' m.  Monad m
-  => OldestFirst NE Block
+  => ConsensusEra
+  -> OldestFirst NE Block
   -> TxValidationRules
   -> TranslateT e' m (Validated VerifyBlocksException (OldestFirst NE Undo, Utxo))
-verifyBlocksPrefix blocks txValRules =
+verifyBlocksPrefix era blocks txValRules =
     case splitEpochs blocks of
       ESREmptyEpoch _          ->
         validatedFromExceptT . throwError $ VerifyBlocksError "Whoa! Empty epoch!"
@@ -237,6 +238,7 @@ verifyBlocksPrefix blocks txValRules =
         pm
         txValRules
         ccHash0
+        era
         Nothing
         ccInitLeaders
         (OldestFirst [])
@@ -250,6 +252,7 @@ verifyBlocksPrefix blocks txValRules =
         pm
         txValRules
         (ebb ^. headerHashG)
+        era
         Nothing
         (ebb ^. gbBody . gbLeaders)
         (OldestFirst []) -- ^ TODO pass these?

--- a/utxo/src/UTxO/Verify.hs
+++ b/utxo/src/UTxO/Verify.hs
@@ -232,12 +232,13 @@ verifyBlocksPrefix
     :: ProtocolMagic       -- ^ Protocol magic
     -> TxValidationRules   -- ^ Tx validation rules
     -> HeaderHash          -- ^ Expected tip
+    -> ConsensusEra        -- ^ Original or OBFT
     -> Maybe SlotId        -- ^ Current slot
     -> SlotLeaders         -- ^ Slot leaders for this epoch
     -> LastBlkSlots        -- ^ Last block slots
     -> OldestFirst NE Block
     -> Verify VerifyBlocksException (OldestFirst NE Undo)
-verifyBlocksPrefix pm txValRules tip curSlot leaders lastSlots blocks = do
+verifyBlocksPrefix pm txValRules tip era curSlot leaders lastSlots blocks = do
     when (tip /= blocks ^. _Wrapped . _neHead . prevBlockL) $
         throwError $ VerifyBlocksError "the first block isn't based on the tip"
 
@@ -245,7 +246,7 @@ verifyBlocksPrefix pm txValRules tip curSlot leaders lastSlots blocks = do
 
     -- Verify block envelope
     slogUndos <- mapVerifyErrors VerifyBlocksError $
-                   slogVerifyBlocks curSlot txValRules leaders lastSlots blocks
+                   slogVerifyBlocks era curSlot txValRules leaders lastSlots blocks
 
     -- We skip SSC verification
     {-
@@ -299,13 +300,14 @@ verifyBlocksPrefix pm txValRules tip curSlot leaders lastSlots blocks = do
 -- * Uses 'gsAdoptedBVData' instead of 'getAdoptedBVFull'
 -- * Use hard-coded 'dataMustBeKnown' (instead of deriving this from 'adoptedBV')
 slogVerifyBlocks
-    :: Maybe SlotId  -- ^ Current slot
-    -> TxValidationRules
-    -> SlotLeaders   -- ^ Slot leaders for this epoch
-    -> LastBlkSlots  -- ^ Last block slots
+    :: ConsensusEra       -- ^ Original or OBFT
+    -> Maybe SlotId       -- ^ Current slot
+    -> TxValidationRules  -- ^ Tx validation rules
+    -> SlotLeaders        -- ^ Slot leaders for this epoch
+    -> LastBlkSlots       -- ^ Last block slots
     -> OldestFirst NE Block
     -> Verify Text (OldestFirst NE SlogUndo)
-slogVerifyBlocks curSlot txValRules leaders lastSlots blocks = do
+slogVerifyBlocks era curSlot txValRules leaders lastSlots blocks = do
     adoptedBVD <- gsAdoptedBVData
 
     -- We take head here, because blocks are in oldest first order and
@@ -319,7 +321,7 @@ slogVerifyBlocks curSlot txValRules leaders lastSlots blocks = do
     let blocksList = OldestFirst (toList (getOldestFirst blocks))
     -- eos assumes `curSlot` is in fact the current slot
     verResToMonadError formatAllErrors $
-        verifyBlocks dummyConfig txValRules curSlot dataMustBeKnown adoptedBVD leaders blocksList
+        verifyBlocks dummyConfig era txValRules curSlot dataMustBeKnown adoptedBVD leaders blocksList
 
     -- Here we need to compute 'SlogUndo'. When we add apply a block,
     -- we can remove one of the last slots stored in

--- a/utxo/src/UTxO/Verify.hs
+++ b/utxo/src/UTxO/Verify.hs
@@ -319,9 +319,18 @@ slogVerifyBlocks era curSlot txValRules leaders lastSlots blocks = do
             throwError "Genesis block leaders don't match with LRC-computed"
         _ -> pass
     let blocksList = OldestFirst (toList (getOldestFirst blocks))
+        lastBlkSlotsAndK = Just (lastSlots, dummyK)
     -- eos assumes `curSlot` is in fact the current slot
     verResToMonadError formatAllErrors $
-        verifyBlocks dummyConfig era txValRules curSlot dataMustBeKnown adoptedBVD leaders blocksList
+        verifyBlocks dummyConfig
+                     era
+                     txValRules
+                     lastBlkSlotsAndK
+                     curSlot
+                     dataMustBeKnown
+                     adoptedBVD
+                     leaders
+                     blocksList
 
     -- Here we need to compute 'SlogUndo'. When we add apply a block,
     -- we can remove one of the last slots stored in

--- a/utxo/src/UTxO/Verify.hs
+++ b/utxo/src/UTxO/Verify.hs
@@ -234,7 +234,7 @@ verifyBlocksPrefix
     -> HeaderHash          -- ^ Expected tip
     -> ConsensusEra        -- ^ Original or OBFT
     -> Maybe SlotId        -- ^ Current slot
-    -> SlotLeaders         -- ^ Slot leaders for this epoch
+    -> ConsensusEraLeaders -- ^ Slot leaders for this epoch
     -> LastBlkSlots        -- ^ Last block slots
     -> OldestFirst NE Block
     -> Verify VerifyBlocksException (OldestFirst NE Undo)
@@ -300,24 +300,28 @@ verifyBlocksPrefix pm txValRules tip era curSlot leaders lastSlots blocks = do
 -- * Uses 'gsAdoptedBVData' instead of 'getAdoptedBVFull'
 -- * Use hard-coded 'dataMustBeKnown' (instead of deriving this from 'adoptedBV')
 slogVerifyBlocks
-    :: ConsensusEra       -- ^ Original or OBFT
-    -> Maybe SlotId       -- ^ Current slot
-    -> TxValidationRules  -- ^ Tx validation rules
-    -> SlotLeaders        -- ^ Slot leaders for this epoch
-    -> LastBlkSlots       -- ^ Last block slots
+    :: ConsensusEra         -- ^ Original or OBFT
+    -> Maybe SlotId         -- ^ Current slot
+    -> TxValidationRules    -- ^ Tx validation rules
+    -> ConsensusEraLeaders  -- ^ Slot leaders for this epoch
+    -> LastBlkSlots         -- ^ Last block slots
     -> OldestFirst NE Block
     -> Verify Text (OldestFirst NE SlogUndo)
 slogVerifyBlocks era curSlot txValRules leaders lastSlots blocks = do
     adoptedBVD <- gsAdoptedBVData
 
-    -- We take head here, because blocks are in oldest first order and
-    -- we know that all of them are from the same epoch. So if there
-    -- is a genesis block, it must be head and only head.
-    case blocks ^. _Wrapped . _neHead of
-        (Left block) ->
-            when (block ^. genBlockLeaders /= leaders) $
-            throwError "Genesis block leaders don't match with LRC-computed"
-        _ -> pass
+    case leaders of
+        OriginalLeaders ls ->
+            -- We take head here, because blocks are in oldest first order and
+            -- we know that all of them are from the same epoch. So if there
+            -- is a genesis block, it must be head and only head.
+            case blocks ^. _OldestFirst . _neHead of
+                (Left block) ->
+                    when (block ^. genBlockLeaders /= ls) $
+                    throwError "Genesis block leaders don't match with LRC-computed"
+                _ -> pass
+        ObftStrictLeaders _ -> pass
+        ObftLenientLeaders {} -> pass
     let blocksList = OldestFirst (toList (getOldestFirst blocks))
         lastBlkSlotsAndK = Just (lastSlots, dummyK)
     -- eos assumes `curSlot` is in fact the current slot
@@ -325,7 +329,6 @@ slogVerifyBlocks era curSlot txValRules leaders lastSlots blocks = do
         verifyBlocks dummyConfig
                      era
                      txValRules
-                     lastBlkSlotsAndK
                      curSlot
                      dataMustBeKnown
                      adoptedBVD

--- a/wallet/test/unit/Test/Spec/Translation.hs
+++ b/wallet/test/unit/Test/Spec/Translation.hs
@@ -8,6 +8,7 @@ import           Universum
 import qualified Data.Set as Set
 import           Formatting (bprint, build, shown, (%))
 import qualified Formatting.Buildable
+import           Pos.Chain.Update (ConsensusEra (..))
 import           Pos.Core.Chrono
 import           Pos.Crypto (ProtocolMagic (..), RequiresNetworkMagic (..))
 import           Serokell.Util (mapJson)
@@ -298,7 +299,7 @@ intAndVerifyChain pm pc = runTranslateT pm $ do
         let chain'' = fromMaybe (error "intAndVerify: Nothing")
                     $ nonEmptyOldestFirst
                     $ chain'
-        isCardanoValid <- verifyBlocksPrefix chain'' dummyTxValRules
+        isCardanoValid <- verifyBlocksPrefix Original chain'' dummyTxValRules
         case (dslIsValid, isCardanoValid) of
           (Invalid _ e' , Invalid _ e) -> return $ ExpectedInvalid e' e
           (Invalid _ e' , Valid     _) -> return $ Disagreement ledger (UnexpectedValid e')


### PR DESCRIPTION
## Description

Implementation of block validation, both strict and lenient, for the `OBFT` era.

Since `OBFT ObftLenient` validation is able to validate blocks from the `Original` era, I've decided to raise this PR before the implementation of `OBFT` block generation as it could serve as a pretty good test for whether lenient validation operates as expected. 

After this change, the node should actually create and verify blocks as per usual even while in the `OBFT ObftLenient` era. However, we should expect block validation to fail during the `OBFT ObftStrict` era since this form of validation expects slot leaders to follow the strict round-robin schedule.

## Linked issues

https://iohk.myjetbrains.com/youtrack/issue/CBR-481

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.