### PR TITLE
add extra guard to fail if trying to submit a too big transaction

### DIFF
--- a/wallet/src/Cardano/Wallet/Kernel/Transactions.hs
+++ b/wallet/src/Cardano/Wallet/Kernel/Transactions.hs
@@ -177,7 +177,7 @@ pay activeWallet spendingPassword opts accountId payees = do
              Right (txAux, partialMeta, _utxo) -> do
                  let sz = fromIntegral $ BL.length $ serialize txAux
                  maxSz <- Node.getMaxTxSize (walletPassive activeWallet ^. walletNode)
-                 if sz > maxSz then
+                 if sz >= maxSz then
                      return
                      . Left
                      . PaymentNewTransactionError


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

This can happen because we only _estimate_ the maximum number of inputs allowed for the coin selection.
As a result, the transaction generated as a result of the coin selection may be slightly bigger than
the maximum sized allowed by the network (currently 8kb). So, having an extra sanity checks prevent
wrong transactions to be submitted (and added to our pendin set)


## Linked issue

<!--- Put here the relevant issue from YouTrack -->

?

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
