### PR TITLE
Preserve query and fragment part of the URI while redirecting for relative paths (swagger doc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 - New "common use-case" entry the API doc about importing addresses ([CO-448](https://iohk.myjetbrains.com/youtrack/issue/CO-448) [#4040](https://github.com/input-output-hk/cardano-sl/pull/4040))
 
+- Links to specific sections of the API doc now work [#4064](https://github.com/input-output-hk/cardano-sl/pull/4064)
 
 ## Cardano SL 2.0.1
 

--- a/lib/src/Pos/Util/Swagger.hs
+++ b/lib/src/Pos/Util/Swagger.hs
@@ -32,8 +32,8 @@ swaggerSchemaUIServer =
     <script>
         // Force Strict-URL Routing for assets relative paths
         (function onload() {
-            if (!window.location.href.endsWith("/")) {
-                window.location.href += "/";
+            if (!window.location.pathname.endsWith("/")) {
+                window.location.pathname += "/";
             }
         }());
     </script>

--- a/wallet/src/Cardano/Wallet/API/V1/Swagger.hs
+++ b/wallet/src/Cardano/Wallet/API/V1/Swagger.hs
@@ -1050,8 +1050,8 @@ swaggerSchemaUIServer =
     <script>
         // Force Strict-URL Routing for assets relative paths
         (function onload() {
-            if (!window.location.href.endsWith("/")) {
-                window.location.href += "/";
+            if (!window.location.pathname.endsWith("/")) {
+                window.location.pathname += "/";
             }
         }());
     </script>


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

Ported from cardano-wallet c49e93a350e8294a380385258b9232df2d00ac20 to
- lib/src/Pos/Util/Swagger.hs (for the node monitoring api docs)
- wallet/src/Cardano/Wallet/API/V1/Swagger.hs (for the wallet docs)

### Todo:
- [x] Update changelog
- [x] Fill in QA

## Linked issue

input-output-hk/cardano-wallet#299

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] ~I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.~
- [ ] ~If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).~
- [ ] ~I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.~
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## QA

### Wallet API docs

1. Build and run a wallet with `--wallet-doc-address` set
```
stack exec cardano-node -- --topology=docs/network/example-topologies/mainnet-staging.yaml \
    --configuration-key mainnet_dryrun_full \
    --db-path ../staging-db \
    --tlscert ../tls-certs/server.crt --tlskey ../tls-certs/server.key --tlsca ../tls-certs/ca.crt --no-client-auth --wallet-doc-address         127.0.0.1:8190
```

2. Visit https://127.0.0.1:8190/docs/v1/index/#section/Errors

3. Should load at the Error section

<img width="1340" alt="skarmavbild 2019-02-04 kl 22 13 56" src="https://user-images.githubusercontent.com/304423/52237613-53721100-28ca-11e9-9513-854fa167b6e3.png">

### Node monitoring API docs

1. 
```
stack build cardano-sl-node --ghc-options=-optl-Wl,-dead_strip_dylibs
stack exec cardano-node-simple -- --topology=wallet/topology-examples/testnet.yaml \
    --configuration-key=mainnet_staging_short_epoch_full \
    --log-config=log-configs/cluster.yaml       \
    --node-api-address           127.0.0.1:8080 \
    --node-doc-address           127.0.0.1:8180 \
                                                \
    --tlsca       scripts/tls-files/ca.crt      \
    --tlscert     scripts/tls-files/server.crt  \
    --tlskey      scripts/tls-files/server.key  \
```

2. Visit https://127.0.0.1:8180/docs/v1/index/#tag/Settings
<img width="1340" alt="skarmavbild 2019-02-05 kl 14 05 32" src="https://user-images.githubusercontent.com/304423/52275201-20259580-294f-11e9-9e92-4d3fc291fd65.png">


**Note**: endpoints without tags don't work, but this is a separate issue. See input-output-hk/cardano-wallet#306.


## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).