### PR TITLE
Remove logs which attempt to write entire slot leader schedule

### DIFF
--- a/chain/src/Pos/Chain/Block/Logic/Integrity.hs
+++ b/chain/src/Pos/Chain/Block/Logic/Integrity.hs
@@ -21,7 +21,7 @@ module Pos.Chain.Block.Logic.Integrity
 import           Universum
 
 import           Control.Lens (ix)
-import           Formatting (build, int, sformat, shown, (%))
+import           Formatting (build, int, sformat, (%))
 import           Serokell.Data.Memory.Units (Byte, memory)
 import           Serokell.Util (VerificationRes (..), verifyGeneric)
 
@@ -202,9 +202,8 @@ verifyHeader pm VerifyHeaderParams {..} h =
                     -- and `Original` cases.
                     ObftLenientLeaders ldrs blkSecurityParam lastBlkSlots ->
                         [  ( (blockSlotLeader `elem` ldrs)
-                            , sformat ("slot leader who published block, "%build%", is not an acceptable leader. acceptableLeaders: "%shown)
-                                    blockSlotLeader
-                                    ldrs)
+                            , sformat ("slot leader who published block, "%build%", is not an acceptable leader.")
+                                    blockSlotLeader)
                             , ( (obftLeaderCanMint blockSlotLeader blkSecurityParam lastBlkSlots)
                             , sformat ("slot leader who published block, "%build%", has minted too many blocks in the past "%build%" slots.")
                                     blockSlotLeader
@@ -213,20 +212,16 @@ verifyHeader pm VerifyHeaderParams {..} h =
 
                     ObftStrictLeaders ldrs ->
                         [  ( (Just blockSlotLeader == (scheduleSlotLeader ldrs))
-                            , sformat ("slot leader from schedule, "%build%", is different from slot leader who published block, "%build%". slotIndex: "%build%", leaders: "%shown)
+                            , sformat ("slot leader from schedule, "%build%", is different from slot leader who published block, "%build%".")
                                     (scheduleSlotLeader ldrs)
-                                    blockSlotLeader
-                                    slotIndex
-                                    ldrs)
+                                    blockSlotLeader)
                             ]
 
                     OriginalLeaders ldrs ->
                         [  ( (Just blockSlotLeader == (scheduleSlotLeader ldrs))
-                            , sformat ("slot leader from schedule, "%build%", is different from slot leader who published block, "%build%". slotIndex: "%build%", leaders: "%shown)
+                            , sformat ("slot leader from schedule, "%build%", is different from slot leader who published block, "%build%".")
                                     (scheduleSlotLeader ldrs)
-                                    blockSlotLeader
-                                    slotIndex
-                                    ldrs)
+                                    blockSlotLeader)
                             ]
       where
         -- Determine whether the leader is allowed to mint a block based on

--- a/db/src/Pos/DB/Block/Slog/Logic.hs
+++ b/db/src/Pos/DB/Block/Slog/Logic.hs
@@ -180,7 +180,6 @@ slogVerifyBlocks genesisConfig curSlot blocks = runExceptT $ do
                 ObftLenientLeaders (Set.fromList gStakeholders)
                                    (configBlkSecurityParam genesisConfig)
                                    lastSlots
-    logInfo $ sformat ("slogVerifyBlocks: Leaders are " % shown) leaders
 
 
     -- This is pretty much equivalent to performing a case on `era` since the


### PR DESCRIPTION
## Description

In #4059, I mistakenly left some log messages which can end up being very large as they include the entire slot leader schedule which, in the case of mainnet, is huge.

## Linked issues

https://iohk.myjetbrains.com/youtrack/issue/CBR-481

## Type of change
- [~] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
- [~] I have added tests to cover my changes.
- [x] All new and existing tests passed.