### PR TITLE
[CBR-505] Extend LocalTimeInformation in node-info API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
     - Improve block validation tests ([CBR-504](https://iohk.myjetbrains.com/youtrack/issue/CBR-504) [#4081](https://github.com/input-output-hk/cardano-sl/pull/4081))
     - Implement OBFT block creation ([CBR-482](https://iohk.myjetbrains.com/youtrack/issue/CBR-481) [#4077](https://github.com/input-output-hk/cardano-sl/pull/4077))
 
+- Review node-info 'localTimeInfo' API to include pending statuses ([CBR-505](https://iohk.myjetbrains.com/youtrack/issue/CBR-505) [#4099](https://github.com/input-output-hk/cardano-sl/pull/4099))
+
+
 ### Improvements
 
 - Removal of V0 API & Legacy Data Layer ([CO-372](https://iohk.myjetbrains.com/youtrack/issue/CO-372))

--- a/wallet/test/unit/Test/Spec/TxMetaScenarios.hs
+++ b/wallet/test/unit/Test/Spec/TxMetaScenarios.hs
@@ -394,7 +394,7 @@ nodeStParams1 =
       , mockNodeStateSlotStart = const $ Right getSomeTimestamp
       , mockNodeStateSecurityParameter = SecurityParameter 2160
       , mockNodeStateNextEpochSlotDuration = fromMicroseconds 200
-      , mockNodeStateNtpDrift = const (V1.TimeInfo Nothing)
+      , mockNodeStateNtpDrift = const V1.TimeInfoUnavailable
       , mockNodeStateSyncProgress = (Just 100, 100)
       , mockNodeStateCreationTimestamp = getSomeTimestamp
       }
@@ -408,7 +408,7 @@ nodeStParams2 =
       , mockNodeStateSlotStart = const $ Right getSomeTimestamp
       , mockNodeStateSecurityParameter = SecurityParameter 2160
       , mockNodeStateNextEpochSlotDuration = fromMicroseconds 200
-      , mockNodeStateNtpDrift = const (V1.TimeInfo Nothing)
+      , mockNodeStateNtpDrift = const V1.TimeInfoUnavailable
       , mockNodeStateSyncProgress = (Just 100, 100)
       , mockNodeStateCreationTimestamp = getSomeTimestamp
       }


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

it would be nice if the frontend got more descriptive information out of the ntp api endpoint. The ntp client exposes:

```
    data NtpStatus =
          -- | The difference between NTP time and local system time
          NtpDrift NtpOffset
          -- | NTP client has send requests to the servers
        | NtpSyncPending
          -- | NTP is not available: the client has not received any respond within
          -- `ntpResponseTimeout` or NTP was not configured.
        | NtpSyncUnavailable deriving (Eq, Show)```
```

At the moment the node maps both NtpSyncPending and NtpSyncUnavailable to null, but it would be better if null mean just one thing, and that NtpSyncPending was also revealed to the wallet.

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

[CBR-505](https://iohk.myjetbrains.com/youtrack/issue/CBR-505)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

The `localTimeInformation` field can now have three different shapes:

```json
{ "status": "unavailable" }
{ "status": "pending" }
{ "status": "available", "localTimeDifference": { "quantity": 14, "unit": "microseconds" } }
```

The two former are a refinement over the old `null`. Note that, when passing the `force_ntp_check` flag, the API call is blocking, so the API will return either an "unavailable" status or "available" one. 

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

The API docs now looks like this:

![image](https://user-images.githubusercontent.com/5680256/53488174-d3386900-3a8d-11e9-9669-639f5f9b52b7.png)


## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
