### PR TITLE
[DEVOPS-1195] add api to query a wallet balance, given only an EncryptedSecretKey

### DIFF
--- a/crypto/Pos/Crypto/Signing/Types/Safe.hs
+++ b/crypto/Pos/Crypto/Signing/Types/Safe.hs
@@ -13,6 +13,7 @@ module Pos.Crypto.Signing.Types.Safe
        , encToPublic
        , noPassEncrypt
        , checkPassMatches
+       , passScryptParam
        ) where
 
 import qualified Cardano.Crypto.Wallet as CC

--- a/nix/.stack.nix/cardano-sl-tools.nix
+++ b/nix/.stack.nix/cardano-sl-tools.nix
@@ -200,6 +200,7 @@
             (hsPkgs.text)
             (hsPkgs.cardano-sl)
             (hsPkgs.cardano-sl-util)
+            (hsPkgs.cardano-sl-crypto)
           ];
         };
       };

--- a/nix/.stack.nix/cardano-sl-tools.nix
+++ b/nix/.stack.nix/cardano-sl-tools.nix
@@ -196,11 +196,14 @@
         "wallet-extractor" = {
           depends = [
             (hsPkgs.base)
-            (hsPkgs.universum)
-            (hsPkgs.text)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-crypto)
             (hsPkgs.cardano-sl)
-            (hsPkgs.cardano-sl-util)
             (hsPkgs.cardano-sl-crypto)
+            (hsPkgs.cardano-sl-util)
+            (hsPkgs.formatting)
+            (hsPkgs.text)
+            (hsPkgs.universum)
           ];
         };
       };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16419,6 +16419,7 @@ license = stdenv.lib.licenses.mit;
 , base58-bytestring
 , bytestring
 , canonical-json
+, cardano-crypto
 , cardano-report-server
 , cardano-sl
 , cardano-sl-binary
@@ -16498,6 +16499,7 @@ base
 base58-bytestring
 bytestring
 canonical-json
+cardano-crypto
 cardano-report-server
 cardano-sl
 cardano-sl-binary

--- a/tools/cardano-sl-tools.cabal
+++ b/tools/cardano-sl-tools.cabal
@@ -383,10 +383,14 @@ executable wallet-extractor
                        -Wall
                        -O2
   build-depends:       base
-                     , universum
-                     , text
+                     , bytestring
+                     , cardano-crypto
                      , cardano-sl
+                     , cardano-sl-crypto
                      , cardano-sl-util
+                     , formatting
+                     , text
+                     , universum
 
 test-suite cardano-sl-tools-test
   main-is:             Test.hs

--- a/tools/src/wallet-extractor/Main.hs
+++ b/tools/src/wallet-extractor/Main.hs
@@ -3,15 +3,16 @@
 
 module Main (main) where
 
+import           Cardano.Crypto.Wallet (unXPrv)
+import qualified Data.ByteString as BS
+import qualified Data.Text.Lazy.Builder as T
+import           Formatting (Format, bprint, fprint, hex, later, shown, (%))
+import           Formatting.Internal.Raw (left)
+import           Pos.Crypto (EncryptedSecretKey (eskHash, eskPayload),
+                     getEncryptedPass)
 import           Pos.Util.Trace (fromTypeclassWlog)
 import           Pos.Util.UserSecret
 import           Universum
-import           Pos.Crypto (EncryptedSecretKey(eskPayload, eskHash), getEncryptedPass)
-import Cardano.Crypto.Wallet (unXPrv)
-import           Formatting (bprint, hex, shown, (%), fprint, Format, later)
-import qualified Data.ByteString as BS
-import qualified Data.Text.Lazy.Builder as T
-import Formatting.Internal.Raw (left)
 
 hexString :: Format r (ByteString -> r)
 hexString = later f

--- a/tools/src/wallet-extractor/Main.hs
+++ b/tools/src/wallet-extractor/Main.hs
@@ -1,11 +1,36 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
-import qualified Data.Text as T
 import           Pos.Util.Trace (fromTypeclassWlog)
 import           Pos.Util.UserSecret
 import           Universum
