### PR TITLE
fix wrong order of last transactions

### DIFF
--- a/explorer/src/Pos/Explorer/BListener.hs
+++ b/explorer/src/Pos/Explorer/BListener.hs
@@ -144,7 +144,7 @@ onApplyLastTxsExplorer blunds = generalLastTxsExplorer blocksNE getTopTxsDiff
     getTopTxsDiff oldTxs newTxs = take numOfLastTxs reversedCombined
       where
         reversedCombined :: [Tx]
-        reversedCombined = reverse $ getOldTxs oldTxs ++ getNewTxs newTxs
+        reversedCombined = reverse (getNewTxs newTxs) ++ getOldTxs oldTxs
 
     blocksNE :: NE Block
     blocksNE = fst <$> getOldestFirst blunds
@@ -185,7 +185,7 @@ onRollbackLastTxsExplorer blunds = generalLastTxsExplorer blocksNE getTopTxsDiff
         :: OldTxs
         -> NewTxs
         -> [Tx]
-    getTopTxsDiff oldTxs newTxs = getOldTxs oldTxs \\ getNewTxs newTxs
+    getTopTxsDiff oldTxs newTxs = getOldTxs oldTxs \\ (reverse $ getNewTxs newTxs)
 
     blocksNE :: NE Block
     blocksNE = fst <$> getNewestFirst blunds


### PR DESCRIPTION
## Description

The 'getLastTxs' function may always get wrong order of last transactions

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [~] 🛠 New feature (non-breaking change which adds functionality)
- [~] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [~] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [~] 🔨 New or improved tests for existing code
- [~] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [x] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [x] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [~] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [~] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [~] I have added tests to cover my changes.
- [~] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
