### PR TITLE
Adjust the epoch0 EBB construction to follow the consensus era

### DIFF
--- a/chain/src/Pos/Chain/Block/Block.hs
+++ b/chain/src/Pos/Chain/Block/Block.hs
@@ -252,8 +252,12 @@ mkGenesisBlock pm prevHeader epoch leaders = GenericBlock header body extra
     extra = GenesisExtraBodyData $ mkAttributes ()
 
 -- | Creates the very first genesis block.
-genesisBlock0 :: ProtocolMagic -> GenesisHash -> SlotLeaders -> GenesisBlock
-genesisBlock0 pm genesisHash leaders = mkGenesisBlock pm (Left genesisHash) 0 leaders
+genesisBlock0 :: ConsensusEra -> ProtocolMagic -> GenesisHash -> SlotLeaders -> GenesisBlock
+genesisBlock0 Original pm genesisHash leaders =
+    mkGenesisBlock pm (Left genesisHash) 0 leaders
+
+genesisBlock0 (OBFT _) pm genesisHash _leaders =
+    mkGenesisBlock pm (Left genesisHash) 0 []
 
 -- | To verify a genesis block we only have to check the body proof.
 verifyGenesisBlock

--- a/chain/src/Pos/Chain/Lrc/Fts.hs
+++ b/chain/src/Pos/Chain/Lrc/Fts.hs
@@ -10,7 +10,6 @@ import           Universum
 import           Control.Lens (makeLenses, makePrisms, uses)
 import           Data.Conduit (ConduitT, await, runConduitPure, (.|))
 import qualified Data.Conduit.List as CL
-import           Data.List.NonEmpty (fromList)
 
 import           Formatting (int, sformat, (%))
 
@@ -237,7 +236,7 @@ followTheSatoshiM epochSlots (SharedSeed seed) totalCoins = do
     ftsState <- ftsStateInit <$> nextStakeholder
     let sortedCoinIndices = sortWith snd (assignToSlots epochSlots coinIndices)
     res <- evaluatingStateT ftsState $ findLeaders sortedCoinIndices
-    pure . fromList . arrangeBySlots $ res
+    pure . arrangeBySlots $ res
   where
     coinIndices :: [CoinIndex]
     coinIndices = map (CoinIndex . fromInteger) . deterministic seed $

--- a/chain/src/Pos/Chain/Lrc/OBFT.hs
+++ b/chain/src/Pos/Chain/Lrc/OBFT.hs
@@ -39,9 +39,9 @@ getEpochSlotLeaderScheduleObftPure
     -> NonEmpty StakeholderId
     -> SlotLeaders
 getEpochSlotLeaderScheduleObftPure epochIndex epochSlotCount stakeholders =
-    case nonEmpty slotLeaderSchedule of
-        Just sls -> sls
-        Nothing  -> error "getEpochSlotLeaderScheduleObftPure: Empty slot leader schedule"
+    case slotLeaderSchedule of
+        []  -> error "getEpochSlotLeaderScheduleObftPure: Empty slot leader schedule"
+        sls -> sls
   where
     slotLeaderSchedule =
         map (\si -> getSlotLeaderObftPure si epochSlotCount stakeholders)

--- a/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
+++ b/chain/test/Test/Pos/Chain/Block/Arbitrary.hs
@@ -492,9 +492,9 @@ genHeaderAndParams pm era = do
                 Block.BlockHeaderGenesis h -> h ^. Block.gbhExtra . Block.gehAttributes
                 Block.BlockHeaderMain h    -> h ^. Block.gbhExtra . Block.mehAttributes
 
-        thisEpochLeaderSchedule :: Maybe (NonEmpty (Core.AddressHash PublicKey))
+        thisEpochLeaderSchedule :: Maybe [Core.AddressHash PublicKey]
         thisEpochLeaderSchedule =