+import           Pos.Crypto (EncryptedSecretKey(eskPayload, eskHash), getEncryptedPass)
+import Cardano.Crypto.Wallet (unXPrv)
+import           Formatting (bprint, hex, shown, (%), fprint, Format, later)
+import qualified Data.ByteString as BS
+import qualified Data.Text.Lazy.Builder as T
+import Formatting.Internal.Raw (left)
+
+hexString :: Format r (ByteString -> r)
+hexString = later f
+  where
+    f :: ByteString -> T.Builder
+    f bs = foldl' f2 "" $ BS.unpack bs
+    f2 :: T.Builder -> Word8 -> T.Builder
+    f2 str byte = str <> (left 2 '0' (bprint hex byte))
+
+extract :: EncryptedSecretKey -> FilePath -> IO ()
+extract esk path = do
+  let
+    (epriv,remain) = BS.splitAt 64 $ unXPrv $ eskPayload esk
+    (pub,chaincode) = BS.splitAt 32 remain
+  fprint ("XPrv: " % hexString % ", pub: " % hexString % ", CC: " % hexString % "\n") epriv pub chaincode
+  fprint ("pass hash: " % shown % "\n") (getEncryptedPass $ eskHash esk)
+  let
+    newkey = (defaultUserSecret & usWallet .~ Just (WalletUserSecret esk "exported key" [] [])) & usPath .~ path
+  writeUserSecret newkey
 
 main :: IO ()
 main = do
@@ -15,6 +40,10 @@ main = do
     zero :: Int
     zero = 0
   forM_ (zip (view usKeys originalKey) [zero..]) $ \(key, x) -> do
-    let
-      newkey = (defaultUserSecret & usWallet .~ Just (WalletUserSecret key (T.pack "head key") [] [])) & usPath .~ ("output-" <> show x <> ".key")
-    writeUserSecret newkey
+    fprint ("extracting key#" % shown % "\n") x
+    extract key ("output-" <> show x <> ".key")
+  case (view usWallet originalKey) of
+    Nothing -> fprint "no wallet key"
+    Just key -> do
+      fprint "extracting wallet key"
+      extract (view wusRootKey key) "output-wallet.key"

--- a/wallet/server/Main.hs
+++ b/wallet/server/Main.hs
@@ -18,6 +18,6 @@ main = withCompileInfo $ do
     let lArgs = loggingParams "node" cArgs
     let nArgs = NodeArgs { behaviorConfigPath = Nothing }
 
-    putText "Wallet is starting..."
+    putText "Wallet is starting...\n"
 
     launchNode nArgs cArgs lArgs (actionWithWallet wArgs)

--- a/wallet/shell.nix
+++ b/wallet/shell.nix
@@ -1,0 +1,35 @@
+let
+  cardanoPkgs = import ../. {};
+  cfgFiles = cardanoPkgs.pkgs.runCommand "cfg" {} ''
+    mkdir $out
+    cd $out
+    cp ${../lib/configuration.yaml} configuration.yaml
+    cp ${../lib/mainnet-genesis.json} mainnet-genesis.json
+    cp ${../lib/testnet-genesis.json} testnet-genesis.json
+    cp ${../lib/mainnet-genesis-dryrun-with-stakeholders.json} mainnet-genesis-dryrun-with-stakeholders.json
+  '';
+  makeHelper = cfg: cardanoPkgs.pkgs.writeScriptBin "test-wallet-${cfg.name}" ''
+    #!/bin/sh
+
+    set -e
+
+    runhaskell Setup.hs build cardano-node
+
+    mkdir -pv states/${cfg.name}/tls/{server,client}
+    STATE=states/${cfg.name}
+
+    ${cardanoPkgs.cardano-sl-tools}/bin/cardano-x509-certificates --server-out-dir $STATE/tls/server --clients-out-dir $STATE/tls/client --configuration-file ${cfgFiles}/configuration.yaml --configuration-key ${cfg.key}
+
+    dist/build/cardano-node/cardano-node --configuration-file ${cfgFiles}/configuration.yaml --configuration-key ${cfg.key} \
+        --db-path states/${cfg.name}/DB --keyfile states/${cfg.name}/secret.key \
+        --logs-prefix states/${cfg.name}/logs --topology ${../script-runner/. + "/topology-${cfg.name}.yaml"} \
+        --tlscert $STATE/tls/server/server.crt --tlskey $STATE/tls/server/server.key \
+        --tlsca $STATE/tls/server/ca.crt \
+        --log-console-off
+  '';
+  mainnet = makeHelper { name = "mainnet"; key = "mainnet_full"; };
+  staging = makeHelper { name = "staging"; key = "mainnet_dryrun_full"; };
+  testnet = makeHelper { name = "testnet"; key = "testnet_full"; };
+in cardanoPkgs.cardano-wallet.env.overrideAttrs (drv: {
+  buildInputs = drv.buildInputs ++ [ mainnet staging testnet ];
+})

