### PR TITLE
export legacy wallets in a friendly way for automatic import in cardano-wallet

### DIFF
--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -149,6 +149,7 @@
             (hsPkgs.cardano-sl-util)
             (hsPkgs.cardano-wallet)
             (hsPkgs.contravariant)
+            (hsPkgs.directory)
             (hsPkgs.memory)
             (hsPkgs.optparse-applicative)
             (hsPkgs.text)

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -149,6 +149,7 @@
             (hsPkgs.cardano-sl-util)
             (hsPkgs.cardano-wallet)
             (hsPkgs.contravariant)
+            (hsPkgs.cryptonite)
             (hsPkgs.directory)
             (hsPkgs.memory)
             (hsPkgs.optparse-applicative)

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -134,6 +134,27 @@
             (hsPkgs.universum)
             ];
           };
+        "export-wallets" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.aeson)
+            (hsPkgs.aeson-pretty)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-crypto)
+            (hsPkgs.cardano-sl)
+            (hsPkgs.cardano-sl-core)
+            (hsPkgs.cardano-sl-crypto)
+            (hsPkgs.cardano-sl-crypto)
+            (hsPkgs.cardano-sl-infra)
+            (hsPkgs.cardano-sl-util)
+            (hsPkgs.cardano-wallet)
+            (hsPkgs.contravariant)
+            (hsPkgs.memory)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.text)
+            (hsPkgs.universum)
+            ];
+          };
         };
       tests = {
         "unit" = {

--- a/wallet/cardano-wallet.cabal
+++ b/wallet/cardano-wallet.cabal
@@ -369,6 +369,7 @@ executable export-wallets
     , cardano-sl-util
     , cardano-wallet
     , contravariant
+    , cryptonite
     , directory
     , memory
     , optparse-applicative

--- a/wallet/cardano-wallet.cabal
+++ b/wallet/cardano-wallet.cabal
@@ -337,6 +337,49 @@ executable cardano-generate-swagger-file
   main-is:
       Main.hs
 
+executable export-wallets
+  default-language:
+      Haskell2010
+  default-extensions:
+      FlexibleContexts
+      MonadFailDesugaring
+      NoImplicitPrelude
+      OverloadedStrings
+      RecordWildCards
+      ScopedTypeVariables
+      TypeApplications
+      TypeOperators
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+      -fno-warn-orphans
+      -O2
+
+  build-depends:
+      base
+    , aeson
+    , aeson-pretty
+    , bytestring
+    , cardano-crypto
+    , cardano-sl
+    , cardano-sl-core
+    , cardano-sl-crypto
+    , cardano-sl-crypto
+    , cardano-sl-infra
+    , cardano-sl-util
+    , cardano-wallet
+    , contravariant
+    , memory
+    , optparse-applicative
+    , text
+    , universum >= 0.1.11
+
+  hs-source-dirs:
+      export-wallets
+  main-is:
+      Main.hs
+
+
 test-suite unit
   default-language:
       Haskell2010

--- a/wallet/cardano-wallet.cabal
+++ b/wallet/cardano-wallet.cabal
@@ -369,6 +369,7 @@ executable export-wallets
     , cardano-sl-util
     , cardano-wallet
     , contravariant
+    , directory
     , memory
     , optparse-applicative
     , text

--- a/wallet/export-wallets/Main.hs
+++ b/wallet/export-wallets/Main.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module Main where
+
+import           Universum
+
+import           Cardano.Crypto.Wallet (unXPrv)
+import           Cardano.Wallet.Kernel (DatabaseMode (..), DatabaseOptions (..),
+                     bracketPassiveWallet)
+import           Cardano.Wallet.Kernel.DB.HdWallet (HdRoot (..), HdRootId (..),
+                     HdRootId (..), WalletName (..), eskToHdRootId)
+import           Cardano.Wallet.Kernel.DB.InDb (fromDb)
+import           Cardano.Wallet.Kernel.Keystore (bracketLegacyKeystore)
+import           Cardano.Wallet.Kernel.NodeStateAdaptor (mockNodeStateDef)
+import           Data.Aeson (ToJSON (..), (.=))
+import           Data.ByteArray.Encoding (Base (..), convertToBase)
+import           Data.ByteString (ByteString)
+import           Data.Functor.Contravariant (Contravariant (..), Op (..))
+import           Options.Applicative
+import           Pos.Core.Common (addrToBase58)
+import           Pos.Core.NetworkMagic (makeNetworkMagic)
+import           Pos.Crypto (EncryptedPass (..), EncryptedSecretKey (..))
+import           Pos.Crypto.Configuration (ProtocolMagic (..),
+                     ProtocolMagicId (..), RequiresNetworkMagic (..))
+import           Pos.Infra.InjectFail (mkFInjects)
+import           Pos.Util.Log.Severity (Severity (..))
+import           Pos.Util.Trace (Trace (..))
+import           Pos.Util.UserSecret (readUserSecret)
+
+import qualified Cardano.Wallet.Kernel as Kernel
+import qualified Cardano.Wallet.Kernel.Internal as Kernel
+import qualified Cardano.Wallet.Kernel.Keystore as Keystore
+import qualified Cardano.Wallet.Kernel.Read as Kernel
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Encode.Pretty as Json
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as TIO
+
+data Options = Options
+    { pm     :: ProtocolMagic
+    , dbPath :: FilePath
+    , usPath :: FilePath
+    }
+
+main :: IO ()
+main = do
+    let preferences = prefs showHelpOnEmpty
+    Options{pm,dbPath,usPath} <- customExecParser preferences parserInfo
+    userSecret <- readUserSecret (contramap snd stderrTrace) usPath
+    bracketLegacyKeystore userSecret $ \ks -> do
+        let dbMode = UseFilePath $ DatabaseOptions
+                { Kernel.dbPathAcidState = dbPath <> "-acid"
+                , Kernel.dbPathMetadata  = dbPath <> "-sqlite.sqlite3"
+                , Kernel.dbRebuild       = False
+                }
+        fInjects <- mkFInjects Nothing
+        bracketPassiveWallet pm dbMode log ks mockNodeStateDef fInjects $ \pw -> do
+            wallets <- extractWallet pw
+            BL8.putStrLn $ Json.encodePretty (Export <$> wallets)
+  where
+    log = const (B8.hPutStrLn stderr . T.encodeUtf8)
+    stderrTrace = Trace $ Op $ TIO.hPutStrLn stderr
+
+extractWallet
+    :: Kernel.PassiveWallet
+        -- ^ A passive wallet
+    -> IO [(WalletName, EncryptedSecretKey)]
+extractWallet pw = do
+    wKeys <- Keystore.getKeys (pw ^. Kernel.walletKeystore)
+    let nm  = makeNetworkMagic (pw ^.  Kernel.walletProtocolMagic)
+    snapshot <- Kernel.getWalletSnapshot pw
+    fmap catMaybes $ forM wKeys $ \esk -> do
+        let rootId  = eskToHdRootId nm esk
+        case Kernel.lookupHdRootId snapshot rootId of
+            Left _                    -> do
+                let wid = T.decodeUtf8 $ addrToBase58 $ getHdRootId rootId ^. fromDb
+                log Error $ "No wallet for id: " <> wid
+                pure Nothing
+
+            Right HdRoot{_hdRootName} ->
+                pure $ Just (_hdRootName, esk)
+  where
+    log = pw ^. Kernel.walletLogMessage
+
+newtype Export a = Export a deriving (Show)
+
+instance ToJSON (Export (WalletName, EncryptedSecretKey)) where
+    toJSON (Export (name, EncryptedSecretKey{eskPayload, eskHash})) = Json.object
+        [ "name" .= getWalletName name
+        , "encrypted_root_private_key" .= base16 (unXPrv eskPayload)
+        , "passphrase_hash" .= base16 (getEncryptedPass eskHash)
+        ]
+      where
+        base16 = T.decodeUtf8 . convertToBase @ByteString @ByteString Base16
+
+--
+-- Command-line
+--
+--
+
+parserInfo :: ParserInfo Options
+parserInfo = info (helper <*> parser) $
+    progDesc "Export known legacy wallets with their encrypted secret key"
+  where
+    parser = Options <$> pmOption <*> dbOption <*> usOption
+
+-- --mainnet | --testnet MAGIC
+pmOption :: Parser ProtocolMagic
+pmOption = mainnetFlag <|> (ProtocolMagic <$> magicOption <*> pure RequiresMagic)
+  where
+    mainnetFlag = flag'
+        (ProtocolMagic (ProtocolMagicId 764824073) RequiresNoMagic)
+        (long "mainnet")
+
+    magicOption = fmap ProtocolMagicId $ option auto $ mempty
+        <> long "testnet"
+        <> metavar "MAGIC"
+
+-- --db-path FILEPATH
+dbOption :: Parser FilePath
+dbOption = option str $ mempty
+    <> long "wallet-db-path"
+    <> metavar "FILEPATH"
+    <> help "Path to the wallet's database."
+
+-- --keyfile FILEPATH
+usOption :: Parser FilePath
+usOption = option str $ mempty
+    <> long "keyfile"
+    <> metavar "FILEPATH"
+    <> help "Path to the secret key-store."

--- a/wallet/export-wallets/Main.hs
+++ b/wallet/export-wallets/Main.hs
@@ -25,7 +25,6 @@ import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (EncryptedPass (..), EncryptedSecretKey (..))
 import           Pos.Crypto.Configuration (ProtocolMagic (..),
                      ProtocolMagicId (..), RequiresNetworkMagic (..))
-import           Pos.Crypto.Signing (checkPassMatches, emptyPassphrase)
 import           Pos.Infra.InjectFail (mkFInjects)
 import           Pos.Util.Log.Severity (Severity (..))
 import           Pos.Util.Trace (Trace (..))
@@ -95,12 +94,10 @@ extractWallet pw = do
 newtype Export a = Export a deriving (Show)
 
 instance ToJSON (Export (WalletName, EncryptedSecretKey)) where
-    toJSON (Export (name, esk@EncryptedSecretKey{eskPayload, eskHash})) = Json.object
+    toJSON (Export (name, EncryptedSecretKey{eskPayload, eskHash})) = Json.object
         [ "name" .= getWalletName name
         , "encrypted_root_private_key" .= base16 (unXPrv eskPayload)
-        , "passphrase_hash" .= case (checkPassMatches emptyPassphrase esk) of
-            Nothing -> toJSON $ base16 (getEncryptedPass eskHash)
-            Just () -> Json.Null
+        , "passphrase_hash" .= base16 (getEncryptedPass eskHash)
         ]
       where
         base16 = T.decodeUtf8 . convertToBase @ByteString @ByteString Base16

--- a/wallet/export-wallets/Main.hs
+++ b/wallet/export-wallets/Main.hs
@@ -24,6 +24,7 @@ import           Pos.Core.NetworkMagic (makeNetworkMagic)
 import           Pos.Crypto (EncryptedPass (..), EncryptedSecretKey (..))
 import           Pos.Crypto.Configuration (ProtocolMagic (..),
                      ProtocolMagicId (..), RequiresNetworkMagic (..))
+import           Pos.Crypto.Signing (checkPassMatches, emptyPassphrase)
 import           Pos.Infra.InjectFail (mkFInjects)
 import           Pos.Util.Log.Severity (Severity (..))
 import           Pos.Util.Trace (Trace (..))
@@ -67,7 +68,6 @@ main = do
 
 extractWallet
     :: Kernel.PassiveWallet
-        -- ^ A passive wallet
     -> IO [(WalletName, EncryptedSecretKey)]
 extractWallet pw = do
     wKeys <- Keystore.getKeys (pw ^. Kernel.walletKeystore)
@@ -89,10 +89,12 @@ extractWallet pw = do
 newtype Export a = Export a deriving (Show)
 
 instance ToJSON (Export (WalletName, EncryptedSecretKey)) where
-    toJSON (Export (name, EncryptedSecretKey{eskPayload, eskHash})) = Json.object
+    toJSON (Export (name, esk@EncryptedSecretKey{eskPayload, eskHash})) = Json.object
         [ "name" .= getWalletName name
         , "encrypted_root_private_key" .= base16 (unXPrv eskPayload)
-        , "passphrase_hash" .= base16 (getEncryptedPass eskHash)
+        , "passphrase_hash" .= case (checkPassMatches emptyPassphrase esk) of
+            Nothing -> toJSON $ base16 (getEncryptedPass eskHash)
+            Just () -> Json.Null
         ]
       where
         base16 = T.decodeUtf8 . convertToBase @ByteString @ByteString Base16


### PR DESCRIPTION
## Description

<!--- A brief description of this PR and the problem is trying to solve -->

- f63761ebe5a9edcbf01310f7ebf263f7a5f0e12b
  implement export-wallets for Byron reboot migration
  This little command-line tool extract the name and encrypted XPrv of
known wallets and spits them back in a user-friendly format on stdout.

The format matches exactly the JSON format expected by the
cardano-wallet for restoring legacy wallet from xprv.

- 148076e40c6393c022b0d60e9fa0c0bd50d07fab
  Return 'null' for 'passphrase_hash' when there's no passphrase set

  `$ export-wallets --mainnet --wallet-db-path state-wallet-mainnet/wallet-db --keyfile state-wallet-mainnet/secret.key`

```json
[
    {
        "encrypted_root_private_key": "b824f5268bdf05d783b0c594936e51c65d6d155021ddcbdb3370bb7a51caba4bedece046fc9d12143ce900d8238e444904e08a85af80299b012e7f12030a2ab6d3d1cf6fc565476c17326baebddcf31c5e3409ba697b9bf04ac588cb59868c22d043e0237a3ba2eb167d1504dd93f788fc4a72503a261cf338ad7e4cf8837aff",
        "name": "My Wallet",
        "passphrase_hash": null
    },
    {
        "encrypted_root_private_key": "5da58210e3f6e2b1e24659158554f91bb5970202ba0e0cd2d32767ce3c2893c29515a5469493f6133857c0dc86f127aa70e46d047424e07f7221715357bfb35052aed22cefd53ea7d75b5804add54e653c21e03ffd7c01cb8f6c033f7d383cc127046148d89a1828b76bdb46b56f6fec06d31b5b412dc68ab4b5ffa2418e7e8d",
        "name": "My Wallet",
        "passphrase_hash": "31347c387c317c57434478796c7064635a736853367a6d3150766d54456a34667038795a34623145557868627765347a36596645413d3d7c48544739445a456d4f2b79535a6a705a76553145614d795a437170732b43347330704738414562745638773d"
    }
]
```

## Linked issue

<!--- Put here the relevant issue from YouTrack -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply and `~` in the ones that do not: -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏭 Refactoring that does not change existing functionality but does improve things like code readability, structure etc
- [ ] 🔨 New or improved tests for existing code
- [ ] ⛑ git-flow chore (backport, hotfix, etc)

## Developer checklist
<!--- A mental checklist for the developer submitting the PR. Put an `x` in all the boxes that apply and `~` in the ones that do not: --->
- [ ] I have read the [style guide](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/style-guide.md) document, and my code follows the code style of this project.
- [ ] If my code deals with exceptions, it follows the [guidelines](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/exceptions.md).
- [ ] I have updated any documentation accordingly, if needed. Documentation changes can be reflected in opening a PR on [cardanodocs.com](https://github.com/input-output-hk/cardanodocs.com), amending the inline [Haddock](https://www.haskell.org/haddock/) comments, any relevant README file or one of the document listed in the [docs](https://github.com/input-output-hk/cardano-sl/tree/develop/docs) directory.
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub.

## Testing checklist
<!-- If you aren't providing any tests as part of this PR, use this section to state clearly why. It needs to be a strong motivation and definitely the exception, not the rule. -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## QA Steps
<!--- Which are the steps needed to test this feature, if any? -->

## Screenshots (if available)
<!--- Upload a GIF, an asciinema video or an image demoing the feature -->

## How to merge

Send the message `bors r+` to merge this PR. For more information, see
[`docs/how-to/bors.md`](https://github.com/input-output-hk/cardano-sl/blob/develop/docs/how-to/bors.md).
