### PR TITLE
full diffusion layer normal shutdown

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ before_test:
     $env:PATH="$env:PATH;C:\ghc\ghc-8.4.4\bin"
 
 # Install OpenSSL 1.0.2 (see https://github.com/appveyor/ci/issues/1665)
-- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2q.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
+- ps: (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/Win64OpenSSL-1_0_2r.exe', "$($env:USERPROFILE)\Win64OpenSSL.exe")
 - ps: cmd /c start /wait "$($env:USERPROFILE)\Win64OpenSSL.exe" /silent /verysilent /sp- /suppressmsgboxes /DIR=C:\OpenSSL-Win64-v102
 - ps: Install-Product node 6
 # Install stack

--- a/lib/bench/Bench/Pos/Diffusion/BlockDownload.hs
+++ b/lib/bench/Bench/Pos/Diffusion/BlockDownload.hs
@@ -151,6 +151,7 @@ withServer transport logic k = do
         , fdcRecoveryHeadersMessage = 2200
         , fdcLastKnownBlockVersion = blockVersion
         , fdcConvEstablishTimeout = 15000000 -- us
+        , fdcBatchSize = 64
         , fdcStreamWindow = 65536
         , fdcTrace = noTrace
         }
@@ -195,6 +196,7 @@ withClient transport logic serverAddress@(Node.NodeId _) k = do
         , fdcRecoveryHeadersMessage = 2200
         , fdcLastKnownBlockVersion = blockVersion
         , fdcConvEstablishTimeout = 15000000 -- us
+        , fdcBatchSize = 64
         , fdcStreamWindow = 65536
         , fdcTrace = noTrace
         }

--- a/lib/src/Pos/Diffusion/Full.hs
+++ b/lib/src/Pos/Diffusion/Full.hs
@@ -96,7 +96,10 @@ data FullDiffusionConfiguration = FullDiffusionConfiguration
     , fdcRecoveryHeadersMessage :: !Word
     , fdcLastKnownBlockVersion  :: !BlockVersion
     , fdcConvEstablishTimeout   :: !Microsecond
+    , fdcBatchSize              :: !Word32
+      -- ^ Size of batches of blocks to process when streaming.
     , fdcStreamWindow           :: !Word32
+      -- ^ Size of window for block streaming.
     , fdcTrace                  :: !(Trace IO (LogNamed (Severity, Text)))
     }
 
@@ -207,6 +210,7 @@ diffusionLayerFullExposeInternals fdconf
         protocolConstants = fdcProtocolConstants fdconf
         lastKnownBlockVersion = fdcLastKnownBlockVersion fdconf
         recoveryHeadersMessage = fdcRecoveryHeadersMessage fdconf
+        batchSize    = fdcBatchSize    fdconf
         streamWindow = fdcStreamWindow fdconf
         logTrace = named (fdcTrace fdconf)
 
@@ -379,7 +383,7 @@ diffusionLayerFullExposeInternals fdconf
                      -> [HeaderHash]
                      -> StreamBlocks Block IO t
                      -> IO (Maybe t)
-        streamBlocks = Diffusion.Block.streamBlocks logTrace diffusionHealth logic streamWindow enqueue
+        streamBlocks = Diffusion.Block.streamBlocks logTrace diffusionHealth logic batchSize streamWindow enqueue
 
         announceBlockHeader :: MainBlockHeader -> IO ()
         announceBlockHeader = void . Diffusion.Block.announceBlockHeader logTrace logic protocolConstants recoveryHeadersMessage enqueue

--- a/lib/src/Pos/Diffusion/Full/Block.hs
+++ b/lib/src/Pos/Diffusion/Full/Block.hs
@@ -284,6 +284,7 @@ streamBlocks
        Trace IO (Severity, Text)
     -> Maybe DiffusionHealth
     -> Logic IO
+    -> Word32 -- ^ Size of batches of blocks (deliver to StreamBlocks).
     -> Word32 -- ^ Size of stream window. 0 implies 'Nothing' is returned.
     -> EnqueueMsg
     -> NodeId
@@ -291,13 +292,11 @@ streamBlocks
     -> [HeaderHash]
     -> StreamBlocks Block IO t
     -> IO (Maybe t)
-streamBlocks _        _   _     0            _       _      _         _           _ =
+streamBlocks _        _   _     _         0            _       _      _         _           _ =
     return Nothing -- Fallback to batch mode
-streamBlocks logTrace smM logic streamWindow enqueue nodeId tipHeader checkpoints streamBlocksK =
+streamBlocks logTrace smM logic batchSize streamWindow enqueue nodeId tipHeader checkpoints streamBlocksK =
     requestBlocks >>= Async.wait
   where
-
-    batchSize = min 64 streamWindow
 
     mkStreamStart :: [HeaderHash] -> HeaderHash -> MsgStream
     mkStreamStart chain wantedBlock =

--- a/lib/src/Pos/Launcher/Runner.hs
+++ b/lib/src/Pos/Launcher/Runner.hs
@@ -182,6 +182,8 @@ runServer uc genesisConfig NodeParams {..} ekgNodeMetrics shdnContext mkLogic ac
         -- Use the Wlog.Compatibility name trace (magic CanLog IO instance)
         , fdcTrace = appendName "diffusion" fromTypeclassNamedTraceWlog
         , fdcStreamWindow = streamWindow
+        -- TODO should be configurable
+        , fdcBatchSize    = 64
         }
     exitOnShutdown action = do
         result <- race (waitForShutdown shdnContext) action

--- a/lib/test/Test/Pos/Diffusion/BlockSpec.hs
+++ b/lib/test/Test/Pos/Diffusion/BlockSpec.hs
@@ -151,6 +151,7 @@ withServer pm transport logic k = do
         , fdcRecoveryHeadersMessage = 2200
         , fdcLastKnownBlockVersion = blockVersion
         , fdcConvEstablishTimeout = 15000000 -- us
+        , fdcBatchSize = 64
         , fdcStreamWindow = 2048
         , fdcTrace = appendName "server"
               (appendName "diffusion" fromTypeclassNamedTraceWlog)
@@ -199,6 +200,7 @@ withClient pm streamWindow transport logic serverAddress@(Node.NodeId _) k = do
         , fdcRecoveryHeadersMessage = 2200
         , fdcLastKnownBlockVersion = blockVersion
         , fdcConvEstablishTimeout = 15000000 -- us
+        , fdcBatchSize = 64
         , fdcStreamWindow = streamWindow
         , fdcTrace = appendName "client"
               (appendName "diffusion" fromTypeclassNamedTraceWlog)


### PR DESCRIPTION
## Description

The subscription thread is now killed when the main continuation ends. This means that applications which actually have a "normal" shutdown path (such as the Byron proxy) can actually shutdown without throwing exceptions / control+c.

Ending the full diffusion layer continuation while there is a `streamBlocks` in process will no longer hang.

Also adds a config option for the streaming batch size.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