--- a/wallet/shell.nix
+++ b/wallet/shell.nix
@@ -22,6 +22,7 @@ let
 
     dist/build/cardano-node/cardano-node --configuration-file ${cfgFiles}/configuration.yaml --configuration-key ${cfg.key} \
         --db-path states/${cfg.name}/DB --keyfile states/${cfg.name}/secret.key \
+        --wallet-db-path states/${cfg.name}/Wallet
         --logs-prefix states/${cfg.name}/logs --topology ${../script-runner/. + "/topology-${cfg.name}.yaml"} \
         --tlscert $STATE/tls/server/server.crt --tlskey $STATE/tls/server/server.key \
         --tlsca $STATE/tls/server/ca.crt \

--- a/wallet/src/Cardano/Wallet/API/Internal.hs
+++ b/wallet/src/Cardano/Wallet/API/Internal.hs
@@ -9,7 +9,8 @@ import           Servant
 
 import           Cardano.Wallet.API.Response (APIResponse, ValidJSON)
 import           Cardano.Wallet.API.Types
-import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletImport)
+import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletImport, WalletBalance)
+import Pos.Crypto.Signing (EncryptedSecretKey)
 
 type API = Tag "Internal" ('TagDescription
     "This section contains endpoints so-called 'Internal'. They are only\
@@ -37,4 +38,8 @@ type API = Tag "Internal" ('TagDescription
         :> Summary "Import a Wallet from disk."
         :> ReqBody '[ValidJSON] WalletImport
         :> Post '[ValidJSON] (APIResponse Wallet)
+    :<|> "query-balance"
+        :> Summary "query the balance from a pubkey"
+        :> ReqBody '[ValidJSON] EncryptedSecretKey
+        :> Post '[ValidJSON] (APIResponse WalletBalance)
     )

--- a/wallet/src/Cardano/Wallet/API/Internal.hs
+++ b/wallet/src/Cardano/Wallet/API/Internal.hs
@@ -9,8 +9,9 @@ import           Servant
 
 import           Cardano.Wallet.API.Response (APIResponse, ValidJSON)
 import           Cardano.Wallet.API.Types
-import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletImport, WalletBalance)
-import Pos.Crypto.Signing (EncryptedSecretKey)
+import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletBalance,
+                     WalletImport)
+import           Pos.Crypto.Signing (EncryptedSecretKey)
 
 type API = Tag "Internal" ('TagDescription
     "This section contains endpoints so-called 'Internal'. They are only\

--- a/wallet/src/Cardano/Wallet/API/Internal/Handlers.hs
+++ b/wallet/src/Cardano/Wallet/API/Internal/Handlers.hs
@@ -8,10 +8,11 @@ import           Pos.Chain.Update (SoftwareVersion)
 
 import qualified Cardano.Wallet.API.Internal as Internal
 import           Cardano.Wallet.API.Response (APIResponse, single)
-import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletImport, WalletBalance)
+import           Cardano.Wallet.API.V1.Types (V1, Wallet, WalletBalance,
+                     WalletImport)
 import           Cardano.Wallet.WalletLayer (PassiveWalletLayer)
 import qualified Cardano.Wallet.WalletLayer as WalletLayer