-            mkEpochLeaderSchedule era (getEpochOrSlot header) headers
+            toList <$> mkEpochLeaderSchedule era (getEpochOrSlot header) headers
 
         params = Block.VerifyHeaderParams
             { Block.vhpPrevHeader = prev

--- a/client/src/Pos/Client/Txp/History.hs
+++ b/client/src/Pos/Client/Txp/History.hs
@@ -39,13 +39,14 @@ import           Serokell.Util.Text (listJson)
 import           Pos.Chain.Block (Block, MainBlock, genesisBlock0, headerHash,
                      mainBlockSlot, mainBlockTxPayload)
 import           Pos.Chain.Genesis as Genesis (Config (..))
-import           Pos.Chain.Genesis (GenesisData)
+import           Pos.Chain.Genesis (GenesisData, configBlockVersionData)
 import           Pos.Chain.Lrc (genesisLeaders)
 import           Pos.Chain.Txp (ToilVerFailure, Tx (..), TxAux (..), TxId,
                      TxOut, TxOutAux (..), TxWitness, TxpConfiguration,
                      TxpError (..), UtxoLookup, UtxoM, UtxoModifier,
                      applyTxToUtxo, evalUtxoM, flattenTxPayload, genesisUtxo,
                      runUtxoM, topsortTxs, txOutAddress, utxoGet, utxoToLookup)
+import           Pos.Chain.Update (consensusEraBVD)
 import           Pos.Core (Address, ChainDifficulty, Timestamp (..),
                      difficultyL)
 import           Pos.Core.JsonLog (CanJsonLog (..))
@@ -222,6 +223,7 @@ getBlockHistoryDefault
 getBlockHistoryDefault genesisConfig addrs = do
     let genesisHash = configGenesisHash genesisConfig
     let bot = headerHash $ genesisBlock0
+            (consensusEraBVD (configBlockVersionData genesisConfig))
             (configProtocolMagic genesisConfig)
             genesisHash
             (genesisLeaders genesisConfig)

--- a/core/src/Pos/Core/Common/SlotLeaders.hs
+++ b/core/src/Pos/Core/Common/SlotLeaders.hs
@@ -10,8 +10,8 @@ import           Serokell.Util (enumerate, listChunkedJson, pairBuilder)
 
 import           Pos.Core.Common.StakeholderId
 
--- | 'NonEmpty' list of slot leaders.
-type SlotLeaders = NonEmpty StakeholderId
+-- | list of slot leaders.
+type SlotLeaders = [StakeholderId]
 
 -- | Pretty-printer for slot leaders. Note: it takes list (not
 -- 'NonEmpty' as an argument, because one can always convert @NonEmpty

--- a/core/test/Test/Pos/Core/ExampleHelpers.hs
+++ b/core/test/Test/Pos/Core/ExampleHelpers.hs
@@ -53,7 +53,6 @@ module Test.Pos.Core.ExampleHelpers
 import           Universum
 
 import           Data.List ((!!))
-import           Data.List.NonEmpty (fromList)
 import qualified Data.Map as M
 import           Data.Maybe (fromJust)
 import qualified Data.Text as T
@@ -183,7 +182,7 @@ exampleStakesList = zip sis coins
     coins = map Coin [79, 44, 9999999]
 
 exampleSlotLeaders :: SlotLeaders
-exampleSlotLeaders = map abstractHash (fromList (examplePublicKeys 16 3))
+exampleSlotLeaders = map abstractHash (examplePublicKeys 16 3)
 
 staticSafeSigners :: [SafeSigner]
 staticSafeSigners = map FakeSigner (exampleSecretKeys 1 6)

--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -65,7 +65,6 @@ import           Universum
 
 import           Data.Fixed (Fixed (..))
 import qualified Data.Map as M
-import           Data.Maybe
 import           Data.Time.Units (Microsecond, Millisecond, fromMicroseconds)
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen

--- a/core/test/Test/Pos/Core/Gen.hs
+++ b/core/test/Test/Pos/Core/Gen.hs
@@ -211,9 +211,7 @@ genSharedSeed :: Gen SharedSeed
 genSharedSeed = SharedSeed <$> gen32Bytes
 
 genSlotLeaders :: Gen SlotLeaders
-genSlotLeaders = do
-    stakeHolderList <- Gen.list (Range.linear 1 10) genStakeholderId
-    pure $ fromJust $ nonEmpty stakeHolderList
+genSlotLeaders = Gen.list (Range.linear 1 10) genStakeholderId
 
 genStakeholderId :: Gen StakeholderId
 genStakeholderId = genAbstractHash genPublicKey

--- a/explorer/src/Pos/Explorer/TestUtil.hs
+++ b/explorer/src/Pos/Explorer/TestUtil.hs
@@ -379,7 +379,7 @@ produceBlocksByBlockNumberAndSlots blockNumber slotsNumber producedSlotLeaders s
 
 -- | Produce N slot leaders so we can test it realistically.
 produceSlotLeaders :: MonadIO m => SlotLeadersNumber -> m SlotLeaders
-produceSlotLeaders slotLeadersNumber = liftIO $ NE.fromList <$> stakeholders
+produceSlotLeaders slotLeadersNumber = liftIO stakeholders
   where
     stakeholders :: IO [StakeholderId]
     stakeholders = replicateM (fromIntegral slotLeadersNumber) generatedStakeHolder

--- a/lib/src/Pos/DB/DB.hs
+++ b/lib/src/Pos/DB/DB.hs
@@ -8,9 +8,9 @@ module Pos.DB.DB
 import           Universum
 
 import           Pos.Chain.Block (genesisBlock0, headerHash)
-import           Pos.Chain.Genesis as Genesis (Config (..))
+import           Pos.Chain.Genesis as Genesis (Config (..), configBlockVersionData)
 import           Pos.Chain.Lrc (genesisLeaders)
-import           Pos.Chain.Update (BlockVersionData)
+import           Pos.Chain.Update (BlockVersionData, consensusEraBVD)
 import           Pos.DB.Block (prepareBlockDB)
 import           Pos.DB.Class (MonadDB, MonadDBRead (..))
 import           Pos.DB.Lrc (prepareLrcDB)
@@ -30,7 +30,8 @@ initNodeDBs genesisConfig = do
     prepareGStateDB genesisConfig initialTip
     prepareLrcDB genesisConfig
   where
-    gb = genesisBlock0 (configProtocolMagic genesisConfig)
+    gb = genesisBlock0 (consensusEraBVD (configBlockVersionData genesisConfig))
+                       (configProtocolMagic genesisConfig)
                        (configGenesisHash genesisConfig)
                        (genesisLeaders genesisConfig)
 

--- a/utxo/src/UTxO/Context.hs
+++ b/utxo/src/UTxO/Context.hs
@@ -54,9 +54,10 @@ import           Pos.Chain.Delegation (ProxySKHeavy)
 import           Pos.Chain.Genesis as Genesis (Config (..),
                      GeneratedSecrets (..), GenesisData (..),
                      GenesisDelegation (..), PoorSecret (..), RichSecrets (..),
-                     configEpochSlots)
+                     configEpochSlots, configBlockVersionData)
 import           Pos.Chain.Lrc
 import           Pos.Chain.Txp
+import           Pos.Chain.Update (consensusEraBVD)
 import           Pos.Core as Core
 import           Pos.Core.NetworkMagic (NetworkMagic (..))
 import           Pos.Crypto
@@ -113,7 +114,8 @@ initCardanoContext genesisConfig = CardanoContext
     ccData       = configGenesisData genesisConfig
     ccLeaders    = genesisLeaders genesisConfig
     ccMagic      = configProtocolMagic genesisConfig
-    ccBlock0     = genesisBlock0 ccMagic (configGenesisHash genesisConfig) ccLeaders
+    consensusEra = consensusEraBVD (configBlockVersionData genesisConfig)
+    ccBlock0     = genesisBlock0 consensusEra ccMagic (configGenesisHash genesisConfig) ccLeaders
     ccUtxo       = genesisUtxo ccData
 
 {-------------------------------------------------------------------------------

--- a/utxo/src/UTxO/Context.hs
+++ b/utxo/src/UTxO/Context.hs
@@ -39,6 +39,7 @@ module UTxO.Context (
   ) where
 
 import qualified Data.HashMap.Strict as HM
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Formatting (bprint, build, sformat, (%))
@@ -567,7 +568,7 @@ leaderForSlot leaders slotId TransCtxt{..} = actorsStake Map.! leader
     CardanoContext{..} = tcCardano
 
     leader :: StakeholderId
-    leader = leaders NE.!! slotIx
+    leader = leaders List.!! slotIx
 
     slotIx :: Int
     slotIx = fromIntegral $ getSlotIndex (siSlot slotId)


### PR DESCRIPTION
When we start a chain from a genesis in the OBFT era, rather than the Original era, the epoch zero EBB must still exist, even though all other epoch EBBs do not exist.

That EBB ought to have an empty slot leader schedule, otherwise we cannot have new non-legcay nodes create the same EBB, since new nodes do not implement the logic for Original era leader schedules. This does not affects any existing chain, since existing chains all start in the Original era and go through a hard fork to enter the OBFT era. This change only affects new test/dev chains that start in the OBFT era. This is needed to test mixed clusters of old/new nodes in a convenient way, that all start from genesis in the OBFT era.

