### PR TITLE
[DEVOPS-1250] backport RCD-47 fix about 'hasSpendingPassword' metadata with extra sanity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Cardano SL 3.0.1
+
+### Fixes
+
+- Fix inconsistent 'hasSpendingPassword' resolution from legacy data layer migration ([DEVOPS-1250](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1250) [#4112](https://github.com/input-output-hk/cardano-sl/pull/4112))
+
 ## Cardano SL 3.0.0
 
 ### Fixes

--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14851,7 +14851,7 @@ mainnet_wallet_win64: &mainnet_wallet_win64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14861,7 +14861,7 @@ mainnet_wallet_macos64: &mainnet_wallet_macos64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14871,7 +14871,7 @@ mainnet_wallet_linux64: &mainnet_wallet_linux64
   <<: *mainnet_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 13
+    applicationVersion: 14
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 1
@@ -14945,7 +14945,7 @@ testnet_wallet: &testnet_wallet
   <<: *testnet_full
   update: &testnet_wallet_update
     applicationName: csl-daedalus
-    applicationVersion: 9
+    applicationVersion: 10
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 0
@@ -14984,7 +14984,7 @@ mainnet_dryrun_wallet_win64: &mainnet_dryrun_wallet_win64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 22
+    applicationVersion: 23
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -14994,7 +14994,7 @@ mainnet_dryrun_wallet_macos64: &mainnet_dryrun_wallet_macos64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 22
+    applicationVersion: 23
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2
@@ -15004,7 +15004,7 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
   <<: *mainnet_dryrun_full
   update:
     applicationName: csl-daedalus
-    applicationVersion: 22
+    applicationVersion: 23
     lastKnownBlockVersion:
       bvMajor: 0
       bvMinor: 2

--- a/wallet/src/Cardano/Wallet/Action.hs
+++ b/wallet/src/Cardano/Wallet/Action.hs
@@ -22,7 +22,8 @@ import           Cardano.Wallet.Kernel (PassiveWallet)
 import qualified Cardano.Wallet.Kernel as Kernel
 import qualified Cardano.Wallet.Kernel.Internal as Kernel.Internal
 import qualified Cardano.Wallet.Kernel.Keystore as Keystore
-import           Cardano.Wallet.Kernel.Migration (migrateLegacyDataLayer)
+import           Cardano.Wallet.Kernel.Migration (migrateLegacyDataLayer,
+                     sanityCheckSpendingPassword)
 import qualified Cardano.Wallet.Kernel.Mode as Kernel.Mode
 import qualified Cardano.Wallet.Kernel.NodeStateAdaptor as NodeStateAdaptor
 import           Cardano.Wallet.Server.CLI (WalletBackendParams,
@@ -68,6 +69,7 @@ actionWithWallet params genesisConfig walletConfig txpConfig ntpConfig nodeParam
         let pm = configProtocolMagic genesisConfig
         WalletLayer.Kernel.bracketPassiveWallet pm dbMode logMessage' keystore nodeState (npFInjects nodeParams) $ \walletLayer passiveWallet -> do
             migrateLegacyDataLayer passiveWallet dbPath (getFullMigrationFlag params)
+            sanityCheckSpendingPassword passiveWallet
 
             let plugs = plugins (walletLayer, passiveWallet) dbMode
 


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

Since a few users have already ran the migration, they might have migrated wallet with incorrect metadata, wrongly stating that
their wallet has no spending password, and as a consequence, preventing them from doing anything with their wallet. So, we do now
run an extra sanity check upon every start to make sure that the wallet acid state metadata matches what we find in the keystore.


## Linked issue

<!--- Put here the relevant issue from YouTrack -->

[[DEVOPS-150]](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-1250)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [x] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

### Creating Wallets on 1.3.x

```
$ curl -vkX POST "http://localhost:8090/api/v1/wallets" \
  -H "Content-Type: application/json;charset=utf-8" \
  -d '{
  "operation": "create",
  "spendingPassword": "",
  "backupPhrase": [...],
  "assuranceLevel": "normal",
  "name": "Without Password"
}' | jq .data

{
  "id": "Ae2tdPwUPEZ1UMga1bnFFD7FoFN9ZFoPLCWLaGcqNnfovcrcT3oMSuAz8DD",
  "name": "Without Password",
  "hasSpendingPassword": false,
  [..]
}
```

```
$ curl -vkX POST "http://localhost:8090/api/v1/wallets" \
  -H "Content-Type: application/json;charset=utf-8" \
  -d '{
  "operation": "create",
  "backupPhrase": [...],
  "spendingPassword": "5416b2988745725998907addf4613c9b0764f04959030e1b81c603b920a115d0",
  "assuranceLevel": "normal",
  "name": "With Password"
}' | jq .data

{
    "id": "Ae2tdPwUPEYvuFeJoBAiYtbFWaZwzya1om6Mqvbz9aL85TncK47bRhL4oZv",
    "name": "With Password",
    "hasSpendingPassword": true,
    [..]
}
```

## Migrating wallet (without patch) from 1.3.x --> 3.0.x

#### Logs

```
[2019-03-21 11:32:50.15 UTC] Migrating HdRoot { id: HdRootId Ae2tdPw...SuAz8DD, name: <Migrated Wallet>, hasPassword: no ... }
[2019-03-21 11:32:51.27 UTC] Migrating HdRoot { id: HdRootId Ae2tdPw...RhL4oZv, name: <Migrated Wallet>, hasPassword: no ... }
[2019-03-21 11:32:52.14 UTC] Migration succeeded, restoration of migrated wallets in progress...
```

#### Wallet State

```
$ curl -kX GET http://localhost:8090/api/v1/wallets | jq .data
[
  {
    "id": "Ae2tdPwUPEZ1UMga1bnFFD7FoFN9ZFoPLCWLaGcqNnfovcrcT3oMSuAz8DD",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": false,
    [...]
  },
  {
    "id": "Ae2tdPwUPEYvuFeJoBAiYtbFWaZwzya1om6Mqvbz9aL85TncK47bRhL4oZv",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": false,
    [...]
  }
]
```

### Restarting (with patch) an already migrated wallet (without patch) from 1.3.x --> 3.0.x

#### Logs

```
[cardano-sl.node:Info:ThreadId 1727] [2019-03-21 11:42:23.90 UTC] Starting wallet(s) migration
[cardano-sl.node:Info:ThreadId 1727] [2019-03-21 11:42:23.90 UTC] No legacy DB at state-devops1250/wallet-db, migration is not needed.
```

#### Wallet State

```
$ curl -kX GET http://localhost:8090/api/v1/wallets | jq .data
[
  {
    "id": "Ae2tdPwUPEZ1UMga1bnFFD7FoFN9ZFoPLCWLaGcqNnfovcrcT3oMSuAz8DD",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": false,
    [...]
  },
  {
    "id": "Ae2tdPwUPEYvuFeJoBAiYtbFWaZwzya1om6Mqvbz9aL85TncK47bRhL4oZv",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": true,
    [...]
  }
]
```

### Migrating wallet (with patch) from 1.3.x --> 3.0.x

#### Logs

```
[2019-03-21 11:49:03.24 UTC] Migrating HdRoot { id: HdRootId Ae2tdPw...SuAz8DD, name: <Migrated Wallet>, hasPassword: no ... }
[2019-03-21 11:49:04.50 UTC] Migrating HdRoot { id: HdRootId Ae2tdPw...RhL4oZv, name: <Migrated Wallet>, hasPassword: updated 1553168943743216 ... }
[2019-03-21 11:49:04.50 UTC] Migration succeeded, restoration of migrated wallets in progress...
```

#### Wallet State

```
$ curl -kX GET http://localhost:8090/api/v1/wallets | jq .data
[
  {
    "id": "Ae2tdPwUPEZ1UMga1bnFFD7FoFN9ZFoPLCWLaGcqNnfovcrcT3oMSuAz8DD",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": false,
    [..]
  },
  {
    "id": "Ae2tdPwUPEYvuFeJoBAiYtbFWaZwzya1om6Mqvbz9aL85TncK47bRhL4oZv",
    "name": "<Migrated Wallet>",
    "hasSpendingPassword": true,
    [...]
  }
]
```


## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