-import Pos.Crypto.Signing (EncryptedSecretKey)
+import           Pos.Crypto.Signing (EncryptedSecretKey)
 
 handlers :: PassiveWalletLayer IO -> ServerT Internal.API Handler
 handlers w = nextUpdate       w

--- a/wallet/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
+++ b/wallet/src/Cardano/Wallet/API/V1/ReifyWalletError.hs
@@ -206,6 +206,9 @@ importWalletError e = case e of
     ex@(ImportWalletNoWalletFoundInBackup _file) ->
         V1.UnknownError (sformat build ex)
 
+    ex@(ImportWalletMissingField) ->
+        V1.UnknownError (sformat build ex)
+
     (ImportWalletCreationFailed e') ->
         createWalletError e'
 

--- a/wallet/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet/src/Cardano/Wallet/API/V1/Types.hs
@@ -161,18 +161,19 @@ import           Cardano.Wallet.Types.UtxoStatistics
 import           Cardano.Wallet.Util (mkJsonKey, showApiUtcTime)
 
 import           Cardano.Mnemonic (Mnemonic)
+import           Pos.Binary.Class (decodeFull')
 import qualified Pos.Chain.Txp as Txp
 import qualified Pos.Client.Txp.Util as Core
 import qualified Pos.Core as Core
-import           Pos.Crypto (PublicKey (..), decodeHash, hashHexF, EncryptedSecretKey)
+import           Pos.Crypto (EncryptedSecretKey, PublicKey (..), decodeHash,
+                     hashHexF)
 import qualified Pos.Crypto.Signing as Core
 import           Pos.Infra.Communication.Types.Protocol ()
-import Pos.Binary.Class (decodeFull')
 import           Pos.Infra.Diffusion.Subscription.Status
                      (SubscriptionStatus (..))
-import           Pos.Infra.Util.LogSafe (BuildableSafeGen (..), buildSafe,
-                     buildSafeList, buildSafeMaybe, deriveSafeBuildable,
-                     plainOrSecureF, SecureLog)
+import           Pos.Infra.Util.LogSafe (BuildableSafeGen (..), SecureLog,
+                     buildSafe, buildSafeList, buildSafeMaybe,
+                     deriveSafeBuildable, plainOrSecureF)
 import           Test.Pos.Core.Arbitrary ()
 
 -- | Declare generic schema, while documenting properties
@@ -1636,7 +1637,7 @@ mkEncryptedSecretKey eskhex = join $
 
 instance FromJSON EncryptedSecretKey where
   parseJSON (String eskhex) = case mkEncryptedSecretKey eskhex of
-      Left e -> fail (toString e)
+      Left e    -> fail (toString e)
       Right esk -> pure esk
   parseJSON x = typeMismatch "parseJSON failed for EncryptedSecretKey" x
 

--- a/wallet/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet/src/Cardano/Wallet/API/V1/Types.hs
@@ -1598,7 +1598,8 @@ instance BuildableSafeGen WalletSoftwareUpdate where
         updScriptVersion
 
 data WalletBalance = WalletBalance
-  { wbBalance :: V1 (Core.Coin)
+  { wbBalance  :: V1 (Core.Coin)
+  , wbWalletId :: Text
   } deriving (Show, Eq, Generic)
 deriveJSON Aeson.defaultOptions ''WalletBalance
 
@@ -1611,10 +1612,10 @@ instance ToSchema WalletBalance where
 
 instance Example WalletBalance
 instance Arbitrary WalletBalance where
-    arbitrary = WalletBalance <$> arbitrary
+    arbitrary = WalletBalance <$> arbitrary <*> arbitrary
 
 instance Buildable WalletBalance where
-    build (WalletBalance bal) = "WalletBalance { ballence = " <> (show bal) <> " }"
+    build (WalletBalance bal walid) = "WalletBalance { ballence = " <> (show bal) <> ", walletid = " <> show walid <> " }"
 
 instance ToSchema EncryptedSecretKey where
     declareNamedSchema _ =

--- a/wallet/src/Cardano/Wallet/API/V1/Types.hs
+++ b/wallet/src/Cardano/Wallet/API/V1/Types.hs
@@ -1608,6 +1608,8 @@ instance ToSchema WalletBalance where
         genericSchemaDroppingPrefix "wb" (\(--^) props -> props
             & "balance"
             --^ "the balance of a given public key"
+            & "walletId"
+            --^ "the walletid of the given public key"
         )
 
 instance Example WalletBalance
@@ -1615,7 +1617,7 @@ instance Arbitrary WalletBalance where
     arbitrary = WalletBalance <$> arbitrary <*> arbitrary
 
 instance Buildable WalletBalance where
-    build (WalletBalance bal walid) = "WalletBalance { ballence = " <> (show bal) <> ", walletid = " <> show walid <> " }"
+    build (WalletBalance bal walid) = "WalletBalance { balence = " <> (show bal) <> ", walletId = " <> show walid <> " }"
 
 instance ToSchema EncryptedSecretKey where
     declareNamedSchema _ =
@@ -1624,17 +1626,12 @@ instance ToSchema EncryptedSecretKey where
             & format ?~ "hex|base16"
 
 instance ToJSON EncryptedSecretKey where
-  toJSON _esk = "todo"
+  toJSON _esk = "<encrypted secret>"
 
 mkEncryptedSecretKey :: Text -> Either Text EncryptedSecretKey
-mkEncryptedSecretKey eskhex = join $
-  case Base16.decode eskhex of
-    Left e -> Left e
-    Right bs -> do
-      let
-        esk :: Either Text EncryptedSecretKey
-        esk = decodeFull' bs
-      pure esk
+mkEncryptedSecretKey eskhex = case Base16.decode eskhex of
+    Left e   -> Left e
+    Right bs -> decodeFull' bs
 
 instance FromJSON EncryptedSecretKey where
   parseJSON (String eskhex) = case mkEncryptedSecretKey eskhex of
@@ -1643,7 +1640,7 @@ instance FromJSON EncryptedSecretKey where
   parseJSON x = typeMismatch "parseJSON failed for EncryptedSecretKey" x
 
 instance Buildable (SecureLog EncryptedSecretKey) where
-  build _ = "todo"
+  build _ = "<encrypted secret>"
 
 -- | A type encapsulating enough information to import a wallet from a
 -- backup file.

--- a/wallet/src/Cardano/Wallet/Client.hs
+++ b/wallet/src/Cardano/Wallet/Client.hs
@@ -44,6 +44,7 @@ import           Servant.Client (GenResponse (..), Response, ServantError (..))
 import qualified Pos.Chain.Txp as Core
 import           Pos.Chain.Update (SoftwareVersion)
 import qualified Pos.Core as Core
+import           Pos.Crypto (EncryptedSecretKey)
 
 import           Cardano.Wallet.API.Request.Filter
 import           Cardano.Wallet.API.Request.Pagination
@@ -155,6 +156,7 @@ data WalletClient m
         :: m (Either ClientError ())
     , importWallet
         :: WalletImport -> Resp m Wallet
+    , queryBalance :: EncryptedSecretKey -> Resp m WalletBalance
     } deriving Generic
 
 data WalletDocClient m = WalletDocClient
@@ -286,6 +288,7 @@ natMapClient phi f wc = WalletClient
         f $ phi $ resetWalletState wc
     , importWallet =
         f . phi . importWallet wc
+    , queryBalance = f . phi . queryBalance wc
     }
 
 -- | Run the given natural transformation over the 'WalletClient'.

--- a/wallet/src/Cardano/Wallet/Client/Http.hs
+++ b/wallet/src/Cardano/Wallet/Client/Http.hs
@@ -108,6 +108,7 @@ mkHttpClient baseUrl manager = WalletClient
 
     , importWallet
         = run . importWalletR
+    , queryBalance = run . queryBalanceR
     }
 
   where
@@ -162,6 +163,7 @@ mkHttpClient baseUrl manager = WalletClient
         :<|> postponeUpdateR
         :<|> resetWalletStateR
         :<|> importWalletR
+        :<|> queryBalanceR
         = internalAPI
 
     addressesAPI

--- a/wallet/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
+++ b/wallet/src/Cardano/Wallet/Kernel/DB/HdWallet.hs
@@ -120,7 +120,8 @@ import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto (HDPassphrase)
 import qualified Pos.Crypto as Core
 
-import           Cardano.Wallet.API.V1.Types (V1 (..))
+import           Cardano.Wallet.API.V1.Types (V1 (..),
+                     WAddressMeta (WAddressMeta))
 import           Cardano.Wallet.Kernel.DB.BlockContext
 import           Cardano.Wallet.Kernel.DB.InDb
 import           Cardano.Wallet.Kernel.DB.Spec
@@ -128,6 +129,8 @@ import           Cardano.Wallet.Kernel.DB.Util.AcidState
 import           Cardano.Wallet.Kernel.DB.Util.IxSet hiding (foldl')
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet hiding (Indexable)
 import qualified Cardano.Wallet.Kernel.DB.Util.Zoomable as Z
+import           Cardano.Wallet.Kernel.Decrypt (WalletDecrCredentials,
+                     decryptAddress)
 import           Cardano.Wallet.Kernel.NodeStateAdaptor (SecurityParameter (..))
 import qualified Cardano.Wallet.Kernel.Util.StrictList as SL
 import           Cardano.Wallet.Kernel.Util.StrictNonEmpty (StrictNonEmpty (..))
@@ -534,6 +537,16 @@ instance IsOurs [(HdRootId, Core.EncryptedSecretKey)] where
         let accId = HdAccountId rootId accountIx
         let addrId = HdAddressId accId addressIx
         return $ HdAddress addrId (InDb addr)
+
+instance IsOurs [ (HdRootId, WalletDecrCredentials) ] where
+    isOurs addr s = (,s) $ foldl' (<|>) Nothing $ flip map s $ \(rootId, wdc) -> do
+        case decryptAddress wdc (addr::Core.Address) of
+          Just (WAddressMeta _wid accountIx addressIx _addrv1) -> do
+            let
+              accId = HdAccountId rootId (HdAccountIx accountIx)
+              addrId = HdAddressId accId (HdAddressIx addressIx)
+            pure (HdAddress addrId (InDb addr))
+          Nothing -> Nothing
 
 decryptHdLvl2DerivationPath
     :: Core.HDPassphrase

--- a/wallet/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet/src/Cardano/Wallet/WalletLayer.hs
@@ -50,8 +50,8 @@ import           Cardano.Wallet.API.V1.Types (Account, AccountBalance,
                      ForceNtpCheck, NewAccount, NewAddress, NewWallet,
                      NodeInfo, NodeSettings, PasswordUpdate, Payment,
                      Redemption, SpendingPassword, Transaction, V1 (..),
-                     Wallet, WalletAddress, WalletId, WalletImport,
-                     WalletBalance, WalletUpdate)
+                     Wallet, WalletAddress, WalletBalance, WalletId,
+                     WalletImport, WalletUpdate)
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric

--- a/wallet/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet/src/Cardano/Wallet/WalletLayer.hs
@@ -357,6 +357,8 @@ data ImportWalletError =
     -- didn't provide any.
     | ImportWalletCreationFailed CreateWalletError
     -- ^ When trying to import this wallet, the wallet creation failed.
+    | ImportWalletMissingField
+    -- ^ one of FilePath or RawSecret must be specified
 
 -- | Unsound show instance needed for the 'Exception' instance.
 instance Show ImportWalletError where
@@ -371,6 +373,7 @@ instance Buildable ImportWalletError where
         bprint ("ImportWalletNoWalletFoundInBackup " % build) fp
     build (ImportWalletCreationFailed err) =
         bprint ("ImportWalletCreationFailed " % build) err
+    build (ImportWalletMissingField) = "ImportWalletMissingField"
 
 ------------------------------------------------------------
 -- Errors when getting Transactions

--- a/wallet/src/Cardano/Wallet/WalletLayer.hs
+++ b/wallet/src/Cardano/Wallet/WalletLayer.hs
@@ -51,7 +51,7 @@ import           Cardano.Wallet.API.V1.Types (Account, AccountBalance,
                      NodeInfo, NodeSettings, PasswordUpdate, Payment,
                      Redemption, SpendingPassword, Transaction, V1 (..),
                      Wallet, WalletAddress, WalletId, WalletImport,
-                     WalletUpdate)
+                     WalletBalance, WalletUpdate)
 import qualified Cardano.Wallet.Kernel.Accounts as Kernel
 import qualified Cardano.Wallet.Kernel.Addresses as Kernel
 import           Cardano.Wallet.Kernel.CoinSelection.FromGeneric
@@ -482,6 +482,7 @@ data PassiveWalletLayer m = PassiveWalletLayer
     , postponeUpdate       :: m ()
     , resetWalletState     :: m ()
     , importWallet         :: WalletImport -> m (Either ImportWalletError Wallet)
+    , queryWalletBalance   :: EncryptedSecretKey -> IO WalletBalance
 
     -- updates
     , waitForUpdate        :: m ConfirmedProposalState

--- a/wallet/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -22,8 +22,8 @@ import qualified Formatting as F
 
 import           Pos.Chain.Block (Blund, blockHeader, headerHash, prevBlockL)
 import           Pos.Chain.Genesis (Config (..))
-import           Pos.Chain.Txp (TxIn, TxOutAux)
-import           Pos.Chain.Txp (toaOut, txOutAddress, txOutValue)
+import           Pos.Chain.Txp (TxIn, TxOutAux, toaOut, txOutAddress,
+                     txOutValue)
 import           Pos.Chain.Update (HasUpdateConfiguration)
 import           Pos.Core.Chrono (OldestFirst (..))
 import           Pos.Core.Common (Coin, addrToBase58, mkCoin, unsafeAddCoin)

--- a/wallet/src/Cardano/Wallet/WalletLayer/Kernel.hs
+++ b/wallet/src/Cardano/Wallet/WalletLayer/Kernel.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE RankNTypes   #-}
 
 module Cardano.Wallet.WalletLayer.Kernel
     ( bracketPassiveWallet
@@ -21,35 +21,37 @@ import qualified Formatting as F
 
 import           Pos.Chain.Block (Blund, blockHeader, headerHash, prevBlockL)
 import           Pos.Chain.Genesis (Config (..))
-import           Pos.Core.Chrono (OldestFirst (..))
-import           Pos.Crypto (ProtocolMagic, EncryptedSecretKey)
-import           Pos.Infra.InjectFail (FInjects)
-import           Pos.Util.Wlog (Severity (Debug, Warning))
-import Pos.Core.Common (Coin, unsafeAddCoin, mkCoin)
-import Pos.Chain.Txp (TxOutAux, TxIn)
-import           Pos.Core.NetworkMagic (makeNetworkMagic)
-import Pos.DB.Txp.Utxo (getAllPotentiallyHugeUtxo)
-import Pos.Chain.Txp (Utxo, toaOut, txOutAddress, txOutValue)
+import           Pos.Chain.Txp (TxIn, TxOutAux)
+import           Pos.Chain.Txp (Utxo, toaOut, txOutAddress, txOutValue)
 import           Pos.Chain.Update (HasUpdateConfiguration)
-import Pos.Util.CompileInfo(HasCompileInfo)
+import           Pos.Core.Chrono (OldestFirst (..))
+import           Pos.Core.Common (Coin, mkCoin, unsafeAddCoin)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
+import           Pos.Crypto (EncryptedSecretKey, ProtocolMagic)
+import           Pos.DB.Txp.Utxo (getAllPotentiallyHugeUtxo)
+import           Pos.Infra.InjectFail (FInjects)
+import           Pos.Util.CompileInfo (HasCompileInfo)
+import           Pos.Util.Wlog (Severity (Debug, Warning))
 
-import           Cardano.Wallet.Kernel.Internal (walletProtocolMagic, walletNode)
+import           Cardano.Wallet.API.V1.Types (V1 (V1), WalletBalance (..))
 import qualified Cardano.Wallet.Kernel as Kernel
-import Cardano.Wallet.Kernel.PrefilterTx (WalletKey, filterOurs)
-import Cardano.Wallet.Kernel.Decrypt (eskToWalletDecrCredentials)
-import           Cardano.Wallet.Kernel.Types (WalletId(WalletIdHdRnd))
 import qualified Cardano.Wallet.Kernel.Actions as Actions
 import qualified Cardano.Wallet.Kernel.BListener as Kernel
 import           Cardano.Wallet.Kernel.DB.AcidState (dbHdWallets)
-import           Cardano.Wallet.Kernel.DB.HdWallet (hdAccountRestorationState,
-                     hdRootId, hdWalletsRoots, eskToHdRootId, HdAddressId)
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdAddressId, eskToHdRootId,
+                     hdAccountRestorationState, hdRootId, hdWalletsRoots)
 import qualified Cardano.Wallet.Kernel.DB.Read as Kernel
 import qualified Cardano.Wallet.Kernel.DB.Util.IxSet as IxSet
+import           Cardano.Wallet.Kernel.Decrypt (eskToWalletDecrCredentials)
 import           Cardano.Wallet.Kernel.Diffusion (WalletDiffusion (..))
+import           Cardano.Wallet.Kernel.Internal (walletNode,
+                     walletProtocolMagic)
 import           Cardano.Wallet.Kernel.Keystore (Keystore)
 import           Cardano.Wallet.Kernel.NodeStateAdaptor
+import           Cardano.Wallet.Kernel.PrefilterTx (WalletKey, filterOurs)
 import qualified Cardano.Wallet.Kernel.Read as Kernel
 import qualified Cardano.Wallet.Kernel.Restore as Kernel
+import           Cardano.Wallet.Kernel.Types (WalletId (WalletIdHdRnd))
 import           Cardano.Wallet.WalletLayer (ActiveWalletLayer (..),
                      PassiveWalletLayer (..))
 import qualified Cardano.Wallet.WalletLayer.Kernel.Accounts as Accounts
@@ -60,7 +62,6 @@ import qualified Cardano.Wallet.WalletLayer.Kernel.Internal as Internal
 import qualified Cardano.Wallet.WalletLayer.Kernel.Settings as Settings
 import qualified Cardano.Wallet.WalletLayer.Kernel.Transactions as Transactions
 import qualified Cardano.Wallet.WalletLayer.Kernel.Wallets as Wallets
-import Cardano.Wallet.API.V1.Types (WalletBalance(..), V1(V1))
 
 -- | Initialize the passive wallet.
 -- The passive wallet cannot send new transactions.

--- a/wallet/test/integration/Test/Integration/Framework/DSL.hs
+++ b/wallet/test/integration/Test/Integration/Framework/DSL.hs
@@ -776,7 +776,7 @@ withNextFaucet actionWithFaucet = do
     let acquireFaucet = do
             let (key:rest) = ctx ^. faucets
             put (ctx & faucets .~ rest)
-            successfulRequest $ Client.importWallet $- WalletImport Nothing key
+            successfulRequest $ Client.importWallet $- WalletImport Nothing (Just key) Nothing
 
     let releaseFaucet faucet = do
             successfulRequest (Client.deleteWallet $- walId faucet)


### PR DESCRIPTION
## Description

from nodejs:
`> cbor.encode(cbor.decode(fs.readFileSync("/home/clever/.local/share/Daedalus/testnet/Secrets/secret.key"))[2][0]).toString("hex")`
this will read a given `secret.key` file, extract the 0th wallet `EncryptedSecretKey`, and then print it out as hex

```
curl --cert tls/client/client.pem --cacert tls/server/ca.crt https://localhost:8090/api/internal/query-balance -X POST -d '"RAWHEXHERE"' -H "Content-Type: application/json; charset=utf-8"
{"data":{"balance":1884697408},"status":"success","meta":{"pagination":{"totalPages":1,"page":1,"perPage":1,"totalEntries":1}}}
```
you can then throw that hex directly at cardano, without importing any wallets, and without using any spending pw, and just query the current balance of the given key

https://github.com/input-output-hk/daedalus/pull/1268 can then use this new api, to get the balance of secrets, before knowing the pw

this also serves as an example of how to start with DEVOPS-1148

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
